### PR TITLE
#2666 add error message for invalid preflabels in a concept-list

### DIFF
--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -62,12 +62,17 @@ class ConceptDataType(BaseConceptDataType):
 
     def validate(self, value, source=''):
         errors = []
+        
+        ## first check to see if the validator has been passed a valid UUID,
+        ## which should be the case at this point. return error if not.
         try:
             uuid.UUID(value)
         except ValueError:
             message = "This is an invalid concept prefLabel, or an incomplete UUID"
             errors.append({'type': 'ERROR', 'message': 'datatype: {0} value: {1} {2} - {3}. {4}'.format(self.datatype_model.datatype, value, source, message, 'This data was not imported.')})
             return errors
+            
+        ## if good UUID, test whether it corresponds to an actual Value object
         try:
             models.Value.objects.get(pk=value)
         except ObjectDoesNotExist:
@@ -110,6 +115,8 @@ class ConceptDataType(BaseConceptDataType):
 class ConceptListDataType(BaseConceptDataType):
     def validate(self, value, source=''):
         errors = []
+        
+        ## iterate list of values and use the concept validation on each one
         validate_concept = ConceptDataType().validate
         for v in value:
             val = v.strip()

--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -107,9 +107,15 @@ class ConceptListDataType(BaseConceptDataType):
         for v in value:
             val = v.strip()
             try:
+                uuid.UUID(val)
+            except ValueError:
+                message = "This is an invalid concept prefLabel, or an incomplete UUID"
+                errors.append({'type': 'ERROR', 'message': 'datatype: {0} value: {1} {2} - {3}. {4}'.format(self.datatype_model.datatype, val, source, message, 'This data was not imported.')})
+                continue
+            try:
                 models.Value.objects.get(pk=val)
             except ObjectDoesNotExist:
-                message = "Not a valid domain value"
+                message = "This UUID does not correspond to a valid domain value"
                 errors.append({'type': 'ERROR', 'message': 'datatype: {0} value: {1} {2} - {3}. {4}'.format(self.datatype_model.datatype, val, source, message, 'This data was not imported.')})
         return errors
 


### PR DESCRIPTION
### Description of Change
This is a small addition to the error handling that happens during upload, specifically with regard to label-based concepts and concept-lists. A new error message has been added to indicate that a bad prefLabel has been provided, in order to distinguish this scenario from a situation in which an incorrect UUID has been provided.

### Issues Solved
This is a not a far-reaching fix, but serves to address issue #2666 

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
Much more could be done to unify the error messages and validation functions that occur during upload. This is just a targeted fix for a recorded issue.
