### PR TITLE
Clear geojson in map widget

### DIFF
--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -165,6 +165,7 @@ define([
             }, this)
 
             this.loadGeometriesIntoDrawLayer = function() {
+                self.geojsonInput(false)
                 if (self.draw) {
                     var val = koMapping.toJS(self.value);
                     self.draw.deleteAll()


### PR DESCRIPTION
### Description of Change
Closing and clearing the geojson input when a user cancels or saves a card, re #1990
