### PR TITLE
1505 fix ui tests

### DIFF
--- a/tests/ui/page_elements/element_locators.py
+++ b/tests/ui/page_elements/element_locators.py
@@ -15,7 +15,7 @@ class MapWidgetLocators(BaseWidgetLocators):
     OVERLAY_LIBRARY_BUTTON = (By.XPATH, "//*[@id='overlays-panel']/div[1]/h4/i")
     OVERLAY_TO_ADD = (By.XPATH, "//*[@id='overlay-grid']/div[1]")
     ADDED_OVERLAYS = (By.CSS_SELECTOR, "#overlays-panel .map-widget-overlay-item .map-overlay-name")
-    MAP_CANVAS = (By.XPATH, "//*[@id='map']/div[8]/canvas")
+    MAP_CANVAS = (By.CSS_SELECTOR, ".mapboxgl-canvas")
     MAP_DRAW_TOOLS = (By.CSS_SELECTOR, ".drawing-map-tools")
     POINT_DRAW_TOOL = (By.XPATH, "//*[@id='maptools-panel']/div[2]")
 

--- a/tests/ui/page_tests.py
+++ b/tests/ui/page_tests.py
@@ -218,7 +218,7 @@ class UITest(StaticLiveServerTestCase):
             uuid.UUID(form_id)
         except:
             form_id_is_valid = False
-        form_page.configure_form("Form A")
+        form_page.configure_form("FormA")
 
         self.assertTrue(form_id_is_valid)
 
@@ -262,7 +262,7 @@ class UITest(StaticLiveServerTestCase):
             if v != True:
                 map_tools_working = False
         print 'map tools results in report manager', results
-        report_editor_page.save_report("Report A")
+        report_editor_page.save_report("ReportA")
 
         self.assertTrue(map_tools_working)
 
@@ -285,7 +285,7 @@ class UITest(StaticLiveServerTestCase):
         #Navigate to the report manager and click on the correspoding card for the node created above
         form_page = FormPage(self.driver, self.live_server_url, resource_graph_id)
         form_id = form_page.add_new_form()
-        form_page.configure_form("Form B")
+        form_page.configure_form("FormB")
 
         report_manager_page = ReportManagerPage(self.driver, self.live_server_url, resource_graph_id)
         report_id = report_manager_page.add_new_report()
@@ -295,7 +295,7 @@ class UITest(StaticLiveServerTestCase):
         map_widget = report_editor_page.add_widget(MapWidget)
         map_widget.open_tools()
         map_widget.add_overlay(2)
-        report_editor_page.save_report("Report B")
+        report_editor_page.save_report("ReportB")
 
         resource_manager_page = ResourceManagerPage(self.driver, self.live_server_url, resource_graph_id)
         resource_instance_id = resource_manager_page.add_new_resource()

--- a/tests/ui/pages/form_page.py
+++ b/tests/ui/pages/form_page.py
@@ -51,8 +51,8 @@ class FormPage(BasePage):
             EC.element_to_be_clickable(locators.ADD_FORM_CARD_BUTTON)
         ).click()
         form_name_input = self.driver.find_element(*locators.FORM_NAME_INPUT)
+        form_name_input.clear()
         form_name_input.send_keys(form_name)
         self.wait.until(
             EC.element_to_be_clickable(locators.SAVE_EDITS_BUTTON)
         ).click()
-        print form_name, 'created'

--- a/tests/ui/pages/page_locators.py
+++ b/tests/ui/pages/page_locators.py
@@ -44,7 +44,7 @@ class MapWidgetPageLocators(BasePageLocators):
     OVERLAY_LIBRARY_BUTTON = (By.XPATH, "//*[@id='overlays-panel']/div[1]/h4/i")
     OVERLAY_TO_ADD = (By.XPATH, "//*[@id='overlay-grid']/div[1]")
     ADDED_OVERLAYS = (By.CSS_SELECTOR, "#overlays-panel .map-widget-overlay-item .map-overlay-name")
-    MAP_CANVAS = (By.XPATH, "//*[@id='map']/div[8]/canvas")
+    MAP_CANVAS = (By.XPATH, "//*[@id='mapboxgl-map']/div[8]/canvas")
     MAP_DRAW_TOOLS = (By.CSS_SELECTOR, ".drawing-map-tools")
     POINT_DRAW_TOOL = (By.XPATH, "//*[@id='maptools-panel']/div[2]")
 
@@ -55,6 +55,7 @@ class FormPageLocators(BasePageLocators):
     ADD_FORM_BUTTON = (By.XPATH, "//*[@id='report-image-grid']/div[1]")
     ADD_FORM_CARD_BUTTON = (By.XPATH, "//*[@id='report-image-grid']/div/div/div[4]/a")
     FORM_NAME_INPUT = (By.XPATH, "//*[@id='form-id-card']/div/div/div[2]/form/div[1]/div/div[2]/input")
+    SAVE_EDITS_BUTTON = (By.XPATH, "//*[@id='content-container']/div/div[4]/div[3]/span/button[2]")
 
 class ReportManagerPageLocators(BasePageLocators):
     def __init__(self):
@@ -70,6 +71,8 @@ class ReportEditorPageLocators(MapWidgetPageLocators):
 
     REPORT_NAME_INPUT = (By.XPATH, "//*[@id='ep-card-container-crud']/div[2]/div[2]/input")
     ACTIVATE_REPORT_BUTTON = (By.XPATH, "//*[@id='ep-card-container-crud']/div[1]/div/div/span[1]")
+    SAVE_EDITS_BUTTON = (By.XPATH, "//*[@id='content-container']/div/div[4]/div[3]/span/button[2]")
+    ADD_NEW_RESOURCE_NAVBAR_BUTTON = (By.XPATH, "//*[@id='content-container']/div/div[4]/div[3]/a")
 
 class ResourceManagerPageLocators(BasePageLocators):
     def __init__(self):

--- a/tests/ui/pages/report_editor_page.py
+++ b/tests/ui/pages/report_editor_page.py
@@ -15,7 +15,7 @@ class ReportEditorPage(BaseWidgetPage):
     def save_report(self, report_name):
         self.driver.find_element(*locators.ACTIVATE_REPORT_BUTTON).click()
         report_name_input = self.driver.find_element(*locators.REPORT_NAME_INPUT)
+        report_name_input.clear()
         report_name_input.send_keys(report_name)
         self.driver.find_element(*locators.SAVE_EDITS_BUTTON).click()
         self.driver.find_element(*locators.ADD_NEW_RESOURCE_NAVBAR_BUTTON).click()
-        print report_name, 'created'


### PR DESCRIPTION
This fixes #1505.

For some reason, Chrome Crashes when you use spaces in text fields while doing these tests.  The current workaround is removing theses spaces.