### PR TITLE
Adding .gitkeep to empty package directories

### DIFF
--- a/arches/install/arches-templates/project_name/system_settings/readme.txt
+++ b/arches/install/arches-templates/project_name/system_settings/readme.txt
@@ -2,7 +2,7 @@ This directory is used as the default directory for loading package system
 settings data. This is also the default directory that will be used when exporting
 system settings. Do not edit settings in this directory unless you are doing so for
 development purposes. Instead, use the system settings manager in the Arches UI.
-If you want to export your system settings from Arches you can do so with the
+If you want to export your system settings from Arches, you can do so with the
 following command:
 
 > python manage.py packages -o save_system_settings

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -246,7 +246,11 @@ class Command(BaseCommand):
                     print e
                     print 'Could not read resource to resource constraints'
 
-            self.save_system_settings(data_dest=os.path.join(dest_dir, 'system_settings'))
+            try:
+                self.save_system_settings(data_dest=os.path.join(dest_dir, 'system_settings'))
+            except Exception as e:
+                print e
+                print "Could not save system settings"
 
     def load_package(self, source, setup_db=True, overwrite_concepts='ignore', stage_concepts='stage'):
 

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -232,6 +232,11 @@ class Command(BaseCommand):
             for directory in dirs:
                 os.makedirs(os.path.join(dest_dir, directory))
 
+            for directory in dirs:
+                if len(glob.glob(os.path.join(dest_dir, directory, '*'))) == 0:
+                    with open(os.path.join(dest_dir, directory, '.gitkeep'), 'w'):
+                        print 'added', os.path.join(dest_dir, directory, '.gitkeep')
+
             with open(os.path.join(dest_dir, 'package_config.json'), 'w') as config_file:
                 try:
                     constraints = models.Resource2ResourceConstraint.objects.all()

--- a/docs/create-package.txt
+++ b/docs/create-package.txt
@@ -24,7 +24,7 @@ Loading a Package
 
     \*It is important to note that you cannot load a package directly into core Arches. Currently packages must be loaded into a project. :doc:`Create a project <../project-setup>`.
 
-    If you are a developer running the latest arches you probably want to create a project in a fresh Arches installation. This ensures that the `arches_project create` command uses the latest project templates.
+    If you are a developer running the latest arches you probably want to create a project with a new arches installation. This ensures that the `arches_project create` command uses the latest project templates.
 
         #. Uninstall arches from your virtualenv
 

--- a/docs/create-package.txt
+++ b/docs/create-package.txt
@@ -7,7 +7,7 @@ A package is an external collection of arches data (resource models, business da
 Loading a Package
 `````````````````
 
-#. To load a package simply run the load_package command:
+#. To load a package simply run the load_package command using your \*project's manage.py file:
 
     .. code-block:: bash
 
@@ -21,6 +21,38 @@ Loading a Package
     -o     operation name
 
     If you do not pass the `-db True` to the load_package command, your database will not be recreated. If you already have resource models and branches with the same id as those you are importing, you will be prompted to confirm whether you would like to keep or overwrite each model or branch.
+
+    \*It is important to note that you cannot load a package directly into core Arches. Currently packages must be loaded into a project. :doc:`Create a project <../project-setup>`.
+
+    If you are a developer running the latest arches you probably want to create a project in a fresh Arches installation. This ensures that the `arches_project create` command uses the latest project templates.
+
+        #. Uninstall arches from your virtualenv
+
+            .. code-block:: bash
+
+                pip uninstall arches
+
+        #. Navigate into arches root folder delete the `build` directory
+
+        #. Reinstall arches
+
+            .. code-block:: bash
+
+                python setup.py install
+
+                python setup.py develop
+
+        #. Navigate to where you want to create your new project and run:
+
+            .. code-block:: bash
+
+                arches-project create mynewproject
+
+        #. Finally run the `load_package` command using the projects manage.py file.
+
+            .. code-block:: bash
+
+                python manage.py packages -o load_package -s https://github.com/package/archive/branch.zip -db true
 
 
 Creating a New Package


### PR DESCRIPTION
### Description of Change
re #2335 

- Adding .gitkeep to empty package directories created by the create_package command so that git recognizes them.
- Handling for cases when a user tries to create a package from a project without having first created a database for their project.
- Added documentation for developers that are creating projects from their development arches directory.
