### PR TITLE
Fixed missing 'remove' error when saving nodes with domain datatypes

### DIFF
--- a/arches/app/media/js/views/graph/datatypes/domain-value.js
+++ b/arches/app/media/js/views/graph/datatypes/domain-value.js
@@ -19,6 +19,15 @@ define(['arches', 'knockout', 'uuid'], function (arches, ko, uuid) {
                 setupOption(option);
                 self.options.push(option);
                 self.newOptionLabel('');
+            };
+            if (ko.isObservable(this.options)) {
+                this.options.subscribe(function(opts){
+                    _.each(opts, function(opt){
+                        if (!opt.remove) {
+                            setupOption(opt);
+                        }
+                    })
+                }, this)
             }
         },
         template: { require: 'text!datatype-config-templates/domain-value' }


### PR DESCRIPTION
re #1943

