### PR TITLE
Asterisks scroll with page movement inside wrapper - issue #2576

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5863,6 +5863,7 @@ div.row.widget-wrapper {
     margin: 0;
     margin-right: 10px;
     padding: 5px 5px 15px 5px;
+    position: relative;
 }
 
 .input-group .form-control {


### PR DESCRIPTION
### Description of Change
Added position: relative to the widget-wrapper class, as the asterisk widget for required fields has position: absolute, which was causing it to have a fixed position on the page.

### Issues Solved
#2576 

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
2 Unit tests fail, but they failed before I had made any changes. Unsure if this is to do with issues with my local system, but it's doubtful that this change would be enough to cause those tests to fail.
