### PR TITLE
#2689 replace all pyshp and shapely operations with django.contrib.gi…

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -19,7 +19,6 @@ from django.contrib.gis.geos import fromstr
 from django.contrib.gis.geos import Polygon
 from django.core.exceptions import ValidationError
 from django.db import connection, transaction
-from shapely.geometry import asShape
 from elasticsearch import Elasticsearch
 
 EARTHCIRCUM = 40075016.6856

--- a/arches/app/utils/data_management/resources/importer.py
+++ b/arches/app/utils/data_management/resources/importer.py
@@ -115,7 +115,6 @@ class BusinessDataImporter(object):
                         zipfile = ZipFile(StringIO(open(file[0], 'r').read()))
                         filenames = [y for y in sorted(zipfile.namelist()) for ending in ['dbf', 'prj', 'shp', 'shx'] if y.endswith(ending)]
                         dbf, prj, shp, shx = [StringIO(zipfile.read(filename)) for filename in filenames]
-                        shape_file = shapefile.Reader(shp=shp, shx=shx, dbf=dbf)
                         self.business_data = self.shape_to_csv(path)
                     elif self.file_format == 'shp':
                         self.business_data = self.shape_to_csv(path)

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -6,11 +6,9 @@ rdflib==4.2.2
 rdflib-jsonld==0.4.0
 unicodecsv==0.14.1
 PyYAML==3.12
-pyshp==1.2.3
 pycrypto==2.6.1
 django-guardian==1.4.9
 TileStache==1.51.6
-Shapely==1.6.1
 python-memcached==1.58
 mapbox-vector-tile==0.5.0
 mapnik==0.1


### PR DESCRIPTION
…s.gdal

These two libraries were only used in one file, `importer.py`, though shapely was imported in `datatypes.py` but not utilized there.

### Issues Solved
#2689
#2912 
#2908
#2923 

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
To test this you will need to pip uninstall pyshp and shapely and then import some shapefiles. I tested with 3 shapefiles which were loaded into a project with this package installed https://github.com/archesproject/arches-sample-data. I used point, line, and polygon (which included a donut polygon for good measure) shapefiles.
