### PR TITLE
3026 resource model lock bug

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1100,7 +1100,7 @@ class Graph(models.GraphModel):
                     if not card.description:
                         card.description = self.nodes[card.nodegroup.pk].description
             card_dict = JSONSerializer().serializeToPython(card)
-            card_dict['is_editable'] = True
+            card_dict['is_editable'] = is_editable
             cards.append(card_dict)
 
         return cards

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -335,13 +335,12 @@ class CardManagerView(GraphBaseView):
 
         context = self.get_context_data(
             main_script='views/graph/card-manager',
-            branches=JSONSerializer().serialize(branch_graphs, exclude=['functions', 'relatable_resource_model_ids', 'domain_connections', 'nodes', 'edges']),
+            branches=JSONSerializer().serialize(branch_graphs, exclude=['functions', 'relatable_resource_model_ids', 'edges']),
         )
         context['nav']['title'] = self.graph.name
         context['nav']['menu'] = True
         context['nav']['help'] = (_('Managing Cards'),'help/base-help.htm')
         context['help'] = 'card-manager-help'
-
         return render(request, 'views/graph/card-manager.htm', context)
 
 


### PR DESCRIPTION
### Issues Solved
Fixes bug preventing cards/nodegroups from being flagged as non-editable and fixes error preventing users from adding cards to resource models in the card manager. re #3027, #3026 