### PR TITLE
Reversed allowing call to update_from_db

### DIFF
--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -109,5 +109,5 @@ def get(id):
 uuid.get_or_create = get
 
 def update_system_settings_cache(tile):
-    if str(tile.resourceinstance_id) == str(settings.RESOURCE_INSTANCE_ID):
+    if tile.resourceinstance_id == settings.RESOURCE_INSTANCE_ID:
         settings.update_from_db()


### PR DESCRIPTION
### Description of Change
Removed call to update_from_db when the datatypes of tile.resourceinstance_id and settings.RESOURCE_INSTANCE_ID differ to prevent errors in the map layer manager.