### PR TITLE
Simplification of system settings to prevent bugs and user errors

### DIFF
--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -29,9 +29,8 @@ def livereload(request):
 
 def map_info(request):
     geo_utils = GeoUtils()
-    hex_bin_bounds_setting = settings.HEX_BIN_BOUNDS if settings.HEX_BIN_BOUNDS != None else settings.DEFAULT_BOUNDS
-    hex_bin_bounds = geo_utils.get_bounds_from_geojson(hex_bin_bounds_setting)
-    default_center = settings.DEFAULT_MAP_CENTER if settings.DEFAULT_MAP_CENTER != None else geo_utils.get_centroid(settings.DEFAULT_BOUNDS)
+    hex_bin_bounds = geo_utils.get_bounds_from_geojson(settings.DEFAULT_BOUNDS)
+    default_center = geo_utils.get_centroid(settings.DEFAULT_BOUNDS)
 
     return {
         'map_info': {

--- a/arches/app/views/tileserver.py
+++ b/arches/app/views/tileserver.py
@@ -28,13 +28,7 @@ def get_tileserver_config(layer_id):
         layer_model = models.TileserverLayer.objects.get(name=layer_id)
         layer_config = layer_model.config
 
-    try:
-        if settings.TILE_CACHE_CONFIG.has_key('name'):
-            tile_cache_config = settings.TILE_CACHE_CONFIG
-    except:
-        tile_cache_config = json.loads(settings.TILE_CACHE_CONFIG.decode('string_escape'))
-        if tile_cache_config.has_key('path'):
-            tile_cache_config['path'] = os.path.join(settings.ROOT_DIR, tile_cache_config['path'])
+    tile_cache_config = settings.TILE_CACHE_CONFIG
 
     config_dict = {
         "cache": tile_cache_config,
@@ -134,12 +128,8 @@ def seed_resource_cache():
     datatype_factory = DataTypeFactory()
     zooms = range(settings.CACHE_SEED_MAX_ZOOM + 1)
     extension = 'pbf'
-    geo_utils = GeoUtils()
-    cache_seed_bounds_setting = settings.CACHE_SEED_BOUNDS if settings.CACHE_SEED_BOUNDS != None else settings.DEFAULT_BOUNDS
-    cache_seed_bounds = geo_utils.get_bounds_from_geojson(cache_seed_bounds_setting)
 
-
-    lat1, lon1, lat2, lon2 = GeoUtils().get_bounds_from_geojson(cache_seed_bounds)
+    lat1, lon1, lat2, lon2 = GeoUtils().get_bounds_from_geojson(settings.CACHE_SEED_BOUNDS)
     south, west = min(lat1, lat2), min(lon1, lon2)
     north, east = max(lat1, lat2), max(lon1, lon2)
 

--- a/arches/db/system_settings/Arches_System_Settings.json
+++ b/arches/db/system_settings/Arches_System_Settings.json
@@ -110,17 +110,6 @@
                 "tiles": {},
                 "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
                 "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
-                "nodegroup_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f",
-                "sortorder": 0,
-                "data": {
-                    "0e8ffd7d-4148-11e7-9396-c4b301baab9f": 5,
-                    "0e9004c0-4148-11e7-a72a-c4b301baab9f": "{\"name\": \"Disk\",  \"path\": \"tileserver/cache\"}"
-                },
-                "tileid": "9d2a9611-7d47-40f3-977e-f26794249cfe"
-            }, {
-                "tiles": {},
-                "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
                 "nodegroup_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f",
                 "sortorder": 0,
                 "data": {
@@ -129,18 +118,6 @@
                     "0e90017a-4148-11e7-82ce-c4b301baab9f": 0
                 },
                 "tileid": "2e49911e-6bcf-4711-bc59-2264cb71c4ab"
-            }, {
-                "tiles": {},
-                "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
-                "nodegroup_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f",
-                "sortorder": 0,
-                "data": {
-                    "0e9003f0-4148-11e7-9487-c4b301baab9f": null,
-                    "0e8ffe4f-4148-11e7-9f25-c4b301baab9f": "2cf08870-18a7-41aa-85a7-bc66e89b3312",
-                    "0e8fffe8-4148-11e7-9ba2-c4b301baab9f": null
-                },
-                "tileid": "34cf5dd1-9fb0-4278-9e43-cfa7df9e02c7"
             }],
             "resourceinstance": {
                 "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c",

--- a/arches/db/system_settings/Arches_System_Settings_Model.json
+++ b/arches/db/system_settings/Arches_System_Settings_Model.json
@@ -11,7 +11,7 @@
                             "feb95991-fa14-11e6-974f-6c4008b05c4c"
                         ]
                     }, 
-                    "id": "ff7ac55c-41c0-11e7-a9e4-6c4008b05c4c"
+                    "id": "ae016b0c-462f-11e7-b21a-c4b301baab9f"
                 }
             ], 
             "mapfeaturecolor": "#FF0000", 
@@ -55,43 +55,13 @@
                 {
                     "cardinality": "1", 
                     "legacygroupid": null, 
-                    "nodegroupid": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
+                    "nodegroupid": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
                     "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
                 }, 
                 {
                     "cardinality": "1", 
                     "legacygroupid": null, 
                     "nodegroupid": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
-                }, 
-                {
-                    "cardinality": "1", 
-                    "legacygroupid": null, 
-                    "nodegroupid": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
-                }, 
-                {
-                    "cardinality": "1", 
-                    "legacygroupid": null, 
-                    "nodegroupid": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
-                    "parentnodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c"
-                }, 
-                {
-                    "cardinality": "1", 
-                    "legacygroupid": null, 
-                    "nodegroupid": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
-                    "parentnodegroup_id": null
-                }, 
-                {
-                    "cardinality": "1", 
-                    "legacygroupid": null, 
-                    "nodegroupid": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
-                    "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
-                }, 
-                {
-                    "cardinality": "n", 
-                    "legacygroupid": null, 
-                    "nodegroupid": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
                     "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
                 }, 
                 {
@@ -103,7 +73,31 @@
                 {
                     "cardinality": "1", 
                     "legacygroupid": null, 
+                    "nodegroupid": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
+                    "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
+                }, 
+                {
+                    "cardinality": "1", 
+                    "legacygroupid": null, 
+                    "nodegroupid": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
+                    "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
+                }, 
+                {
+                    "cardinality": "1", 
+                    "legacygroupid": null, 
+                    "nodegroupid": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
+                    "parentnodegroup_id": null
+                }, 
+                {
+                    "cardinality": "1", 
+                    "legacygroupid": null, 
                     "nodegroupid": "c5a2a2e8-fadd-11e6-9849-6c4008b05c4c", 
+                    "parentnodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c"
+                }, 
+                {
+                    "cardinality": "1", 
+                    "legacygroupid": null, 
+                    "nodegroupid": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
                     "parentnodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c"
                 }, 
                 {
@@ -123,12 +117,6 @@
                     "legacygroupid": null, 
                     "nodegroupid": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
                     "parentnodegroup_id": null
-                }, 
-                {
-                    "cardinality": "1", 
-                    "legacygroupid": null, 
-                    "nodegroupid": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "parentnodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f"
                 }, 
                 {
                     "cardinality": "n", 
@@ -212,32 +200,18 @@
                     "name": "DEFAULT_MAP_ZOOM"
                 }, 
                 {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8ffd7d-4148-11e7-9396-c4b301baab9f", 
-                    "datatype": "number", 
-                    "nodegroup_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "CACHE_SEED_MAX_ZOOM"
-                }, 
-                {
                     "is_collector": true, 
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
+                    "nodeid": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
                     "datatype": "semantic", 
-                    "nodegroup_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
+                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
                     "issearchable": true, 
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "config": null, 
                     "parentproperty": "P140_assigned_attribute_to", 
-                    "name": "Geocoding Providers"
+                    "name": "Search Results Grid"
                 }, 
                 {
                     "is_collector": true, 
@@ -255,17 +229,45 @@
                 }, 
                 {
                     "is_collector": true, 
-                    "description": "", 
+                    "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
+                    "nodeid": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
                     "datatype": "semantic", 
-                    "nodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
+                    "nodegroup_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
                     "issearchable": true, 
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "config": null, 
                     "parentproperty": "P140i_was_attributed_by", 
-                    "name": "SYSTEM_SETTINGS"
+                    "name": "APP_NAMES"
+                }, 
+                {
+                    "is_collector": true, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
+                    "datatype": "semantic", 
+                    "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
+                    "issearchable": true, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140_assigned_attribute_to", 
+                    "name": "Mapbox"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "", 
+                    "istopnode": true, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "ff62303a-fa12-11e6-a889-6c4008b05c4c", 
+                    "datatype": "semantic", 
+                    "nodegroup_id": null, 
+                    "issearchable": true, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "", 
+                    "name": "ARCHES_SYSTEM_SETTINGS"
                 }, 
                 {
                     "is_collector": false, 
@@ -297,175 +299,17 @@
                 }, 
                 {
                     "is_collector": true, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "datatype": "semantic", 
-                    "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "issearchable": true, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140_assigned_attribute_to", 
-                    "name": "Mapbox"
-                }, 
-                {
-                    "is_collector": true, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "datatype": "semantic", 
-                    "nodegroup_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "issearchable": true, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140_assigned_attribute_to", 
-                    "name": "Tile Cache"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "feb96126-fa14-11e6-9f19-6c4008b05c4c", 
-                    "datatype": "string", 
-                    "nodegroup_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "SEARCH_NAME"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e900254-4148-11e7-9902-c4b301baab9f", 
-                    "datatype": "string", 
-                    "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "MAPBOX_SPRITES"
-                }, 
-                {
-                    "is_collector": true, 
                     "description": "", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "nodeid": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
                     "datatype": "semantic", 
-                    "nodegroup_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "nodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
                     "issearchable": true, 
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "config": null, 
                     "parentproperty": "P140i_was_attributed_by", 
-                    "name": "TEMPORAL_SEARCH"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "32f2dc66-fae4-11e6-9556-6c4008b05c4c", 
-                    "datatype": "string", 
-                    "nodegroup_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "TIME_WHEEL_CONFIGURATION"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "feb95eae-fa14-11e6-9683-6c4008b05c4c", 
-                    "datatype": "string", 
-                    "nodegroup_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "SEARCH_URL"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "d0987cc2-fad8-11e6-8581-6c4008b05c4c", 
-                    "datatype": "number", 
-                    "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "SEARCH_DROPDOWN_LENGTH"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8ffcab-4148-11e7-a571-c4b301baab9f", 
-                    "datatype": "number", 
-                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "HEX_BIN_SIZE"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e9004c0-4148-11e7-a72a-c4b301baab9f", 
-                    "datatype": "string", 
-                    "nodegroup_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P141i_was_assigned_by", 
-                    "name": "TILE_CACHE_CONFIG"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8ffe4f-4148-11e7-9f25-c4b301baab9f", 
-                    "datatype": "domain-value", 
-                    "nodegroup_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": {
-                        "options": [
-                            {
-                                "text": "MapBox", 
-                                "selected": false, 
-                                "id": "667316ee-8b90-4f1f-b9ea-bb402303f026"
-                            }, 
-                            {
-                                "text": "Mapzen", 
-                                "selected": false, 
-                                "id": "143157ae-090f-4e7f-8688-b5fdc8dc8f87"
-                            }, 
-                            {
-                                "text": "Bing", 
-                                "selected": false, 
-                                "id": "2cf08870-18a7-41aa-85a7-bc66e89b3312"
-                            }
-                        ]
-                    }, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "PROVIDER_NAME"
+                    "name": "SYSTEM_SETTINGS"
                 }, 
                 {
                     "is_collector": false, 
@@ -486,6 +330,48 @@
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "0e8ffcab-4148-11e7-a571-c4b301baab9f", 
+                    "datatype": "number", 
+                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "HEX_BIN_SIZE"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "0e90031e-4148-11e7-a176-c4b301baab9f", 
+                    "datatype": "string", 
+                    "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "MAPBOX_GLYPHS"
+                }, 
+                {
+                    "is_collector": true, 
+                    "description": "", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "datatype": "semantic", 
+                    "nodegroup_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "issearchable": true, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "TEMPORAL_SEARCH"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
                     "nodeid": "feb96005-fa14-11e6-aa8d-6c4008b05c4c", 
                     "datatype": "file-list", 
                     "nodegroup_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
@@ -494,34 +380,6 @@
                     "config": null, 
                     "parentproperty": "P140i_was_attributed_by", 
                     "name": "IMAGE"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8ffaf5-4148-11e7-b24d-c4b301baab9f", 
-                    "datatype": "number", 
-                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "HEX_BIN_PRECISION"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "", 
-                    "istopnode": true, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "ff62303a-fa12-11e6-a889-6c4008b05c4c", 
-                    "datatype": "semantic", 
-                    "nodegroup_id": null, 
-                    "issearchable": true, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "", 
-                    "name": "ARCHES_SYSTEM_SETTINGS"
                 }, 
                 {
                     "is_collector": false, 
@@ -565,6 +423,76 @@
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "feb96126-fa14-11e6-9f19-6c4008b05c4c", 
+                    "datatype": "string", 
+                    "nodegroup_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "SEARCH_NAME"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "feb95eae-fa14-11e6-9683-6c4008b05c4c", 
+                    "datatype": "string", 
+                    "nodegroup_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "SEARCH_URL"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "0e8ffaf5-4148-11e7-b24d-c4b301baab9f", 
+                    "datatype": "number", 
+                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "HEX_BIN_PRECISION"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "d0987cc2-fad8-11e6-8581-6c4008b05c4c", 
+                    "datatype": "number", 
+                    "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "SEARCH_DROPDOWN_LENGTH"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "32f2dc66-fae4-11e6-9556-6c4008b05c4c", 
+                    "datatype": "string", 
+                    "nodegroup_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "TIME_WHEEL_CONFIGURATION"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
                     "nodeid": "d0987de3-fad8-11e6-a434-6c4008b05c4c", 
                     "datatype": "number", 
                     "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
@@ -587,34 +515,6 @@
                     "config": null, 
                     "parentproperty": "P140i_was_attributed_by", 
                     "name": "Map Settings"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "c5a2ba63-fadd-11e6-9306-6c4008b05c4c", 
-                    "datatype": "string", 
-                    "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "SPARQL_ENDPOINT_PROVIDER"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8fffe8-4148-11e7-9ba2-c4b301baab9f", 
-                    "datatype": "string", 
-                    "nodegroup_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "API_KEY"
                 }, 
                 {
                     "is_collector": true, 
@@ -649,14 +549,14 @@
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e90031e-4148-11e7-a176-c4b301baab9f", 
+                    "nodeid": "0e9000b0-4148-11e7-bd19-c4b301baab9f", 
                     "datatype": "string", 
                     "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
                     "issearchable": false, 
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "config": null, 
                     "parentproperty": "P140i_was_attributed_by", 
-                    "name": "MAPBOX_GLYPHS"
+                    "name": "MAPBOX_API_KEY"
                 }, 
                 {
                     "is_collector": false, 
@@ -677,34 +577,6 @@
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
-                    "datatype": "semantic", 
-                    "nodegroup_id": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
-                    "issearchable": true, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140_assigned_attribute_to", 
-                    "name": "Project Extent"
-                }, 
-                {
-                    "is_collector": false, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e9003f0-4148-11e7-9487-c4b301baab9f", 
-                    "datatype": "string", 
-                    "nodegroup_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "issearchable": false, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "PROVIDER_NAME"
-                }, 
-                {
-                    "is_collector": true, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
                     "nodeid": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
                     "datatype": "semantic", 
                     "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
@@ -715,32 +587,32 @@
                     "name": "SPARQL_ENDPOINT_PROVIDERS"
                 }, 
                 {
-                    "is_collector": true, 
+                    "is_collector": false, 
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "datatype": "semantic", 
-                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "issearchable": true, 
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "config": null, 
-                    "parentproperty": "P140_assigned_attribute_to", 
-                    "name": "Search Results Grid"
-                }, 
-                {
-                    "is_collector": true, 
-                    "description": "Represents a single node in a graph", 
-                    "istopnode": false, 
-                    "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
-                    "datatype": "semantic", 
-                    "nodegroup_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
-                    "issearchable": true, 
+                    "nodeid": "0e900254-4148-11e7-9902-c4b301baab9f", 
+                    "datatype": "string", 
+                    "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
+                    "issearchable": false, 
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "config": null, 
                     "parentproperty": "P140i_was_attributed_by", 
-                    "name": "APP_NAMES"
+                    "name": "MAPBOX_SPRITES"
+                }, 
+                {
+                    "is_collector": false, 
+                    "description": "Represents a single node in a graph", 
+                    "istopnode": false, 
+                    "ontologyclass": "E13_Attribute_Assignment", 
+                    "nodeid": "c5a2ba63-fadd-11e6-9306-6c4008b05c4c", 
+                    "datatype": "string", 
+                    "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
+                    "issearchable": false, 
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "config": null, 
+                    "parentproperty": "P140i_was_attributed_by", 
+                    "name": "SPARQL_ENDPOINT_PROVIDER"
                 }, 
                 {
                     "is_collector": false, 
@@ -822,18 +694,18 @@
                     "name": "DEFAULT_BOUNDS"
                 }, 
                 {
-                    "is_collector": false, 
+                    "is_collector": true, 
                     "description": "Represents a single node in a graph", 
                     "istopnode": false, 
                     "ontologyclass": "E13_Attribute_Assignment", 
-                    "nodeid": "0e9000b0-4148-11e7-bd19-c4b301baab9f", 
-                    "datatype": "string", 
-                    "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "issearchable": false, 
+                    "nodeid": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
+                    "datatype": "semantic", 
+                    "nodegroup_id": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
+                    "issearchable": true, 
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "config": null, 
-                    "parentproperty": "P140i_was_attributed_by", 
-                    "name": "MAPBOX_API_KEY"
+                    "parentproperty": "P140_assigned_attribute_to", 
+                    "name": "Project Extent"
                 }, 
                 {
                     "is_collector": false, 
@@ -866,9 +738,9 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e9050e3-4148-11e7-a1b7-c4b301baab9f", 
-                    "domainnode_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "rangenode_id": "0e8ffd7d-4148-11e7-9396-c4b301baab9f", 
+                    "edgeid": "0e904e8a-4148-11e7-a303-c4b301baab9f", 
+                    "domainnode_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
+                    "rangenode_id": "0e90017a-4148-11e7-82ce-c4b301baab9f", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -884,9 +756,18 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e9051ca-4148-11e7-8f8a-c4b301baab9f", 
-                    "domainnode_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "rangenode_id": "0e9003f0-4148-11e7-9487-c4b301baab9f", 
+                    "edgeid": "0e904d2e-4148-11e7-9626-c4b301baab9f", 
+                    "domainnode_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
+                    "rangenode_id": "0e8ff9d1-4148-11e7-90ed-c4b301baab9f", 
+                    "ontologyproperty": "P140i_was_attributed_by", 
+                    "description": null
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "name": null, 
+                    "edgeid": "c5a2dc7a-fadd-11e6-bce7-6c4008b05c4c", 
+                    "domainnode_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
+                    "rangenode_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -902,18 +783,9 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "c5a2d90a-fadd-11e6-8f2b-6c4008b05c4c", 
-                    "domainnode_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
-                    "rangenode_id": "c5a2b94a-fadd-11e6-a029-6c4008b05c4c", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "0e904b57-4148-11e7-a43b-c4b301baab9f", 
-                    "domainnode_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "rangenode_id": "0e8ffcab-4148-11e7-a571-c4b301baab9f", 
+                    "edgeid": "d09882ba-fad8-11e6-8f6a-6c4008b05c4c", 
+                    "domainnode_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
+                    "rangenode_id": "d0987ec0-fad8-11e6-aad3-6c4008b05c4c", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -956,45 +828,36 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e904e8a-4148-11e7-a303-c4b301baab9f", 
-                    "domainnode_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
-                    "rangenode_id": "0e90017a-4148-11e7-82ce-c4b301baab9f", 
+                    "edgeid": "0e904b57-4148-11e7-a43b-c4b301baab9f", 
+                    "domainnode_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
+                    "rangenode_id": "0e8ffcab-4148-11e7-a571-c4b301baab9f", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e904da6-4148-11e7-811e-c4b301baab9f", 
-                    "domainnode_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "rangenode_id": "0e8ffe4f-4148-11e7-9f25-c4b301baab9f", 
+                    "edgeid": "0e904a5e-4148-11e7-acd2-c4b301baab9f", 
+                    "domainnode_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
+                    "rangenode_id": "0e900254-4148-11e7-9902-c4b301baab9f", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e904d2e-4148-11e7-9626-c4b301baab9f", 
-                    "domainnode_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
-                    "rangenode_id": "0e8ff9d1-4148-11e7-90ed-c4b301baab9f", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "0e9049dc-4148-11e7-8202-c4b301baab9f", 
+                    "edgeid": "0e904914-4148-11e7-8ee1-c4b301baab9f", 
                     "domainnode_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
-                    "rangenode_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
+                    "rangenode_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
                     "ontologyproperty": "P140_assigned_attribute_to", 
                     "description": null
                 }, 
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "c5a2d7b8-fadd-11e6-b1d6-6c4008b05c4c", 
-                    "domainnode_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
-                    "rangenode_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
+                    "edgeid": "32f2e294-fae4-11e6-895a-6c4008b05c4c", 
+                    "domainnode_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "rangenode_id": "32f2dc66-fae4-11e6-9556-6c4008b05c4c", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -1019,9 +882,9 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "feb96a5c-fa14-11e6-bed3-6c4008b05c4c", 
-                    "domainnode_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
-                    "rangenode_id": "feb96005-fa14-11e6-aa8d-6c4008b05c4c", 
+                    "edgeid": "c5a2db8c-fadd-11e6-ab63-6c4008b05c4c", 
+                    "domainnode_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
+                    "rangenode_id": "c5a2bdb3-fadd-11e6-8c96-6c4008b05c4c", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -1037,9 +900,27 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "c5a2dc7a-fadd-11e6-bce7-6c4008b05c4c", 
+                    "edgeid": "c5a2da05-fadd-11e6-b199-6c4008b05c4c", 
                     "domainnode_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
-                    "rangenode_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
+                    "rangenode_id": "c5a2a2e8-fadd-11e6-9849-6c4008b05c4c", 
+                    "ontologyproperty": "P140i_was_attributed_by", 
+                    "description": null
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "name": null, 
+                    "edgeid": "feb96b30-fa14-11e6-a9e4-6c4008b05c4c", 
+                    "domainnode_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
+                    "rangenode_id": "feb95eae-fa14-11e6-9683-6c4008b05c4c", 
+                    "ontologyproperty": "P140i_was_attributed_by", 
+                    "description": null
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "name": null, 
+                    "edgeid": "feb96a5c-fa14-11e6-bed3-6c4008b05c4c", 
+                    "domainnode_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
+                    "rangenode_id": "feb96005-fa14-11e6-aa8d-6c4008b05c4c", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -1055,72 +936,9 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e904f7a-4148-11e7-8ffa-c4b301baab9f", 
-                    "domainnode_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
-                    "rangenode_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "ontologyproperty": "P140_assigned_attribute_to", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "feb96b30-fa14-11e6-a9e4-6c4008b05c4c", 
-                    "domainnode_id": "feb95991-fa14-11e6-974f-6c4008b05c4c", 
-                    "rangenode_id": "feb95eae-fa14-11e6-9683-6c4008b05c4c", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "0e905242-4148-11e7-a08e-c4b301baab9f", 
-                    "domainnode_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "rangenode_id": "0e9004c0-4148-11e7-a72a-c4b301baab9f", 
-                    "ontologyproperty": "P141i_was_assigned_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "0e905063-4148-11e7-9e91-c4b301baab9f", 
-                    "domainnode_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "rangenode_id": "0e90031e-4148-11e7-a176-c4b301baab9f", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
                     "edgeid": "d09883f0-fad8-11e6-9cb6-6c4008b05c4c", 
                     "domainnode_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
                     "rangenode_id": "d0987cc2-fad8-11e6-8581-6c4008b05c4c", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "32f2e294-fae4-11e6-895a-6c4008b05c4c", 
-                    "domainnode_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
-                    "rangenode_id": "32f2dc66-fae4-11e6-9556-6c4008b05c4c", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "d09882ba-fad8-11e6-8f6a-6c4008b05c4c", 
-                    "domainnode_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
-                    "rangenode_id": "d0987ec0-fad8-11e6-aad3-6c4008b05c4c", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "0e904fe8-4148-11e7-a869-c4b301baab9f", 
-                    "domainnode_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "rangenode_id": "0e8fffe8-4148-11e7-9ba2-c4b301baab9f", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -1136,18 +954,9 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e9053f8-4148-11e7-9386-c4b301baab9f", 
-                    "domainnode_id": "ff62303a-fa12-11e6-a889-6c4008b05c4c", 
-                    "rangenode_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "c5a2da05-fadd-11e6-b199-6c4008b05c4c", 
-                    "domainnode_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
-                    "rangenode_id": "c5a2a2e8-fadd-11e6-9849-6c4008b05c4c", 
+                    "edgeid": "0e905063-4148-11e7-9e91-c4b301baab9f", 
+                    "domainnode_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
+                    "rangenode_id": "0e90031e-4148-11e7-a176-c4b301baab9f", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -1163,27 +972,36 @@
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "name": null, 
-                    "edgeid": "0e904a5e-4148-11e7-acd2-c4b301baab9f", 
-                    "domainnode_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f", 
-                    "rangenode_id": "0e900254-4148-11e7-9902-c4b301baab9f", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "c5a2db8c-fadd-11e6-ab63-6c4008b05c4c", 
-                    "domainnode_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
-                    "rangenode_id": "c5a2bdb3-fadd-11e6-8c96-6c4008b05c4c", 
-                    "ontologyproperty": "P140i_was_attributed_by", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
                     "edgeid": "c5a2d880-fadd-11e6-821e-6c4008b05c4c", 
                     "domainnode_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
                     "rangenode_id": "c5a2ba63-fadd-11e6-9306-6c4008b05c4c", 
+                    "ontologyproperty": "P140i_was_attributed_by", 
+                    "description": null
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "name": null, 
+                    "edgeid": "0e9053f8-4148-11e7-9386-c4b301baab9f", 
+                    "domainnode_id": "ff62303a-fa12-11e6-a889-6c4008b05c4c", 
+                    "rangenode_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
+                    "ontologyproperty": "P140i_was_attributed_by", 
+                    "description": null
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "name": null, 
+                    "edgeid": "c5a2d7b8-fadd-11e6-b1d6-6c4008b05c4c", 
+                    "domainnode_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c", 
+                    "rangenode_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
+                    "ontologyproperty": "P140i_was_attributed_by", 
+                    "description": null
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "name": null, 
+                    "edgeid": "c5a2d90a-fadd-11e6-8f2b-6c4008b05c4c", 
+                    "domainnode_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
+                    "rangenode_id": "c5a2b94a-fadd-11e6-a029-6c4008b05c4c", 
                     "ontologyproperty": "P140i_was_attributed_by", 
                     "description": null
                 }, 
