### PR TITLE
3147 save resource tiles to couch

### DIFF
--- a/arches/app/models/mobile_survey.py
+++ b/arches/app/models/mobile_survey.py
@@ -88,7 +88,11 @@ class MobileSurvey(models.MobileSurveyModel):
                 graphs.append(graph)
         ret['graphs'] = graphs
         ret['cards'] = ordered_cards
-        ret['bounds'] = json.loads(ret['bounds'])
+        try:
+            ret['bounds'] = json.loads(ret['bounds'])
+        except TypeError as e:
+            print 'Could not parse', ret['bounds'], e
+
         return ret
 
     def get_ordered_cards(self):

--- a/arches/app/models/mobile_survey.py
+++ b/arches/app/models/mobile_survey.py
@@ -88,6 +88,7 @@ class MobileSurvey(models.MobileSurveyModel):
                 graphs.append(graph)
         ret['graphs'] = graphs
         ret['cards'] = ordered_cards
+        ret['bounds'] = json.loads(ret['bounds'])
         return ret
 
     def get_ordered_cards(self):

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -385,7 +385,9 @@ def build_search_results_dsl(request):
 
         if len(spatial_filter['features']) > 0:
             feature_geom = spatial_filter['features'][0]['geometry']
-            feature_properties = spatial_filter['features'][0]['properties']
+            feature_properties = {}
+            if 'properties' in spatial_filter['features'][0]:
+                feature_properties = spatial_filter['features'][0]['properties']
             buffer = {'width':0,'unit':'ft'}
             if 'buffer' in feature_properties:
                 buffer = feature_properties['buffer']
@@ -488,9 +490,7 @@ def build_search_results_dsl(request):
                 temporal_query.should(Nested(path='date_ranges', query=date_ranges_query))
             temporal_query.should(Nested(path='dates', query=date_query))
 
-
         search_query.filter(temporal_query)
-        #print search_query.dsl
 
     datatype_factory = DataTypeFactory()
     if len(advanced_filters) > 0:


### PR DESCRIPTION
Fixes error when defining search perimeter with the survey perimeter rather than a search filter perimeter. #3147 
Ensures bounds returned from the mobile survey api are JSON rather than a string.
