### PR TITLE
2108 relationship properties form

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5374,6 +5374,12 @@ div.row.widget-wrapper {
     padding-left: 5px;
 }
 
+a.mega-dropdown-toggle.disabled {
+   pointer-events: none;
+   cursor: default;
+   color: #aaa;
+}
+
 .relation-properties-button {
     padding-left: 5px
 }
@@ -5424,6 +5430,18 @@ div.row.widget-wrapper {
 
 .settings-config-panel {
     padding: 5px;
+}
+
+.data-table-selected {
+    text-align: center;
+}
+
+.sorting_asc::after {
+    visibility: hidden;
+}
+
+.center-header {
+    margin-right: -20px;
 }
 
 .shim {

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5436,12 +5436,12 @@ a.mega-dropdown-toggle.disabled {
     text-align: center;
 }
 
-.sorting_asc::after {
+.data-table-selected.sorting_asc::after {
     visibility: hidden;
 }
 
 .center-header {
-    margin-right: -20px;
+    text-align: center;
 }
 
 .shim {

--- a/arches/app/media/js/views/resource/related-resources-manager.js
+++ b/arches/app/media/js/views/resource/related-resources-manager.js
@@ -174,6 +174,11 @@ define([
             this.propertiesDialogOpen.subscribe(function(val){
                 if (val === true) {
                     setTimeout(this.resize, 1000);
+                } else {
+                    this.relatedProperties.notes('')
+                    this.relatedProperties.dateto('')
+                    this.relatedProperties.datefrom('')
+                    this.relatedProperties.relationship_type(this.defaultRelationshipType)
                 }
             }, this)
 

--- a/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
+++ b/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
@@ -223,13 +223,20 @@
                                               paging: true,
                                               dom: 'rtip',
                                               columns:[
-                                                  {width: '10px', orderable:false, className: 'data-table-selected'},
+                                                  {width: '30px', orderable:false, className: 'data-table-selected'},
                                                   {width: '100px'},
                                                   {width: '100px'},
                                                   {width: '100px'},
                                                   {width: '100px'},
                                                   {width:'100px'}
-                                              ]
+                                              ],
+                                              fnInitComplete: function() {
+                                                var self = this;
+                                                setTimeout(function(){
+                                                    self.fnAdjustColumnSizing(true);
+                                                    self.fnSort(0);
+                                                }, 1000);
+                                                }
                                           }
                                       }">
                             <tr class="rr-table-row" data-bind="click: function () {

--- a/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
+++ b/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
@@ -94,7 +94,8 @@
                             <div class="mega-dropdown related-reources-crud-link" data-bind="visible: showGraph() == false">
 
                                 <!--ko if: !showGraph() -->
-                                <a href="#" class="mega-dropdown-toggle" data-bind="click: function(){propertiesDialogOpen(!propertiesDialogOpen())}">
+
+                                <a href="#" class="mega-dropdown-toggle" data-bind="css: {'disabled':selected().length === 0}, click: function(){propertiesDialogOpen(!propertiesDialogOpen());}">
                                     <i class="ion-wrench icon-lg"></i> {% trans "relation properties" %}
                                 </a>
 
@@ -208,6 +209,7 @@
                     <table class="table table-striped table-bordered" cellspacing="0" width="100%">
                         <thead>
                             <tr>
+                                <th class="rr-tab-field"><i class="center-header" data-bind="css: {'ion-checkmark-circled': selected}"></i></th>
                                 <th class="rr-tab-field">{% trans "Resource ID" %}</th>
                                 <th class="rr-tab-field">{% trans "Relationship" %}</th>
                                 <th class="rr-tab-field">{% trans "From" %}</th>
@@ -221,6 +223,7 @@
                                               paging: true,
                                               dom: 'rtip',
                                               columns:[
+                                                  {width: '10px', orderable:false, className: 'data-table-selected'},
                                                   {width: '100px'},
                                                   {width: '100px'},
                                                   {width: '100px'},
@@ -234,6 +237,9 @@
                             }">
                                 <td>
                                     <i data-bind="css: {'ion-checkmark-circled': selected}"></i>
+                                    <span data-bind="text: resource.selected"></span>
+                                </td>
+                                <td>
                                     <span data-bind="text: resource.displayname"></span>
                                 </td>
                                 <td>


### PR DESCRIPTION
Clearing relationship properties form when a user closes it.
Added a column for the selected row indicator in the related resources table.
Disabled the relationship properties form button when no rows are selected.