@@ -1202,15 +1020,6 @@
                     "edgeid": "0e904bcf-4148-11e7-9bda-c4b301baab9f", 
                     "domainnode_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
                     "rangenode_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "ontologyproperty": "P140_assigned_attribute_to", 
-                    "description": null
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "name": null, 
-                    "edgeid": "0e904914-4148-11e7-8ee1-c4b301baab9f", 
-                    "domainnode_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f", 
-                    "rangenode_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
                     "ontologyproperty": "P140_assigned_attribute_to", 
                     "description": null
                 }, 
@@ -1426,6 +1235,34 @@
                 }, 
                 {
                     "widget_id": "10000000-0000-0000-0000-000000000001", 
+                    "card_id": "c5a2b3c7-fadd-11e6-aa79-6c4008b05c4c", 
+                    "label": "Default Data Import/Export Name", 
+                    "node_id": "c5a2bdb3-fadd-11e6-8c96-6c4008b05c4c", 
+                    "sortorder": 1, 
+                    "config": {
+                        "width": "100%", 
+                        "maxLength": null, 
+                        "placeholder": "Enter text", 
+                        "label": "Default Data Import/Export Name"
+                    }, 
+                    "id": "fa41c43d-4263-11e7-9ff9-6c4008b05c4c"
+                }, 
+                {
+                    "widget_id": "10000000-0000-0000-0000-000000000001", 
+                    "card_id": "c5a2b3c7-fadd-11e6-aa79-6c4008b05c4c", 
+                    "label": "Application Name", 
+                    "node_id": "c5a2b94a-fadd-11e6-a029-6c4008b05c4c", 
+                    "sortorder": 0, 
+                    "config": {
+                        "width": "100%", 
+                        "maxLength": null, 
+                        "placeholder": "e.g. Arches", 
+                        "label": "Application Name"
+                    }, 
+                    "id": "fa4205a3-4263-11e7-929e-6c4008b05c4c"
+                }, 
+                {
+                    "widget_id": "10000000-0000-0000-0000-000000000001", 
                     "card_id": "0e8fe699-4148-11e7-85ab-c4b301baab9f", 
                     "label": "MapBox API Key (Optional)", 
                     "node_id": "0e9000b0-4148-11e7-bd19-c4b301baab9f", 
@@ -1467,6 +1304,36 @@
                     "id": "0e90086e-4148-11e7-bc0b-c4b301baab9f"
                 }, 
                 {
+                    "widget_id": "10000000-0000-0000-0000-000000000008", 
+                    "card_id": "0e8feb0c-4148-11e7-9538-c4b301baab9f", 
+                    "label": "Default Zoom", 
+                    "node_id": "0e8ff9d1-4148-11e7-90ed-c4b301baab9f", 
+                    "sortorder": 0, 
+                    "config": {
+                        "max": "", 
+                        "label": "Default Zoom", 
+                        "placeholder": "Enter number", 
+                        "width": "100%", 
+                        "min": ""
+                    }, 
+                    "id": "0e900602-4148-11e7-a580-c4b301baab9f"
+                }, 
+                {
+                    "widget_id": "10000000-0000-0000-0000-000000000008", 
+                    "card_id": "0e8feb0c-4148-11e7-9538-c4b301baab9f", 
+                    "label": "Min Zoom", 
+                    "node_id": "0e90017a-4148-11e7-82ce-c4b301baab9f", 
+                    "sortorder": 1, 
+                    "config": {
+                        "max": "", 
+                        "label": "Min Zoom", 
+                        "placeholder": "Enter number", 
+                        "width": "100%", 
+                        "min": ""
+                    }, 
+                    "id": "0e90090f-4148-11e7-8f32-c4b301baab9f"
+                }, 
+                {
                     "widget_id": "10000000-0000-0000-0000-000000000007", 
                     "card_id": "0e8fe2e3-4148-11e7-aa2d-c4b301baab9f", 
                     "label": "Project map extent", 
@@ -1498,65 +1365,6 @@
                         "basemap": "streets"
                     }, 
                     "id": "0e90054c-4148-11e7-bb73-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000001", 
