### PR TITLE
Sets the index prefix to the project name when creating a new project

### DIFF
--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -26,6 +26,9 @@ SECRET_KEY = '{{ secret_key }}'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# a prefix to append to all elasticsearch indexes, note: must be lower case
+ELASTICSEARCH_PREFIX = '{{ project_name }}'
+
 DATABASES = {
     "default": {
         "ATOMIC_REQUESTS": False,

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -128,7 +128,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         print 'operation: '+ options['operation']
         package_name = settings.PACKAGE_NAME
-        print 'package: '+ package_name
 
         if options['operation'] == 'setup':
             self.setup(package_name, es_install_location=options['dest_dir'])


### PR DESCRIPTION
### Description of Change
Sets the index prefix to the project name when creating a new project. re #2812