### PR TITLE
Temporarily disables system settings update because it causes errors …

### DIFF
--- a/arches/app/models/system_settings.py
+++ b/arches/app/models/system_settings.py
@@ -134,7 +134,7 @@ class SystemSettings(LazySettings):
 
 
 settings = SystemSettings()
-try:
-    settings.update_from_db()
-except OperationalError, ProgrammingError:
-    print "Skipping system settings update"
+# try:
+#     settings.update_from_db()
+# except OperationalError, ProgrammingError:
+#     print "Skipping system settings update"


### PR DESCRIPTION
…when running management commands from a package. re #2962
