### PR TITLE
Ensures settings are refreshed from the db when a tile is deleted

### DIFF
--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -109,5 +109,5 @@ def get(id):
 uuid.get_or_create = get
 
 def update_system_settings_cache(tile):
-    if tile.resourceinstance_id == settings.RESOURCE_INSTANCE_ID:
+    if str(tile.resourceinstance_id) == str(settings.RESOURCE_INSTANCE_ID):
         settings.update_from_db()


### PR DESCRIPTION
### Description of Change
Ensures settings are refreshed from the db when a tile is deleted