### PR TITLE
Allows displaynames to safely load in the resource editor.

### DIFF
--- a/arches/app/templates/views/resource/editor.htm
+++ b/arches/app/templates/views/resource/editor.htm
@@ -63,7 +63,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             resourceid: '{{resourceid}}',
             graph: {{graph_json}},
             relationship_types: {{ relationship_types }},
-            displayName: '{{ displayname }}'
+            displayName: '{{ displayname | escapejs }}'
         };
     });
     define('search-data', [], function() {


### PR DESCRIPTION
Fixes issues with special characters in a displayname that would prevent displaynames passed to the browser as JSON to be invalid.