### PR TITLE
Enable running Arches under Gunicorn production server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ ADD ./arches/install/requirements.txt ${ARCHES_ROOT}/arches/install/requirements
 ADD ./arches/install/requirements_dev.txt ${ARCHES_ROOT}/arches/install/requirements_dev.txt
 RUN	. ${WEB_ROOT}/ENV/bin/activate &&\
 	pip install -r ${ARCHES_ROOT}/arches/install/requirements.txt &&\
-	pip install -r ${ARCHES_ROOT}/arches/install/requirements_dev.txt
+	pip install -r ${ARCHES_ROOT}/arches/install/requirements_dev.txt &&\
+	pip install 'gunicorn==19.7.1'
 
 # Install the Arches application
 COPY . ${ARCHES_ROOT}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -280,7 +280,7 @@ collect_static(){
 run_django_server() {
 	echo ""
 	echo ""
-	echo "----- *** RUNNING DJANGO SERVER *** -----"
+	echo "----- *** RUNNING DJANGO DEVELOPMENT SERVER *** -----"
 	echo ""
 	cd_app_folder
 	if [[ ${DJANGO_NORELOAD} == "True" ]]; then
@@ -292,28 +292,39 @@ run_django_server() {
 }
 
 
+run_gunicorn_server() {
+	echo ""
+	echo ""
+	echo "----- *** RUNNING GUNICORN PRODUCTION SERVER *** -----"
+	echo ""
+	gunicorn arches.wsgi:application -w 2 -b :${DJANGO_PORT}
+}
+
 
 
 #### Main commands 
 run_arches() {
 
 	init_arches
-
-	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
-		set_dev_mode
-	fi
-
 	install_bower_components
 
 	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
+		set_dev_mode
 		run_migrations
-	elif [[ "${DJANGO_MODE}" == "PROD" ]]; then
-		collect_static
 	fi
 
 	run_custom_scripts
 
-	run_django_server
+	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
+		run_django_server
+	elif [[ "${DJANGO_MODE}" == "PROD" ]]; then
+		collect_static
+		run_gunicorn_server
+	fi
+
+	
+
+	
 }
 
 


### PR DESCRIPTION
### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This PR enables the user to run our Arches Docker image in production mode using Gunicorn.

Add Gunicorn package. 
Run gunicorn when MODE=DEV, re #2569

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Before Arches container always ran the development server. Not safe for production.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
