### PR TITLE
Sets sortorder on provisional tiles

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -677,7 +677,7 @@ class TileModel(models.Model): #Tile
         db_table = 'tiles'
 
     def save(self, *args, **kwargs):
-        if(self.sortorder is None):
+        if(self.sortorder is None or (self.provisionaledits is not None and self.data == {})):
             sortorder_max = TileModel.objects.filter(nodegroup_id=self.nodegroup_id, resourceinstance_id=self.resourceinstance_id).aggregate(Max('sortorder'))['sortorder__max']
             self.sortorder = sortorder_max + 1 if sortorder_max is not None else 0
         super(TileModel, self).save(*args, **kwargs) # Call the "real" save() method.


### PR DESCRIPTION
### Description of Change
Sets sortorder on provisional tiles ensuring they appear at the end of a list of child tiles. re #2974
