### PR TITLE
Number widget formatting configs

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -111,6 +111,13 @@ class NumberDataType(BaseDataType):
     def transform_import_values(self, value, nodeid):
         return float(value)
 
+    def convert_value(self, tile, nodeid):
+        try:
+            tile.data[nodeid].upper()
+            tile.data[nodeid] = float(tile.data[nodeid])
+        except:
+            pass
+
     def append_to_document(self, document, nodevalue, nodeid, tile):
         document['numbers'].append({'number': nodevalue, 'nodegroup_id': tile.nodegroup_id})
 

--- a/arches/app/media/js/views/components/widgets/number.js
+++ b/arches/app/media/js/views/components/widgets/number.js
@@ -10,14 +10,26 @@ define(['knockout', 'underscore', 'viewmodels/widget'], function (ko, _, WidgetV
     */
     return ko.components.register('number-widget', {
         viewModel: function(params) {
-            params.configKeys = ['placeholder', 'width', 'min', 'max', 'defaultValue'];
+            params.configKeys = ['placeholder', 'width', 'min', 'max', 'step', 'precision', 'prefix', 'suffix', 'defaultValue'];
 
             WidgetViewModel.apply(this, [params]);
+
             var self = this;
-            if (ko.isObservable(this.value)) {
-                this.value.subscribe(function(val){
-                    if (self.value()){
-                        self.value(Number(val))
+
+            updateVal = ko.computed(function(){
+                if (self.value()){
+                    var val = self.value();
+                    if (self.precision()) {
+                        val = Number(val).toFixed(self.precision())
+                    }
+                    self.value(Number(val));
+                }
+            }, self).extend({ throttle: 600 });
+
+            if (ko.isObservable(this.precision)) {
+                this.precision.subscribe(function(val){
+                    if (self.value() && val){
+                        self.value(Number(self.value()).toFixed(val))
                     }
                 }, self);
             };

--- a/arches/app/models/migrations/2591_formatted_numbers.py
+++ b/arches/app/models/migrations/2591_formatted_numbers.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+from django.db import migrations, models
+from django.core import management
+
+class Migration(migrations.Migration):
+
+  dependencies = [
+      ('models', '2626_mobilesurveymodel_datadownload'),
+  ]
+
+  operations = [
+          migrations.RunSQL("""
+              update widgets set defaultconfig = '{"max":"","defaultValue":"","placeholder":"Enter number","width":"100%","min":"", "step":"", "precision":"", "prefix":"", "suffix":""}'  where name = 'number-widget';
+
+              update cards_x_nodes_x_widgets
+                    set config = (SELECT config || jsonb_build_object('step', '') FROM widgets WHERE name = 'number-widget')
+                    WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+              update cards_x_nodes_x_widgets
+                    set config = (SELECT config || jsonb_build_object('precision', '') FROM widgets WHERE name = 'number-widget')
+                    WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+              update cards_x_nodes_x_widgets
+                    set config = (SELECT config || jsonb_build_object('prefix', '') FROM widgets WHERE name = 'number-widget')
+                    WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+              update cards_x_nodes_x_widgets
+                    set config = (SELECT config || jsonb_build_object('suffix', '') FROM widgets WHERE name = 'number-widget')
+                    WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+              """,
+              """
+                  update widgets set defaultconfig = defaultconfig - 'step' WHERE name = 'number-widget';
+                  update widgets set defaultconfig = defaultconfig - 'precision' WHERE name = 'number-widget';
+                  update widgets set defaultconfig = defaultconfig - 'prefix' WHERE name = 'number-widget';
+                  update widgets set defaultconfig = defaultconfig - 'suffix' WHERE name = 'number-widget';
+                  update cards_x_nodes_x_widgets set config = config - 'step' WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+                  update cards_x_nodes_x_widgets set config = config - 'precision' WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+                  update cards_x_nodes_x_widgets set config = config - 'prefix' WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+                  update cards_x_nodes_x_widgets set config = config - 'suffix' WHERE widgetid in (SELECT widgetid FROM widgets WHERE name = 'number-widget');
+              """),
+  ]

--- a/arches/app/templates/views/components/widgets/number.htm
+++ b/arches/app/templates/views/components/widgets/number.htm
@@ -9,7 +9,15 @@
         <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>
         <!-- /ko -->
         <div class="col-xs-12">
-            <input type="number" data-bind="value: value, attr: {placeholder: placeholder, max: max, min: min, disabled: disabled}, style: {width: width}" class="form-control input-lg widget-input">
+            <div class="input-group" data-bind="style: {width: width}">
+            <!-- ko if: prefix -->
+            <span class="input-group-addon" data-bind="text: prefix"></span>
+            <!-- /ko -->
+            <input type="number" data-bind="value: value, attr: {placeholder: placeholder, max: max, min: min, step: step, disabled: disabled}, style: {width: width}, valueUpdate: 'keyup'" class="form-control input-lg widget-input">
+            <!-- ko if: suffix -->
+            <span class="input-group-addon" data-bind="text: suffix"></span>
+            <!-- /ko -->
+            </div>
         </div>
     </div>
 </div>
@@ -33,6 +41,30 @@
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
     <input type="number" placeholder="{% trans "Max" %}" id="" class="form-control input-md widget-input" data-bind="value: max, valueUpdate: 'keyup'">
+</div>
+<div class="control-label">
+    {% trans "Increment" %}
+</div>
+<div class="col-xs-12 pad-no crud-widget-container">
+    <input type="number" placeholder="{% trans "Increment size" %}" id="" class="form-control input-md widget-input" data-bind="value: step, valueUpdate: 'keyup'">
+</div>
+<div class="control-label">
+    {% trans "Decimal Places" %}
+</div>
+<div class="col-xs-12 pad-no crud-widget-container">
+    <input type="number" placeholder="{% trans "Number of decimal places" %}" id="" class="form-control input-md widget-input" data-bind="value: precision, valueUpdate: 'keyup'">
+</div>
+<div class="control-label">
+    {% trans "Prefix" %}
+</div>
+<div class="col-xs-12 pad-no crud-widget-container">
+    <input type="" placeholder="{% trans "Field prefix" %}" id="" class="form-control input-md widget-input" data-bind="value: prefix, valueUpdate: 'keyup'">
+</div>
+<div class="control-label">
+    {% trans "Suffix" %}
+</div>
+<div class="col-xs-12 pad-no crud-widget-container">
+    <input type="" placeholder="{% trans "Field suffix" %}" id="" class="form-control input-md widget-input" data-bind="value: suffix, valueUpdate: 'keyup'">
 </div>
 <div class="control-label">
     {% trans "Default Value" %}


### PR DESCRIPTION
Adds configs to the number widget allowing a graph editor to define units (as a prefix or suffix), specify the increment, and set the max number of values behind the decimal place. re #2591