### PR TITLE
Enables deletion of saved searches

### DIFF
--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -109,5 +109,5 @@ def get(id):
 uuid.get_or_create = get
 
 def update_system_settings_cache(tile):
-    if tile.resourceinstance_id == settings.RESOURCE_INSTANCE_ID:
+    if str(tile.resourceinstance_id) == settings.RESOURCE_INSTANCE_ID:
         settings.update_from_db()


### PR DESCRIPTION
Ensures comparison of both instance ids are strings upon deletion of a system settings tile, re #2957