### PR TITLE
Add padding to search map display in order for clusters to not be cut…

### DIFF
--- a/arches/app/media/js/views/components/widgets/map.js
+++ b/arches/app/media/js/views/components/widgets/map.js
@@ -701,7 +701,7 @@ define([
                                      aggBounds.top_left.lat
                                  ]
                              ];
-                             map.fitBounds(bounds);
+                             map.fitBounds(bounds, {padding: 30});
                          }
                      }
 


### PR DESCRIPTION
…off by edge of map, re #3300

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add padding to search map to allow clusters to not be cutoff.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3300 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
