### PR TITLE
Add shims to base.htm head for IE to use search page #2993

### DIFF
--- a/arches/app/templates/base.htm
+++ b/arches/app/templates/base.htm
@@ -41,6 +41,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     {% block css %}
         <link href="{% static 'css/arches.css' %}" rel="stylesheet">
     {% endblock css%}
+    
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.10/es5-shim.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.10/es5-sham.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/json3/3.3.2/json3.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.3/es6-shim.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.3/es6-sham.min.js"></script>
 
 </head>
 


### PR DESCRIPTION
### Description of Change
Internet Explorer shims added to base.htm head so that Internet Explorer users can use the search page features.

### Issues Solved
#2993 

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments
