### PR TITLE
assigning graph name to node name on update

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -22,6 +22,7 @@ from django.db import transaction
 from arches.app.models import models
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from django.conf import settings
+from django.utils.translation import ugettext as _
 
 class Graph(object):
     """
@@ -84,7 +85,7 @@ class Graph(object):
         )
         root = models.Node.objects.create(
             pk=newid,
-            name=name,
+            name=_("Top Node"),
             description='',
             istopnode=True,
             ontologyclass=None,
@@ -271,7 +272,7 @@ class Graph(object):
             graph = self.metadata
         )
         branch_copy.add_edge(newEdge)
-        
+
         for key, node in branch_copy.nodes.iteritems():
             self.add_node(node)
         for key, edge in branch_copy.edges.iteritems():
@@ -287,7 +288,7 @@ class Graph(object):
     def clear_ontology_references(self):
         """
         removes any references to ontolgoy classes and properties in a graph
-        
+
         """
 
         for node_id, node in self.nodes.iteritems():

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -90,8 +90,6 @@ def settings(request, graphid):
     graph = node.graph
     if request.method == 'POST':
         data = JSONDeserializer().deserialize(request.body)
-        if data.get('metadata')['name'] != graph.name:
-            node.name = data.get('metadata')['name']
         for key, value in data.get('metadata').iteritems():
             setattr(graph, key, value)
         graph.save()

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -90,6 +90,8 @@ def settings(request, graphid):
     graph = node.graph
     if request.method == 'POST':
         data = JSONDeserializer().deserialize(request.body)
+        if data.get('metadata')['name'] != graph.name:
+            node.name = data.get('metadata')['name']
         for key, value in data.get('metadata').iteritems():
             setattr(graph, key, value)
         graph.save()

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -79,7 +79,6 @@ class GraphTests(ArchesTestCase):
         self.assertEqual(graph.metadata.name, name)
         self.assertEqual(graph.metadata.author, author)
         self.assertTrue(graph.metadata.isresource)
-        self.assertEqual(graph.root.name, name)
         self.assertFalse(graph.root.is_collector())
         self.assertEqual(len(graph.nodes), 1)
 


### PR DESCRIPTION
re: #559

should we allow the name of the root node of a graph to ever be different from the name of the graph itself?

Currently these are distinct values (`nodes.name` and `graphs.name`), and are assigned independently in the UI… I’m wondering if perhaps we should just always keep these two values in sync (and, thus, [potentially] remove `graph.name` entirely….).