### PR TITLE
Add ability to export multiple graphs at once re #1361

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/exporter.py
+++ b/arches/app/utils/data_management/resource_graphs/exporter.py
@@ -90,7 +90,7 @@ def get_graphs_for_export(graphids=None):
     graphs['graph'] = []
     if graphids == None or graphids[0] == 'all' or graphids == ['']:
         resource_graph_query = JSONSerializer().serializeToPython(Graph.objects.all().exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID))
-    elif graphids[0] == 'resources':
+    elif graphids[0] == 'resource_models':
         resource_graph_query = JSONSerializer().serializeToPython(Graph.objects.filter(isresource=True).exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID))
     elif graphids[0] == 'branches':
         resource_graph_query = JSONSerializer().serializeToPython(Graph.objects.filter(isresource=False).exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID))


### PR DESCRIPTION
Add ability to export multiple graphs at once

`python manage.py packages -o export_graphs -d /path/to/destination/directory -g graphid, 'branches', 'resource_models', 'all'`

### Issues Solved
#1361 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)