-                    "card_id": "0e8fee38-4148-11e7-b446-c4b301baab9f", 
-                    "label": "Tile Cache Config", 
-                    "node_id": "0e9004c0-4148-11e7-a72a-c4b301baab9f", 
-                    "sortorder": 0, 
-                    "config": {
-                        "width": "100%", 
-                        "maxLength": null, 
-                        "placeholder": "Enter text", 
-                        "label": "Tile Cache Config"
-                    }, 
-                    "id": "0e9006a3-4148-11e7-b0e6-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000008", 
-                    "card_id": "0e8fee38-4148-11e7-b446-c4b301baab9f", 
-                    "label": "Cache Seed Max Zoom", 
-                    "node_id": "0e8ffd7d-4148-11e7-9396-c4b301baab9f", 
-                    "sortorder": 1, 
-                    "config": {
-                        "max": "", 
-                        "label": "Cache Seed Max Zoom", 
-                        "placeholder": "Enter number", 
-                        "width": "100%", 
-                        "min": ""
-                    }, 
-                    "id": "0e900742-4148-11e7-a856-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000008", 
-                    "card_id": "0e8feb0c-4148-11e7-9538-c4b301baab9f", 
-                    "label": "Default Zoom", 
-                    "node_id": "0e8ff9d1-4148-11e7-90ed-c4b301baab9f", 
-                    "sortorder": 0, 
-                    "config": {
-                        "max": "", 
-                        "label": "Default Zoom", 
-                        "placeholder": "Enter number", 
-                        "width": "100%", 
-                        "min": ""
-                    }, 
-                    "id": "0e900602-4148-11e7-a580-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000008", 
-                    "card_id": "0e8feb0c-4148-11e7-9538-c4b301baab9f", 
-                    "label": "Min Zoom", 
-                    "node_id": "0e90017a-4148-11e7-82ce-c4b301baab9f", 
-                    "sortorder": 1, 
-                    "config": {
-                        "max": "", 
-                        "label": "Min Zoom", 
-                        "placeholder": "Enter number", 
-                        "width": "100%", 
-                        "min": ""
-                    }, 
-                    "id": "0e90090f-4148-11e7-8f32-c4b301baab9f"
                 }, 
                 {
                     "widget_id": "10000000-0000-0000-0000-000000000008", 
@@ -1602,105 +1410,9 @@
                         "min": ""
                     }, 
                     "id": "0e9006f0-4148-11e7-897a-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000015", 
