### PR TITLE
resource tile refresh

### DIFF
--- a/arches/app/media/js/widgets/map.js
+++ b/arches/app/media/js/widgets/map.js
@@ -130,11 +130,17 @@ define([
             }
 
             if (this.form) {
+                var resourcesUrl = null;
                 this.form.on('after-update', function(req, tile) {
                    if (self.draw !== undefined) {
                      self.draw.changeMode('simple_select')
                      self.featureColor(self.resourceColor)
                    }
+                   resourcesUrl = resourcesUrl || self.sources['resources'].tiles[0];
+                   var style = self.map.getStyle();
+                   style.sources['resources'].tiles[0] = self.sources['resources'].tiles[0] + "?" + (new Date().getTime());
+                   style.sources = _.defaults(self.sources, style.sources);
+                   self.map.setStyle(style);
                 });
                 this.form.on('tile-reset', self.loadGeometriesIntoDrawLayer);
             }

--- a/arches/app/media/js/widgets/map.js
+++ b/arches/app/media/js/widgets/map.js
@@ -136,9 +136,18 @@ define([
                      self.draw.changeMode('simple_select')
                      self.featureColor(self.resourceColor)
                    }
+
+                   // Update resources source url w/ defeat cache param and
+                   // reset the map's style to force a refresh of the resources
+                   // vector tiles, see:
+                   // https://github.com/mapbox/mapbox-gl-js/issues/3709#issuecomment-265346656
+                   //
+                   // Currently, this causes the map to flicker, but this
+                   // should be resolved in the next version of mapbox-gl-js:
+                   // https://github.com/mapbox/mapbox-gl-js/pull/3621
                    resourcesUrl = resourcesUrl || self.sources['resources'].tiles[0];
                    var style = self.map.getStyle();
-                   style.sources['resources'].tiles[0] = self.sources['resources'].tiles[0] + "?" + (new Date().getTime());
+                   style.sources['resources'].tiles[0] = resourcesUrl + "?" + (new Date().getTime());
                    style.sources = _.defaults(self.sources, style.sources);
                    self.map.setStyle(style);
                 });

--- a/arches/app/media/js/widgets/map.js
+++ b/arches/app/media/js/widgets/map.js
@@ -132,11 +132,6 @@ define([
             if (this.form) {
                 var resourcesUrl = null;
                 this.form.on('after-update', function(req, tile) {
-                   if (self.draw !== undefined) {
-                     self.draw.changeMode('simple_select')
-                     self.featureColor(self.resourceColor)
-                   }
-
                    // Update resources source url w/ defeat cache param and
                    // reset the map's style to force a refresh of the resources
                    // vector tiles, see:
@@ -150,6 +145,13 @@ define([
                    style.sources['resources'].tiles[0] = resourcesUrl + "?" + (new Date().getTime());
                    style.sources = _.defaults(self.sources, style.sources);
                    self.map.setStyle(style);
+
+                   if (self.draw !== undefined) {
+                     self.draw.changeMode('simple_select')
+                     self.featureColor(self.resourceColor)
+                   }
+
+                   self.loadGeometriesIntoDrawLayer();
                 });
                 this.form.on('tile-reset', self.loadGeometriesIntoDrawLayer);
             }


### PR DESCRIPTION
re: #1315 
Currently, this causes the map to flicker, but this should be resolved in the next version of mapbox-gl-js:
https://github.com/mapbox/mapbox-gl-js/pull/3621