### PR TITLE
Order list of tiles so parent tiles are imported first, re #2882

### DIFF
--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -68,7 +68,7 @@ class ConceptDataType(BaseConceptDataType):
         ## first check to see if the validator has been passed a valid UUID,
         ## which should be the case at this point. return error if not.
         try:
-            uuid.UUID(value)
+            uuid.UUID(str(value))
         except ValueError:
             message = "This is an invalid concept prefLabel, or an incomplete UUID"
             errors.append({'type': 'ERROR', 'message': 'datatype: {0} value: {1} {2} - {3}. {4}'.format(self.datatype_model.datatype, value, source, message, 'This data was not imported.')})

--- a/arches/app/utils/data_management/resources/formats/archesfile.py
+++ b/arches/app/utils/data_management/resources/formats/archesfile.py
@@ -128,7 +128,7 @@ class ArchesFileReader(Reader):
 
                         if resource['tiles'] != []:
                             reporter.update_tiles(len(resource['tiles']))
-                            for tile in resource['tiles']:
+                            for tile in sorted(resource['tiles'], key=lambda k: k['parenttile_id']):
                                 tile['parenttile_id'] = uuid.UUID(str(tile['parenttile_id'])) if tile['parenttile_id'] else None
 
                                 tile, created = Tile.objects.update_or_create(


### PR DESCRIPTION
Fix issue where parent tiles were trying to be saved after child tiles and throwing an error with json import.

### Issues Solved
#2882 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)