### PR TITLE
1491 slow reports

### DIFF
--- a/arches/app/media/js/views/graph/card-configuration-manager.js
+++ b/arches/app/media/js/views/graph/card-configuration-manager.js
@@ -24,6 +24,8 @@ require([
             data: data.graph
         }),
         permissions: data.permissions,
+        ontology_properties: data.ontology_properties,
+        ontologyproperty: data.ontologyproperty,
         helpPreviewActive: ko.observable(false),
         reset: function () {
             viewModel.card.reset();

--- a/arches/app/media/js/views/graph/card-configuration-manager.js
+++ b/arches/app/media/js/views/graph/card-configuration-manager.js
@@ -25,7 +25,7 @@ require([
         }),
         permissions: data.permissions,
         ontology_properties: data.ontology_properties,
-        ontologyproperty: data.ontologyproperty,
+        ontologyproperty: ko.observable(data.ontologyproperty),
         helpPreviewActive: ko.observable(false),
         reset: function () {
             viewModel.card.reset();
@@ -65,6 +65,11 @@ require([
             viewModel.openCard(cardId);
         }
     });
+
+    viewModel.ontologyproperty.subscribe(function(val) {
+        var cardOntologyProperty = viewModel.card.get('ontologyproperty');
+        cardOntologyProperty(val);
+    }, this);
 
     viewModel.cardComponentsTree = new CardComponentsTree(viewModel);
 

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -113,19 +113,12 @@ class Card(models.CardModel):
                         node_model.config = node.get('config', None)
                         self.nodes.append(node_model)
 
-                # self.graph = Graph.objects.get(graphid=self.graph_id)
-
             else:
                 self.widgets = list(self.cardxnodexwidget_set.all())
 
                 sub_groups = models.NodeGroup.objects.filter(parentnodegroup=self.nodegroup)
                 for sub_group in sub_groups:
                     self.cards.extend(Card.objects.filter(nodegroup=sub_group))
-
-                # self.graph = Graph.objects.get(graphid=self.graph_id)
-                #
-                # if self.graph.ontology and self.graph.isresource:
-                #     self.ontologyproperty = self.get_edge_to_parent().ontologyproperty
 
                 self.cardinality = self.nodegroup.cardinality
                 self.groups = self.get_group_permissions(self.nodegroup)
@@ -271,7 +264,6 @@ class Card(models.CardModel):
         ret['visible'] = self.visible
         ret['active'] = self.active
         ret['widgets'] = self.widgets
-        # ret['ontologyproperty'] = self.ontologyproperty
         ret['groups'] = self.groups
         ret['users'] = self.users
         # provide a models.CardXNodeXWidget model for every node
@@ -291,9 +283,6 @@ class Card(models.CardModel):
                     widget_model.config = JSONSerializer().serialize(widget.defaultconfig)
                     widget_model.label = node.name
                     ret['widgets'].append(widget_model)
-
-        # if self.ontologyproperty:
-        #     ret['ontology_properties'] = [item['ontology_property'] for item in self.graph.get_valid_domain_ontology_classes(nodeid=self.nodegroup_id)]
 
         return ret
 

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -113,7 +113,7 @@ class Card(models.CardModel):
                         node_model.config = node.get('config', None)
                         self.nodes.append(node_model)
 
-                self.graph = Graph.objects.get(graphid=self.graph_id)
+                # self.graph = Graph.objects.get(graphid=self.graph_id)
 
             else:
                 self.widgets = list(self.cardxnodexwidget_set.all())
@@ -122,10 +122,10 @@ class Card(models.CardModel):
                 for sub_group in sub_groups:
                     self.cards.extend(Card.objects.filter(nodegroup=sub_group))
 
-                self.graph = Graph.objects.get(graphid=self.graph_id)
-
-                if self.graph.ontology and self.graph.isresource:
-                    self.ontologyproperty = self.get_edge_to_parent().ontologyproperty
+                # self.graph = Graph.objects.get(graphid=self.graph_id)
+                #
+                # if self.graph.ontology and self.graph.isresource:
+                #     self.ontologyproperty = self.get_edge_to_parent().ontologyproperty
 
                 self.cardinality = self.nodegroup.cardinality
                 self.groups = self.get_group_permissions(self.nodegroup)
@@ -205,6 +205,8 @@ class Card(models.CardModel):
         Saves an a card and it's parent ontology property back to the db
 
         """
+        self.graph = Graph.objects.get(graphid=self.graph_id)
+        self.ontologyproperty = self.get_edge_to_parent().ontologyproperty
 
         with transaction.atomic():
             if self.graph.ontology and self.graph.isresource:
@@ -270,13 +272,12 @@ class Card(models.CardModel):
         ret['visible'] = self.visible
         ret['active'] = self.active
         ret['widgets'] = self.widgets
-        ret['ontologyproperty'] = self.ontologyproperty
+        # ret['ontologyproperty'] = self.ontologyproperty
         ret['groups'] = self.groups
         ret['users'] = self.users
-
-        # provide a models.CardXNodeXWidget model for every node 
+        # provide a models.CardXNodeXWidget model for every node
         # even if a widget hasn't been configured
-        for node in ret['nodes']: 
+        for node in ret['nodes']:
             found = False
             for widget in ret['widgets']:
                 if node.nodeid == widget.node_id:
@@ -292,8 +293,8 @@ class Card(models.CardModel):
                     widget_model.label = node.name
                     ret['widgets'].append(widget_model)
 
-        if self.ontologyproperty:
-            ret['ontology_properties'] = [item['ontology_property'] for item in self.graph.get_valid_domain_ontology_classes(nodeid=self.nodegroup_id)]
+        # if self.ontologyproperty:
+        #     ret['ontology_properties'] = [item['ontology_property'] for item in self.graph.get_valid_domain_ontology_classes(nodeid=self.nodegroup_id)]
 
         return ret
 

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -206,7 +206,6 @@ class Card(models.CardModel):
 
         """
         self.graph = Graph.objects.get(graphid=self.graph_id)
-        self.ontologyproperty = self.get_edge_to_parent().ontologyproperty
 
         with transaction.atomic():
             if self.graph.ontology and self.graph.isresource:

--- a/arches/app/templates/views/graph/card-configuration-manager.htm
+++ b/arches/app/templates/views/graph/card-configuration-manager.htm
@@ -74,7 +74,9 @@ define('card-configuration-data', [], function () {
         graph: {{graph_json}},
         permissions: {{ permissions }},
         datatypes: {{ datatypes_json }},
-        widgets: {{ widgets_json }}
+        widgets: {{ widgets_json }},
+        ontology_properties: {{ ontology_properties }},
+        ontologyproperty: '{{ ontologyproperty }}'
     };
 });
 {% endautoescape %}</script>

