### PR TITLE
2549 4.1.x custom popup

### DIFF
--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -174,17 +174,20 @@ define([
                     var popupdata = val()
                     var expression = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
                     var regex = new RegExp(expression);
-                    if (popupdata.arches_description.match(regex)) {
-                        $.ajax({
-                            url: arches.urls.feature_popup_content,
-                            data: {url:popupdata.arches_description},
-                            method: 'POST'
-                        }).done(function(data){
-                            popupdata.arches_description = data;
-                            val(popupdata);
-                        }, this).fail(function(data){
-                            console.log('error', data)
-                        })
+                    var match = popupdata.arches_description.match(regex)
+                    if (match) {
+                        if (popupdata.arches_description === match[0]) {
+                            $.ajax({
+                                url: arches.urls.feature_popup_content,
+                                data: {url:popupdata.arches_description},
+                                method: 'POST'
+                            }).done(function(data){
+                                popupdata.arches_description = data;
+                                val(popupdata);
+                            }, this).fail(function(data) {
+                                console.log('failed', data)
+                            })
+                        }
                     }
                 }
             }
@@ -1488,8 +1491,6 @@ define([
                             }
                             self.map.getCanvas().style.cursor = clickable ? 'pointer' : '';
                             self.map.hoverFeatures = features;
-                        } else {
-                            console.log('already on that feature')
                         }
                 });
 

