### PR TITLE
Normalize graph name to be able to export mapping file and reindex resources

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/exporter.py
+++ b/arches/app/utils/data_management/resource_graphs/exporter.py
@@ -5,6 +5,7 @@ import json
 import uuid
 import csv
 import zipfile
+import unicodedata
 from arches.app.models.graph import Graph
 from arches.app.models.concept import Concept
 from arches.app.models.system_settings import settings
@@ -186,7 +187,8 @@ def create_mapping_configuration_file(graphid, data_dir=None):
         values['Resource to Resource Relationship Types'] = relation_concepts
 
     file_name_prefix = export_json['resource_model_name']
-
+    file_name_prefix = unicodedata.normalize('NFKD', file_name_prefix.replace(" ", "_").replace("'", "").replace("/", "")).encode('ASCII', 'ignore')
+    
     # Concept lookup file
     file_name = os.path.join('{0}_{1}.{2}'.format(file_name_prefix, 'concepts', 'json'))
     dest = StringIO()

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -8,6 +8,7 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query
 from arches.app.datatypes.datatypes import DataTypeFactory
 from datetime import datetime
+import unicodedata
 
 
 def index_db(clear_index=True, batch_size=settings.BULK_IMPORT_BATCH_SIZE):
@@ -64,6 +65,7 @@ def index_resources_by_type(resource_types, clear_index=True, batch_size=setting
         start = datetime.now()
         resources = Resource.objects.filter(graph_id=str(resource_type))
         graph_name = models.GraphModel.objects.get(graphid=str(resource_type)).name
+        graph_name = unicodedata.normalize('NFKD', graph_name.replace(" ", "_").replace("'", "").replace("/", "")).encode('ASCII', 'ignore')
         print "Indexing resource type '{0}'".format(graph_name)
         result_summary = {'database':len(resources), 'indexed':0}
 

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -45,7 +45,7 @@ from arches.app.views.base import BaseManagerView
 from tempfile import NamedTemporaryFile
 from guardian.shortcuts import get_perms_for_model, assign_perm, get_perms, remove_perm, get_group_perms, get_user_perms
 from rdflib import Graph as RDFGraph, RDF, RDFS
-
+import unicodedata
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -214,7 +214,8 @@ class GraphDataView(View):
         elif self.action == 'export_mapping_file':
             files_for_export = create_mapping_configuration_file(graphid)
             file_name = Graph.objects.get(graphid=graphid).name
-
+            file_name = unicodedata.normalize('NFKD', file_name.replace(" ", "_").replace("'", "").replace("/", "")).encode('ASCII', 'ignore')
+            
             buffer = StringIO()
 
             with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zip:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
<!--- You can erase any part of this template that is not applicable to your Issue. -->

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Error when exporting mapping file and reindexing when resource model has diacritics. So we normalize the graph name to create the export mapping and be able to reindex (due to error on print "Indexing resource type '{0}'".format(graph_name)

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