-                    "card_id": "0e8ff214-4148-11e7-b568-c4b301baab9f", 
-                    "label": "Provider Name", 
-                    "node_id": "0e8ffe4f-4148-11e7-9f25-c4b301baab9f", 
-                    "sortorder": 0, 
-                    "config": {
-                        "placeholder": "Select an option", 
-                        "label": "Provider Name"
-                    }, 
-                    "id": "0e9005a8-4148-11e7-a8cf-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000001", 
-                    "card_id": "0e8ff214-4148-11e7-b568-c4b301baab9f", 
-                    "label": "Provider Key", 
-                    "node_id": "0e8fffe8-4148-11e7-9ba2-c4b301baab9f", 
-                    "sortorder": 1, 
-                    "config": {
-                        "width": "100%", 
-                        "maxLength": null, 
-                        "placeholder": "Enter text", 
-                        "label": "Provider Key"
-                    }, 
-                    "id": "0e9008bd-4148-11e7-880b-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000001", 
-                    "card_id": "0e8ff214-4148-11e7-b568-c4b301baab9f", 
-                    "label": "Display Name", 
-                    "node_id": "0e9003f0-4148-11e7-9487-c4b301baab9f", 
-                    "sortorder": 2, 
-                    "config": {
-                        "width": "100%", 
-                        "maxLength": null, 
-                        "placeholder": "Enter text", 
-                        "label": "Display Name"
-                    }, 
-                    "id": "0e900954-4148-11e7-809b-c4b301baab9f"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000001", 
-                    "card_id": "c5a2b3c7-fadd-11e6-aa79-6c4008b05c4c", 
-                    "label": "Default Data Import/Export Name", 
-                    "node_id": "c5a2bdb3-fadd-11e6-8c96-6c4008b05c4c", 
-                    "sortorder": 1, 
-                    "config": {
-                        "width": "100%", 
-                        "maxLength": null, 
-                        "placeholder": "Enter text", 
-                        "label": "Default Data Import/Export Name"
-                    }, 
-                    "id": "fa41c43d-4263-11e7-9ff9-6c4008b05c4c"
-                }, 
-                {
-                    "widget_id": "10000000-0000-0000-0000-000000000001", 
-                    "card_id": "c5a2b3c7-fadd-11e6-aa79-6c4008b05c4c", 
-                    "label": "Application Name", 
-                    "node_id": "c5a2b94a-fadd-11e6-a029-6c4008b05c4c", 
-                    "sortorder": 0, 
-                    "config": {
-                        "width": "100%", 
-                        "maxLength": null, 
-                        "placeholder": "e.g. Arches", 
-                        "label": "Application Name"
-                    }, 
-                    "id": "fa4205a3-4263-11e7-929e-6c4008b05c4c"
                 }
             ], 
             "cards": [
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
-                    "helptext": null, 
-                    "sortorder": 2, 
-                    "cardid": "c5a2b81c-fadd-11e6-8c23-6c4008b05c4c", 
-                    "helptitle": null, 
-                    "instructions": "Arches can access Thesaurus services, such as the Getty AAT, to acquire thesaurus entries using the Reference Data Manager (RDM)", 
-                    "active": true, 
-                    "name": "Thesaurus Service Providers"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
-                    "helptext": null, 
-                    "sortorder": 4, 
-                    "cardid": "0e8ff861-4148-11e7-aabf-c4b301baab9f", 
-                    "helptitle": null, 
-                    "instructions": "Arches aggregates search results and displays them as hexagons.  You will need to set default parameters for the hexagon size  and its precision", 
-                    "active": true, 
-                    "name": "Search Results Grid"
-                }, 
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
                     "helpenabled": false, 
