### PR TITLE
2698 disable map widget

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -6701,6 +6701,15 @@ a .csv-chart-menubar-item {
     line-height: 1.5;
 }
 
+.map-disabled {
+    background-color: black;
+    height: 500px;
+    opacity: 0.2;
+    margin-bottom: -500px;
+    position: relative;
+    z-index: 100;
+}
+
 .map-widget-container a {
     color: #fff;
 }

--- a/arches/app/media/js/viewmodels/widget.js
+++ b/arches/app/media/js/viewmodels/widget.js
@@ -75,16 +75,18 @@ define(['knockout', 'underscore', 'uuid'], function (ko, _, uuid) {
             }
 
             if (!self.form) {
-                self.value.subscribe(function(val){
-                    if (self.defaultValue() != val) {
-                        self.defaultValue(val)
-                    };
-                });
-                self.defaultValue.subscribe(function(val){
-                    if (self.value() != val) {
-                        self.value(val)
-                    };
-                });
+                if (ko.isObservable(self.value)) {
+                    self.value.subscribe(function(val){
+                        if (self.defaultValue() != val) {
+                            self.defaultValue(val)
+                        };
+                    });
+                    self.defaultValue.subscribe(function(val){
+                        if (self.value() != val) {
+                            self.value(val)
+                        };
+                    });
+                }
             };
         };
     };

--- a/arches/app/templates/views/components/widgets/map.htm
+++ b/arches/app/templates/views/components/widgets/map.htm
@@ -12,7 +12,7 @@
         <img data-bind="attr: {src: mapImage() }">
     </div>
     <!-- /ko -->
-
+    <div data-bind="css:{'map-disabled': disabled}"></div>
     <div class="relative" data-bind="mapboxgl: {
         mapOptions: {
             style: mapStyle,
@@ -130,7 +130,7 @@
 
 
                         <!--ko ifnot: featureEditingDisabled -->
-
+                        <!--ko ifnot: disabled -->
                         <div class="leaflet-draw-section">
                             <div class="leaflet-draw-toolbar leaflet-bar">
 
@@ -187,6 +187,7 @@
                             </div>
                             <ul class="leaflet-draw-actions"></ul>
                         </div>
+                        <!--/ko-->
                         <!--/ko-->
                         <!--/ko-->
                     </div>


### PR DESCRIPTION
### Description of Change
Adds disabled state to map widget. re #2698
Also fixes `value.subscribe` error when loading reports
