### PR TITLE
Temporary fix for partial results error re #2975

### DIFF
--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -302,7 +302,7 @@ def build_search_results_dsl(request):
         provisional_resource_filter = Bool()
 
         if include_provisional == False:
-            provisional_resource_filter.filter(Terms(field='provisional', terms=['false', 'partial']))
+            provisional_resource_filter.filter(Terms(field='provisional', terms=['false']))
             nested_agg_filter.add_filter(Terms(field='points.provisional', terms=['false']))
 
         elif include_provisional == 'only provisional':


### PR DESCRIPTION
### Description of Change
Prevents error when filtering provisional data from search results. However, it also prevents non-reviewers from seeing resource instances with partial results. re #2975