### PR TITLE
1062_ontology_node_delete_bug

### DIFF
--- a/arches/app/media/js/models/graph.js
+++ b/arches/app/media/js/models/graph.js
@@ -109,16 +109,21 @@ define(['arches',
          * @memberof GraphModel.prototype
          * @param  {NodeModel} node - the node whose parent should be retrieved
          * @return {object} the parent node of the passed in node
+         * If parent node of the passed in node can't be found then reutrn passed in node.
          */
         getParentNode: function(node) {
             var edge = this.get('edges')()
                 .find(function (edge) {
                     return edge.rangenode_id === node.nodeid;
                 });
-            return this.get('nodes')()
-                .find(function (node) {
-                    return edge.domainnode_id === node.nodeid;
-                });
+            if (edge) {
+              return this.get('nodes')()
+                  .find(function (node) {
+                      return edge.domainnode_id === node.nodeid;
+                    });
+              } else {
+                  return node;
+              };
         },
 
         /**


### PR DESCRIPTION
Fix issue where Arches would hang when you tried to delete a node in a graph with a defined ontology.

Modify getParent function in graph.js to return passed in node if edge to find parent node does not exist.

### Issues Solved
fixes #1062 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
