### PR TITLE
Sets root node name to the graph name

### DIFF
--- a/arches/app/media/js/viewmodels/graph-settings.js
+++ b/arches/app/media/js/viewmodels/graph-settings.js
@@ -27,7 +27,6 @@ define([
         self.node = params.node
         self.graph.name.subscribe(function(val){
             self.node().name(val);
-            self.node()._node(JSON.stringify(self.node()))
         })
 
         var ontologyClass = params.node().ontologyclass;
@@ -50,10 +49,12 @@ define([
         self.jsonCache = ko.observable(self.jsonData());
 
         var dirty = ko.computed(function () {
-            return self.jsonData() !== self.jsonCache();
+            var dirty = self.jsonData() !== self.jsonCache();
+            return dirty
         });
 
         self.dirty = dirty;
+
         self.icon_data = ko.observableArray([]);
         self.iconFilter = params.iconFilter;
         self.icons = ko.computed(function () {
@@ -79,6 +80,7 @@ define([
                 data: self.jsonData()})
                 .done(function(response) {
                     self.jsonCache(self.jsonData());
+                    self.node()._node(JSON.stringify(self.node()))
                 })
                 .fail(function(response) {
                     console.log('there was an error saving the settings', response)
@@ -102,6 +104,7 @@ define([
                 resource.isRelatable(jsonResource.is_relatable);
             });
             self.jsonCache(self.jsonData());
+            self.node()._node(JSON.stringify(self.node()))
         };
 
     };

--- a/arches/app/media/js/viewmodels/graph-settings.js
+++ b/arches/app/media/js/viewmodels/graph-settings.js
@@ -24,8 +24,10 @@ define([
 
         self.graph = params.graph;
 
-        self.graph.ontology_id.subscribe(function(val){
-            console.log(val);
+        self.node = params.node
+        self.graph.name.subscribe(function(val){
+            self.node().name(val);
+            self.node()._node(JSON.stringify(self.node()))
         })
 
         var ontologyClass = params.node().ontologyclass;

--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -44,9 +44,6 @@ define([
         node: viewModel.selectedNode
     });
 
-    viewModel.graphTree = new GraphTree({
-        graphModel: viewModel.graphModel
-    });
 
     viewModel.graphSettingsViewModel = new GraphSettingsViewModel({
         graph: viewModel.graph,
@@ -59,6 +56,11 @@ define([
         ontology_namespaces: data.ontology_namespaces
     });
 
+    viewModel.graphTree = new GraphTree({
+        graphModel: viewModel.graphModel,
+        graphSettings: viewModel.graphSettingsViewModel
+    });
+    
     viewModel.loadGraphSettings = function(){
         var self = this;
         self.contentLoading(true);

--- a/arches/app/media/js/views/graph/graph-settings.js
+++ b/arches/app/media/js/views/graph/graph-settings.js
@@ -106,13 +106,4 @@ require([
         viewModel: viewModel
     });
     var self = this;
-
-    var updatePageViewGraph = function(pageView, prop){
-      return function(e){
-        var graph = _.findWhere(pageView.viewModel.allGraphs(), {graphid: pageView.viewModel.graphid()})
-        graph[prop](e);
-      }
-    }
-    viewModel.graph.name.subscribe(updatePageViewGraph(pageView, 'name'))
-    viewModel.graph.iconclass.subscribe(updatePageViewGraph(pageView, 'iconclass'))
 });

--- a/arches/app/media/js/views/graph/graph-tree.js
+++ b/arches/app/media/js/views/graph/graph-tree.js
@@ -30,6 +30,7 @@ define([
         */
         initialize: function(options) {
             this.graphModel = options.graphModel;
+            this.graphSettings = options.graphSettings;
             this.items = this.graphModel.get('nodes');
             TreeView.prototype.initialize.apply(this, arguments);
         },
@@ -41,8 +42,10 @@ define([
         * @param {object} e - click event object
         */
         selectItem: function(item, e){
-            this.graphModel.selectNode(item);
-            this.trigger('node-selected', item);
+            if (!this.graphSettings.dirty()) {
+                this.graphModel.selectNode(item);
+                this.trigger('node-selected', item);
+            }
         },
 
         addChildNode: function(item, e) {

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -91,6 +91,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             {% endif %}
                         {% endif %}
 
+
+                        {% block graph_title %}
                         <!-- Page Title and Icon -->
                         <div class="ep-tools-title">
                             <h1 class="page-header text-overflow ep-graph-title">
@@ -98,6 +100,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                 <span>{% trans nav.title %}</span>
                             </h1>
                         </div>
+                        {% endblock graph_title %}
 
                         <!-- Login -->
                         {% if nav.login %}

--- a/arches/app/templates/views/graph-designer.htm
+++ b/arches/app/templates/views/graph-designer.htm
@@ -26,6 +26,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endblock title %}
 
 
+{% block graph_title %}
+<div class="ep-tools-title">
+    <h1 class="page-header text-overflow ep-graph-title">
+        <i class="text-center icon-wrap bg-gray ep-graph-title-icon" data-bind="css: (graph.iconclass() || 'fa fa-question')" ></i>
+        <span data-bind="text: graph.name()"></span>
+    </h1>
+</div>
+{% endblock graph_title %}
+
 {% block main_content %}
 <div class="content-panel">
     <!-- Title Block -->

--- a/arches/app/templates/views/graph-designer.htm
+++ b/arches/app/templates/views/graph-designer.htm
@@ -58,7 +58,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
                 <!-- ko if: selectedNode() -->
-                <!-- ko if: selectedNode().dirty() -->
+                <!-- ko if: selectedNode().dirty() && selectedNode().istopnode == false -->
                 <button class="btn btn-sm btn-danger btn-labeled fa fa-trash" data-bind="click: function(){graphModel.get('selectedNode')().reset()}">{% trans "Discard Edits" %}</button>
                 <button class="btn btn-sm btn-primary btn-labeled fa fa-check" data-bind="click: function(){graphModel.get('selectedNode')().save()}">{% trans "Save Edits" %}</button>
                 <!-- /ko -->

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -176,6 +176,7 @@ class NewGraphSettingsView(GraphBaseView):
         node = models.Node.objects.get(graph_id=graphid, istopnode=True)
         node.set_relatable_resources(data.get('relatable_resource_ids'))
         node.ontologyclass = data.get('ontology_class') if data.get('graph').get('ontology_id') is not None else None
+        node.name = graph.name
 
         with transaction.atomic():
             graph.save()


### PR DESCRIPTION
### Description of Change
Updates the root node name when a user modifies the resource model name, Prevents user for switching nodes when the graph settings are dirty. Updates the icon and resource model name in the page title when a user changes those graph properties, re #3202, #3199