### PR TITLE
Enabled scrolling to the bottom of the center panel.

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -3746,7 +3746,6 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     color: #666;
     border-right: solid 1px #dddddd;
     overflow-y: auto;
-    min-height: 740px;
 }
 .card-form-preview-container{
     -ms-flex: 1;


### PR DESCRIPTION
### Description of Change
Removed the min-height property from the center panel because it was preventing users from scrolling to the bottom of the panel. re #1654


### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
