### PR TITLE
Custom map popup content

### DIFF
--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -1446,47 +1446,56 @@ define([
                         }
                     });
                 };
-
+                self.map.hoverFeatures = [];
                 self.map.on('mousemove', function(e) {
                     var features = self.map.queryRenderedFeatures(e.point);
-                    var hoverData = null;
-                    var clickable = false;
-                    var hoverFeature = _.find(features, function(feature) {
-                        if (feature.properties.arches_description) {
-                            hoverData = feature.properties;
+                        var updateFeatures = features.length !== self.map.hoverFeatures.length
+                        if (!updateFeatures && features.length > 0 && self.map.hoverFeatures.length > 0) {
+                            updateFeatures = features[0].id !== self.map.hoverFeatures[0].id
                         }
-                        if (feature.properties.resourceinstanceid) {
-                            return isFeatureVisible(feature);
-                        }
-                    }) || _.find(features, function(feature) {
-                        if (feature.layer.id === 'search-results-hex') {
-                            return isFeatureVisible(feature);
-                        }
-                    }) || (
-                        self.context === 'resource-editor' && _.find(features, function(feature) {
-                            if (feature.properties.geojson) {
-                                return isFeatureVisible(feature);
+                        if (updateFeatures) {
+                            var hoverData = null;
+                            var clickable = false;
+                            var hoverFeature = _.find(features, function(feature) {
+                                if (feature.properties.arches_description) {
+                                    hoverData = feature.properties;
+                                }
+                                if (feature.properties.resourceinstanceid) {
+                                    return isFeatureVisible(feature);
+                                }
+                            }) || _.find(features, function(feature) {
+                                if (feature.layer.id === 'search-results-hex') {
+                                    return isFeatureVisible(feature);
+                                }
+                            }) || (
+                                self.context === 'resource-editor' && _.find(features, function(feature) {
+                                    if (feature.properties.geojson) {
+                                        return isFeatureVisible(feature);
+                                    }
+                                })
+                            ) || null;
+
+                            if (hoverFeature && hoverFeature.properties) {
+                                hoverData = hoverFeature.properties;
+                                if (hoverFeature.properties.resourceinstanceid) {
+                                    hoverData = lookupResourceData(hoverData);
+                                    clickable = true;
+                                }
+                                if (hoverFeature.properties.geojson) {
+                                    clickable = true;
+                                }
                             }
-                        })
-                    ) || null;
 
-                    if (hoverFeature && hoverFeature.properties) {
-                        hoverData = hoverFeature.properties;
-                        if (hoverFeature.properties.resourceinstanceid) {
-                            hoverData = lookupResourceData(hoverData);
-                            clickable = true;
+                            if (self.hoverData() !== hoverData) {
+                                self.hoverData(hoverData);
+                                var hoverFeatureId = hoverFeature && hoverFeature.properties.resourceinstanceid ? hoverFeature.properties.resourceinstanceid : '';
+                                highlightResource(hoverFeatureId, 'hover')
+                            }
+                            self.map.getCanvas().style.cursor = clickable ? 'pointer' : '';
+                            self.map.hoverFeatures = features;
+                        } else {
+                            console.log('already on that feature')
                         }
-                        if (hoverFeature.properties.geojson) {
-                            clickable = true;
-                        }
-                    }
-
-                    if (self.hoverData() !== hoverData) {
-                        self.hoverData(hoverData);
-                        var hoverFeatureId = hoverFeature && hoverFeature.properties.resourceinstanceid ? hoverFeature.properties.resourceinstanceid : '';
-                        highlightResource(hoverFeatureId, 'hover')
-                    }
-                    self.map.getCanvas().style.cursor = clickable ? 'pointer' : '';
                 });
 
                 map.on('click', function(e) {

--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -170,7 +170,32 @@ define([
 
             this.hoverData = ko.observable(null);
             this.clickData = ko.observable(null);
+            this.getMarkup = function(val){
+                if (val().arches_description) {
+                    var popupdata = val()
+                    var expression = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
+                    var regex = new RegExp(expression);
+                    if (popupdata.arches_description.match(regex)) {
+                        $.ajax({
+                            url: arches.urls.feature_popup_content,
+                            data: {url:popupdata.arches_description},
+                            method: 'POST'
+                        }).done(function(data){
+                            popupdata.arches_description = data;
+                            val(popupdata);
+                        }, this).fail(function(data){
+                            console.log('error', data)
+                        })
+                    }
+                }
+            }
             this.popupData = ko.computed(function() {
+                if (self.hoverData()) {
+                    self.getMarkup(self.hoverData);
+                }
+                if (self.clickData()) {
+                    self.getMarkup(self.clickData);
+                }
                 var clickData = self.clickData();
                 return clickData ? clickData : self.hoverData();
             });
@@ -1427,6 +1452,9 @@ define([
                     var hoverData = null;
                     var clickable = false;
                     var hoverFeature = _.find(features, function(feature) {
+                        if (feature.properties.arches_description) {
+                            hoverData = feature.properties;
+                        }
                         if (feature.properties.resourceinstanceid) {
                             return isFeatureVisible(feature);
                         }
@@ -1468,6 +1496,9 @@ define([
                     var features = self.map.queryRenderedFeatures(e.point);
                     var clickData = null;
                     var clickFeature = _.find(features, function(feature) {
+                        if (feature.properties.arches_description) {
+                            clickData = feature.properties;
+                        }
                         if (feature.properties.resourceinstanceid) {
                             return isFeatureVisible(feature);
                         }
@@ -1477,6 +1508,7 @@ define([
                         }
                     }) || null;
                     if (clickFeature) {
+
                         if (clickFeature.properties.resourceinstanceid) {
                             clickData = lookupResourceData(clickFeature.properties);
                         } else if (clickFeature.properties.total > 1) {

--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -175,17 +175,20 @@ define([
                     var popupdata = val()
                     var expression = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
                     var regex = new RegExp(expression);
-                    if (popupdata.arches_description.match(regex)) {
-                        $.ajax({
-                            url: arches.urls.feature_popup_content,
-                            data: {url:popupdata.arches_description},
-                            method: 'POST'
-                        }).done(function(data){
-                            popupdata.arches_description = data;
-                            val(popupdata);
-                        }, this).fail(function(data){
-                            console.log('error', data)
-                        })
+                    var match = popupdata.arches_description.match(regex)
+                    if (match) {
+                        if (popupdata.arches_description === match[0]) {
+                            $.ajax({
+                                url: arches.urls.feature_popup_content,
+                                data: {url:popupdata.arches_description},
+                                method: 'POST'
+                            }).done(function(data){
+                                popupdata.arches_description = data;
+                                val(popupdata);
+                            }, this).fail(function(data) {
+                                console.log('failed', data)
+                            })
+                        }
                     }
                 }
             }
@@ -1493,8 +1496,6 @@ define([
                             }
                             self.map.getCanvas().style.cursor = clickable ? 'pointer' : '';
                             self.map.hoverFeatures = features;
-                        } else {
-                            console.log('already on that feature')
                         }
                 });
 

--- a/arches/app/media/js/views/map-layer-manager.js
+++ b/arches/app/media/js/views/map-layer-manager.js
@@ -380,6 +380,7 @@ define([
             page: 1
         },
         success: function (results) {
+            results.results.aggregations.geo_aggs = results.results.aggregations.geo_aggs.inner.buckets[0]
             searchAggregations(results.results.aggregations);
             searchResults(results);
         }

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -194,6 +194,7 @@
                 reindex: "{% url 'reindex' %}",
                 permission_data: "{% url 'permission_data' %}",
                 get_user_names: "{% url 'get_user_names' %}",
+                feature_popup_content: "{% url 'feature_popup_content' %}",
                 get_domain_connections: function(graphid){return "{% url 'get_domain_connections' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid)},
                 clone_graph: function(graphid){return "{% url 'clone_graph' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid)},
                 export_graph: function(graphid){return "{% url 'export_graph' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid)},

--- a/arches/app/templates/views/components/widgets/map.htm
+++ b/arches/app/templates/views/components/widgets/map.htm
@@ -276,7 +276,20 @@
             </div>
             <!--/ko-->
 
-            <!-- ko if: popupData().geojson -->
+            <!--ko if: popupData().arches_description-->
+            <div class="hover-feature-metadata">
+                <i class="ion-ios-close pull-right add-tooltip hover-panel-dismiss"
+                style="cursor: pointer;"
+                data-placement="left"
+                data-toggle="tooltip"
+                data-original-title="add overlay"
+                data-bind="visible: popupData() === clickData(), click: function () { clickData(null); }"
+                ></i>
+                <div class="hover-feature-body" data-bind="html: popupData().arches_description"></div>
+            </div>
+            <!--/ko-->
+
+            <!-- ko if: popupData().geojson && context != 'search-filter' -->
             <div class="hover-panel-small">
                 <div class="hover-feature-title-bar">
                     <div class="hover-feature-title">{% trans "Add drawing?" %}</div>

--- a/arches/app/views/main.py
+++ b/arches/app/views/main.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
+import urllib2
 from django.shortcuts import render
 from arches.app.models.system_settings import settings
 from django.http import HttpResponseNotFound, HttpResponse
@@ -50,10 +51,12 @@ def help_templates(request):
 
 def feature_popup_content(request):
     url = request.POST.get('url', None)
-    if url is not None:
-        import urllib2
-        f = urllib2.urlopen(url)
-        return HttpResponse(f.read(100))
+    try:
+        if url is not None:
+            f = urllib2.urlopen(url)
+            return HttpResponse(f.read(100))
+    except:
+        return HttpResponseNotFound()
 
 
 

--- a/arches/app/views/main.py
+++ b/arches/app/views/main.py
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
 import urllib2
+from urlparse import urlparse
 from django.shortcuts import render
 from arches.app.models.system_settings import settings
 from django.http import HttpResponseNotFound, HttpResponse
@@ -51,14 +52,20 @@ def help_templates(request):
 
 def feature_popup_content(request):
     url = request.POST.get('url', None)
-    try:
-        if url is not None:
-            f = urllib2.urlopen(url)
-            return HttpResponse(f.read(100))
-    except:
+
+    if url is not None:
+        host = '{uri.hostname}'.format(uri=urlparse(url))
+        try:
+            if host in settings.ALLOWED_HOSTS:
+                if url is not None:
+                    f = urllib2.urlopen(url)
+                    return HttpResponse(f.read())
+            else:
+                raise Exception()
+        except:
+            return HttpResponseNotFound()
+    else:
         return HttpResponseNotFound()
-
-
 
 def custom_404(request):
     request = None

--- a/arches/app/views/main.py
+++ b/arches/app/views/main.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.shortcuts import render
 from arches.app.models.system_settings import settings
+from django.http import HttpResponseNotFound, HttpResponse
 
 def index(request):
     return render(request, 'index.htm', {
@@ -46,6 +47,15 @@ def templates(request, template):
 def help_templates(request):
     template = request.GET.get('template')
     return render(request, 'help/%s.htm' % template)
+
+def feature_popup_content(request):
+    url = request.POST.get('url', None)
+    if url is not None:
+        import urllib2
+        f = urllib2.urlopen(url)
+        return HttpResponse(f.read(100))
+
+
 
 def custom_404(request):
     request = None

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -928,6 +928,11 @@ class Command(BaseCommand):
                     extension = "pbf"
                     tile_size = 512
             if config is not None:
+                try:
+                    config['provider']['kwargs']['dbinfo']['database'] = settings.DATABASES['default']['NAME']
+                except:
+                    pass
+
                 with transaction.atomic():
                     tileserver_layer = models.TileserverLayer(
                         name=layer_name,

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -494,6 +494,7 @@ HEX_BIN_SIZE = 100
 # high precision binning may result in performance issues.
 HEX_BIN_PRECISION = 4
 
+ALLOWED_POPUP_HOSTS = []
 ##########################################
 ### END RUN TIME CONFIGURABLE SETTINGS ###
 ##########################################

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -123,6 +123,7 @@ urlpatterns = [
     url(r'^tileserver/*', tileserver.handle_request, name="tileserver"),
     url(r'^map_layer_manager/(?P<maplayerid>%s)$' % uuid_regex, MapLayerManagerView.as_view(), name='map_layer_update'),
     url(r'^map_layer_manager/*', MapLayerManagerView.as_view(), name="map_layer_manager"),
+    url(r'^feature_popup_content$', main.feature_popup_content, name="feature_popup_content"),
     url(r'^user$', UserManagerView.as_view(), name="user_profile_manager"),
     url(r'^user/get_user_names$', UserManagerView.as_view(action='get_user_names'), name="get_user_names"),
     url(r'^mobile_survey_resources/(?P<surveyid>%s)/resources$' % uuid_regex, MobileSurveyResources.as_view(), name='mobile_survey_resources'),

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -97,7 +97,7 @@ Now that you have Arches installed and a Project created, you are ready to begin
 
 * For a quick start that will create an example database schema in your new Arches project (and allow you to begin recording data right away), you can **load a sample package** with the following command::
 
-    python manage.py packages -o load_package -s https://github.com/archesproject/arches-sample-data/archive/master.zip -db true
+    python manage.py packages -o load_package -s https://github.com/archesproject/arches4-example-pkg/archive/master.zip -db true
 
 General Troubleshooting
 =======================


### PR DESCRIPTION
### Description of Change
Allows users to specify a property in the vector overlays with custom html (as a string or requested via ajax from a url) for display in the map popup.  Also ensures that tileserver config files will use the project database rather than the arches database. re #2549