### PR TITLE
refactoring widget & datatype relationships

### DIFF
--- a/arches/app/models/migrations/0001_initial.py
+++ b/arches/app/models/migrations/0001_initial.py
@@ -571,23 +571,17 @@ class Migration(migrations.Migration):
                 ('defaultlabel', models.TextField(blank=True, null=True)),
                 ('defaultmask', models.TextField(blank=True, null=True)),
                 ('helptext', models.TextField(blank=True, null=True)),
+                ('datatype', models.ForeignKey(db_column='datatype', to='models.DDataType')),
             ],
             options={
                 'db_table': 'widgets',
                 'managed': True,
             },
         ),
-        migrations.CreateModel(
-            name='WidgetXDataType',
-            fields=[
-                ('id', models.UUIDField(default=uuid.uuid1, primary_key=True, serialize=False)),
-                ('widget', models.ForeignKey(db_column='widgetid', to='models.Widget')),
-                ('datatype', models.ForeignKey(db_column='datatypeid', to='models.DDataType')),
-            ],
-            options={
-                'db_table': 'widgets_x_datatypes',
-                'managed': True,
-            },
+        migrations.AddField(
+            model_name='ddatatype',
+            name='defaultwidget',
+            field=models.ForeignKey(db_column='defaultwidget', to='models.Widget', null=True),
         ),
         migrations.AddField(
             model_name='resourcexresource',

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -78,6 +78,7 @@ class Concept(models.Model):
 class DDataType(models.Model):
     datatype = models.TextField(primary_key=True)
     iconclass = models.TextField()
+    defaultwidget = models.ForeignKey(db_column='defaultwidget', to='models.Widget')
 
     class Meta:
         managed = True
@@ -495,17 +496,8 @@ class Widget(models.Model):
     defaultlabel = models.TextField(blank=True, null=True)
     defaultmask = models.TextField(blank=True, null=True)
     helptext = models.TextField(blank=True, null=True)
+    datatype = models.ForeignKey(db_column='datatype', to='models.DDataType')
 
     class Meta:
         managed = True
         db_table = 'widgets'
-
-
-class WidgetXDataType(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid1)  # This field type is a guess.
-    widget = models.ForeignKey(db_column='widgetid', to='models.Widget')
-    datatype = models.ForeignKey(db_column='datatypeid', to='models.DDataType')
-
-    class Meta:
-        managed = True
-        db_table = 'widgets_x_datatypes'

--- a/arches/db/dml/db_data.sql
+++ b/arches/db/dml/db_data.sql
@@ -99,12 +99,12 @@ INSERT INTO d_node_types VALUES ('Collection', 'skos');
 INSERT INTO d_node_types VALUES ('EntityType', 'arches');
 
 --Data types
-INSERT INTO d_data_types VALUES ('string', 'fa fa-file-code-o');
+INSERT INTO d_data_types VALUES ('string', 'fa fa-file-code-o', '10000000-0000-0000-0000-000000000001');
 INSERT INTO d_data_types VALUES ('number', 'fa fa-hashtag');
-INSERT INTO d_data_types VALUES ('date', 'fa fa-calendar');
+INSERT INTO d_data_types VALUES ('date', 'fa fa-calendar', '10000000-0000-0000-0000-000000000004');
 INSERT INTO d_data_types VALUES ('geometry', 'fa fa-globe');
-INSERT INTO d_data_types VALUES ('domain', 'fa fa-list-ul');
-INSERT INTO d_data_types VALUES ('boolean', 'fa fa-toggle-on');
+INSERT INTO d_data_types VALUES ('domain', 'fa fa-list-ul', '10000000-0000-0000-0000-000000000002');
+INSERT INTO d_data_types VALUES ('boolean', 'fa fa-toggle-on', '10000000-0000-0000-0000-000000000003');
 INSERT INTO d_data_types VALUES ('file', 'fa fa-file-image-o');
 INSERT INTO d_data_types VALUES ('semantic', 'fa fa-link');
 
@@ -139,17 +139,17 @@ INSERT INTO auth_user(username, first_name, last_name, email, password, is_staff
 INSERT INTO auth_user(username, first_name, last_name, email, password, is_staff, is_active, is_superuser, last_login, date_joined)
     VALUES ('anonymous', '', '', '', '!S9npj7MhUqm30gT5ldm4TposL8jU5jDL4Ab02uuK', 'f', 't', 'f', '2012-03-15 15:29:31.211-07', '2012-03-15 15:29:31.211-07');
 
-INSERT INTO widgets(widgetid, name, component)
-    VALUES ('10000000-0000-0000-0000-000000000001', 'text-widget', 'widgets/text');
+INSERT INTO widgets(widgetid, name, component, datatype)
+    VALUES ('10000000-0000-0000-0000-000000000001', 'text-widget', 'widgets/text', 'string');
 
-INSERT INTO widgets(widgetid, name, component)
-    VALUES ('10000000-0000-0000-0000-000000000002', 'select-widget', 'widgets/select');
+INSERT INTO widgets(widgetid, name, component, datatype)
+    VALUES ('10000000-0000-0000-0000-000000000002', 'select-widget', 'widgets/select', 'domain');
 
-INSERT INTO widgets(widgetid, name, component)
-    VALUES ('10000000-0000-0000-0000-000000000003', 'switch-widget', 'widgets/switch');
+INSERT INTO widgets(widgetid, name, component, datatype)
+    VALUES ('10000000-0000-0000-0000-000000000003', 'switch-widget', 'widgets/switch', 'boolean');
 
-INSERT INTO widgets(widgetid, name, component)
-    VALUES ('10000000-0000-0000-0000-000000000004', 'datepicker-widget', 'widgets/datepicker');
+INSERT INTO widgets(widgetid, name, component, datatype)
+    VALUES ('10000000-0000-0000-0000-000000000004', 'datepicker-widget', 'widgets/datepicker', 'date');
 
 -- Node graph
 INSERT INTO graphs(graphid, name, author, version, description, isresource, isactive, ontologyid)


### PR DESCRIPTION
removing `widgets_x_datatypes`, instead, managing foreign keys on those tables
this includes support for a `defaultwidget` for each datatype
re: #620