### PR TITLE
1657 related resources in reports

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5645,6 +5645,15 @@ a.mega-dropdown-toggle.disabled {
     margin-top: 5px;
 }
 
+.rp-report-tile.related {
+    padding-bottom: 0px;
+}
+
+.rp-report-tile .reported-relationship {
+    padding-left: 5px;
+    color: #888;
+}
+
 .rp-no-data {
     color: #888;
     margin-top: 10px;

--- a/arches/app/media/js/models/report.js
+++ b/arches/app/media/js/models/report.js
@@ -14,7 +14,7 @@ define(['arches',
          * @name ReportModel
          */
 
-        url: arches.urls.report_editor,
+         url: arches.urls.report_editor,
 
         initialize: function(options) {
             var self = this;
@@ -159,6 +159,28 @@ define(['arches',
             this.forms.sort(function(f1, f2) {
                 return f1.sortorder > f2.sortorder;
             });
+
+            this.related_resources = []
+
+            this.sort_related = function(anArray, property) {
+                anArray.sort(function(a, b){
+                    if (a[property] > b[property]) return 1;
+                    if (b[property] > a[property]) return -1;
+                    return 0;
+                })
+            }
+            _.each(this.get('related_resources'), function(rr){
+                var res = {'graph_name': rr.name, 'related':[]}
+                _.each(rr.resources, function(resource) {
+                    _.each(resource.relationships, function(relationship){
+                        res.related.push({'displayname':resource.displayname,'link': arches.urls.resource_report + resource.instance_id, 'relationship': relationship})
+                    })
+                })
+                this.sort_related(res.related, 'displayname')
+                this.related_resources.push(res);
+            }, this)
+
+            this.sort_related(this.related_resources, 'graph_name');
 
             this._data(JSON.stringify(this.toJSON()));
         },

--- a/arches/app/templates/views/report-templates/default.htm
+++ b/arches/app/templates/views/report-templates/default.htm
@@ -90,14 +90,28 @@
 
 
     {% endblock body %}
-    <!-- ko foreach: { data: report.get('related_resources'), as: 'rr' } -->
-    <div class="rp-card-section">
-        <div data-bind="text:rr.name"></div>
-        <!-- ko foreach: { data: rr.resources } -->
-        <div data-bind="text: $data.displayname"></div>
+    <div class="rp-report-section relative">
+    <div class="rp-report-section-title">
+        <h4 class="rp-section-title">{% trans 'Related Resources' %}</h4>
+    </div>
+    <!-- ko foreach: { data: report.related_resources, as: 'rr' } -->
+    <div class="rp-card-section relative">
+        <h5 class="rp-tile-title">
+            <span class="rp-tile-title-float" data-bind="text:rr.graph_name"></span>
+        </h5>
+        <!--ko if: rr.related.length > 0 -->
+            <!-- ko foreach: { data: rr.related } -->
+            <div class="row rp-report-tile related">
+                <a data-bind="text: $data.displayname, attr: {href: $data.link}"></a><span class='reported-relationship' data-bind="text: '( ' + $data.relationship + ' )'"></span>
+            </div>
+            <!-- /ko -->
         <!-- /ko -->
+        <!--ko if: rr.related.length === 0 -->
+            <div class="row rp-report-tile related">None</div>
+        <!--/ko-->
     </div>
     <!-- /ko -->
+    </div>
 </div>
 
 

--- a/arches/app/templates/views/report-templates/default.htm
+++ b/arches/app/templates/views/report-templates/default.htm
@@ -87,11 +87,23 @@
         </div>
         <!-- /ko -->
     </template>
+
+
     {% endblock body %}
+    <!-- ko foreach: { data: report.get('related_resources'), as: 'rr' } -->
+    <div class="rp-card-section">
+        <div data-bind="text:rr.name"></div>
+        <!-- ko foreach: { data: rr.resources } -->
+        <div data-bind="text: $data.displayname"></div>
+        <!-- /ko -->
+    </div>
+    <!-- /ko -->
 </div>
+
 
 {% endblock report %}
 <!-- /ko -->
+
 
 <!-- ko if: configForm && (configType === 'header') -->
 {% block header_form %}

--- a/arches/app/templates/views/resource/report.htm
+++ b/arches/app/templates/views/resource/report.htm
@@ -64,7 +64,8 @@ define('resource-report-data', [], function () {
         forms_x_cards: {{forms_x_cards}},
         cards: {{cards}},
         tiles: {{tiles}},
-        graph: {{graph_json}}
+        graph: {{graph_json}},
+        related_resources: {{related_resources}}
     };
 });
 {% endautoescape %}</script>

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -166,11 +166,12 @@ class ResourceDescriptors(View):
 @method_decorator(group_required('Resource Editor'), name='dispatch')
 class ResourceReportView(BaseManagerView):
     def get(self, request, resourceid=None):
+        lang = request.GET.get('lang', settings.LANGUAGE_CODE)
         resource_instance = models.ResourceInstance.objects.get(pk=resourceid)
         resource = Resource.objects.get(pk=resourceid)
         resource_models = Graph.objects.filter(isresource=True).exclude(isactive=False).exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID)
         related_resource_summary = [{'graphid':str(g.graphid), 'name':g.name, 'resources':[]} for g in resource_models]
-        related_resources_search_results = resource.get_related_resources(lang="en-US", start=0, limit=15)
+        related_resources_search_results = resource.get_related_resources(lang=lang, start=0, limit=15)
         related_resources = related_resources_search_results['related_resources']
         relationships = related_resources_search_results['resource_relationships']
         resource_relationship_type_values = {i['id']: i['text'] for i in get_resource_relationship_types()['values']}
@@ -252,13 +253,14 @@ class ResourceReportView(BaseManagerView):
 @method_decorator(group_required('Resource Editor'), name='dispatch')
 class RelatedResourcesView(BaseManagerView):
     def get(self, request, resourceid=None):
-        # lang = request.GET.get('lang', settings.LANGUAGE_CODE)
+        lang = request.GET.get('lang', settings.LANGUAGE_CODE)
         start = request.GET.get('start', 0)
         resource = Resource.objects.get(pk=resourceid)
-        related_resources = resource.get_related_resources(lang="en-US", start=start, limit=15)
+        related_resources = resource.get_related_resources(lang=lang, start=start, limit=15)
         return JSONResponse(related_resources, indent=4)
 
     def delete(self, request, resourceid=None):
+        lang = request.GET.get('lang', settings.LANGUAGE_CODE)
         es = Elasticsearch()
         se = SearchEngineFactory().create()
         req = dict(request.GET)
@@ -272,10 +274,11 @@ class RelatedResourcesView(BaseManagerView):
         start = request.GET.get('start', 0)
         es.indices.refresh(index="resource_relations")
         resource = Resource.objects.get(pk=root_resourceinstanceid[0])
-        related_resources = resource.get_related_resources(lang="en-US", start=start, limit=15)
+        related_resources = resource.get_related_resources(lang=lang, start=start, limit=15)
         return JSONResponse(related_resources, indent=4)
 
     def post(self, request, resourceid=None):
+        lang = request.GET.get('lang', settings.LANGUAGE_CODE)
         es = Elasticsearch()
         se = SearchEngineFactory().create()
         res = dict(request.POST)
@@ -337,5 +340,5 @@ class RelatedResourcesView(BaseManagerView):
         start = request.GET.get('start', 0)
         es.indices.refresh(index="resource_relations")
         resource = Resource.objects.get(pk=root_resourceinstanceid[0])
-        related_resources = resource.get_related_resources(lang="en-US", start=start, limit=15)
+        related_resources = resource.get_related_resources(lang=lang, start=start, limit=15)
         return JSONResponse(related_resources, indent=4)

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -170,8 +170,7 @@ class ResourceReportView(BaseManagerView):
         resource = Resource.objects.get(pk=resourceid)
         resource_models = Graph.objects.filter(isresource=True).exclude(isactive=False).exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID)
         related_resource_summary = [{'graphid':str(g.graphid), 'name':g.name, 'resources':[]} for g in resource_models]
-        start = request.GET.get('start', 0)
-        related_resources_search_results = resource.get_related_resources(lang="en-US", start=start, limit=15)
+        related_resources_search_results = resource.get_related_resources(lang="en-US", start=0, limit=15)
         related_resources = related_resources_search_results['related_resources']
         relationships = related_resources_search_results['resource_relationships']
         resource_relationship_type_values = {i['id']: i['text'] for i in get_resource_relationship_types()['values']}
@@ -182,7 +181,7 @@ class ResourceReportView(BaseManagerView):
                     relationship_summary = []
                     for relationship in relationships:
                         if rr['resourceinstanceid'] in (relationship['resourceinstanceidto'], relationship['resourceinstanceidfrom']):
-                            relationship_summary.append(relationship['relationshiptype'])
+                            relationship_summary.append(resource_relationship_type_values[relationship['relationshiptype']])
                     summary['resources'].append({'instance_id':rr['resourceinstanceid'],'displayname':rr['displayname'], 'relationships':relationship_summary})
 
         tiles = models.TileModel.objects.filter(resourceinstance=resource_instance)

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -54,6 +54,14 @@ class ResourceListView(BaseManagerView):
 
         return render(request, 'views/resource.htm', context)
 
+def get_resource_relationship_types():
+    resource_relationship_types = Concept().get_child_concepts('00000000-0000-0000-0000-000000000005', ['member', 'hasTopConcept'], ['prefLabel'], 'prefLabel')
+    default_relationshiptype_valueid = None
+    for relationship_type in resource_relationship_types:
+        if relationship_type[1] == '00000000-0000-0000-0000-000000000007':
+            default_relationshiptype_valueid = relationship_type[5]
+    relationship_type_values = {'values':[{'id':str(c[5]), 'text':str(c[3])} for c in resource_relationship_types], 'default': str(default_relationshiptype_valueid)}
+    return relationship_type_values
 
 @method_decorator(group_required('Resource Editor'), name='dispatch')
 class ResourceEditorView(BaseManagerView):
@@ -67,12 +75,7 @@ class ResourceEditorView(BaseManagerView):
             resource_instance = models.ResourceInstance.objects.get(pk=resourceid)
             resource_graphs = Graph.objects.exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID).exclude(isresource=False).exclude(isactive=False)
             graph = Graph.objects.get(graphid=resource_instance.graph.pk)
-            resource_relationship_types = Concept().get_child_concepts('00000000-0000-0000-0000-000000000005', ['member', 'hasTopConcept'], ['prefLabel'], 'prefLabel')
-            default_relationshiptype_valueid = None
-            for relationship_type in resource_relationship_types:
-                if relationship_type[1] == '00000000-0000-0000-0000-000000000007':
-                    default_relationshiptype_valueid = relationship_type[5]
-            relationship_type_values = {'values':[{'id':str(c[5]), 'text':str(c[3])} for c in resource_relationship_types], 'default': str(default_relationshiptype_valueid)}
+            relationship_type_values = get_resource_relationship_types()
             form = Form(resource_instance.pk)
             datatypes = models.DDataType.objects.all()
             widgets = models.Widget.objects.all()
@@ -164,6 +167,24 @@ class ResourceDescriptors(View):
 class ResourceReportView(BaseManagerView):
     def get(self, request, resourceid=None):
         resource_instance = models.ResourceInstance.objects.get(pk=resourceid)
+        resource = Resource.objects.get(pk=resourceid)
+        resource_models = Graph.objects.filter(isresource=True).exclude(isactive=False).exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID)
+        related_resource_summary = [{'graphid':str(g.graphid), 'name':g.name, 'resources':[]} for g in resource_models]
+        start = request.GET.get('start', 0)
+        related_resources_search_results = resource.get_related_resources(lang="en-US", start=start, limit=15)
+        related_resources = related_resources_search_results['related_resources']
+        relationships = related_resources_search_results['resource_relationships']
+        resource_relationship_type_values = {i['id']: i['text'] for i in get_resource_relationship_types()['values']}
+
+        for rr in related_resources:
+            for summary in related_resource_summary:
+                if rr['graph_id'] == summary['graphid']:
+                    relationship_summary = []
+                    for relationship in relationships:
+                        if rr['resourceinstanceid'] in (relationship['resourceinstanceidto'], relationship['resourceinstanceidfrom']):
+                            relationship_summary.append(relationship['relationshiptype'])
+                    summary['resources'].append({'instance_id':rr['resourceinstanceid'],'displayname':rr['displayname'], 'relationships':relationship_summary})
+
         tiles = models.TileModel.objects.filter(resourceinstance=resource_instance)
         try:
            report = models.Report.objects.get(graph=resource_instance.graph, active=True)
@@ -209,6 +230,7 @@ class ResourceReportView(BaseManagerView):
             forms_x_cards=JSONSerializer().serialize(forms_x_cards),
             cards=JSONSerializer().serialize(permitted_cards),
             datatypes_json=JSONSerializer().serialize(datatypes),
+            related_resources=JSONSerializer().serialize(related_resource_summary),
             widgets=widgets,
             map_layers=map_layers,
             map_sources=map_sources,


### PR DESCRIPTION
Added related resources in reports - each listed under their corresponding resource model name along with their relationship type and display name. Each related resource display name links to its own report as in v3. re #1657.

Also replaced some hard-coded references to 'en-US' with the language code defined in settings.py 