### PR TITLE
fixing bug with adding multiple cards

### DIFF
--- a/arches/app/media/js/models/graph.js
+++ b/arches/app/media/js/models/graph.js
@@ -409,18 +409,20 @@ define(['arches',
                         this.set(key, ko.observableArray(value));
                         break;
                     case 'nodes':
+                        var nodes = [];
                         attributes.data.nodes.forEach(function (node, i) {
-                            attributes.data.nodes[i] = new NodeModel({
+                            var nodeModel = new NodeModel({
                                 source: node,
                                 datatypelookup: datatypelookup,
                                 graph: self
                             });
                             if(node.istopnode){
-                                this.set('root', attributes.data.nodes[i]);
-                                attributes.data.nodes[i].selected(true);
+                                this.set('root', nodeModel);
+                                nodeModel.selected(true);
                             }
+                            nodes.push(nodeModel);
                         }, this);
-                        this.set('nodes', ko.observableArray(value));
+                        this.set('nodes', ko.observableArray(nodes));
                         break;
                     default:
                         this.set(key, value)


### PR DESCRIPTION
Graph model was modifying values in the input array (updating node objects in the incoming list with `NodeModel` instances) which was transforming the source branch viewmodels.

This was causing a bug when a user added multiple cards to a given resource without refreshing the card manager page.

Changed this to not update the source array and instead create a new array of `NodeModel` instances.