### PR TITLE
Hides card's save/edit buttons when a card is disabled. 

### DIFF
--- a/arches/app/templates/views/graph/card-configuration/card-form-preview.htm
+++ b/arches/app/templates/views/graph/card-configuration/card-form-preview.htm
@@ -77,9 +77,12 @@
                                         </form>
 
                                         <!-- Save/Add Button -->
+
+                                        <!-- ko if: !card.get('disabled') -->
                                         <div id="card-save-tile-btn" class="install-buttons" data-bind="visible: card.get('cardinality')() === 'n'" style="display: none;">
                                             <button id="" class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" disabled>{% trans "Add" %}</button>
                                         </div>
+                                        <!-- /ko -->
                                     </div>
                                 </div>
                             </div>

--- a/arches/app/templates/views/resource/editor/form.htm
+++ b/arches/app/templates/views/resource/editor/form.htm
@@ -144,8 +144,8 @@
                                         <!-- ko if: innerTile.dirty() && !forceBlank -->
                                         <!--ko if: !card.get('disabled') -->
                                         <div class="install-buttons" data-bind="css: { 'expanded-buttons': innerTile.expanded() }">
-                                            <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile, innerTile)">{% trans "Cancel--" %}</button>
-                                            <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-refresh" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans "Save++" %}</button>
+                                            <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile, innerTile)">{% trans "Cancel" %}</button>
+                                            <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-refresh" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans "Save" %}</button>
                                         </div>
                                         <!-- /ko -->
                                         <!-- /ko -->

--- a/arches/app/templates/views/resource/editor/form.htm
+++ b/arches/app/templates/views/resource/editor/form.htm
@@ -142,10 +142,12 @@
 
                                         <!-- Save/Add Button -->
                                         <!-- ko if: innerTile.dirty() && !forceBlank -->
+                                        <!--ko if: !card.get('disabled') -->
                                         <div class="install-buttons" data-bind="css: { 'expanded-buttons': innerTile.expanded() }">
-                                            <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile, innerTile)">{% trans "Cancel" %}</button>
-                                            <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-refresh" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans "Save" %}</button>
+                                            <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile, innerTile)">{% trans "Cancel--" %}</button>
+                                            <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-refresh" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans "Save++" %}</button>
                                         </div>
+                                        <!-- /ko -->
                                         <!-- /ko -->
 
                                     </div>
@@ -205,23 +207,22 @@
 
                                         <!-- Save/Add Buttons -->
                                         <!-- ko if: tile.dirty -->
+                                        <!--ko if: !card.get('disabled') -->
                                             <!-- ko if: forceBlank -->
                                             <div class="install-buttons" data-bind="visible: card.get('cardinality')() === 'n', css: { 'expanded-buttons': tile.expanded() }" style="display: none;">
                                                 <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile)">{% trans "Cancel" %}</button>
                                                 <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans 'Add' %}</button>
                                             </div>
-                                            <!-- ko if: card.get('cardinality')() === '1' ? parentTile.dirty(true): null -->
-                                            <!-- /ko -->
+                                            <!-- ko if: card.get('cardinality')() === '1' ? parentTile.dirty(true): null --><!-- /ko -->
                                             <!-- /ko -->
 
                                             <!-- ko if: !forceBlank -->
-                                            <!--ko if: !card.get('disabled') -->
                                             <div class="install-buttons" data-bind="css: { 'expanded-buttons': tile.expanded() }">
                                                 <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile)">{% trans "Cancel" %}</button>
                                                 <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans "Save" %}</button>
                                             </div>
                                             <!-- /ko -->
-                                            <!-- /ko -->
+                                        <!-- /ko -->
                                         <!-- /ko -->
 
                                         <!-- ko if: !tile.dirty() -->

--- a/arches/app/templates/views/resource/editor/form.htm
+++ b/arches/app/templates/views/resource/editor/form.htm
@@ -215,10 +215,12 @@
                                             <!-- /ko -->
 
                                             <!-- ko if: !forceBlank -->
+                                            <!--ko if: !card.get('disabled') -->
                                             <div class="install-buttons" data-bind="css: { 'expanded-buttons': tile.expanded() }">
                                                 <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: form.cancelEdit.bind(form, parentTile)">{% trans "Cancel" %}</button>
                                                 <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: form.saveTile.bind(form, parentTile, cardinality)">{% trans "Save" %}</button>
                                             </div>
+                                            <!-- /ko -->
                                             <!-- /ko -->
                                         <!-- /ko -->
 


### PR DESCRIPTION
### Description of Change
Hides card's save/edit buttons when a card is disabled.  This prevents the save button from appearing when a widget has a default value.  #2710
