### PR TITLE
Revert graph/branch status labels to ‘Active’ and ‘Inactive’

### DIFF
--- a/arches/app/templates/help/settings-help.htm
+++ b/arches/app/templates/help/settings-help.htm
@@ -46,13 +46,12 @@
         <div class="ep-help-topic-content">
             <p>
                 {% if not graph.isresource %}
-                <strong>Editable</strong> - Until a Branch is set to Editable, you will not be able to add it to a Resource Models. Keep a Branch <em>Non-Editable</em> until you are ready for it to be used.</br>
+                <strong>Active</strong> - Until a Branch is set to active, you will not be able to add it to a Resource Models. Keep a Branch <em>Inactive</em> until you are ready for it to be used.</br>
                 {% else %}
-                <strong>Editable</strong> - You will only be able to create Resources using this Resource Model until you have set its status to <em>Editable</em>. Use <em>Non-Editable</em> while designing a Resource Model over an extended period of time.</br>
+                <strong>Active</strong> - You will only be able to create Resources using this Resource Model until you have set its status to <em>Active</em>. Use <em>Inactive</em> while designing a Resource Model over an extended period of time.</br>
                 <strong>Resource models that may be related</strong> - Choose what other which Resource Models can be related to this one.</br>
                 {% endif %}
             </p>
         </div>
     </div>
 </div>
-

--- a/arches/app/templates/views/graph.htm
+++ b/arches/app/templates/views/graph.htm
@@ -136,7 +136,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         </ul>
                     </div>
                     <div>
-                        <p class="resource-status-label">{% trans "Status" %}: <span class="resource-status" data-bind="text:isactive?'{% trans "Editable" %}':'{% trans "Non-Editable" %}'"></span></p>
+                        <p class="resource-status-label">{% trans "Status" %}: <span class="resource-status" data-bind="text:isactive?'{% trans "Active" %}':'{% trans "Inactive" %}'"></span></p>
                     </div>
                 </div>
             </div>

--- a/arches/app/templates/views/graph/graph-settings.htm
+++ b/arches/app/templates/views/graph/graph-settings.htm
@@ -336,10 +336,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                     <div class="col-xs-12">
                                                         <div class="pad-hor">
                                                             <label data-bind="css: { 'active': graph.isactive() }, click: function () { graph.isactive(true) }" class="form-radio form-normal form-text">
-                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="true"> {% trans "Editable" %}
+                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="true"> {% trans "Active" %}
                                                             </label>
                                                             <label data-bind="css: { 'active': !graph.isactive() }, click: function () { graph.isactive(false) }" class="form-radio form-normal form-text">
-                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="false"> {% trans "Non-Editable" %}
+                                                                <input type="radio" name="stat-w-label" data-bind="checked: graph.isactive" value="false"> {% trans "Inactive" %}
                                                             </label>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
Revert graph status labels to 'Active' and 'Inactive' in the graph manager.

### Issues Solved
re 1378

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)