### PR TITLE
Added the disabled attribute to the number input. re #2697

### DIFF
--- a/arches/app/templates/views/components/widgets/number.htm
+++ b/arches/app/templates/views/components/widgets/number.htm
@@ -9,7 +9,7 @@
         <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>
         <!-- /ko -->
         <div class="col-xs-12">
-            <input type="number" data-bind="value: value, attr: {placeholder: placeholder, max: max, min: min}, style: {width: width}" class="form-control input-lg widget-input">
+            <input type="number" data-bind="value: value, attr: {placeholder: placeholder, max: max, min: min, disabled: disabled}, style: {width: width}" class="form-control input-lg widget-input">
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Description of Change
Adds the disabled attribute to the number widget setting the input as disabled if a user does not have write permissions for the widget's nodegroup. re #2697