### PR TITLE
Enable 'export' property in export mapping json.

### DIFF
--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -57,7 +57,7 @@ class CsvWriter(Writer):
         concept_export_value_lookup = {}
         for resource_export_config in resource_export_configs:
             for node in resource_export_config['nodes']:
-                if node['file_field_name'] != '': # and node['export'] == True <-- Add this to enable the 'export' parameter in the mapping json
+                if node['file_field_name'] != '' and node['export'] == True:
                     mapping[node['arches_nodeid']] = node['file_field_name']
                 if 'concept_export_value' in node:
                     concept_export_value_lookup[node['arches_nodeid']] = node['concept_export_value']
@@ -86,6 +86,9 @@ class CsvWriter(Writer):
                                         csv_record[mapping[k]] = value
                                     del tile['data'][k]
                                 else:
+                                    concept_export_value_type = None
+                                    if k in concept_export_value_lookup:
+                                        concept_export_value_type = concept_export_value_lookup[k]
                                     value = self.transform_value_for_export(self.node_datatypes[k], tile['data'][k], concept_export_value_type, k)
                                     other_group_record[mapping[k]] = value
                             else:


### PR DESCRIPTION
Enable property in export mapping json. Now export respects the 'export' property in the mapping json. If export is set to false for a given node that business data will not be exported and vice versa.

### Issues Solved
#2363 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)