### PR TITLE
add new management command that finds a uuid in your db

### DIFF
--- a/arches/management/commands/whatisthis.py
+++ b/arches/management/commands/whatisthis.py
@@ -1,22 +1,17 @@
 from django.core import management
 from django.core.management.base import BaseCommand, CommandError
-# 
 import django.apps
-# import psycopg2
-import arches
-import json
 import uuid
-import time
 
 class Command(BaseCommand):
 
-    help = 'finds a uuid throughout your database and prints info from postgres'
+    help = 'finds any arches objects whose primary key is the input uuid and'\
+        'returns these objects in the form of a list.'
 
     def add_arguments(self, parser):
         parser.add_argument("uuid",help='input the uuid string to find')
 
     def handle(self, *args, **options):
-
         self.find_uuid(options['uuid'])
 
     def find_uuid(self,in_uuid):
@@ -24,32 +19,36 @@ class Command(BaseCommand):
         ## check for valid uuid input
         try:
             val = uuid.UUID(in_uuid, version=4)
-        except:
-            print "  -- this is not a vali uuid"
+        except ValueError:
+            print("  -- this is not a valid uuid")
             return False
-        
-        # start1 = time.time()
-        
+
         ## search all models and see if the UUID matches an existing object
-        neo = False
+        objs = []
         for m in django.apps.apps.get_models():
-            if m._meta.pk.get_internal_type() == "UUIDField":
-                ob = m.objects.filter(pk=in_uuid)
-                if len(ob) == 1:
-                    neo = ob[0]
-                    break
-        
+            if not m.__module__.startswith('arches'):
+                continue
+            if m._meta.pk.get_internal_type() != "UUIDField":
+                continue
+            ob = m.objects.filter(pk=in_uuid)
+            objs+=ob
+
         ## return False if nothing was found
-        if not neo:
-            print "  -- this uuid doesn't match any objects in your database"
+        if not objs:
+            print("  -- this uuid doesn't match any objects in your database")
             return False
         
-        print "this is a", neo
-        
-        for k,v in vars(neo).iteritems():
-            print k
-            print " ",v
-        
-        # print round(time.time()-start1,2)
-        
-        return neo
+        ## print summary of found objects
+        print(80*"=")
+        print("This UUID is the primary key for {} object{}:".format(
+            len(objs),"s" if len(objs) > 1 else ""))
+        for o in objs:
+            print(80*"-")
+            print(o)
+            keys = vars(o).keys()
+            keys.sort()
+            for k in keys:
+                print(k)
+                print("  {}".format(vars(o)[k]))
+        print(80*"=")
+        return objs

--- a/arches/management/commands/whatisthis.py
+++ b/arches/management/commands/whatisthis.py
@@ -1,0 +1,81 @@
+from django.core import management
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+import psycopg2
+import json
+import uuid
+
+class Command(BaseCommand):
+
+    help = 'finds a uuid throughout your database and prints info from postgres'
+
+    def add_arguments(self, parser):
+        parser.add_argument("uuid",help='input the uuid string to find')
+
+    def handle(self, *args, **options):
+
+        self.find_uuid(options['uuid'])
+
+    def find_uuid(self,in_uuid):
+    
+        ## check for valid uuid input
+        try:
+            val = uuid.UUID(in_uuid, version=4)
+        except:
+            print "  -- invalid uuid"
+            return
+    
+        db = settings.DATABASES['default']
+        db_conn = "dbname = {} user = {} host = {} password = {}".format(
+            db['NAME'],db['USER'],db['HOST'],db['PASSWORD'])
+        conn = psycopg2.connect(db_conn)
+        cur = conn.cursor()
+        
+        sql = '''
+        SELECT tc.table_name, kc.column_name
+            FROM  
+                information_schema.table_constraints tc,  
+                information_schema.key_column_usage kc,
+                information_schema.columns c
+            WHERE 
+                kc.table_name = tc.table_name and kc.table_schema = tc.table_schema
+                AND kc.constraint_name = tc.constraint_name
+                AND kc.table_name = c.table_name and kc.table_schema = c.table_schema
+                AND c.data_type = 'uuid'
+                AND tc.constraint_type = 'PRIMARY KEY' 
+            GROUP BY tc.table_name, kc.column_name
+            ORDER BY table_name;
+        '''
+        
+        cur.execute(sql)
+        result = cur.fetchall()
+       
+        match = False
+        for table,column in result:
+            sql = '''SELECT * FROM {} WHERE {} = '{}';'''.format(table,column,in_uuid)
+            cur.execute(sql)
+            result = cur.fetchall()
+            if len(result) > 0:
+                sql2 = '''
+                    SELECT COLUMN_NAME
+                        FROM INFORMATION_SCHEMA.COLUMNS
+                        WHERE TABLE_NAME='{}';
+                    '''.format(table)
+                cur.execute(sql2)
+                col_names = cur.fetchall()
+                match = True
+                break
+        
+        if not match:
+            print "  -- this uuid could not be found in your database"
+            return
+        
+        info = {}
+        info['table name']=table
+        for i, col in enumerate(col_names):
+            info[col[0]] = str(result[0][i])
+        
+        print json.dumps(info, indent=2)
+        
+        return info
+        


### PR DESCRIPTION
UPDATE: please check comments below.

This management command will take a given uuid and return information about what that uuid refers to in your database. At present, all it does is return the name of the table that the uuid can be found in, and the contents of the corresponding row. It would be great to instantiate an actual object and return its properties as well, but that would be a lot more work, as I didn't see any standard way of linking a django model with an arches model.

This command could become the basis of a new view/url in the future as well, which would return a json response and/or help create a top-level utility which would take in any uuid and return the corresponding arches object.

Thanks @adamlodge for the kernal of sql to get this going.

##### USAGE

input:
`python manage.py whatisthis b7112550-43d3-4f44-bdf4-2f50f2f81433`

output:

    {
      "createdtime": "2017-10-26 15:55:26.894000-05:00",
      "graphid": "c67216bf-8cc2-11e7-883c-06ed184dc22c",
      "resourceinstanceid": "b7112550-43d3-4f44-bdf4-2f50f2f81433",
      "legacyid": "b7112550-43d3-4f44-bdf4-2f50f2f81433",
      "table name": "resource_instances"
    }

input:
`python manage.py whatisthis ad342550-43d3-4f44-bdf4-2f50f2f81433`

output:

    -- this uuid could not be found in your database

input:
`python manage.py whatisthis b7112550-43`

output:

    -- invalid uuid
