### PR TITLE
Displays user friendly ontology classes and properties in the graph manager node form

### DIFF
--- a/arches/app/media/js/models/graph.js
+++ b/arches/app/media/js/models/graph.js
@@ -167,7 +167,8 @@ define(['arches',
                         self.get('nodes').push(new NodeModel({
                             source: node,
                             datatypelookup: self.get('datatypelookup'),
-                            graph: self
+                            graph: self,
+                            ontology_namespaces: self.get('root').ontology_namespaces
                         }));
                     }, this);
                     response.responseJSON.edges.forEach(function(edge){


### PR DESCRIPTION
Adds ontology namespaces to newly created nodes in the graph manager making them available to the node model's "getFriendlyOntolgyName" method. re #2856