### PR TITLE
Obscured nav menu and arches designer scroll bar issue

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -3797,7 +3797,7 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     overflow-x: hidden;
     border: 1px solid #ddd;
     border-top-width: 0;
-    margin-bottom: 0px;
+    margin-bottom: 50px;
 }
 .crud-menu-panel {
     width: 250px;

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -3603,7 +3603,7 @@ ul.jqtree_common li.jqtree-folder {
 }
 
 .left-column-container.ep-card-tools-panel {
-    margin-bottom: 50px;
+    margin-bottom: 0px;
 }
 
 #node-listing .panel {
@@ -3797,7 +3797,7 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     overflow-x: hidden;
     border: 1px solid #ddd;
     border-top-width: 0;
-    margin-bottom: 50px;
+    margin-bottom: 0px;
 }
 .crud-menu-panel {
     width: 250px;
@@ -4371,6 +4371,9 @@ a.list-group-item:not(.active):hover, .clear-find:hover, div .switch label:hover
     z-index: 1;
     width: 100%;
     height: 100%;
+}
+.graph-base-content {
+    margin-bottom: 50px;
 }
 .graph-base-content .alert-active .ep-form-content.card-grid {
     top: 0px;

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -2261,6 +2261,9 @@ ul .collapse li:last-of-type {
     width: 450px;
     z-index: 10;
 }
+.graph-list-header .find-widget {
+    z-index: 1;
+}
 .clear-find {
     position: absolute;
     right: 10px;
@@ -2890,9 +2893,9 @@ ul.jqtree-tree li.jqtree-ghost span.jqtree-line {
 }
 
 .primary-descriptors-card-container {
-    margin-top: -5px; 
-    margin-left: 0px; 
-    padding-left: 15px; 
+    margin-top: -5px;
+    margin-left: 0px;
+    padding-left: 15px;
     padding-right: 15px
 }
 .primary-descriptors-container {

--- a/arches/app/templates/views/graph/graph-base.htm
+++ b/arches/app/templates/views/graph/graph-base.htm
@@ -52,7 +52,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </div>
 
     <!-- Edit Content -->
-    <div class="flex">
+    <div class="flex graph-base-content">
 
         <!-- Settings -->
         <!-- <div id="settings-form" class="relative fade in" style="display: block;"> -->


### PR DESCRIPTION
re #1313, #1654

### Description of Change
Adjusted z-index of the Find input element in Arches Designer and resolved the issue of scrollbars scrolling past the bottom of the page in the Arches Designer panels. 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
