### PR TITLE
change to firefox compatible event properties

### DIFF
--- a/arches/app/media/js/views/map.js
+++ b/arches/app/media/js/views/map.js
@@ -118,9 +118,9 @@ define([
                 self.trigger('viewChanged', view.getZoom(), extent);
             });
 
-
             this.map.on('click', function(e) {
-                var clickFeature = self.map.forEachFeatureAtPixel(e.pixel, function (feature, layer) {
+                var pixels = [e.originalEvent.layerX,e.originalEvent.layerY];
+                var clickFeature = self.map.forEachFeatureAtPixel(pixels, function (feature, layer) {
                     return feature;
                 });
                 self.trigger('mapClicked', e, clickFeature);
@@ -129,16 +129,7 @@ define([
 
         handleMouseMove: function(e) {
             var self = this;
-            if(e.offsetX === undefined) {
-                // this works in Firefox
-                var xpos = e.pageX-$('#map').offset().left;
-                var ypos = e.pageY-$('#map').offset().top;
-            } else { 
-                // works in Chrome, IE and Safari
-                var xpos = e.offsetX;
-                var ypos = e.offsetY;
-            }
-            var pixels = [xpos, ypos];
+            var pixels = [e.originalEvent.layerX,e.originalEvent.layerY];
             var coords = this.map.getCoordinateFromPixel(pixels);
             var point = new ol.geom.Point(coords);
             var format = ol.coordinate.createStringXY(4);
@@ -153,7 +144,6 @@ define([
                 this.trigger('mousePositionChanged', '');
             }
         },
-
 
         handleMouseOut: function () {
             this.trigger('mousePositionChanged', '');


### PR DESCRIPTION
modify two functions so that firefox can interpret the pixel position correctly.