### PR TITLE
fixes raw unicode string in ontology prefixes for non-CRM ontologies.

### DIFF
--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -58,7 +58,7 @@ def get_ontology_namespaces():
         g.parse(ontology.path.path)
     for namespace in g.namespaces():
         if str(namespace[1]) not in ontology_namespaces:
-            ontology_namespaces[str(namespace[1])] = namespace[0]
+            ontology_namespaces[str(namespace[1])] = str(namespace[0])
     return ontology_namespaces
 
 


### PR DESCRIPTION
Fixes #2744

<!--- Provide a general summary of the Pull Request in the Title above -->
<!--- You can erase any part of this template that is not applicable to your Issue. -->

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Wraps the ontology prefixes in a `str()` function to avoid raw Python unicode strings, which cannot be parsed a JavaScript parser.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Fixes #2744 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