--- a/arches/app/templates/views/graph/card-configuration/component-forms/card-configuration.htm
+++ b/arches/app/templates/views/graph/card-configuration/component-forms/card-configuration.htm
@@ -39,7 +39,7 @@
                 {% trans "Relation to Resource" %}
             </div>
             <div data-bind="with: card">
-                <select class="resources" data-bind="value: $data.get('ontologyproperty'), options: $data.get('ontology_properties'), valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
+                <select class="resources" data-bind="value: ontologyproperty, options: ontology_properties, valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
             </div>
         </div>
 
@@ -81,7 +81,7 @@
                 </div>
             </div>
         </div>
-        
+
     </div>
 
     <!-- Card CRUD Permissions Form -->

--- a/arches/app/templates/views/graph/card-configuration/component-forms/card-configuration.htm
+++ b/arches/app/templates/views/graph/card-configuration/component-forms/card-configuration.htm
@@ -39,7 +39,7 @@
                 {% trans "Relation to Resource" %}
             </div>
             <div data-bind="with: card">
-                <select class="resources" data-bind="value: ontologyproperty, options: ontology_properties, valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
+                <select class="resources" data-bind="value: $root.ontologyproperty, options: $root.ontology_properties, valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
             </div>
         </div>
 

--- a/arches/app/templates/views/graph/card-configuration/component-forms/card-container-configuration.htm
+++ b/arches/app/templates/views/graph/card-configuration/component-forms/card-container-configuration.htm
@@ -33,7 +33,7 @@
                 {% trans "Relation to Resource" %}
             </div>
             <div data-bind="with: card">
