### PR TITLE
concept widget bug

### DIFF
--- a/arches/app/media/plugins/knockout-select2.js
+++ b/arches/app/media/plugins/knockout-select2.js
@@ -103,6 +103,11 @@ define(['jquery', 'knockout', 'underscore', 'select2'], function($, ko, _) {
             $(el).on("change", function(val) {
                 return value(val.val);
             });
+            $(el).on("select2-opening", function(val) {
+                if (select2Config.clickBubble) {
+                    $(el).parent().trigger('click');
+                }
+            });
             value.subscribe(function(newVal) {
                 select2Config.value = newVal;
                 $(el).select2("val", newVal);

--- a/arches/app/templates/views/forms/widgets/select.htm
+++ b/arches/app/templates/views/forms/widgets/select.htm
@@ -10,6 +10,7 @@
             <input style="width:30%; display:inline-block;"
                 data-bind="select2: {
                     select2Config: {
+                        clickBubble: true,
                         data: options,
                         value: value,
                         multiple: multiple,


### PR DESCRIPTION
optionally bubbling click events in select binding to parent element on open of select dropdown
using this to drive select of widget in card manager on click of dropdown as select2 v3 doesn't support native events, such as click (which are supported in select2 v4)
fixes #1099 