@@ -1714,62 +1426,6 @@
                     "instructions": "Arches uses the Mapbox mapping library for map display and data creation.  Arches also supports Mapbox basemaps and other services", 
                     "active": true, 
                     "name": "Mapbox API"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "0e8fec61-4148-11e7-b9fd-c4b301baab9f", 
-                    "helptext": null, 
-                    "sortorder": 2, 
-                    "cardid": "0e8fee38-4148-11e7-b446-c4b301baab9f", 
-                    "helptitle": null, 
-                    "instructions": "Arches includes a geospatial data server to speed map display performance.  This form allows you to define where to save map caches on disk.", 
-                    "active": true, 
-                    "name": "Tile Cache"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
-                    "helptext": null, 
-                    "sortorder": 0, 
-                    "cardid": "c5a2b3c7-fadd-11e6-aa79-6c4008b05c4c", 
-                    "helptitle": null, 
-                    "instructions": "Names used to identify your application and the system data import personna", 
-                    "active": true, 
-                    "name": "Default Application Names"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
-                    "helptext": null, 
-                    "sortorder": 1, 
-                    "cardid": "0e8fe2e3-4148-11e7-aa2d-c4b301baab9f", 
-                    "helptitle": null, 
-                    "instructions": "Draw a polygon representing your project's extent. These bounds will serve as the default for the cache seed bounds, search result grid bounds, and map bounds in search, cards, and reports", 
-                    "active": true, 
-                    "name": "Project Extent"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
-                    "helptext": null, 
-                    "sortorder": 3, 
-                    "cardid": "0e8feb0c-4148-11e7-9538-c4b301baab9f", 
-                    "helptitle": null, 
-                    "instructions": "You can define the zoom behavior of your maps by specifying max/min and default values.  Zoom level 0 shows the whole world (and is the minimum zoom level).  Most map services support a maximum of 20 or so zoom levels", 
-                    "active": true, 
-                    "name": "Map Zoom"
                 }, 
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
@@ -1790,6 +1446,76 @@
                     "helpenabled": false, 
                     "description": "Represents a single node in a graph", 
                     "visible": true, 
