### PR TITLE
Add cards_x_nodes_x_widgets data to graph export and graph import.

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/importer.py
+++ b/arches/app/utils/data_management/resource_graphs/importer.py
@@ -16,9 +16,27 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
+import sys
 from arches.app.models.graph import Graph
+from arches.app.models.models import CardXNodeXWidget
+from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+from django.db import transaction
 
 def import_graph(graphs):
-	for resource in graphs:
-		graph = Graph(resource)
-		graph.save()
+	with transaction.atomic():
+		for resource in graphs:
+			graph = Graph(resource)
+			graph.save()
+
+			if not hasattr(graph, 'cards_x_nodes_x_widgets'):
+				print '*********This graph has no attribute cards_x_nodes_x_widgets*********'
+				sys.exit()
+			else:
+				for	card_x_node_x_widget in graph.cards_x_nodes_x_widgets:
+					functions = card_x_node_x_widget['functions']
+					card_x_node_x_widget.pop('functions', None)
+					cardxnodexwidget = CardXNodeXWidget.objects.create(**card_x_node_x_widget)
+					cardxnodexwidget.save()
+					cardxnodexwidget.functions.set(functions)
+
+			return Graph

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -34,6 +34,7 @@ from arches.app.models.card import Card
 from arches.app.models.concept import Concept
 from arches.app.models import models
 from arches.app.utils.data_management.resource_graphs.exporter import get_graphs_for_export
+from arches.app.utils.data_management.resource_graphs import importer as GraphImporter
 from arches.app.views.base import BaseManagerView
 from tempfile import NamedTemporaryFile
 from guardian.shortcuts import get_perms_for_model
@@ -190,10 +191,9 @@ class GraphDataView(View):
         if self.action == 'import_graph':
             graph_file = request.FILES.get('importedGraph').read()
             graphs = JSONDeserializer().deserialize(graph_file)['graph']
+            GraphImporter.import_graph(graphs)
             for graph in graphs:
-                new_graph = Graph(graph)
-                new_graph.save()
-                ret = new_graph
+                ret = graph
         else:
             if graphid is not None:
                 graph = Graph.objects.get(graphid=graphid)

--- a/arches/db/branches/Activity Phase.json
+++ b/arches/db/branches/Activity Phase.json
@@ -2101,6 +2101,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Appellation.json
+++ b/arches/db/branches/Appellation.json
@@ -1452,6 +1452,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Beginning of Existence.json
+++ b/arches/db/branches/Beginning of Existence.json
@@ -2428,6 +2428,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Condition Assessment.json
+++ b/arches/db/branches/Condition Assessment.json
@@ -3377,6 +3377,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/External Resource.json
+++ b/arches/db/branches/External Resource.json
@@ -700,6 +700,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Information Carrier.json
+++ b/arches/db/branches/Information Carrier.json
@@ -2154,6 +2154,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Keyword.json
+++ b/arches/db/branches/Keyword.json
@@ -1759,6 +1759,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Language.json
+++ b/arches/db/branches/Language.json
@@ -1759,6 +1759,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Name.json
+++ b/arches/db/branches/Name.json
@@ -691,6 +691,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Publication Event.json
+++ b/arches/db/branches/Publication Event.json
@@ -3180,6 +3180,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Resource Creation Event.json
+++ b/arches/db/branches/Resource Creation Event.json
@@ -3209,6 +3209,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Resource Type Classification.json
+++ b/arches/db/branches/Resource Type Classification.json
@@ -1759,6 +1759,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Right.json
+++ b/arches/db/branches/Right.json
@@ -1608,6 +1608,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/arches/db/branches/Temporal Coverage.json
+++ b/arches/db/branches/Temporal Coverage.json
@@ -2065,6 +2065,7 @@
       "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
       "version": "",
       "cards": [],
+      "cards_x_nodes_x_widgets": [],
       "subtitle": "",
       "nodes": [
         {

--- a/tests/fixtures/resource_graphs/archesv4_resource.json
+++ b/tests/fixtures/resource_graphs/archesv4_resource.json
@@ -5422,7 +5422,7 @@
           "ontologyclass": "E47_Spatial_Coordinates",
           "nodeid": "2d18cb13-d175-47d6-b218-8f2644cf8b3c",
           "nodegroup_id": "2d18cb13-d175-47d6-b218-8f2644cf8b3c",
-          "datatype": "geometry",
+          "datatype": "geojson-feature-collection",
           "cardinality": ""
         },
         {
@@ -7051,7 +7051,8 @@
           "description": ""
         }
       ],
-      "cards": []
+      "cards": [],
+      "cards_x_nodes_x_widgets": []
     }
   ],
   "business_data": {
@@ -7105,19 +7106,6 @@
           "name": "",
           "title": "",
           "subtitile": ""
-        }
-      ]
-    },
-    {
-      "cards": [
-        {
-          "cardid": "",
-          "name": "",
-          "title": "",
-          "subtitle": "",
-          "helptext": "",
-          "nodegroup_id": "",
-          "parentcardid": ""
         }
       ]
     },


### PR DESCRIPTION
Adds cards_x_nodes_widgets data to import/export. This commit will break import of resource models or branches that do not have a cards_x_nodes_x_widgets property in their graph object.

"cards_x_nodes_widges": [],


### Issues Solved
re #1010 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)