### PR TITLE
Index permissions

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -90,143 +90,145 @@ class BaseDataType(object):
             "type": "vector",
             "tiles": ["%s/%s/{z}/{x}/{y}.pbf" % (tileserver_url, node.nodeid)]
         }
-        count = models.TileModel.objects.filter(data__has_key=str(node.nodeid)).count()
-        if preview and count == 0:
-            source_config = {
-                "type": "geojson",
-                "data": {
-                    "type": "FeatureCollection",
-                    "features": [
-                        {
-                            "type": "Feature",
-                            "properties": {
-                                "total": 1
-                            },
-                            "geometry": {
-                                "type": "Point",
-                                "coordinates": [
-                                    -122.4810791015625,
-                                    37.93553306183642
-                                ]
-                            }
-                        },
-                        {
-                            "type": "Feature",
-                            "properties": {
-                                "total": 100
-                            },
-                            "geometry": {
-                                "type": "Point",
-                                "coordinates": [
-                                    -58.30078125,
-                                    -18.075412438417395
-                                ]
-                            }
-                        },
-                        {
-                            "type": "Feature",
-                            "properties": {
-                                "total": 1
-                            },
-                            "geometry": {
-                                "type": "LineString",
-                                "coordinates": [
-                                    [
-                                        -179.82421875,
-                                        44.213709909702054
-                                    ],
-                                    [
-                                        -154.16015625,
-                                        32.69486597787505
-                                    ],
-                                    [
-                                        -171.5625,
-                                        18.812717856407776
-                                    ],
-                                    [
-                                        -145.72265625,
-                                        2.986927393334876
-                                    ],
-                                    [
-                                        -158.37890625,
-                                        -30.145127183376115
+        count = None
+        if preview == True:
+            count = models.TileModel.objects.filter(data__has_key=str(node.nodeid)).count()
+            if count == 0:
+                source_config = {
+                    "type": "geojson",
+                    "data": {
+                        "type": "FeatureCollection",
+                        "features": [
+                            {
+                                "type": "Feature",
+                                "properties": {
+                                    "total": 1
+                                },
+                                "geometry": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        -122.4810791015625,
+                                        37.93553306183642
                                     ]
-                                ]
-                            }
-                        },
-                        {
-                            "type": "Feature",
-                            "properties": {
-                                "total": 1
+                                }
                             },
-                            "geometry": {
-                                "type": "Polygon",
-                                "coordinates": [
-                                    [
+                            {
+                                "type": "Feature",
+                                "properties": {
+                                    "total": 100
+                                },
+                                "geometry": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        -58.30078125,
+                                        -18.075412438417395
+                                    ]
+                                }
+                            },
+                            {
+                                "type": "Feature",
+                                "properties": {
+                                    "total": 1
+                                },
+                                "geometry": {
+                                    "type": "LineString",
+                                    "coordinates": [
                                         [
-                                            -50.9765625,
-                                            22.59372606392931
+                                            -179.82421875,
+                                            44.213709909702054
                                         ],
                                         [
-                                            -23.37890625,
-                                            22.59372606392931
+                                            -154.16015625,
+                                            32.69486597787505
                                         ],
                                         [
-                                            -23.37890625,
-                                            42.94033923363181
+                                            -171.5625,
+                                            18.812717856407776
                                         ],
                                         [
-                                            -50.9765625,
-                                            42.94033923363181
+                                            -145.72265625,
+                                            2.986927393334876
                                         ],
                                         [
-                                            -50.9765625,
-                                            22.59372606392931
+                                            -158.37890625,
+                                            -30.145127183376115
                                         ]
                                     ]
-                                ]
-                            }
-                        },
-                        {
-                            "type": "Feature",
-                            "properties": {
-                                "total": 1
+                                }
                             },
-                            "geometry": {
-                                "type": "Polygon",
-                                "coordinates": [
-                                    [
+                            {
+                                "type": "Feature",
+                                "properties": {
+                                    "total": 1
+                                },
+                                "geometry": {
+                                    "type": "Polygon",
+                                    "coordinates": [
                                         [
-                                            -27.59765625,
-                                            -14.434680215297268
-                                        ],
-                                        [
-                                            -24.43359375,
-                                            -32.10118973232094
-                                        ],
-                                        [
-                                            0.87890625,
-                                            -31.653381399663985
-                                        ],
-                                        [
-                                            2.28515625,
-                                            -12.554563528593656
-                                        ],
-                                        [
-                                            -14.23828125,
-                                            -0.3515602939922709
-                                        ],
-                                        [
-                                            -27.59765625,
-                                            -14.434680215297268
+                                            [
+                                                -50.9765625,
+                                                22.59372606392931
+                                            ],
+                                            [
+                                                -23.37890625,
+                                                22.59372606392931
+                                            ],
+                                            [
+                                                -23.37890625,
+                                                42.94033923363181
+                                            ],
+                                            [
+                                                -50.9765625,
+                                                42.94033923363181
+                                            ],
+                                            [
+                                                -50.9765625,
+                                                22.59372606392931
+                                            ]
                                         ]
                                     ]
-                                ]
+                                }
+                            },
+                            {
+                                "type": "Feature",
+                                "properties": {
+                                    "total": 1
+                                },
+                                "geometry": {
+                                    "type": "Polygon",
+                                    "coordinates": [
+                                        [
+                                            [
+                                                -27.59765625,
+                                                -14.434680215297268
+                                            ],
+                                            [
+                                                -24.43359375,
+                                                -32.10118973232094
+                                            ],
+                                            [
+                                                0.87890625,
+                                                -31.653381399663985
+                                            ],
+                                            [
+                                                2.28515625,
+                                                -12.554563528593656
+                                            ],
+                                            [
+                                                -14.23828125,
+                                                -0.3515602939922709
+                                            ],
+                                            [
+                                                -27.59765625,
+                                                -14.434680215297268
+                                            ]
+                                        ]
+                                    ]
+                                }
                             }
-                        }
-                    ]
+                        ]
+                    }
                 }
-            }
         return {
             "nodeid": node.nodeid,
             "name": "resources-%s" % node.nodeid,

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -141,7 +141,7 @@ class Card(models.CardModel):
         return self
 
     def confirm_enabled_state(self, user, nodegroup):
-        if user.has_perms(['write_nodegroup'], self.nodegroup) == False:
+        if user.has_perms(['write_nodegroup'], self.nodegroup_id) == False:
             self.disabled = True
 
     def get_edge_to_parent(self):
@@ -161,11 +161,11 @@ class Card(models.CardModel):
 
         """
         if user:
-            if user.has_perm(perm, self.nodegroup):
+            if user.has_perm(perm, self.nodegroup_id):
                 self.confirm_enabled_state(user, self.nodegroup)
                 cards = []
                 for card in self.cards:
-                    if user.has_perm(perm, card.nodegroup):
+                    if user.has_perm(perm, card.nodegroup_id):
                         card.confirm_enabled_state(user, card.nodegroup)
                         cards.append(card)
                 self.cards = cards

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -380,12 +380,12 @@ class Tile(models.TileModel):
 
     def filter_by_perm(self, user, perm):
         if user:
-            if user.has_perm(perm, self.nodegroup):
+            if user.has_perm(perm, self.nodegroup_id):
                 filtered_tiles = {}
                 for key, tiles in self.tiles.iteritems():
                     filtered_tiles[key] = []
                     for tile in tiles:
-                        if user.has_perm(perm, tile.nodegroup):
+                        if user.has_perm(perm, tile.nodegroup_id):
                             filtered_tiles[key].append(tile)
                 self.tiles = filtered_tiles
             else:

--- a/arches/app/views/base.py
+++ b/arches/app/views/base.py
@@ -61,7 +61,7 @@ class MapBaseManagerView(BaseManagerView):
         resource_layers = []
         resource_sources = []
         for node in geom_nodes:
-            if self.request.user.has_perm('read_nodegroup', node.nodegroup):
+            if self.request.user.has_perm('read_nodegroup', node.nodegroup_id):
                 datatype = datatype_factory.get_instance(node.datatype)
                 map_source = datatype.get_map_source(node)
                 if map_source is not None:

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -414,6 +414,7 @@ class ResourceReportView(MapBaseManagerView):
             map_sources = models.MapSource.objects.all()
             geocoding_providers = models.Geocoder.objects.all()
         else:
+            map_markers=None
             map_layers = []
             map_sources = []
             geocoding_providers = []

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -112,7 +112,7 @@ class ResourceEditorView(MapBaseManagerView):
             required_widgets = []
 
             for form_x_card in forms_x_cards:
-                if request.user.has_perm('read_nodegroup', form_x_card.card.nodegroup):
+                if request.user.has_perm('read_nodegroup', form_x_card.card.nodegroup_id):
                     forms_w_cards.append(form_x_card.form)
 
             widget_datatypes = [v.datatype for k, v in graph.nodes.iteritems()]
@@ -248,7 +248,7 @@ class ResourceEditLogView(BaseManagerView):
             for edit in edits:
                 if edit.nodegroupid != None:
                     nodegroup = models.NodeGroup.objects.get(pk=edit.nodegroupid)
-                    if request.user.has_perm('read_nodegroup', nodegroup):
+                    if request.user.has_perm('read_nodegroup', nodegroup_id):
                         if edit.newvalue != None:
                             self.getEditConceptValue(edit.newvalue)
                         if edit.oldvalue != None:
@@ -309,7 +309,7 @@ class ResourceTiles(View):
             tiles = tiles.filter(nodegroup=node.nodegroup)
 
         for tile in tiles:
-            if request.user.has_perm(perm, tile.nodegroup):
+            if request.user.has_perm(perm, tile.nodegroup_id):
                 tile = Tile.objects.get(pk=tile.tileid)
                 tile.filter_by_perm(request.user, perm)
                 tile_dict = model_to_dict(tile)
@@ -395,13 +395,13 @@ class ResourceReportView(MapBaseManagerView):
         perm = 'read_nodegroup'
 
         for card in cards:
-            if request.user.has_perm(perm, card.nodegroup):
+            if request.user.has_perm(perm, card.nodegroup_id):
                 matching_forms_x_card = filter(lambda forms_x_card: card.nodegroup_id == forms_x_card.card.nodegroup_id, forms_x_cards)
                 card.filter_by_perm(request.user, perm)
                 permitted_cards.append(card)
 
         for tile in tiles:
-            if request.user.has_perm(perm, tile.nodegroup):
+            if request.user.has_perm(perm, tile.nodegroup_id):
                 tile.filter_by_perm(request.user, perm)
                 permitted_tiles.append(tile)
 

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -68,13 +68,13 @@ class SearchView(MapBaseManagerView):
         # only allow cards that the user has permission to read
         searchable_cards = []
         for card in resource_cards:
-            if request.user.has_perm('read_nodegroup', card.nodegroup):
+            if request.user.has_perm('read_nodegroup', card.nodegroup_id):
                 searchable_cards.append(card)
 
         # only allow date nodes that the user has permission to read
         searchable_date_nodes = []
         for node in date_nodes:
-            if request.user.has_perm('read_nodegroup', node.nodegroup):
+            if request.user.has_perm('read_nodegroup', node.nodegroup_id):
                 searchable_date_nodes.append(node)
 
         context = self.get_context_data(
@@ -497,7 +497,7 @@ def build_search_results_dsl(request):
             for key, val in advanced_filter.iteritems():
                 if key != 'op':
                     node = models.Node.objects.get(pk=key)
-                    if request.user.has_perm('read_nodegroup', node.nodegroup):
+                    if request.user.has_perm('read_nodegroup', node.nodegroup_id):
                         datatype = datatype_factory.get_instance(node.datatype)
                         datatype.append_search_filters(val, node, tile_query, request)
             nested_query = Nested(path='tiles', query=tile_query)
@@ -521,7 +521,7 @@ def get_permitted_nodegroups(user):
 def get_nodegroups_by_datatype_and_perm(request, datatype, permission):
     nodes = []
     for node in models.Node.objects.filter(datatype=datatype):
-        if request.user.has_perm(permission, node.nodegroup):
+        if request.user.has_perm(permission, node.nodegroup_id):
             nodes.append(str(node.nodegroup_id))
     return nodes
 

--- a/arches/app/views/tileserver.py
+++ b/arches/app/views/tileserver.py
@@ -22,7 +22,7 @@ def get_tileserver_config(layer_id, request=None):
     try:
         node = models.Node.objects.get(pk=layer_id)
         datatype = datatype_factory.get_instance(node.datatype)
-        if request == None or request.user.has_perm('read_nodegroup', node.nodegroup):
+        if request == None or request.user.has_perm('read_nodegroup', node.nodegroup_id):
             layer_config = datatype.get_layer_config(node)
         else:
             layer_config = datatype.get_layer_config(None)


### PR DESCRIPTION
### Description of Change
Relies uses id rather than objects when calling user.has_perm. This prevents unnecessary calls to the db. re #3071.
Also - Fixes unassigned variable in reports and when getting map sources in the base datatype - only queries for relevant tiles when 'Preview' is true. 