--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -169,7 +169,32 @@ define([
 
             this.hoverData = ko.observable(null);
             this.clickData = ko.observable(null);
+            this.getMarkup = function(val){
+                if (val().arches_description) {
+                    var popupdata = val()
+                    var expression = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
+                    var regex = new RegExp(expression);
+                    if (popupdata.arches_description.match(regex)) {
+                        $.ajax({
+                            url: arches.urls.feature_popup_content,
+                            data: {url:popupdata.arches_description},
+                            method: 'POST'
+                        }).done(function(data){
+                            popupdata.arches_description = data;
+                            val(popupdata);
+                        }, this).fail(function(data){
+                            console.log('error', data)
+                        })
+                    }
+                }
+            }
             this.popupData = ko.computed(function() {
+                if (self.hoverData()) {
+                    self.getMarkup(self.hoverData);
+                }
+                if (self.clickData()) {
+                    self.getMarkup(self.clickData);
+                }
                 var clickData = self.clickData();
                 return clickData ? clickData : self.hoverData();
             });
@@ -1422,6 +1447,9 @@ define([
                     var hoverData = null;
                     var clickable = false;
                     var hoverFeature = _.find(features, function(feature) {
+                        if (feature.properties.arches_description) {
+                            hoverData = feature.properties;
+                        }
                         if (feature.properties.resourceinstanceid) {
                             return isFeatureVisible(feature);
                         }
@@ -1463,6 +1491,9 @@ define([
                     var features = self.map.queryRenderedFeatures(e.point);
                     var clickData = null;
                     var clickFeature = _.find(features, function(feature) {
+                        if (feature.properties.arches_description) {
+                            clickData = feature.properties;
+                        }
                         if (feature.properties.resourceinstanceid) {
                             return isFeatureVisible(feature);
                         }
@@ -1472,6 +1503,7 @@ define([
                         }
                     }) || null;
                     if (clickFeature) {
+
                         if (clickFeature.properties.resourceinstanceid) {
                             clickData = lookupResourceData(clickFeature.properties);
                         } else if (clickFeature.properties.total > 1) {

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -178,6 +178,7 @@
                 time_wheel_config: "{% url 'time_wheel_config' %}",
                 reindex: "{% url 'reindex' %}",
                 permission_data: "{% url 'permission_data' %}",
+                feature_popup_content: "{% url 'feature_popup_content' %}",
                 get_domain_connections: function(graphid){return "{% url 'get_domain_connections' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid)},
                 clone_graph: function(graphid){return "{% url 'clone_graph' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid)},
                 export_graph: function(graphid){return "{% url 'export_graph' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}".replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid)},

--- a/arches/app/templates/views/components/widgets/map.htm
+++ b/arches/app/templates/views/components/widgets/map.htm
@@ -276,7 +276,20 @@
             </div>
             <!--/ko-->
 
-            <!-- ko if: popupData().geojson -->
+            <!--ko if: popupData().arches_description-->
+            <div class="hover-feature-metadata">
+                <i class="ion-ios-close pull-right add-tooltip hover-panel-dismiss"
+                style="cursor: pointer;"
+                data-placement="left"
+                data-toggle="tooltip"
+                data-original-title="add overlay"
+                data-bind="visible: popupData() === clickData(), click: function () { clickData(null); }"
+                ></i>
+                <div class="hover-feature-body" data-bind="html: popupData().arches_description"></div>
+            </div>
+            <!--/ko-->
+
+            <!-- ko if: popupData().geojson && context != 'search-filter' -->
             <div class="hover-panel-small">
                 <div class="hover-feature-title-bar">
                     <div class="hover-feature-title">{% trans "Add drawing?" %}</div>

--- a/arches/app/views/main.py
+++ b/arches/app/views/main.py
@@ -16,6 +16,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
+import urllib2
+from urlparse import urlparse
 from django.shortcuts import render
 from arches.app.models.system_settings import settings
 from django.http import HttpResponseNotFound, HttpResponse
@@ -50,12 +52,20 @@ def help_templates(request):
 
 def feature_popup_content(request):
     url = request.POST.get('url', None)
+
     if url is not None:
-        import urllib2
-        f = urllib2.urlopen(url)
-        return HttpResponse(f.read(100))
-
-
+        host = '{uri.hostname}'.format(uri=urlparse(url))
+        try:
+            if host in settings.ALLOWED_HOSTS:
+                if url is not None:
+                    f = urllib2.urlopen(url)
+                    return HttpResponse(f.read())
+            else:
+                raise Exception()
+        except:
+            return HttpResponseNotFound()
+    else:
+        return HttpResponseNotFound()
 
 def custom_404(request):
     request = None

--- a/arches/app/views/main.py
+++ b/arches/app/views/main.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.shortcuts import render
 from arches.app.models.system_settings import settings
+from django.http import HttpResponseNotFound, HttpResponse
 
 def index(request):
     return render(request, 'index.htm', {
@@ -46,6 +47,15 @@ def templates(request, template):
 def help_templates(request):
     template = request.GET.get('template')
     return render(request, 'help/%s.htm' % template)
+
+def feature_popup_content(request):
+    url = request.POST.get('url', None)
+    if url is not None:
+        import urllib2
+        f = urllib2.urlopen(url)
+        return HttpResponse(f.read(100))
+
+
 
 def custom_404(request):
     request = None

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -925,6 +925,11 @@ class Command(BaseCommand):
                     extension = "pbf"
                     tile_size = 512
             if config is not None:
+                try:
+                    config['provider']['kwargs']['dbinfo']['database'] = settings.DATABASES['default']['NAME']
+                except:
+                    pass
+
                 with transaction.atomic():
                     tileserver_layer = models.TileserverLayer(
                         name=layer_name,

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -494,6 +494,7 @@ HEX_BIN_SIZE = 100
 # high precision binning may result in performance issues.
 HEX_BIN_PRECISION = 4
 
+ALLOWED_POPUP_HOSTS = []
 ##########################################
 ### END RUN TIME CONFIGURABLE SETTINGS ###
 ##########################################

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -122,6 +122,7 @@ urlpatterns = [
     url(r'^tileserver/*', tileserver.handle_request, name="tileserver"),
     url(r'^map_layer_manager/(?P<maplayerid>%s)$' % uuid_regex, MapLayerManagerView.as_view(), name='map_layer_update'),
     url(r'^map_layer_manager/*', MapLayerManagerView.as_view(), name="map_layer_manager"),
+    url(r'^feature_popup_content$', main.feature_popup_content, name="feature_popup_content"),
     url(r'^user$', UserManagerView.as_view(), name="user_profile_manager"),
 
     # Uncomment the admin/doc line below to enable admin documentation:


### PR DESCRIPTION
### Description of Change
Allows users to define custom html content for map pop-ups. Also ensures that tileserver layers that read from postgres, read from the default project database. re #2549
