### PR TITLE
2458 project summaries

### DIFF
--- a/arches/app/media/js/models/project.js
+++ b/arches/app/media/js/models/project.js
@@ -10,6 +10,9 @@ define([
         initialize: function(options) {
             var self = this;
             self.identities = options.identities || [];
+            if (this.identities.items().length) {
+                this.identities.items()[0].selected(true)
+            }
             self._project = ko.observable('{}');
             self.name = ko.observable('');
             self.active = ko.observable(false);
@@ -169,6 +172,7 @@ define([
 
         update: function() {
             this.identities.clearSelection();
+            this.identities.items()[0].selected(true)
             var groups = ko.unwrap(this.groups)
             var users = ko.unwrap(this.users)
             _.each(this.identities.items(), function(item) {

--- a/arches/app/templates/views/project-manager.htm
+++ b/arches/app/templates/views/project-manager.htm
@@ -283,7 +283,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                                                 <input class="form-control input-lg" placeholder="find a user..." type="text" data-bind="value: selectedProject().userFilter, valueUpdate: 'keyup'">
                                                                             </div>
                                                                         </div>
-                                                                        <!--/ko-->
 
                                                                         <!-- ko foreach: selectedProject().filteredUsers() -->
                                                                             <a href="#" class="list-group-item get-user-detail">
@@ -298,6 +297,23 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                                                 <p class="mpm-user-subtitle">Activity: 13x edits<span class="pull-right" data-bind="text:$data.last_login"></span></p>
                                                                             </a>
                                                                         <!-- /ko -->
+                                                                        <!--/ko-->
+
+                                                                        <!--ko if: selectedProject().identities.selected().type === 'user' -->
+                                                                        <!-- ko foreach: selectedProject().identities.groupUsers() -->
+                                                                            <a href="#" class="list-group-item get-user-detail">
+                                                                                <h4 class="mpm-user-name" data-bind='text: $data.username'></h4>
+                                                                                <!--ko if: $data.groups-->
+                                                                                    <!--ko if: _.intersection($root.selectedProject().groups(), $data.groups).length > 0 || _.contains($root.selectedProject().users(), $data.id)-->
+                                                                                    <div>
+                                                                                        <span>{% trans 'Approved' %}</span>
+                                                                                    </div>
+                                                                                    <!--/ko-->
+                                                                                <!--/ko-->
+                                                                                <p class="mpm-user-subtitle">Activity: 13x edits<span class="pull-right" data-bind="text:$data.last_login"></span></p>
+                                                                            </a>
+                                                                        <!-- /ko -->
+                                                                        <!--/ko-->
 
                                                                     </div>
 

--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
+from datetime import datetime
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User, Group
 import django.contrib.auth.password_validation as validation
@@ -94,5 +95,5 @@ class GroupUsers(View):
             users = User.objects.filter(id=identity_id)
 
         if len(users) > 0:
-            res = [{'id': user.id, 'first_name': user.first_name, 'last_name': user.last_name, 'email': user.email, 'last_login': user.last_login, 'username': user.username, 'groups': [group.id for group in user.groups.all()] } for user in users]
+            res = [{'id': user.id, 'first_name': user.first_name, 'last_name': user.last_name, 'email': user.email, 'last_login': datetime.strftime(user.last_login, '%Y-%m-%d %H:%M'), 'username': user.username, 'groups': [group.id for group in user.groups.all()] } for user in users]
         return JSONResponse(res)


### PR DESCRIPTION
### Description of Change

Formatting improvements to the project manager people tab, re #2581

Within the project manager's people tab: 

1. Fixes date formatting in the group user list
2. Automatically loads the first identity when loading the project manager
3. Uses the unfiltered user list when selecting a user from the identity list (left panel) rather than a group.