### PR TITLE
3221 missing resource types in resource instance datatype

### DIFF
--- a/arches/app/media/js/views/components/datatypes/resource-instance.js
+++ b/arches/app/media/js/views/components/datatypes/resource-instance.js
@@ -1,10 +1,9 @@
 define([
     'knockout',
     'underscore',
-    'arches',
     'view-data',
     'views/components/widgets/resource-instance-select'
-], function (ko, _, arches, data) {
+], function (ko, _, data) {
     var name = 'resource-instance-datatype-config';
     ko.components.register(name, {
         viewModel: function(params) {

--- a/arches/app/media/js/views/components/datatypes/resource-instance.js
+++ b/arches/app/media/js/views/components/datatypes/resource-instance.js
@@ -2,8 +2,9 @@ define([
     'knockout',
     'underscore',
     'arches',
+    'view-data',
     'views/components/widgets/resource-instance-select'
-], function (ko, _, arches) {
+], function (ko, _, arches, data) {
     var name = 'resource-instance-datatype-config';
     ko.components.register(name, {
         viewModel: function(params) {
@@ -11,7 +12,7 @@ define([
             this.resourceModels = [{
                 graphid: null,
                 name: ''
-            }].concat(_.filter(arches.graphs, function (graph) {
+            }].concat(_.filter(data.createableResources, function (graph) {
                 return graph.isresource && graph.isactive;
             }));
             this.config = params.config;


### PR DESCRIPTION
### Description of Change
Makes 'createableResources' available to the resource instance datatype (rather than graphs which were removed to reduce db queries and payload). re #3221, #3105