+                    "nodegroup_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c", 
+                    "helptext": null, 
+                    "sortorder": 0, 
+                    "cardid": "c5a2b3c7-fadd-11e6-aa79-6c4008b05c4c", 
+                    "helptitle": null, 
+                    "instructions": "Names used to identify your application and the system data import personna", 
+                    "active": true, 
+                    "name": "Default Application Names"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": false, 
+                    "description": "Represents a single node in a graph", 
+                    "visible": true, 
+                    "nodegroup_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f", 
+                    "helptext": null, 
+                    "sortorder": 2, 
+                    "cardid": "0e8feb0c-4148-11e7-9538-c4b301baab9f", 
+                    "helptitle": null, 
+                    "instructions": "You can define the zoom behavior of your maps by specifying max/min and default values.  Zoom level 0 shows the whole world (and is the minimum zoom level).  Most map services support a maximum of 20 or so zoom levels", 
+                    "active": true, 
+                    "name": "Map Zoom"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": false, 
+                    "description": "Represents a single node in a graph", 
+                    "visible": true, 
+                    "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f", 
+                    "helptext": null, 
+                    "sortorder": 3, 
+                    "cardid": "0e8ff861-4148-11e7-aabf-c4b301baab9f", 
+                    "helptitle": null, 
+                    "instructions": "Arches aggregates search results and displays them as hexagons.  You will need to set default parameters for the hexagon size  and its precision.", 
+                    "active": true, 
+                    "name": "Search Results Grid"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": false, 
+                    "description": "Represents a single node in a graph", 
+                    "visible": true, 
+                    "nodegroup_id": "0e8fdef0-4148-11e7-8330-c4b301baab9f", 
+                    "helptext": null, 
+                    "sortorder": 1, 
+                    "cardid": "0e8fe2e3-4148-11e7-aa2d-c4b301baab9f", 
+                    "helptitle": null, 
+                    "instructions": "Draw a polygon representing your project's extent. These bounds will serve as the default for the cache seed bounds, search result grid bounds, and map bounds in search, cards, and reports", 
+                    "active": true, 
+                    "name": "Project Extent"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": false, 
+                    "description": "Represents a single node in a graph", 
+                    "visible": true, 
+                    "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c", 
+                    "helptext": null, 
+                    "sortorder": 2, 
+                    "cardid": "c5a2b81c-fadd-11e6-8c23-6c4008b05c4c", 
+                    "helptitle": null, 
+                    "instructions": "Arches can access Thesaurus services, such as the Getty AAT, to acquire thesaurus entries using the Reference Data Manager (RDM)", 
+                    "active": true, 
+                    "name": "Thesaurus Service Providers"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": false, 
+                    "description": "Represents a single node in a graph", 
+                    "visible": true, 
                     "nodegroup_id": "c5a2a2e8-fadd-11e6-9849-6c4008b05c4c", 
                     "helptext": null, 
                     "sortorder": 1, 
@@ -1798,6 +1524,34 @@
                     "instructions": "Google service used to track application usage and other metrics", 
                     "active": true, 
                     "name": "Web Analytics"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": false, 
