### PR TITLE
1990 clear geojson when geojson is invalid

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -6685,7 +6685,7 @@ a#close-map-tools.map-widget-icon:hover {
     height: 120px;
     font-size: 14px;
     white-space: nowrap;
-    overflow: hidden;
+    overflow: scroll;
     text-overflow: ellipsis;
 }
 

--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -362,9 +362,11 @@ define([
                             self.geoJsonStringValid(true);
                         } catch(err) {
                             self.geoJsonStringValid(false);
+                            setTimeout(function(){self.geojsonString('')}, 500)
                         }
                     } catch(err) {
                         self.geoJsonStringValid(false);
+                        setTimeout(function(){self.geojsonString('')}, 500)
                     }
                 }
             }


### PR DESCRIPTION
### Description of Change
Enabled scrolling when geojson exceeds size of the GeoJson input area.
Clearing geojson if geojson is invalid.