-                <select class="resources" data-bind="value: $parent.ontologyproperty, options: $parent.ontology_properties, valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
+                <select class="resources" data-bind="value: $root.ontologyproperty, options: $root.ontology_properties, valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
             </div>
         </div>
 

--- a/arches/app/templates/views/graph/card-configuration/component-forms/card-container-configuration.htm
+++ b/arches/app/templates/views/graph/card-configuration/component-forms/card-container-configuration.htm
@@ -33,7 +33,7 @@
                 {% trans "Relation to Resource" %}
             </div>
             <div data-bind="with: card">
-                <select class="resources" data-bind="value: $data.get('ontologyproperty'), options: $data.get('ontology_properties'), valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
+                <select class="resources" data-bind="value: $parent.ontologyproperty, options: $parent.ontology_properties, valueAllowUnset: true, optionsCaption: '{% trans "Choose a relation..." %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
             </div>
         </div>
 

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -305,6 +305,7 @@ class CardView(GraphBaseView):
         for concept in top_concepts:
             if concept.label == 'Dropdown Lists':
                 concept_collections = concept.children
+        print ontology_properties
 
         context = self.get_context_data(
             main_script='views/graph/card-configuration-manager',
@@ -319,7 +320,8 @@ class CardView(GraphBaseView):
             map_sources=map_sources,
             resource_graphs=resource_graphs,
             concept_collections=concept_collections,
-            ontology_properties=ontology_properties,
+            ontology_properties=JSONSerializer().serialize(ontology_properties),
+            ontologyproperty=ontologyproperty,
         )
 
         context['nav']['title'] = self.graph.name

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -284,6 +284,17 @@ class CardView(GraphBaseView):
             # assume this is a graph id
             card = Card.objects.get(cardid=Graph.objects.get(graphid=cardid).get_root_card().cardid)
         self.graph = Graph.objects.get(graphid=card.graph_id)
+
+        def get_edge_to_parent():
+            for edge in self.graph.edges.itervalues():
+                if str(edge.rangenode_id) == str(card.nodegroup_id):
+                    return edge
+
+        ontologyproperty = get_edge_to_parent().ontologyproperty
+        ontology_properties = []
+        if ontologyproperty:
+            ontology_properties = [item['ontology_property'] for item in self.graph.get_valid_domain_ontology_classes(nodeid=card.nodegroup_id)]
+
         datatypes = models.DDataType.objects.all()
         widgets = models.Widget.objects.all()
         map_layers = models.MapLayers.objects.all()
@@ -308,6 +319,7 @@ class CardView(GraphBaseView):
             map_sources=map_sources,
             resource_graphs=resource_graphs,
             concept_collections=concept_collections,
+            ontology_properties=ontology_properties,
         )
 
         context['nav']['title'] = self.graph.name
@@ -424,7 +436,6 @@ class ReportManagerView(GraphBaseView):
         cards = Card.objects.filter(nodegroup__parentnodegroup=None, graph=self.graph)
         datatypes = models.DDataType.objects.all()
         widgets = models.Widget.objects.all()
-
         context = self.get_context_data(
             main_script='views/graph/report-manager',
             reports=JSONSerializer().serialize(self.graph.report_set.all()),

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -156,7 +156,6 @@ class ResourceReportView(BaseManagerView):
         map_layers = models.MapLayers.objects.all()
         map_sources = models.MapSources.objects.all()
         templates = models.ReportTemplate.objects.all()
-
         context = self.get_context_data(
             main_script='views/resource/report',
             report=JSONSerializer().serialize(report),


### PR DESCRIPTION
Creating a graph proxy model for every card in a report was slowing down report rendering.  To avoid creating a graph model I moved the creation of the ontology_properties list from card proxy model to the card view.  I also added ontology_properties and ontologyproperty to the card-configuration-manager view model.