### PR TITLE
2342 allowable card edits

### DIFF
--- a/arches/app/media/js/views/components/datatypes/concept.js
+++ b/arches/app/media/js/views/components/datatypes/concept.js
@@ -27,7 +27,11 @@ define(['arches', 'knockout', 'viewmodels/concept-widget'], function (arches, ko
                     params.filterValue(val);
                 });
             } else {
-                this.isEditable = params.graph ? params.graph.get('is_editable') : true;
+                this.isEditable = true;
+                var cards = _.filter(params.graph.get('cards')(), function(card){return card.nodegroup_id === params.nodeGroupId()})
+                if (cards.length) {
+                    this.isEditable = cards[0].is_editable
+                }
                 this.topConcept = params.config.rdmCollection;
                 this.conceptCollections = arches.conceptCollections;
                 this.conceptCollections.unshift({

--- a/arches/app/media/js/views/components/datatypes/domain-value.js
+++ b/arches/app/media/js/views/components/datatypes/domain-value.js
@@ -20,7 +20,10 @@ define(['arches', 'knockout', 'uuid'], function (arches, ko, uuid) {
                 });
 
             } else {
-                this.isEditable = params.graph ? params.graph.get('is_editable') : true;
+                var cards = _.filter(params.graph.get('cards')(), function(card){return card.nodegroup_id === params.nodeGroupId()})
+                if (cards.length) {
+                    this.isEditable = cards[0].is_editable
+                }
                 this.options = params.config.options;
                 var setupOption = function(option) {
                     option.remove = function () {

--- a/arches/app/media/js/views/components/datatypes/resource-instance.js
+++ b/arches/app/media/js/views/components/datatypes/resource-instance.js
@@ -17,7 +17,10 @@ define([
             this.config = params.config;
             this.search = params.search;
             if (!this.search) {
-                this.isEditable = params.graph ? params.graph.get('is_editable') : true;
+                var cards = _.filter(params.graph.get('cards')(), function(card){return card.nodegroup_id === params.nodeGroupId()})
+                if (cards.length) {
+                    this.isEditable = cards[0].is_editable
+                }
             } else {
                 var filter = params.filterValue();
                 this.node = params.node;

--- a/arches/app/media/js/views/graph/card-manager.js
+++ b/arches/app/media/js/views/graph/card-manager.js
@@ -23,9 +23,7 @@ require([
         }),
         showCardLibrary: showCardLibrary,
         toggleCardLibrary: function(){
-            if (this.cardsEditable === true) {
-                showCardLibrary(!showCardLibrary());
-            };
+            showCardLibrary(!showCardLibrary());
         },
         selectedCardId: ko.observable(null)
     };
@@ -53,8 +51,6 @@ require([
         items: viewModel.availableGraphs
     });
 
-    viewModel.cardsEditable = viewModel.graphModel.get('is_editable')
-
     var alertFailure = function () {
         pageView.viewModel.alert(new AlertViewModel('ep-alert-red', arches.requestFailed.title, arches.requestFailed.text));
     };
@@ -73,7 +69,7 @@ require([
     };
 
     viewModel.deleteCard = function (card) {
-        if (this.cardsEditable === true) {
+        if (card.is_editable === true) {
             var self = this
             var node = _.find(this.graphModel.get('nodes')(), function(node) {
                 return node.nodeid === card.nodegroup_id;

--- a/arches/app/media/js/views/graph/graph-manager/node-form.js
+++ b/arches/app/media/js/views/graph/graph-manager/node-form.js
@@ -35,11 +35,15 @@ define([
                 return self.graphModel.get('isresource') && node && node.istopnode;
             });
             this.disableDatatype = ko.computed(function () {
-                var is_immutable = !self.graphModel.get('is_editable');
+                var is_immutable = false;
                 var node = self.node();
                 var isInParentGroup = false;
                 if (node) {
                     isInParentGroup = self.graphModel.isNodeInParentGroup(node);
+                    var cards = _.filter(node.graph.get('cards')(), function(card){return card.nodegroup_id === node.nodeGroupId()})
+                    if (cards.length) {
+                        is_immutable = !cards[0].is_editable
+                    }
                 }
                 return self.isResourceTopNode() || isInParentGroup || is_immutable;
             });

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -80,7 +80,7 @@ class Card(models.CardModel):
         if args:
             if isinstance(args[0], dict):
                 for key, value in args[0].iteritems():
-                    if not (key == 'cards' or key == 'widgets' or key == 'nodes'):
+                    if key not in ('cards', 'widgets', 'nodes', 'is_editable'):
                         setattr(self, key, value)
 
                 for card in args[0]["cards"]:
@@ -181,6 +181,7 @@ class Card(models.CardModel):
         ret['visible'] = self.visible
         ret['active'] = self.active
         ret['widgets'] = self.widgets
+        ret['is_editable'] = self.is_editable
         ret['ontologyproperty'] = self.ontologyproperty
 
         if self.graph and self.graph.ontology and self.graph.isresource:

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1143,6 +1143,10 @@ class Graph(models.GraphModel):
                     if 'cards' in diff[0] and 'cards' in diff[1]:
                         if len(diff[0]['cards']) > len(diff[1]['cards']):
                             res = None
+                    if 'datatype' in diff[0] and 'datatype' in diff[1]:
+                        res = None
+                    if 'config' in diff[0] and 'config' in diff[1]:
+                        res = None
             return res
 
         if self.isresource == True:

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -707,31 +707,34 @@ class Graph(models.GraphModel):
 
         """
 
-        if self.is_editable == False:
-            raise GraphValidationError(_("Your resource model: {0}, already has instances saved. You cannot delete nodes from a Resource Model with instances.".format(self.name)), 1006)
-
         if node is not None:
+
             if not isinstance(node, models.Node):
                 node = self.nodes[uuid.UUID(str(node))]
 
-            nodes = []
-            edges = []
-            nodegroups = []
+                nodes = []
+                edges = []
+                nodegroups = []
 
-            tree = self.get_tree(root=node)
-            def traverse_tree(tree):
-                nodes.append(tree['node'])
-                if tree['node'].is_collector:
-                    nodegroups.append(tree['node'].nodegroup)
-                for child in tree['children']:
-                    edges.append(child['parent_edge'])
-                    traverse_tree(child)
-            traverse_tree(tree)
+                tree = self.get_tree(root=node)
+                tiles = models.TileModel.objects.filter(nodegroup=node.nodegroup)
 
-            with transaction.atomic():
-                [nodegroup.delete() for nodegroup in nodegroups]
-                [edge.delete() for edge in edges]
-                [node.delete() for node in nodes]
+                if self.is_editable == False and len(tiles) > 0:
+                    raise GraphValidationError(_("Your resource model: {0}, already has instances saved. You cannot delete nodes from a Resource Model with instances.".format(self.name)), 1006)
+
+                def traverse_tree(tree):
+                    nodes.append(tree['node'])
+                    if tree['node'].is_collector:
+                        nodegroups.append(tree['node'].nodegroup)
+                    for child in tree['children']:
+                        edges.append(child['parent_edge'])
+                        traverse_tree(child)
+                traverse_tree(tree)
+
+                with transaction.atomic():
+                    [nodegroup.delete() for nodegroup in nodegroups]
+                    [edge.delete() for edge in edges]
+                    [node.delete() for node in nodes]
 
     def can_append(self, graphToAppend, nodeToAppendTo):
         """
@@ -1128,12 +1131,18 @@ class Graph(models.GraphModel):
 
     def check_if_resource_is_editable(self):
 
+
         def find_unpermitted_edits(obj_a, obj_b, ignore_list):
             res = None
             pre_diff = self._compare(obj_a, obj_b, ignore_list)
             diff = filter(lambda x: len(x.keys()) > 0, pre_diff)
             if len(diff) > 0:
                 res = diff
+                if len(diff) == 2:
+                    #Allowing edit if user is adding cards:
+                    if 'cards' in diff[0] and 'cards' in diff[1]:
+                        if len(diff[0]['cards']) > len(diff[1]['cards']):
+                            res = None
             return res
 
         if self.isresource == True:
@@ -1144,7 +1153,6 @@ class Graph(models.GraphModel):
                     unpermitted_node_edits = find_unpermitted_edits(db_node, self.nodes[db_node.nodeid], ['name', 'issearchable', 'ontologyclass','description'])
                     if unpermitted_node_edits != None:
                         unpermitted_edits.append(unpermitted_node_edits)
-
                 db_graph = Graph.objects.get(pk=self.graphid)
                 unpermitted_graph_edits = find_unpermitted_edits(self, db_graph, ['name','ontology_id','subtitle','iconclass','author','description','isactive'])
                 if unpermitted_graph_edits != None:

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -708,33 +708,32 @@ class Graph(models.GraphModel):
         """
 
         if node is not None:
-
             if not isinstance(node, models.Node):
                 node = self.nodes[uuid.UUID(str(node))]
 
-                nodes = []
-                edges = []
-                nodegroups = []
+            nodes = []
+            edges = []
+            nodegroups = []
 
-                tree = self.get_tree(root=node)
-                tiles = models.TileModel.objects.filter(nodegroup=node.nodegroup)
+            tree = self.get_tree(root=node)
+            tiles = models.TileModel.objects.filter(nodegroup=node.nodegroup)
 
-                if self.is_editable == False and len(tiles) > 0:
-                    raise GraphValidationError(_("Your resource model: {0}, already has instances saved. You cannot delete nodes from a Resource Model with instances.".format(self.name)), 1006)
+            if self.is_editable == False and len(tiles) > 0:
+                raise GraphValidationError(_("Your resource model: {0}, already has instances saved. You cannot delete nodes from a Resource Model with instances.".format(self.name)), 1006)
 
-                def traverse_tree(tree):
-                    nodes.append(tree['node'])
-                    if tree['node'].is_collector:
-                        nodegroups.append(tree['node'].nodegroup)
-                    for child in tree['children']:
-                        edges.append(child['parent_edge'])
-                        traverse_tree(child)
-                traverse_tree(tree)
+            def traverse_tree(tree):
+                nodes.append(tree['node'])
+                if tree['node'].is_collector:
+                    nodegroups.append(tree['node'].nodegroup)
+                for child in tree['children']:
+                    edges.append(child['parent_edge'])
+                    traverse_tree(child)
+            traverse_tree(tree)
 
-                with transaction.atomic():
-                    [nodegroup.delete() for nodegroup in nodegroups]
-                    [edge.delete() for edge in edges]
-                    [node.delete() for node in nodes]
+            with transaction.atomic():
+                [nodegroup.delete() for nodegroup in nodegroups]
+                [edge.delete() for edge in edges]
+                [node.delete() for node in nodes]
 
     def can_append(self, graphToAppend, nodeToAppendTo):
         """

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -44,6 +44,15 @@ class CardModel(models.Model):
     visible = models.BooleanField(default=True)
     sortorder = models.IntegerField(blank=True, null=True, default=None)
 
+    @property
+    def is_editable(self):
+        result = True
+        tiles = TileModel.objects.filter(nodegroup=self.nodegroup).count()
+        result = False if tiles > 0 else True
+        if settings.OVERRIDE_RESOURCE_MODEL_LOCK == True:
+            result = True
+        return result
+
     class Meta:
         managed = True
         db_table = 'cards'
@@ -330,8 +339,8 @@ class GraphModel(models.Model):
     def is_editable(self):
         result = True
         if self.isresource:
-            resource_instances = ResourceInstance.objects.filter(graph_id=self.graphid)
-            result = False if len(resource_instances) > 0 else True
+            resource_instances = ResourceInstance.objects.filter(graph_id=self.graphid).count()
+            result = False if resource_instances > 0 else True
             if settings.OVERRIDE_RESOURCE_MODEL_LOCK == True:
                 result = True
         return result

--- a/arches/app/templates/help/card-manager-help.htm
+++ b/arches/app/templates/help/card-manager-help.htm
@@ -17,5 +17,10 @@
           When a Card is added, it comes with its initial configurations, as defined in its Branch. However, you may further customize it to meet special needs for this particular Resource Model. For example, you may want to change the label of a "Name" widget to "Building Name", or modify a Card's help text. To do so, click on the Card and you will be brought to the Card Designer.
           {% endblocktrans %}
         </p>
+        <p>
+          {% blocktrans %}
+          If you would like to delete a card, simply click the Remove Card button at the bottom of the card on this page. The button will be disabled if a user has already saved resource instances using this card.
+          {% endblocktrans %}
+        </p>
     </div>
 </div>

--- a/arches/app/templates/help/graph-designer-help.htm
+++ b/arches/app/templates/help/graph-designer-help.htm
@@ -80,6 +80,7 @@
         <div class="ep-help-topic-content">
             <p>{% trans "When editing a Resource Model's graph, you will be adding entire Branch's to the top node of the graph (the one in the middle). By adding Branches (instead of individual nodes) This encourages consistency between Resource Models by allowing you to reuse a single Branch many times." %}</p>
             <p>{% blocktrans %}As shown below, you must select the top node and then use <i class="ion-ios-plus"></i> to add a Branch. Once you have added a Branch, you may fine-tune the settings of its descendant nodes if desired. Note that any changes you make here will not be applied back to the original Branch. {% endblocktrans %}</p>
+            <p>{% trans "Once data is saved to a nodegroup, nodes belonging to that nodegroup cannot be deleted" %}</p>
             <p><a href="{{ STATIC_URL }}img/help/add-graph-branch.gif" target="_blank"><img class="reloadable-img" src="{{ STATIC_URL }}img/help/add-graph-branch.gif"></img></a></p>
         </div>
     </div>
@@ -96,6 +97,7 @@
             <p>{% trans "<code>boolean</code> Use this to record a simple 'yes or no' or 'true or false' value." %}</p>
             <p>{% trans "<code>file-list</code> Allows this node to store one or mores files. Use this to upload images, documents, etc." %}</p>
             <p>{% trans "<code>semantic</code> A 'semantic' node <strong>does not store data</strong>. Semantic nodes are used where necessary to make symbolic connections between nodes, generally in order to follow ontoligical rules. Note that the top node of <em>every</em> graph is a semantic node." %}</p>
+            <p>{% trans "Once a user saves data belonging to a node, the datatype and the datatype configs <strong>cannot be modified</strong>" %}</p>
         </div>
     </div>
 </div>

--- a/arches/app/templates/views/graph/card-manager.htm
+++ b/arches/app/templates/views/graph/card-manager.htm
@@ -51,7 +51,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!-- Isotope Layout -->
             <div id="report-image-grid" class="report-image-grid">
 
-                <div class="box-vmiddle bg-primary pad-all text-center card-wz-add-record project-grid-item form-item new-card" data-bind="click: toggleCardLibrary, css: {'disabled': !cardsEditable}">
+                <div class="box-vmiddle bg-primary pad-all text-center card-wz-add-record project-grid-item form-item new-card" data-bind="click: toggleCardLibrary">
                     <a id="add-card" href="" data-toggle="modal" class="" style="">
                         <h3 class="text-thin" style="margin-top: 10px;">{% trans "Add Card" %}</h3>
 
@@ -85,7 +85,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
                         <!-- card Tools -->
                         <div class="panel-footer" style="height: 40px;">
-                            <a href="#" class="pull-right" data-bind="css: {'disabled': !$parent.cardsEditable}, click: function () { $parent.deleteCard($data) }, clickBubble: false"><i class="ion-minus-circled"></i> {% trans 'Remove Card' %}</a>
+                            <a href="#" class="pull-right" data-bind="css: {'disabled': is_editable === false }, click: function () { $parent.deleteCard($data) }, clickBubble: false"><i class="ion-minus-circled"></i> {% trans 'Remove Card' %}</a>
                         </div>
 
                     </div>


### PR DESCRIPTION
### Description of Change
re #2342. 

Relaxed resource model restrictions for models with instances by:

- allowing users to delete cards and nodegroups that do not have data saved against them
- allowing users to modify the configs of nodes that belong to nodegroups that do not have data saved against them
- allowing users to add new cards/branches
