### PR TITLE
Made reports readable by guest users

### DIFF
--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -163,7 +163,7 @@ class ResourceDescriptors(View):
 
         return HttpResponseNotFound()
 
-@method_decorator(group_required('Resource Editor'), name='dispatch')
+@method_decorator(group_required('Guest'), name='dispatch')
 class ResourceReportView(BaseManagerView):
     def get(self, request, resourceid=None):
         lang = request.GET.get('lang', settings.LANGUAGE_CODE)


### PR DESCRIPTION
### Description of Change
Changed the required group for the ResourceReportView from 'Resource Editor' to 'Guest' so that guests are not redirected to the login page when trying to view a report. re #1635