### PR TITLE
update sphinx version

### DIFF
--- a/arches/install/requirements_dev.txt
+++ b/arches/install/requirements_dev.txt
@@ -1,4 +1,4 @@
-sphinx==1.2.2
+sphinx==1.3.1
 sphinx_rtd_theme
 fabric
 livereload


### PR DESCRIPTION
Just found out I'm using at least one sphinx tag (caption) that is only supported in a later version of sphinx. updating requirements_dev.txt as necessary.