### PR TITLE
Fixes #771

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -959,8 +959,6 @@ class Graph(models.GraphModel):
         else:
             if self.root.is_collector == False:
                 if len(self.nodes) > 1:
-                    print '*'*40
-                    print self.root.name
                     raise ValidationError(_("If your graph contains more than one node and is not a resource the root must be a collector."))
 
 

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -951,12 +951,11 @@ class Graph(models.GraphModel):
 
         # validates that the top node of a resource graph is semantic and a collector
 
-        if self.root.datatype != 'semantic':
-            raise ValidationError(_("The top node of your resource graph must have a datatype of 'semantic'."))
-
         if self.isresource == True:
             if self.root.is_collector == True:
                 raise ValidationError(_("The top node of your resource graph: {0} needs to be a collector. Hint: check that nodegroup_id of your resource node(s) are not null.".format(self.root.name)))
+            if self.root.datatype != 'semantic':
+                raise ValidationError(_("The top node of your resource graph must have a datatype of 'semantic'."))
         else:
             if self.root.is_collector == False:
                 if len(self.nodes) > 1:


### PR DESCRIPTION
Fixes graph validation bug that wouldn't allow user to save graph if the top node was not semantic. The top node only needs to be semantic if you are creating a resource.

### Description of Change
Bug fix


### Issues Solved
#771 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)