### PR TITLE
1573 recent edits button on nav bar

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -241,7 +241,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         {% endif %}
 
                         <!-- Recently Added -->
-                        {% if nav.edit_history %}
+                        {% if nav.edit_history and 'edit' in user.user_groups %}
                         <ul class="nav navbar-top-links pull-left">
                             <li class="mega-dropdown open">
                                 <a href="#" class="mega-dropdown-toggle navbar-button" data-bind="click:function() { recentsActive(!recentsActive()); }, clickBubble: false">

--- a/arches/app/views/base.py
+++ b/arches/app/views/base.py
@@ -38,7 +38,7 @@ class BaseManagerView(TemplateView):
             'menu':False,
             'search':True,
             'res_edit':False,
-            'edit_history':False,
+            'edit_history':True,
             'login':True,
             'print':False,
         }


### PR DESCRIPTION
### Description of Change
changed the nav configuration settings to show the recent edit buttons by default, and add filter in the menu to disable if user is not part of the 'edit' group.

### Issues Solved
takes care of #1573 

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
