### PR TITLE
1738 xychart widget

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -598,8 +598,6 @@ class CSVChartJsonDataType(FileListDataType):
         super(CSVChartJsonDataType, self).__init__(model=model)
 
     def manage_files(self, previously_saved_tile, current_tile, request, node):
-        print len(previously_saved_tile)
-        print previously_saved_tile.count()
         try:
             if previously_saved_tile.count() == 1:
                 for previously_saved_file in previously_saved_tile[0].data[str(node.pk)]['files']:

--- a/arches/app/media/js/views/components/widgets/csv-chart.js
+++ b/arches/app/media/js/views/components/widgets/csv-chart.js
@@ -55,9 +55,7 @@ define([
 
             if (this.form) {
                 this.form.on('after-update', function(req, tile) {
-
-                    var isParent = _.every(tile.data, function(value) { return value === null });
-                    if (isParent === true){
+                    if (tile.isParent === true){
                         if (self.dropzone) {
                             self.dropzone.removeAllFiles(true);
                         }

--- a/arches/app/media/js/views/components/widgets/csv-chart.js
+++ b/arches/app/media/js/views/components/widgets/csv-chart.js
@@ -73,13 +73,12 @@ define([
                 });
                 this.form.on('tile-reset', function(tile) {
                     if ((self.tile === tile || _.contains(tile.tiles, self.tile))) {
-                        if (isObservable(self.value)) {
-                            if (self.filesForUpload().length > 0) {
-                                self.filesForUpload.removeAll();
-                            }
-                            if (Array.isArray(self.value().files)) {
-                                self.uploadedFiles(self.value().files)
-                            }
+                        var value = ko.unwrap(self.value);
+                        if (self.filesForUpload().length > 0) {
+                            self.filesForUpload.removeAll();
+                        }
+                        if (Array.isArray(value.files)) {
+                            self.uploadedFiles(value.files)
                         }
                         self.dropzone.removeAllFiles(true);
                         self.formData.delete('file-list_' + self.node.nodeid);

--- a/arches/app/media/js/views/components/widgets/file.js
+++ b/arches/app/media/js/views/components/widgets/file.js
@@ -25,10 +25,7 @@ define([
 
             if (this.form) {
                 this.form.on('after-update', function(req, tile) {
-                    var isParent = _.every(tile.data, function(value) {
-                        return ko.unwrap(value) === null
-                    });
-                    if (isParent === true){
+                    if (tile.isParent === true){
                         if (self.dropzone) {
                             self.dropzone.removeAllFiles(true);
                         }

--- a/arches/app/media/js/views/resource/editor/form.js
+++ b/arches/app/media/js/views/resource/editor/form.js
@@ -125,7 +125,9 @@ define([
         initTile: function(tile){
             if('tiles' in tile && _.keys(tile.tiles).length > 0){
                 tile.dirty = ko.observable(false);
+                tile.isParent = true;
             }else{
+                tile.isParent = false;
                 tile._data = ko.observable(koMapping.toJSON(tile.data));
                 tile.dirty = ko.computed(function(){
                     return !_.isEqual(JSON.parse(tile._data()), JSON.parse(koMapping.toJSON(tile.data)));
@@ -134,6 +136,7 @@ define([
             if(!!tile.tiles){
                 this.initTiles(tile.tiles);
             }
+
             tile.formData = new FormData();
             this.formTiles.push(tile);
             return tile;
@@ -299,7 +302,6 @@ define([
          */
         saveTileGroup: function(parentTile, e){
             var model = new TileModel(koMapping.toJS(parentTile));
-
             var appendFormData = function() {
                 var parent = parentTile;
                 return function(tile) {


### PR DESCRIPTION
### Description of Change
Added an isParent property to tiles in form.js so that widgets are aware of whether a tile is a parent. Also fixed a bug in the csv_chart widget that prevented files from clearing when a user would click cancel.


### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

