### PR TITLE
Fix for travis postgis 2.3 build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - libpq-dev
       - openjdk-7-jdk
       - python-dev
+      - postgresql-9.6-postgis-2.3
 
 services:
   - postgresql


### PR DESCRIPTION
Add postgresql-9.6-postgis-2.3 to the list of addon packages for postgres in the travis.yml file.