### PR TITLE
Add min-height to flex class to allow scrollbars in firefox #1989

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -2724,6 +2724,7 @@ ul .collapse li:last-of-type {
     -ms-flex: 1;
     -webkit-flex: 1;
     flex: 1;
+    min-height: 0;
 }
 
 .content-panel {


### PR DESCRIPTION
### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Adding a minimum height into the css of a flex box bypasses a bug in firefox that causes it to not create custom scrollbars.

### Issues Solved
#1989 

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
