### PR TITLE
1635 permissions reports

### DIFF
--- a/arches/app/templates/views/report-templates/default.htm
+++ b/arches/app/templates/views/report-templates/default.htm
@@ -83,7 +83,12 @@
 
         <!-- ko if: tiles.length === 0 -->
         <div class="row rp-report-tile rp-no-data">
+        <!-- ko ifnot: card.get('cardid') -->
+            {% trans "Sorry, you don't have access to this information" %}
+        <!-- /ko -->
+        <!-- ko if: card.get('cardid') -->
             {% trans "No data added yet for" %} "<span data-bind="text: card.get('name')"></span>"
+        <!-- /ko -->
         </div>
         <!-- /ko -->
     </template>

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -166,7 +166,7 @@ class ResourceDescriptors(View):
 
         return HttpResponseNotFound()
 
-@method_decorator(group_required('Guest'), name='dispatch')
+@method_decorator(group_required('Resource Editor', 'Guest'), name='dispatch')
 class ResourceReportView(BaseManagerView):
     def get(self, request, resourceid=None):
         lang = request.GET.get('lang', settings.LANGUAGE_CODE)


### PR DESCRIPTION
### Description of Change
Allowing Resource Editors as well as Guests to access reports.
Informing users in reports when they do not have permissions to see card data.