+                    "description": "Configuration settings for search returns", 
+                    "visible": true, 
+                    "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
+                    "helptext": null, 
+                    "sortorder": null, 
+                    "cardid": "d0987b78-fad8-11e6-9a59-6c4008b05c4c", 
+                    "helptitle": null, 
+                    "instructions": "Set the default search results behavior", 
+                    "active": true, 
+                    "name": "Settings Basic Search"
+                }, 
+                {
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
+                    "helpenabled": true, 
+                    "description": "Configuration Settings for temporal search", 
+                    "visible": true, 
+                    "nodegroup_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
+                    "helptext": "<p>You can see the color ramps at:</p><p><a href=\"https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md\"><font color=\"#f7f7f7\">https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md</font></a><br></p>", 
+                    "sortorder": null, 
+                    "cardid": "32f2daa6-fae4-11e6-a8c8-6c4008b05c4c", 
+                    "helptitle": "<p>You can see the color ramps at:</p><p><a href=\"https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md\"><font color=\"#f7f7f7\">https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md</font></a><br></p>", 
+                    "instructions": "Arches supports temporal binning.  Define the configuration and colors to use in your time wheel", 
+                    "active": true, 
+                    "name": "Settings Time Search"
                 }, 
                 {
                     "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
@@ -1826,48 +1580,6 @@
                     "instructions": "Arches allows you save a search and present it as convenience for your users.", 
                     "active": true, 
                     "name": "Saved Searches"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": true, 
-                    "description": "Configuration Settings for temporal search", 
-                    "visible": true, 
-                    "nodegroup_id": "32f2d663-fae4-11e6-83ad-6c4008b05c4c", 
-                    "helptext": "<p>You can see the color ramps at:</p><p><a href=\"https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md\"><font color=\"#f7f7f7\">https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md</font></a><br></p>", 
-                    "sortorder": null, 
-                    "cardid": "32f2daa6-fae4-11e6-a8c8-6c4008b05c4c", 
-                    "helptitle": "Time Wheel Configuration", 
-                    "instructions": "Arches supports temporal binning.  Define the configuration and colors to use in your time wheel", 
-                    "active": true, 
-                    "name": "Settings Time Search"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Configuration settings for search returns", 
-                    "visible": true, 
-                    "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c", 
-                    "helptext": null, 
-                    "sortorder": null, 
-                    "cardid": "d0987b78-fad8-11e6-9a59-6c4008b05c4c", 
-                    "helptitle": null, 
-                    "instructions": "Set the default search results behavior", 
-                    "active": true, 
-                    "name": "Settings Basic Search"
-                }, 
-                {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c", 
-                    "helpenabled": false, 
-                    "description": "Represents a single node in a graph", 
-                    "visible": true, 
-                    "nodegroup_id": "0e8fefbd-4148-11e7-9e0b-c4b301baab9f", 
-                    "helptext": null, 
-                    "sortorder": 5, 
-                    "cardid": "0e8ff214-4148-11e7-b568-c4b301baab9f", 
-                    "helptitle": null, 
-                    "instructions": "Arches uses geocoding services to convert addresses to map locations.  Register the service(s) you want to use.", 
-                    "active": true, 
-                    "name": "Geocoders"
                 }
             ], 
             "root": {
@@ -1888,9 +1600,9 @@
         }
     ], 
     "metadata": {
-        "git hash": "add2e6f 2017-05-25 17:36:22 -0700", 
-        "db": "PostgreSQL 9.6.1 on x86_64-apple-darwin14.5.0, compiled by Apple LLVM version 7.0.0 (clang-700.1.76), 64-bit", 
-        "os version": "15.6.0", 
+        "git hash": "b2f0cf4 2017-05-30 14:41:55 -0700", 
+        "db": "PostgreSQL 9.6.1 on x86_64-apple-darwin16.1.0, compiled by Apple LLVM version 8.0.0 (clang-800.0.42.1), 64-bit", 
+        "os version": "16.4.0", 
         "os": "Darwin"
     }
 }

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -310,29 +310,7 @@ BUSINESS_DATA_FILES = (
 # The following settings control the extent and max zoom level to which tiles
 # will be seeded.  Be aware, seeding tiles at high zoom levels (more zoomed in)
 # will take a long time
-# The CACHE_SEED_BOUNDS the DEFAULT_BOUNDS will be used if the CACHE_SEED_BOUNDS == None
-CACHE_SEED_BOUNDS = None
-# CACHE_SEED_BOUNDS = {
-#                 "type": "FeatureCollection",
-#                 "features": [{
-#                     "geometry": {
-#                         "type": "Polygon",
-#                         "coordinates": [
-#                             [
-#                                 [-179.99, -60],
-#                                 [179.99, -60],
-#                                 [179.99, 77],
-#                                 [-179.99, 77],
-#                                 [-179.99, -60]
-#                             ]
-#                         ]
-#                     },
-#                     "type": "Feature",
-#                     "id": "2f9f403cde3510eb87973313213cb8c9",
-#                     "properties": {}
-#                 }]
-#             }
-
+CACHE_SEED_BOUNDS = (-122.0, -52.0, 128.0, 69.0)
 CACHE_SEED_MAX_ZOOM = 5
 
 # configure where the tileserver should store its cache
@@ -355,19 +333,12 @@ MAPBOX_API_KEY = '' # Put your Mapbox key here!
 MAPBOX_SPRITES = "mapbox://sprites/mapbox/basic-v9"
 MAPBOX_GLYPHS = "mapbox://fonts/mapbox/{fontstack}/{range}.pbf"
 
-# Default map settings for search and map layer manager pages
-# The DEFAULT_BOUNDS will be used if the DEFAULT_MAP_CENTER = None
-DEFAULT_MAP_CENTER = None
-# DEFAULT_MAP_CENTER = {
-    # "geometry": {
-    #     "type": "Point",
-    #     "coordinates": [-0.0016980786644751333, 51.47783519865435]
-    # }
-
 DEFAULT_MAP_ZOOM = 0
 MAP_MIN_ZOOM = 0
 MAP_MAX_ZOOM = 20
 
+# bounds for search results hex binning fabric (search grid).
+# a smaller bbox will give you less distortion in hexes and better performance
 DEFAULT_BOUNDS = {
     "type": "FeatureCollection",
     "features": [{
@@ -388,29 +359,6 @@ DEFAULT_BOUNDS = {
     }]
 }
 
-# bounds for search results hex binning fabric (search grid).
-# a smaller bbox will give you less distortion in hexes and better performance
-# The DEFAULT_BOUNDS will be used if the HEX_BIN_BOUNDS == None
-HEX_BIN_BOUNDS = None
-# HEX_BIN_BOUNDS = {
-#     "type": "FeatureCollection",
-#     "features": [{
-#         "geometry": {
-#             "type": "Polygon",
-#             "coordinates": [
-#                 [
-#                     [-122, -52],
-#                     [128, -52],
-#                     [128, 69],
-#                     [-122, 69],
-#                     [-122, -52]
-#                 ]
-#             ]
-#         },
-#         "type": "Feature",
-#         "properties": {}
-#     }]
-# }
 # size to use for hex binning search results on map (in km)
 HEX_BIN_SIZE = 100
 # binning uses elasticsearch GeoHash grid aggregation.


### PR DESCRIPTION
Simplified settings by removing tile cache settings from the system_settings, made sure system_settings have precedence over settings.py settings, removed DEFAULT_MAP_CENTER and HEX_BIN_BOUNDS settings from settings.py as they are now handeled by DEFAULT_MAP_BOUNDS, re #346.