### PR TITLE
Prevented fitting to bounds when a user switches draw tools in search

### DIFF
--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -729,10 +729,6 @@ define([
                         this.draw.deleteAll();
                         this.queryFeature = undefined;
                         this.updateSearchQueryLayer([]);
-                        this.value({
-                          "type": "FeatureCollection",
-                          "features": []
-                        });
                     }
                     if (this.form) {
                         this.featureColor(this.featureColorCache);


### PR DESCRIPTION
### Description of Change
Removed the reset of the view model's value property when switching draw tools. Resetting the value no longer appeared need and it was causing the searchAggregations subscription to fire which subsequently caused the zoom level to reset to the bounds of the data. re #1959 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
