### PR TITLE
Map Search Issues

### DIFF
--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -102,7 +102,6 @@ define([
                 }
                 return result;
             }, this)
-
             this.overlaySelectorClosed = ko.observable(true);
             this.geocodeShimAdded = ko.observable(false);
             this.selectedBasemap = this.basemap;
@@ -1193,7 +1192,14 @@ define([
                 self.map.on('draw.selectionchange', self.updateFeatureStyles());
 
                 if (this.context === 'search-filter') {
-                    self.map.on('moveend', this.searchByExtent)
+                    self.map.on('dragend', this.searchByExtent);
+                    self.map.on('zoomend', this.searchByExtent);
+                    self.map.on('rotateend', this.searchByExtent);
+                    self.map.on('pitch', this.searchByExtent);
+                    this.resizeOnChange.subscribe(function(){
+                        setTimeout(this.searchByExtent, 600);
+                    }, self);
+                    $(window).on("resize", this.searchByExtent);
                 } else {
                     self.map.on('moveend', this.updateConfigs());
                 }


### PR DESCRIPTION
Expanding the map was causing numerous moveend events to fire and consequently too many searches overwhelming the browser. Firing search by extent handler when specific map events fire (pitch, dragend, rotateend) rather than the general moveend event. re #1717