### PR TITLE
Resource model filter list formatting

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -8640,7 +8640,6 @@ a.search-query-link-captions:focus {
         justify-content: right;
         margin-top: -30px;
         float: right;
-        width: 165px;
 }
 
 .search-inline-filters div {


### PR DESCRIPTION
Prevents resource model list from extending under nav bar when resource names are long and user is logged out. re #3124
