### PR TITLE
Handles for long resource names in the resource instance filter

### DIFF
--- a/arches/app/templates/views/search/search-base-manager.htm
+++ b/arches/app/templates/views/search/search-base-manager.htm
@@ -54,7 +54,7 @@
                             <ul class="dropdown-menu dropdown-menu-right">
                                 <li><a href="#" data-bind="click: selectModelType.bind($data, null)">{% trans "All resources" %}</a></li>
                                 <!-- ko foreach: $root.resources -->
-                                <li><a href="#" data-bind="text: name, click: $parent.selectModelType.bind($parent)"></a></li>
+                                <li><a href="#" data-bind="text: name().length > 55 ? name().substring(55, length) + '...' : name(), click: $parent.selectModelType.bind($parent)"></a></li>
                                 <!-- /ko -->
                             </ul>
                         </div>


### PR DESCRIPTION
Abbreviates a resource name in the resource filter list with an ellipsis if the name is longer than 55 char. re #3124