### PR TITLE
Moved the button to open the overlay library out from under a scroll bar that briefly

### DIFF
--- a/arches/app/media/css/arches-nifty.css
+++ b/arches/app/media/css/arches-nifty.css
@@ -4738,6 +4738,11 @@ div.row.widget-wrapper.report-header:hover {
   padding: 10px;
 }
 
+.map-controls-overlay-icon {
+    padding-right: 10px;
+    /*margin-right: -10px;*/
+}
+
 .overlay-selection-container {
     position: absolute;
     top: 0px;

--- a/arches/app/templates/views/forms/widgets/map.htm
+++ b/arches/app/templates/views/forms/widgets/map.htm
@@ -204,11 +204,12 @@
 
         <div id="overlays-panel" class="panel map-widget-panel" data-bind="css: {'map-panel-inactive': mapControls.mapControlPanels.overlays}">
             <div class="map-widget-panel-title">
-                <h4 class="" data-bind="click: toggleOverlaySelector">{% trans "Overlays" %}
-                  <i class="ion-ios-plus pull-right add-tooltip"
+                <h4>{% trans "Overlays" %}
+                  <i class="map-controls-overlay-icon ion-ios-plus pull-right add-tooltip"
                     data-placement="left"
                     data-toggle="tooltip"
                     data-original-title="add overlay"
+                    data-bind="click: toggleOverlaySelector"
                     ></i></h4>
             </div>
           <!--ko let: { self: $data }-->

--- a/tests/ui/page_tests.py
+++ b/tests/ui/page_tests.py
@@ -186,13 +186,9 @@ class UITest(StaticLiveServerTestCase):
         results['opened maptools'] = map_widget.open_tools()
         results['added basemap'] = map_widget.add_basemap()
         results['added overlay'] = map_widget.add_overlay(1)
-        map_tools_working = True
-        for k, v in results.iteritems():
-            if v != True:
-                map_tools_working = False
-        print 'map tools results', results
 
-        self.assertTrue(map_tools_working)
+        print results
+        self.assertTrue(results['opened maptools'] == True and results['added basemap'] == True and results['added overlay'] == True)
 
     def test_make_form(self):
         print "Testing form creation"
@@ -257,14 +253,10 @@ class UITest(StaticLiveServerTestCase):
         results['opened maptools'] = map_widget.open_tools()
         results['added basemap'] = map_widget.add_basemap()
         results['added overlay'] = map_widget.add_overlay(2)
-        map_tools_working = True
-        for k, v in results.iteritems():
-            if v != True:
-                map_tools_working = False
-        print 'map tools results in report manager', results
         report_editor_page.save_report("ReportA")
 
-        self.assertTrue(map_tools_working)
+        print results
+        self.assertTrue(results['opened maptools'] == True and results['added basemap'] == True and results['added overlay'] == True)
 
     def test_add_resource(self):
         print "Testing resource instance creation and crud"


### PR DESCRIPTION
…appears during ui tests. The scroll bar was masking the button preventing the overlay library from opening. Also did a little clean up in page_tests.py