### PR TITLE
Set workdir for `setup_db`, change when run_migrations is called

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -64,12 +64,13 @@ init_arches() {
 		setup_arches
 	fi
 
-	init_arches_projects
+	init_arches_project
 }
 
 
+# Setup Postgresql and Elasticsearch
 setup_arches() {
-	# Setup Postgresql and Elasticsearch (this deletes your existing database)
+	cd_arches_root
 
 	echo "" && echo ""
 	echo "*** Initializing database ***"
@@ -113,6 +114,7 @@ setup_arches() {
 		fi
 	fi
 
+	run_migrations
 }
 
 
@@ -152,6 +154,7 @@ set_dev_mode() {
 	echo ""
 	echo "----- SETTING DEV MODE -----"
 	echo ""
+	cd_arches_root
 	python ${ARCHES_ROOT}/setup.py develop
 }
 
@@ -171,7 +174,7 @@ install_bower_components() {
 
 #### Misc
 
-init_arches_projects() {
+init_arches_project() {
 	if [[ ! -z ${ARCHES_PROJECT} ]]; then
 		echo "Checking if Arches project "${ARCHES_PROJECT}" exists..."
 		if [[ ! -d ${APP_FOLDER} ]] || [[ ! "$(ls -A ${APP_FOLDER})" ]]; then
@@ -310,13 +313,12 @@ run_gunicorn_server() {
 
 #### Main commands 
 run_arches() {
-
+	
 	init_arches
 	install_bower_components
 
 	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
 		set_dev_mode
-		run_migrations
 	fi
 
 	run_custom_scripts
@@ -326,11 +328,7 @@ run_arches() {
 	elif [[ "${DJANGO_MODE}" == "PROD" ]]; then
 		collect_static
 		run_gunicorn_server
-	fi
-
-	
-
-	
+	fi	
 }
 
 


### PR DESCRIPTION
Set workdir to arches root before running `setup_db` AND `set_dev_mode`. 
Move run_migrations to `setup_arches` command, re #2646

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Workdir was not set in entrypoint.sh (Docker) before running setup_db.
When the workdir is changed, e.g. by a custom arches project, then setup_db is run from the wrong folder, leading to unpredictable behavior (e.g. django migration order gets messed up).

Additionally, Django migrations were being run on every startup (when MODE=DEV). Changed this to run only once by incorporating the `run_migrations` command in the `setup_arches` command.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
