### PR TITLE
948_missing_hidden_forms_bug

### DIFF
--- a/arches/app/media/css/arches-nifty.css
+++ b/arches/app/media/css/arches-nifty.css
@@ -4099,6 +4099,8 @@ div.row.widget-wrapper {
 	color: #abb1b7;
 	transform: translate(0, -2px);
 }
+.arches-menu-item-disabled {
+}
 .add-card-icon {
 	color: #fff;
 	height: 56px;

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -233,7 +233,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                 <!-- ko foreach: allGraphs -->
                                                 <!-- ko if: isresource -->
                                                 <li class="link-submenu-item">
-                                                    <a class="link-submenu" href="#" data-bind="click: $parent.navigate.bind(this, '/graph/' + graphid + '/add_resource') ">
+                                                    <a class="link-submenu" href="#" data-bind="click: !hasforms || !isactive || !formsviewable ? null: $parent.navigate.bind(this, '/graph/' + graphid + '/add_resource'), css: { 'arches-menu-item-disabled': (!hasforms || !isactive || !formsviewable) }  ">
                                                         <i class="fa arches-menu-icon" data-bind="css: iconclass"></i> <span data-bind="text:name"></span></a>
                                                 </li>
                                                 <!-- /ko -->

--- a/arches/app/views/base.py
+++ b/arches/app/views/base.py
@@ -28,4 +28,12 @@ class BaseManagerView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(BaseManagerView, self).get_context_data(**kwargs)
         context['graphs'] = JSONSerializer().serialize(models.GraphModel.objects.all())
+
+        new_graphs = []
+        for graph in JSONDeserializer().deserialize(context['graphs']):
+            graph['hasforms'] = True if models.Form.objects.filter(graph_id=graph['graphid']).count() > 0 else False
+            graph['formsviewable'] = True if models.Form.objects.filter(graph_id=graph['graphid'], visible=True).count() > 0 else False
+            new_graphs.append(graph)
+        context['graphs'] = JSONSerializer().serialize(new_graphs)
+
         return context


### PR DESCRIPTION
Disable create resource instance links in lefthand vertical arches menu. Add ‘arches-menu-item-disabled’ class to when link is disabled.

### Description of Change
Disables 'create resource' link in the vertical resource instance menu on the lefthand side of the page when a resource either does not have forms, all forms are not visible, or the resource is inactive.


### Issues Solved
#948 #1311 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)