### PR TITLE
2225 remove sub card terminology

### DIFF
--- a/arches/app/templates/help/graph-designer-help.htm
+++ b/arches/app/templates/help/graph-designer-help.htm
@@ -57,7 +57,7 @@
                       <strong>Searchable</strong> - If true users will be able to search on this node's value.<br>
                       <strong>Required</strong> - If true a value must be entered for this node in order to save its tile. <em>Important:</em> Once data is collected for this node, this setting cannot be changed<br>
                       <strong>Data type</strong> - Choose what type of data will be collected in this node. See below for more information.<br>
-                      <strong>Make Make parent into Card Container</strong> This setting defines data collection grouping for this node. Read more about what this means in the Cards documentation.
+                      <strong>Make parent into Card Container</strong> - This setting defines data collection grouping for this node. Read more about what this means in the Cards documentation.
                     {% endblocktrans %}
                 </p>
             </div>

--- a/arches/app/templates/help/graph-designer-help.htm
+++ b/arches/app/templates/help/graph-designer-help.htm
@@ -57,7 +57,7 @@
                       <strong>Searchable</strong> - If true users will be able to search on this node's value.<br>
                       <strong>Required</strong> - If true a value must be entered for this node in order to save its tile. <em>Important:</em> Once data is collected for this node, this setting cannot be changed<br>
                       <strong>Data type</strong> - Choose what type of data will be collected in this node. See below for more information.<br>
-                      <strong>Make Sub-Card</strong> - NEEDS TO BE UPDATED - when the card collection/card terminology is fully implemented. -----OLD This setting defines data collection grouping for this node. Read more about what this means in the Cards documentation.
+                      <strong>Make Make parent into Card Container</strong> This setting defines data collection grouping for this node. Read more about what this means in the Cards documentation.
                     {% endblocktrans %}
                 </p>
             </div>

--- a/arches/app/templates/views/graph/graph-manager/node-form.htm
+++ b/arches/app/templates/views/graph/graph-manager/node-form.htm
@@ -139,7 +139,7 @@
                 <span class="switch switch-small arches-switch" data-bind="css: {'on': node().isCollector()}, click: toggleIsCollector"><small></small></span>
 
                 <p class="control-label" style="margin-left: 40px; margin-top: -17px; margin-bottom: 0px;">
-                    <span data-bind="text: (node().nodeGroupId() && !node().isCollector() || graphModel.isNodeInChildGroup(node())) ? '{% trans "Make sub-card" %}' : '{% trans "Make card" %}'"></span>
+                    <span data-bind="text: (node().nodeGroupId() && !node().isCollector() || graphModel.isNodeInChildGroup(node())) ? '{% trans "Make Make parent into Card Container" %}' : '{% trans "Make card" %}'"></span>
                 </p>
                 <span style="margin-left: 40px; display: inline-block; color: #8ba2b9; font-size: 10px;">
                     <!-- ko if: node().istopnode -->

--- a/arches/app/templates/views/graph/graph-manager/node-form.htm
+++ b/arches/app/templates/views/graph/graph-manager/node-form.htm
@@ -139,7 +139,7 @@
                 <span class="switch switch-small arches-switch" data-bind="css: {'on': node().isCollector()}, click: toggleIsCollector"><small></small></span>
 
                 <p class="control-label" style="margin-left: 40px; margin-top: -17px; margin-bottom: 0px;">
-                    <span data-bind="text: (node().nodeGroupId() && !node().isCollector() || graphModel.isNodeInChildGroup(node())) ? '{% trans "Make Make parent into Card Container" %}' : '{% trans "Make card" %}'"></span>
+                    <span data-bind="text: (node().nodeGroupId() && !node().isCollector() || graphModel.isNodeInChildGroup(node())) ? '{% trans "Make parent into Card Container" %}' : '{% trans "Make card" %}'"></span>
                 </p>
                 <span style="margin-left: 40px; display: inline-block; color: #8ba2b9; font-size: 10px;">
                     <!-- ko if: node().istopnode -->


### PR DESCRIPTION
### Description of Change
Change the terminology of "card" and "sub-card" into "card container" and "card" 

### Issues Solved
#2225 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
The screenshot in the help section for Graph Manager - Graph Designer Overview still contains the old terminology of "Sub-Card" and needs to be updated.
