### PR TITLE
943 inactive resource models bug

### DIFF
--- a/arches/app/media/css/arches-nifty.css
+++ b/arches/app/media/css/arches-nifty.css
@@ -2800,6 +2800,13 @@ span.editable-card i.fa.fa-align-justify:hover{
     opacity: 1.0;
     border: 1px solid #aaa;
 }
+.card-grid-item.disabled {
+  float: left;
+  width: 290px;
+  border: 1px solid #ddd;
+  opacity: .79;
+  margin: 3px;
+}
 div.card-grid-item.selected {
     border: 1px solid #aaa;
     opacity: 1.0;

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -33,12 +33,9 @@ define([
                 });
             });
             options.viewModel.resources = ko.computed(function() {
-                var resources =  ko.utils.arrayFilter(options.viewModel.allGraphs(), function(graph) {
-                    graph.disable = true;
+                return  ko.utils.arrayFilter(options.viewModel.allGraphs(), function(graph) {
                     return graph.isresource;
                 });
-                console.log(resources);
-                return resources;
             });
 
             options.viewModel.setResourceOptionDisable = function(option, item) {

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -9,7 +9,7 @@ define([
 
     var BaseManager = PageView.extend({
         /**
-        * Creates an instance of PageView, optionally using a passed in view model 
+        * Creates an instance of PageView, optionally using a passed in view model
         * appends the following properties to viewModel:
         * allGraphs - an array of graphs models as JSON (not model instances)
         *
@@ -33,10 +33,19 @@ define([
                 });
             });
             options.viewModel.resources = ko.computed(function() {
-                return ko.utils.arrayFilter(options.viewModel.allGraphs(), function(graph) {
+                var resources =  ko.utils.arrayFilter(options.viewModel.allGraphs(), function(graph) {
+                    graph.disable = true;
                     return graph.isresource;
                 });
+                console.log(resources);
+                return resources;
             });
+
+            options.viewModel.setResourceOptionDisable = function(option, item) {
+              if (item) {
+                ko.applyBindingsToNode(option, {disable: !item.isactive || !item.forms}, item);
+              }
+            };
 
             PageView.prototype.constructor.call(this, options);
             return this;

--- a/arches/app/templates/views/graph.htm
+++ b/arches/app/templates/views/graph.htm
@@ -86,7 +86,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             </div>
         </div>
 
-        
+
     </div>
 
 
@@ -106,7 +106,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 </div>
 
                 <div class="resource-grid-tools-container" data-bind="clickBubble: false, hover: hover">
-                    <div class="btn-group">
+                    <div class="btn-group" style="float:right;">
                         <button class="btn btn-sm btn-mint dropdown-toggle" data-toggle="dropdown" type="button" aria-expanded="false"> {% trans "Manage" %} <i class="ion-ios-more"></i></button>
                         <ul class="dropdown-menu dropdown-menu-right">
                             <li><a href="#" data-bind="click:function() { $parent.navigate(graphid + '/settings') }"><i class="fa fa-wrench"></i> {% trans "Settings" %}</a>
@@ -135,7 +135,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         </ul>
                     </div>
                     <div>
-                        <p class="resource-status">{% trans "Status" %}: <span data-bind="text:isactive?'{% trans "Active" %}':'{% trans "Inactive" %}'"></span></p>
+                        <p class="resource-status">{% trans "Status" %}: <span data-bind="text:isactive?'{% trans "Editable" %}':'{% trans "Non-Editable" %}'"></span></p>
                     </div>
                 </div>
             </div>

--- a/arches/app/templates/views/graph/graph-settings.htm
+++ b/arches/app/templates/views/graph/graph-settings.htm
@@ -324,10 +324,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                     <div class="col-xs-12">
                                                         <div class="pad-hor">
                                                             <label data-bind="css: { 'active': graph.isactive() }, click: function () { graph.isactive(true) }" class="form-radio form-normal form-text">
-                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="true"> {% trans "Active" %}
+                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="true"> {% trans "Editable" %}
                                                             </label>
                                                             <label data-bind="css: { 'active': !graph.isactive() }, click: function () { graph.isactive(false) }" class="form-radio form-normal form-text">
-                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="false"> {% trans "Inactive" %}
+                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="false"> {% trans "Non-Editable" %}
                                                             </label>
                                                         </div>
                                                     </div>

--- a/arches/app/templates/views/resource.htm
+++ b/arches/app/templates/views/resource.htm
@@ -77,7 +77,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
             <!-- ko foreach: allGraphs -->
             <!-- ko if: isresource -->
-            <div class="card-grid-item">
+            <div class="card-grid-item" data-bind="css: { 'disabled': !forms || !isactive }">
                 <div class="panel mar-no">
                     <!-- card Name -->
                     <div class="panel-heading">
@@ -87,17 +87,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <div class="panel-body library-card-body">
                       <p>
                         <!-- ko if: !forms -->
-                          <span class="fa fa-warning" style="padding-top: 19px; color: #b20000" data-bind="text: ' Add forms to this resource model to create a resource from it.'"></span>
+                          <span class="fa fa-warning" style="padding-top: 19px; color: #b20000" data-bind="text: ' Add form(s) to make this resource editable.'"></span>
+                        <!-- /ko -->
+                        <!-- ko if: !isactive -->
+                          <span class="fa fa-warning" style="padding-top: 19px; color: #b20000" data-bind="text: ' Change resource model status in graph manager to make this resource editable.'"></span>
                         <!-- /ko -->
                       </p>
-                      <p data-bind="text: description"></p>
+                      <!-- ko if: isactive && forms -->
+                        <p data-bind="text: description"></p>
+                      <!-- /ko -->
                     </div>
 
                     <!-- card Tools -->
                     <div class="panel-footer" style="height: 53px;">
                         <div class="pull-right">
-                            <a href="#" class="btn btn-primary btn-labeled fa fa-plus" role="button" data-bind="attr: { href: '/graph/' + graphid + '/add_resource', 'data-arches-graphid': graphid}, css: { 'disabled': !forms }">{% trans "Create Resource" %}</a>
-                    <!--         <button id="select-blank" class="btn btn-primary btn-labeled fa fa-plus ">{% trans "Create Resource" %}</button> -->
+                            <a href="#" class="btn btn-primary btn-labeled fa fa-plus" role="button" data-bind="attr: { href: '/graph/' + graphid + '/add_resource', 'data-arches-graphid': graphid}, css: { 'disabled': !forms || !isactive}">{% trans "Create Resource" %}</a>
                         </div>
                     </div>
                 </div>

--- a/arches/app/templates/views/resource.htm
+++ b/arches/app/templates/views/resource.htm
@@ -54,7 +54,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 <!-- Find resource -->
                 <div class="find-widget" style="display: none;" data-bind="visible: showFind()">
                     <div>
-                        <select data-bind="chosen: {width: '100%'}, value: graphId, options: resources, optionsText: 'name', optionsValue: 'graphid', optionsCaption: '{% trans "Select a resource..." %}'"></select>
+                        <select data-bind="chosen: {width: '100%'}, value: graphId, options: resources, optionsText: 'name', optionsValue: 'graphid', optionsCaption: '{% trans "Select a resource..." %}', optionsAfterRender: setResourceOptionDisable"></select>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Disables 'create resource' button and list options for resource models in the resource manager that do not have forms or are not-editable. Change resource model status from 'active/inactive' to 'editable/non-editable'.

### Issues Solved
Fixes #943 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

