### PR TITLE
Limiting loading mask to card panel in resource editor when switching menus

### DIFF
--- a/arches/app/media/js/views/resource/editor.js
+++ b/arches/app/media/js/views/resource/editor.js
@@ -29,9 +29,9 @@ require([
     });
 
     var loadForm = function(form) {
-        loading(true);
+        cardLoading(true);
         formView.loadForm(form.formid, function(){
-            loading(false);
+            cardLoading(false);
         });
     };
 


### PR DESCRIPTION
Moved loading mask to the panel containing cards when switching menus, re #937
