### PR TITLE
723 geom widget

### DIFF
--- a/arches/app/media/css/arches-nifty.css
+++ b/arches/app/media/css/arches-nifty.css
@@ -4319,7 +4319,7 @@ div.row.widget-wrapper.report-header:hover {
     top: 0px;
     left: 0px;
     z-index: 1;
-    width: 50%;
+    width: 40%;
 }
 
 .geocode-container.hide-geocoder {
@@ -4384,7 +4384,7 @@ div.row.widget-wrapper.report-header:hover {
     color: #fff;
 }
 
-.map-widget-tool {
+/*.map-widget-tool {
     padding-top: 5px;
     font-size: 17px;
     height: 50px;
@@ -4393,7 +4393,7 @@ div.row.widget-wrapper.report-header:hover {
     vertical-align: middle;
     display: table-cell;
     border-right: 1px solid rgba(0, 0, 0, 1);
-}
+}*/
 
 .map-widget-icon {
     color: rgba(255, 255, 255, 1);
@@ -4404,12 +4404,49 @@ div.row.widget-wrapper.report-header:hover {
   background-color: #f3f3f3;
 }
 
-.map-widget-tool.disabled {
-  background-color: #999999;
+.map-widget-toolbar-list {
+    list-style: none;
+    padding-left: 0px;
+    display: inline-block;
+    width: 250px;
 }
 
-.map-widget-tool.disabled i {
-  color: black;
+.map-widget-toolbar-item {
+   padding-top: 5px;
+   font-size: 17px;
+   height: 50px;
+   width: 50px;
+   color: #fff;
+   vertical-align: middle;
+   text-align: center;
+   display: table-cell;
+   border-right: 1px solid rgba(0, 0, 0, 1);
+}
+
+.map-widget-toolbar-item:hover{
+    background: steelblue;
+    cursor: pointer;
+}
+
+.map-widget-toolbar-item.active{
+    background: steelblue;
+}
+
+.map-widget-icon {
+    color: #fff;
+}
+a.map-widget-icon:hover {
+    color: #fff;
+}
+
+
+
+
+
+
+
+.basemap-icon-unselected {
+  color: #ddd;
 }
 
 .map-widget-overlay-item {

--- a/arches/app/media/css/arches-nifty.css
+++ b/arches/app/media/css/arches-nifty.css
@@ -4319,6 +4319,7 @@ div.row.widget-wrapper.report-header:hover {
     top: 0px;
     left: 0px;
     z-index: 1;
+    width: 50%;
 }
 
 .geocode-container.hide-geocoder {

--- a/arches/app/media/js/widgets/map.js
+++ b/arches/app/media/js/widgets/map.js
@@ -90,6 +90,7 @@ define([
                 self.geocodeShimAdded(expanded);
             });
 
+            this.anchorLayerId = this.resourceEditor ? 'gl-draw-point.cold' : '';
             this.layers = _.clone(arches.mapLayers);
 
             this.geocoderOptions = ko.observableArray([{
@@ -378,7 +379,7 @@ define([
                 this.redrawGeocodeLayer = function() {
                     var cacheLayer = map.getLayer('geocode-point');
                     map.removeLayer('geocode-point');
-                    map.addLayer(cacheLayer, 'gl-draw-point.cold');
+                    map.addLayer(cacheLayer, this.anchorLayerId);
                 }
 
                 this.map.on('load', function() {
@@ -400,6 +401,12 @@ define([
                             }, self)
                             data = result;
                             source.setData(data)
+                            _.each(['resource-poly', 'resource-line', 'resource-point'], function(layerId) { //clear and add resource layers so that they are on top of map
+                                    var cacheLayer = self.map.getLayer(layerId);
+                                    self.map.removeLayer(layerId);
+                                    self.map.addLayer(cacheLayer, self.anchorLayerId)
+                                }, self)
+
                         } else if (self.reportHeader === false && !ko.isObservable(self.value)) {
                             data = koMapping.toJS(self.value);
                             self.loadGeometriesIntoDrawLayer()
@@ -638,7 +645,6 @@ define([
                 this.map.on('click', this.updateDrawMode())
 
                 this.overlays.subscribe(function(overlays) {
-                    var anchorLayer = 'gl-draw-point.cold';
                     for (var i = overlays.length; i-- > 0;) { //Using a conventional loop because we want to go backwards over the array
                         overlays[i].layer_definitions.forEach(function(layer) {
                             map.removeLayer(layer.id)
@@ -646,7 +652,7 @@ define([
                     }
                     for (var i = overlays.length; i-- > 0;) {
                         overlays[i].layer_definitions.forEach(function(layer) {
-                            map.addLayer(layer, anchorLayer);
+                            map.addLayer(layer, this.anchorLayerId);
                             map.setPaintProperty(layer.id, layer.type + '-opacity', overlays[i].opacity() / 100.0);
                         })
                     }

--- a/arches/app/media/js/widgets/map.js
+++ b/arches/app/media/js/widgets/map.js
@@ -90,7 +90,7 @@ define([
                 self.geocodeShimAdded(expanded);
             });
 
-            this.anchorLayerId = this.resourceEditor ? 'gl-draw-point.cold' : '';
+            this.anchorLayerId = 'gl-draw-point.cold'; //Layers are added below this drawing layer
             this.layers = _.clone(arches.mapLayers);
 
             this.geocoderOptions = ko.observableArray([{
@@ -176,7 +176,9 @@ define([
 
             this.addInitialLayers = function() {
                 var initialLayers = [];
-                this.layers.unshift(this.defineResourceLayer());
+                if (this.reportHeader) {
+                  this.layers.unshift(this.defineResourceLayer());
+                }
                 var overlayLayers = _.sortBy(_.where(this.layers, {
                     isoverlay: true
                 }), 'sortorder').reverse();
@@ -654,7 +656,7 @@ define([
                         overlays[i].layer_definitions.forEach(function(layer) {
                             map.addLayer(layer, this.anchorLayerId);
                             map.setPaintProperty(layer.id, layer.type + '-opacity', overlays[i].opacity() / 100.0);
-                        })
+                        }, this)
                     }
                     this.redrawGeocodeLayer();
                 }, this)

--- a/arches/app/templates/views/forms/widgets/map.htm
+++ b/arches/app/templates/views/forms/widgets/map.htm
@@ -16,41 +16,39 @@
           bearing: bearing
        }, afterRender: function(){setupMap(map)} }">
 
-       <!--ko if: drawMode -->
-       <div class="geometry-editing-notifications">
-           <div class="alert-wrap in animated jellyIn">
-               <div class="alert alert-warning" role="alert">
-                   <button class="close" type="button">
+        <!--ko if: drawMode -->
+        <div class="geometry-editing-notifications">
+            <div class="alert-wrap in animated jellyIn">
+                <div class="alert alert-warning" role="alert">
+                    <button class="close" type="button">
                    </button>
-                     <!-- ko if: drawMode() === 'draw_point'  -->
-                   <div class="media">
-                     <strong>Edit Mode</strong> You are creating points.  Click the Point tool to exit.
-                   </div>
-                   <!-- /ko -->
-                   <!-- ko if: drawMode() === 'draw_polygon'-->
-                   <div class="media">
-                     <strong>Edit Mode</strong> You are creating polygons.  Click the Polygon tool to exit.
-                   </div>
-                   <!-- /ko -->
-                   <!-- ko if: drawMode() === 'draw_line_string'-->
-                   <div class="media">
-                     <strong>Edit Mode</strong> You are creating lines.  Click the Line tool to exit.
-                   </div>
-                   <!-- /ko -->
-                   <!-- ko if: drawMode() === 'simple_select'-->
-                   <div class="media">
-                     <strong>Edit Mode</strong> You are editing a <span data-bind="text: selectedFeatureType"></span>. Drag to move <!-- ko if: selectedFeatureType() !== 'Point'--> or click it again to edit verticies <!-- /ko -->
-                   </div>
-                   <!-- /ko -->
-                   <!-- ko if: drawMode() === 'direct_select'-->
-                   <div class="media">
-                     <strong>Edit Mode</strong> You are editing <span data-bind="text: selectedFeatureType"></span> verticies. Click outside the feature to exit.
-                   </div>
-                   <!-- /ko -->
-               </div>
-           </div>
-       </div>
-       <!-- /ko -->
+                    <div class="media">
+                        <!-- ko if: drawMode() === 'draw_point'  -->
+                        <strong>Edit Mode</strong> You are creating points. Click the Point tool to exit.
+                        <!-- /ko -->
+                        <!-- ko if: drawMode() === 'draw_polygon'-->
+                        <strong>Edit Mode</strong> You are creating polygons. Click the Polygon tool to exit.
+                        <!-- /ko -->
+                        <!-- ko if: drawMode() === 'draw_line_string'-->
+                        <strong>Edit Mode</strong> You are creating lines. Click the Line tool to exit.
+                        <!-- /ko -->
+                        <!-- ko if: drawMode() === 'simple_select'-->
+                        <strong>Edit Mode</strong> You are editing a <span data-bind="text: selectedFeatureType"></span>.
+                        <!-- ko if: selectedFeatureType() !== 'point'-->
+                        <span>Click and drag to move.</span>
+                        <!-- /ko -->
+                        <!-- ko if: selectedFeatureType() !== 'point'-->
+                        <span>Click and drag to move, or click it again to edit verticies.</span>
+                        <!-- /ko -->
+                        <!-- /ko -->
+                        <!-- ko if: drawMode() === 'direct_select'-->
+                        <strong>Edit Mode</strong> You are editing <span data-bind="text: selectedFeatureType"></span> verticies. Click outside the feature to exit.
+                        <!-- /ko -->
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- /ko -->
 
         <!-- Geocode Panel -->
         <div class="geocode-container" data-bind="css : {'geocode-container-shim' : mapToolsExpanded, 'hide-geocoder': geocoderVisible}">
@@ -390,8 +388,7 @@
                 <div class="col-xs-12 pad-no crud-widget-container">
                     <input id="select2Input2" data-bind="
                       select2v4Data: geometryTypes,
-                      select2v4: geomTypeSelectSetup"
-                      style="width: 100%">
+                      select2v4: geomTypeSelectSetup" style="width: 100%">
                     </input>
                 </div>
             </div>

--- a/arches/app/templates/views/forms/widgets/map.htm
+++ b/arches/app/templates/views/forms/widgets/map.htm
@@ -2,9 +2,6 @@
 <div class="row widget-wrapper" data-bind="css: {'report-header': reportHeader}">
     <label class="control-label widget-input-label" for="" data-bind="text:label"></label>
 
-
-
-
     <div id='map' class="map-crud-container relative" data-bind="mapboxgl: { mapOptions: {
           style: mapStyle,
           zoom: zoom,
@@ -67,28 +64,25 @@
             </div>
 
             <div id="map-widget-toolbar" class="map-widget-toolbar relative" data-bind="fadeVisible: mapToolsExpanded, delay:200, fade:400">
-                <div class="map-widget-tool text-center" data-bind="click: function(){toggleMapControlPanels('basemaps')}, css : {'active': !mapControlPanels.basemaps()}">
+              <ul class="map-widget-toolbar-list" style="">
+                <li class="map-widget-toolbar-item text-center" data-bind="click: function(){toggleMapControlPanels('basemaps')}, css : {'active': !mapControlPanels.basemaps()}">
                     <a id="" href="" class="map-widget-icon"><i class="ion-map add-tooltip" data-bind="tooltip: { title: '{% trans "Basemaps" %}', placement: 'bottom' }"></i></a>
-                </div>
-                <div id="btn-overlays" class="map-widget-tool text-center" data-bind="click: function(){toggleMapControlPanels('overlays')}, css : { 'active': !mapControlPanels.overlays()}">
+                </li>
+                <li id="btn-overlays" class="map-widget-toolbar-item text-center" data-bind="click: function(){toggleMapControlPanels('overlays')}, css : { 'active': !mapControlPanels.overlays()}">
                     <a id="overlays" href="" class="map-widget-icon"><i class="ion-navicon add-tooltip" data-bind="tooltip: { title: '{% trans "Overlays" %}', placement: 'bottom' }"></i></a>
-                </div>
-                <!-- ko if: featureEditingDisabled -->
-                <div class="map-widget-tool text-center" data-bind="css : {'disabled': featureEditingDisabled}">
-                    <a id="" href="" class="map-widget-icon"><i class="ion-crop add-tooltip" data-bind="tooltip: { title: '{% trans "Map Tools" %}', placement: 'bottom' }"></i></a>
-                </div>
-                <!-- /ko -->
+                </li>
                 <!-- ko ifnot: featureEditingDisabled -->
-                <div class="map-widget-tool text-center" data-bind="click: function(){toggleMapControlPanels('maptools')}, css : {'active': !mapControlPanels.maptools() }">
+                <li class="map-widget-toolbar-item text-center" data-bind="click: function(){toggleMapControlPanels('maptools')}, css : {'active': !mapControlPanels.maptools() }">
                     <a id="" href="" class="map-widget-icon"><i class="ion-crop add-tooltip" data-bind="tooltip: { title: '{% trans "Map Tools" %}', placement: 'bottom' }"></i></a>
-                </div>
+                </li>
                 <!-- /ko -->
-                <div class="map-widget-tool text-center" data-bind="click: function(){toggleMapControlPanels('legend')}, css : {'active': !mapControlPanels.legend()}">
+                <li class="map-widget-toolbar-item text-center" data-bind="click: function(){toggleMapControlPanels('legend')}, css : {'active': !mapControlPanels.legend()}">
                     <a id="" href="" class="map-widget-icon"><i class="ion-ios-list add-tooltip" data-bind="tooltip: { title: '{% trans "Legend" %}', placement: 'bottom' }"></i></a>
-                </div>
-                <div class="map-widget-tool text-center" data-bind="click: function(){toggleMapControlPanels('basemaps')}, css : {'map-widget-tool-expanded' : mapToolsExpanded}">
+                </li>
+                <li class="map-widget-toolbar-item text-center" data-bind="click: function(){toggleMapControlPanels('basemaps')}, css : {'map-widget-tool-expanded' : mapToolsExpanded}">
                     <a id="close-map-tools" href="#" class="map-widget-icon" data-bind="click: toggleMapTools"><i class="ion-ios-close add-tooltip" data-bind="tooltip: { title: '{% trans "Close" %}', placement: 'bottom' }"></i></a>
-                </div>
+                </li>
+              </ul>
             </div>
 
             <!-- Basemaps -->
@@ -107,7 +101,7 @@
                         <i class="ion-checkmark-circled"></i>
                         <!-- /ko -->
                         <!-- ko if: name !== self.basemap() -->
-                        <i class="ion-checkmark-circled fade"></i>
+                        <i class="ion-checkmark-circled basemap-icon-unselected"></i>
                         <!-- /ko -->
                     </div>
                     <div class="map-overlay-name">

--- a/arches/db/dml/db_data.sql
+++ b/arches/db/dml/db_data.sql
@@ -2268,50 +2268,58 @@ INSERT INTO map_layers(name, layerdefinitions, isoverlay, sortorder, icon)
         }]', TRUE, 2, 'fa fa-flag');
 
 INSERT INTO map_sources(name, source)
-  VALUES ('golden-gate-park', '{
-              "type": "geojson",
-              "data":
-              {
-                "type": "FeatureCollection",
-                "features": [
-                  {
-                    "type": "Feature",
-                    "properties": {},
-                    "geometry": {
-                      "type": "Polygon",
-                      "coordinates": [
-                        [
-                          [
-                            -122.51060485839844,
-                            37.77125750792944
-                          ],
-                          [
-                            -122.47163772583008,
-                            37.77288579232439
-                          ],
-                          [
-                            -122.45412826538086,
-                            37.77505678240509
-                          ],
-                          [
-                            -122.45292663574217,
-                            37.766643840752764
-                          ],
-                          [
-                            -122.51043319702148,
-                            37.76365837331252
-                          ],
-                          [
-                            -122.51060485839844,
-                            37.77125750792944
-                          ]
-                        ]
-                      ]
-                    }
-                  }
+  VALUES ('sf-national-cemetery',
+    '{
+        "type": "geojson",
+        "data":
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "Point",
+                "coordinates": [
+                  -118.828125,
+                  37.996162679728116
                 ]
               }
-              }');
+            },
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [
+                      -122.46423482894897,
+                      37.80166319140713
+                    ],
+                    [
+                      -122.4621319770813,
+                      37.800459411713945
+                    ],
+                    [
+                      -122.46494293212889,
+                      37.79742444343689
+                    ],
+                    [
+                      -122.46711015701293,
+                      37.79861131738665
+                    ],
+                    [
+                      -122.46423482894897,
+                      37.80166319140713
+                    ]
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+    }');
 
 INSERT INTO map_sources(name, source)
   VALUES ('stamen-terrain', '{
@@ -2331,16 +2339,16 @@ INSERT INTO map_sources(name, source)
 
 
 INSERT INTO map_layers(name, layerdefinitions, isoverlay, sortorder, icon)
-    VALUES ('golden-gate-park', '[{
-        "id":"golden-gate-park",
-        "source":"golden-gate-park",
+    VALUES ('sf-national-cemetery', '[{
+        "id":"sf-national-cemetery",
+        "source":"sf-national-cemetery",
         "type":"fill",
         "layout": {},
         "paint": {
             "fill-color": "#088",
             "fill-opacity": 0.8
         }
-      }]', TRUE, 3, 'ion-leaf');
+      }]', TRUE, 3, 'ion-ios-flag');
 
 INSERT INTO map_layers(name, layerdefinitions, isoverlay, sortorder, icon)
     VALUES ('stamen-terrain', '[{


### PR DESCRIPTION
Made features that had been saved in a form editable when the form is reopened. 
Now showing resource layer instance features as an overlay in the report - not in the form where the resource instance is represented as the draw layer.
Switched the map tools from divs to lists to maintain proper spacing when the drawing tools are not included in a report. 
Added unselected icon to basemap switcher. re #723