### PR TITLE
Add es import error messages

### DIFF
--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -236,12 +236,12 @@ class CsvReader(Reader):
                     newresourceinstance.save()
                 except TransportError as e:
                     cause = json.dumps(e.info['error']['caused_by'],indent=1)
-                    msg = '%s: WARNING: failed to index document in resource: %s. Exception detail:\n%s\n' % (datetime.datetime.now(), resourceid, cause)
+                    msg = '%s: WARNING: failed to index document in resource: %s. Exception detail:\n%s\n' % (datetime.datetime.now(), resourceinstanceid, cause)
                     errors.append({'type': 'WARNING', 'message': msg})
                     newresourceinstance.delete()
                     save_count=save_count-1
                 except Exception as e:
-                    msg = '%s: WARNING: failed to index document in resource: %s. Exception detail:\n%s\n' % (datetime.datetime.now(), resourceid, e)
+                    msg = '%s: WARNING: failed to index document in resource: %s. Exception detail:\n%s\n' % (datetime.datetime.now(), resourceinstanceid, e)
                     errors.append({'type': 'WARNING', 'message': msg})
                     newresourceinstance.delete()
                     save_count=save_count-1


### PR DESCRIPTION
### Description of Change
This pull request adds some more explanatory error messages to the import log if an elasticsearch geometry error is encountered during business data import. Previously, an ES geometry indexing error was reported in the console and would break the import process. Now, lines like the following are added to the `resource_import.log` which is where import errors are recorded:
```
Thu Dec 21 07:10:28 2017 WARNING: 2017-12-21 09:10:28.639000: WARNING: failed to index document in resource: 48b572bc-b513-4a78-8f25-eaea4ed6bf52. Exception detail:
{
 "reason": "Provided shape has duplicate consecutive coordinates at: (-82.3241091909999, 29.622251416, NaN)", 
 "type": "invalid_shape_exception"
}
```




### Further comments
A whole lot more could be done to unify and improve the error handling during import. This is just a small improvement.
