### PR TITLE
report performance optimization

### DIFF
--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -123,8 +123,6 @@ class Card(models.CardModel):
                 self.groups = self.get_group_permissions(self.nodegroup)
                 self.users = self.get_user_permissions(self.nodegroup)
 
-        self.graph = Graph.objects.get(graphid=self.graph_id)
-
     def get_group_permissions(self, nodegroup=None):
         """
         get's a list of object level permissions allowed for a all groups
@@ -246,10 +244,7 @@ class Card(models.CardModel):
         Finds the edge model that relates this card to it's parent node
 
         """
-
-        for edge in self.graph.edges.itervalues():
-            if str(edge.rangenode_id) == str(self.nodegroup_id):
-                return edge
+        return models.Edge.objects.get(rangenode_id=self.nodegroup_id)
 
     def serialize(self):
         """


### PR DESCRIPTION
re: #2093

some benchmarking - before this change: 

```
         8562773 function calls (8357766 primitive calls) in 21.007 seconds

   Ordered by: internal time, call count
   List reduced from 957 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    12287    5.308    0.000    5.472    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/backends/utils.py:58(execute)
   366557    0.568    0.000    1.020    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/base.py:469(__eq__)
157441/125442    0.428    0.000    1.997    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:361(compile)
    32323    0.420    0.000    0.630    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:265(clone)
   445620    0.386    0.000   12.008    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/fields/related_descriptors.py:143(__get__)
   277896    0.383    0.000    0.383    0.000 /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/uuid.py:197(__str__)
   878899    0.367    0.000    0.367    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/base.py:525(_get_pk_val)
   245110    0.299    0.000    0.494    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:344(quote_name_unless_alias)
    18767    0.296    0.000    0.388    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/base.py:351(__init__)
    12287    0.279    0.000    6.011    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/backends/utils.py:76(execute)
30326/1045    0.248    0.000   20.284    0.019 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/query.py:46(__iter__)
  3466/38    0.242    0.000    1.305    0.034 /Users/rgaston/Projects/arches4/arches/arches/app/models/graph.py:373(find_child_edges)
    48397    0.237    0.000    0.399    0.000 /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py:66(copy)
   112593    0.236    0.000    0.286    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/fields/__init__.py:348(get_col)
12294/12287    0.233    0.000    3.982    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:371(as_sql)
    52337    0.232    0.000    0.232    0.000 /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/uuid.py:101(__init__)
    14281    0.215    0.000    1.700    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1117(build_filter)
   393389    0.211    0.000    0.211    0.000 /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/uuid.py:180(__cmp__)
    32553    0.211    0.000    0.379    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1277(names_to_path)
   112607    0.209    0.000    0.691    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/expressions.py:647(as_sql)
    11623    0.208    0.000    0.674    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:488(get_default_columns)
    12294    0.200    0.000    1.866    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:167(get_select)
    27570    0.172    0.000    0.220    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/fields/related_descriptors.py:184(__set__)
   108435    0.163    0.000    1.689    0.000 /Users/rgaston/Projects/arches4/arches/arches/app/models/models.py:388(is_collector)
   119853    0.161    0.000    0.161    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/backends/postgresql/operations.py:92(quote_name)
```

and after: 

``` 
         2331235 function calls (2252780 primitive calls) in 7.033 seconds

   Ordered by: internal time, call count
   List reduced from 811 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3327    2.001    0.001    2.039    0.001 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/backends/utils.py:58(execute)
46359/32282    0.128    0.000    0.723    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:361(compile)
    14631    0.121    0.000    0.258    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1277(names_to_path)
     7552    0.110    0.000    0.167    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:265(clone)
    15714    0.098    0.000    0.158    0.000 /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/copy.py:66(copy)
 23479/22    0.093    0.000    4.401    0.200 /Users/rgaston/Projects/arches4/arches/arches/app/utils/betterJSONSerializer.py:63(handle_object)
    67748    0.085    0.000    0.144    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:344(quote_name_unless_alias)
     5320    0.084    0.000    0.868    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1117(build_filter)
     3327    0.084    0.000    2.196    0.001 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/backends/utils.py:76(execute)
    27230    0.076    0.000    0.114    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/fields/related.py:593(foreign_related_fields)
3334/3327    0.065    0.000    1.526    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:371(as_sql)
    28392    0.063    0.000    0.074    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/fields/__init__.py:348(get_col)
     3334    0.062    0.000    0.458    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:231(get_order_by)
    28406    0.058    0.000    0.193    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/expressions.py:647(as_sql)
6454/1231    0.057    0.000    6.254    0.005 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/query.py:46(__iter__)
    36035    0.056    0.000    0.101    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/base.py:469(__eq__)
     9311    0.054    0.000    0.087    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1422(trim_joins)
     3855    0.054    0.000    0.076    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/base.py:351(__init__)
     5245    0.052    0.000    1.122    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1248(_add_q)
    35653    0.052    0.000    0.052    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/backends/postgresql/operations.py:92(quote_name)
    32296    0.051    0.000    0.051    0.000 /usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/uuid.py:197(__str__)
    45503    0.051    0.000    1.916    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/fields/related_descriptors.py:143(__get__)
     9311    0.051    0.000    0.321    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/query.py:1377(setup_joins)
     3334    0.049    0.000    0.418    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:167(get_select)
     2663    0.048    0.000    0.144    0.000 /Users/rgaston/Projects/arches4/arches/virtualenv/ENV/lib/python2.7/site-packages/django/db/models/sql/compiler.py:488(get_default_columns)
```