### PR TITLE
3118 missing report error

### DIFF
--- a/arches/app/media/js/views/search/search-results.js
+++ b/arches/app/media/js/views/search/search-results.js
@@ -7,9 +7,10 @@ define(['jquery',
     'knockout',
     'knockout-mapping',
     'view-data',
+    'viewmodels/alert',
     'bootstrap-datetimepicker',
     'plugins/knockout-select2'],
-    function($, _, Backbone, bootstrap, arches, select2, ko, koMapping, viewdata) {
+    function($, _, Backbone, bootstrap, arches, select2, ko, koMapping, viewdata, AlertViewModel) {
         return Backbone.View.extend({
 
             events: {
@@ -169,7 +170,20 @@ define(['jquery',
             },
 
             viewReport: function(resourceinstance){
-                window.open(arches.urls.resource_report + resourceinstance.resourceinstanceid);
+                    var self = this;
+                    var missingReportAlert = function(data){
+                        return function(data){
+                             var response = data.responseJSON;
+                             self.viewModel.alert(new AlertViewModel('ep-alert-red', response.title, response.message));
+                        }
+                    }
+                    $.ajax({
+                        type: "GET",
+                        url: arches.urls.report_data,
+                        data: {resourceid: resourceinstance.resourceinstanceid}
+                    }).done(function(data){
+                        window.open(arches.urls.resource_report + resourceinstance.resourceinstanceid);
+                    }).fail(missingReportAlert());
             },
 
             editResource: function(resourceinstance){

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -389,7 +389,7 @@ class Graph(models.GraphModel):
 
         def find_child_edges(tree):
             for edge_id, edge in self.edges.iteritems():
-                if edge.domainnode_id == tree['node'].nodeid:
+                if edge.domainnode == tree['node']:
                     tree['children'].append(find_child_edges({
                         'node': edge.rangenode,
                         'children':[],

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -389,7 +389,7 @@ class Graph(models.GraphModel):
 
         def find_child_edges(tree):
             for edge_id, edge in self.edges.iteritems():
-                if edge.domainnode == tree['node']:
+                if edge.domainnode_id == tree['node'].nodeid:
                     tree['children'].append(find_child_edges({
                         'node': edge.rangenode,
                         'children':[],

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -179,6 +179,7 @@
                 resource_report: "{% url 'resource_report' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ''),
                 resource_edit_log: "{% url 'resource_edit_log' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ''),
                 resource_data: "{% url 'resource_data' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace(/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/g, ''),
+                report_data: "{% url 'report_data' %}",
                 resource_cards: "{% url 'resource_cards' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ''),
                 related_resources: "{% url 'related_resources' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ''),
                 resource_descriptors: "{% url 'resource_descriptors' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', ''),

--- a/arches/app/templates/navbar/resource-manage-menu.htm
+++ b/arches/app/templates/navbar/resource-manage-menu.htm
@@ -40,6 +40,7 @@
                 </li>
 
                 <!-- Menu Item -->
+                {% if active_report_count > 0 %}
                 <li id="report-manager" class="edit-menu-item" data-bind="css: {'disabled': !resourceInstanceExists()}">
                     <a href="#" data-bind="click: function () {window.open('{% url 'resource_report' resourceid %}')}">
                         <div class="media-body">
@@ -48,6 +49,18 @@
                         </div>
                     </a>
                 </li>
+                {% else %}
+                <li id="report-manager" class="edit-menu-item disabled">
+                    <a href="#">
+                        <div class="media-body">
+                            <div class="menu-item-title"><i class="fa fa-book"></i> {% trans "Report Not Available" %}</div>
+                            <span class="text-muted menu-item-subtitle">{% trans "Report template not activated" %}</span>
+                        </div>
+                    </a>
+                </li>
+                {% endif %}
+
+
 
             </ul>
         </div>

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -154,6 +154,7 @@ class ResourceEditorView(MapBaseManagerView):
                 saved_searches=JSONSerializer().serialize(settings.SAVED_SEARCHES),
                 resource_instance_exists=resource_instance_exists,
                 user_is_reviewer=json.dumps(request.user.groups.filter(name='Resource Reviewer').exists()),
+                active_report_count = models.Report.objects.filter(graph_id=resource_instance.graph_id, active=True).count(),
                 userid=request.user.id
             )
 

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -21,7 +21,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from arches.app.views import concept, main, map, search, graph, tileserver, api
 from arches.app.views.admin import ReIndexResources
 from arches.app.views.graph import GraphManagerView, GraphSettingsView, GraphDataView, DatatypeTemplateView, CardManagerView, CardView, FormManagerView, FormView, ReportManagerView, ReportEditorView, FunctionManagerView, PermissionManagerView, PermissionDataView
-from arches.app.views.resource import ResourceEditorView, ResourceListView, ResourceData, ResourceCards, ResourceReportView, RelatedResourcesView, ResourceDescriptors, ResourceEditLogView, ResourceTiles
+from arches.app.views.resource import ResourceEditorView, ResourceListView, ResourceData, ResourceCards, ResourceReportView, ResourceReportData, RelatedResourcesView, ResourceDescriptors, ResourceEditLogView, ResourceTiles
 from arches.app.views.concept import RDMView
 from arches.app.views.user import UserManagerView
 from arches.app.views.tile import TileData
@@ -105,11 +105,12 @@ urlpatterns = [
     url(r'^resource/descriptors/(?P<resourceid>%s|())$' % uuid_regex, ResourceDescriptors.as_view(), name="resource_descriptors"),
     url(r'^resource/(?P<resourceid>%s)/tiles$' % uuid_regex, ResourceTiles.as_view(), name='resource_tiles'),
     url(r'^report/(?P<resourceid>%s)$' % uuid_regex, ResourceReportView.as_view(), name='resource_report'),
+    url(r'^report/(?P<resourceid>%s)$' % uuid_regex, ResourceReportView.as_view(), name='resource_report'),
     url(r'^card/(?P<cardid>%s|())$' % uuid_regex, CardView.as_view(), name='card'),
     url(r'^form/(?P<formid>%s|())$' % uuid_regex, FormView.as_view(), name='form'),
     url(r'^form/(?P<formid>%s)/delete$' % uuid_regex, FormView.as_view(), name='delete_form'),
     url(r'^report_editor/(?P<reportid>%s|())$' % uuid_regex, ReportEditorView.as_view(), name='report_editor'),
-    url(r'^report_editor/(?P<reportid>%s)/delete$' % uuid_regex, ReportEditorView.as_view(), name='delete_report'),
+    url(r'^report/data$', ResourceReportData.as_view(), name='report_data'),
     url(r'^node/(?P<graphid>%s)$' % uuid_regex, GraphDataView.as_view(action='update_node'), name='node'),
     url(r'^node_layer/(?P<graphid>%s)$' % uuid_regex, GraphDataView.as_view(action='update_node_layer'), name='node_layer'),
     url(r'^widgets/(?P<template>[a-zA-Z_-]*)', main.widget, name="widgets"),


### PR DESCRIPTION
### Description of Change
Handles for errors when navigating to a resource instance report of a model that does not have an active report.

If there is not report available for a resource's model and a user tries to open a report:

- In search they will see an alert notifying them that no report is available.
- In the resource editor, the `Jump to Report` link is disabled (with text reading that no report is available)
- Navigating directly from the url, the appl will navigate to a 404 page with a message stating that the resource has no report. 
