### PR TITLE
2152 settings help updates

### DIFF
--- a/arches/app/templates/help/system-settings-help.htm
+++ b/arches/app/templates/help/system-settings-help.htm
@@ -14,7 +14,7 @@
             <p>
               {% blocktrans %}
                 <strong>Application Name</strong> - Name of your Arches app, to be displayed in the browser title bar and elsewhere.<br>
-                <strong>Default Data Import/Export User</strong> - <br>
+                <strong>Default Data Import/Export User</strong> - Name to associate with data that is imported into the system.<br>
               {% endblocktrans %}
             </p>
             <h4>{% trans "Web Analytics" %}</h4>
@@ -44,7 +44,12 @@
             <h4>{% trans "Project Extent" %}</h4>
             <p>{% trans "Draw a polygon representing your project's extent. These bounds will serve as the default for the cache seed bounds, search result grid bounds, and map bounds in search, cards, and reports." %}</p>
             <h4>{% trans "Map Zoom" %}</h4>
-            <p>{% trans "You can define the zoom behavior of your maps by specifying max/min and default values. Zoom level 0 shows the whole world (and is the minimum zoom level). Most map services support a maximum of 20 or so zoom levels." %}</p>
+            <p>{% trans "You can define the zoom behavior of your maps by specifying the <strong>Min Zoom</strong> (how far youmax/min and default values. Zoom level 0 shows the whole world (and is the minimum zoom level). Most map services support a maximum of 20 or so zoom levels." %}</p>
+            <p>
+                {% trans "<strong>Default Zoom</strong> - Set the zoom level that the map will be shown at by default. Note that <br>
+                {% trans "<strong>Mapbox Sprites</strong> - Path to Mapbox sprites (use default)." %}<br>
+                {% trans "<strong>Mapbox Glyphs</strong> - Path to Mapbox glyphs (use default)." %}<br>
+            </p>
             <h4>{% trans "Search Results Grid" %}</h4>
             <p>{% trans "Arches aggregates search results and displays them as hexagons. You will need to set default parameters for the hexagon size and precision." %}</p>
             <p><em>{% trans "<strong>Warning:</strong> A large project area combined with a small hexagon size and/or high precision will take a very long time to load, and can crash your browser. We suggest changing these settings in small increments to find the best combination for your project." %}</em></p>
@@ -53,9 +58,14 @@
     <div>
         <a href="javascript:void(0)" class="ep-help-topic-toggle"><h4>{% trans "Basic Search Settings" %}</h4></a>
         <div class="ep-help-topic-content">
-          {% blocktrans %}
-            <p>Set the default search results behavior. This is also where you will define the max number of resources per export operation.</p>
-          {% endblocktrans %}
+            <p>{% trans "Set the default search results behavior." %}</p>
+            {% blocktrans %}
+            <p>
+                <strong>Number of search results per page</strong> - Set the number of search results shown per page. Note this also defines the number of search result markers that are shown on the map.<br>
+                <strong>Number of search hints per dropdown</strong> - Set the number of search hints that will appear under the search bar as you type in search terms.<!--<br>
+                <strong>Max number of search results to export</strong> - Set the maximum number of resources to be exported from the search results.-->
+            </p>
+            {% endblocktrans %}
         </div>
     </div>
     <div>
@@ -63,8 +73,7 @@
         <div class="ep-help-topic-content">
             <p>{% trans "Arches creates a Time Wheel based on the resources in your database, to allow for quick temporal visualization and queries. A few aspects of this temporal search are defined here." %}</p>
             <p>
-                {% trans "<strong>Color Ramp</strong> - The color ramp for the time wheel. For further reference, check out the <a href='https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md'>d3 API reference</a>." %}<br>
-                {% trans "<strong>Time wheel configuration</strong> - Configure the time wheel here (____)." %}
+                {% trans "<strong>Color Ramp</strong> - The color ramp for the time wheel. For further reference, check out the <a href='https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md'>d3 API reference</a>." %}
             </p>
         </div>
     </div>
@@ -72,8 +81,10 @@
         <a href="javascript:void(0)" class="ep-help-topic-toggle"><h4>{% trans "Saved Searches" %}</h4></a>
         <div class="ep-help-topic-content">
             {% blocktrans %}
+            <p>Arches allows you save a search and present it as convenience for your users. Saved Searches appear as search options in the main Search page. Creating a Saved Search is a three-step process.</p>
+            {% endblocktrans %}
+            {% blocktrans %}
             <p>
-                <p>Arches allows you save a search and present it as convenience for your users. Saved Searches appear as search options in the main Search page. Creating a Saved Search is a three-step process.</p>
                 <strong>1. Specify Search Criteria</strong> - Go to the Search page and enter all the criteria you would like to use to configure your Saved Search. You may notice that with the addition of each new search filter (either by using the term filter, map filtering tools, or temporal filters) the URL for the page will change.<br>
                 <strong>2. Copy the URL</strong> - In your browser address bar, copy the <em>entire</em> URL. This will be a long string that defines each of the search filters created in step 1.<br>
                 <strong>3. Create the Saved Search</strong> - Finally, head back to this page and fill out the settings that you see at left. You can also upload an image that will be shown along with your Search Search.

--- a/arches/app/templates/help/system-settings-help.htm
+++ b/arches/app/templates/help/system-settings-help.htm
@@ -44,11 +44,11 @@
             <h4>{% trans "Project Extent" %}</h4>
             <p>{% trans "Draw a polygon representing your project's extent. These bounds will serve as the default for the cache seed bounds, search result grid bounds, and map bounds in search, cards, and reports." %}</p>
             <h4>{% trans "Map Zoom" %}</h4>
-            <p>{% trans "You can define the zoom behavior of your maps by specifying the <strong>Min Zoom</strong> (how far youmax/min and default values. Zoom level 0 shows the whole world (and is the minimum zoom level). Most map services support a maximum of 20 or so zoom levels." %}</p>
+            <p>{% trans "You can define the zoom behavior of your map. Zoom level 0 shows the whole world (and is the absolute minimum zoom level) and zoom level 20 is the maximum level that most map services support." %}</p>
             <p>
-                {% trans "<strong>Default Zoom</strong> - Set the zoom level that the map will be shown at by default. Note that <br>
-                {% trans "<strong>Mapbox Sprites</strong> - Path to Mapbox sprites (use default)." %}<br>
-                {% trans "<strong>Mapbox Glyphs</strong> - Path to Mapbox glyphs (use default)." %}<br>
+                {% trans "<strong>Default Zoom</strong> - Set the zoom level that the map will be shown at by default." %}<br>
+                {% trans "<strong>Min Zoom</strong> - Minimum zoom level defines how far the user can zoom out when viewing the map." %}<br>
+                {% trans "<strong>Max Zoom</strong> - Maximum zoom level defines how far the user can zoom in when viewing the map." %}<br>
             </p>
             <h4>{% trans "Search Results Grid" %}</h4>
             <p>{% trans "Arches aggregates search results and displays them as hexagons. You will need to set default parameters for the hexagon size and precision." %}</p>

--- a/arches/app/templates/help/system-settings-help.htm
+++ b/arches/app/templates/help/system-settings-help.htm
@@ -26,7 +26,7 @@
             <h4> {% trans "Thesaurus Service Providers" %}</h4>
             <p>
               {% blocktrans %}
-                <strong>Thesaurus SPAQRL Endpoint</strong> - Advanced users may create more SPAQRL endpoints and register them here. These endpoints will be available in the RDM and allow you to import thesaurus entries from external sources.<br>
+                <strong>Thesaurus SPARQL Endpoint</strong> - Advanced users may create more SPARQL endpoints and register them here. These endpoints will be available in the RDM and allow you to import thesaurus entries from external sources.<br>
               {% endblocktrans %}
             </p>
         </div>

--- a/arches/app/templates/help/system-settings-help.htm
+++ b/arches/app/templates/help/system-settings-help.htm
@@ -52,6 +52,10 @@
             </p>
             <h4>{% trans "Search Results Grid" %}</h4>
             <p>{% trans "Arches aggregates search results and displays them as hexagons. You will need to set default parameters for the hexagon size and precision." %}</p>
+            <p>
+                {% trans "<strong>Hexagon Size (in km)</strong> - Set the actual size of the hex bins that will be shown on the map." %}<br>
+                {% trans "<strong>Hexagon Grid Precision</strong> - Set the precision with which the contents of the hex bins will be calculated." %}<br>
+            </p>
             <p><em>{% trans "<strong>Warning:</strong> A large project area combined with a small hexagon size and/or high precision will take a very long time to load, and can crash your browser. We suggest changing these settings in small increments to find the best combination for your project." %}</em></p>
         </div>
     </div>


### PR DESCRIPTION
### Description of Change
Changes made:
Default Data Import/Export User as described above
Reformatted map zoom section into properties
Reformatted Basic Search settings to include "Number of search hints shown in dropdown".
However, looking closer at Basic Search settings led to #2262, so I have commented out the lines for "Max search results to export" with the expectation that that setting will be removed or perhaps altered.
Removed time wheel configuration entry.
Add properties for hex bin settings