### PR TITLE
3199 graph settings

### DIFF
--- a/arches/app/media/js/models/graph.js
+++ b/arches/app/media/js/models/graph.js
@@ -324,7 +324,7 @@ define(['arches',
         },
 
         /**
-         * getValidNodesEdges - gets a list of possible ontolgoy properties and classes the node
+         * getValidNodesEdges - gets a list of possible ontology properties and classes the node
          * referenced by it's id could be based on the location of the node in the graph
          * @memberof GraphModel.prototype
          * @param  {string} nodeid - the node id of the node of interest
@@ -341,7 +341,7 @@ define(['arches',
         },
 
         /**
-         * getValidDomainClasses - gets a list of possible ontolgoy properties and classes the node
+         * getValidDomainClasses - gets a list of possible ontology properties and classes the node
          * referenced by it's id could use to be appened to other nodes
          * @memberof GraphModel.prototype
          * @param  {string} nodeid - the node id of the node of interest
@@ -533,7 +533,7 @@ define(['arches',
          * @param  {NodeModel} root - a reference to the root node in the nodes parameter, or of this graph if not defined
          * @param  {[NodeModel]} nodes - the nodes to make a tree from, defaults to the nodes in this graph
          * @param  {array} edges - the edges to make a tree from, defaults to the edges in this graph
-         * @param  {boolean} append - if true, won't remove the existing hierarchy 
+         * @param  {boolean} append - if true, won't remove the existing hierarchy
          * @return {object} a hierchical node listing
          */
         constructTree: function(root, nodes, edges, append){
@@ -569,11 +569,11 @@ define(['arches',
                 return this.getValidDomainClasses('', function(responseJSON) {
                     this.set('domain_connections', responseJSON);
                     this.set('domain_connections_loaded', true);
-                }, this);   
+                }, this);
             } else {
                 return Promise.resolve()
             }
-                
+
         },
 
         /**

--- a/arches/app/media/js/viewmodels/graph-settings.js
+++ b/arches/app/media/js/viewmodels/graph-settings.js
@@ -23,11 +23,17 @@ define([
         var srcJSON = JSON.stringify(koMapping.toJS(params.graph));
 
         self.graph = params.graph;
-
         self.node = params.node
         self.graph.name.subscribe(function(val){
             self.node().name(val);
         })
+
+        self.graphModel = params.graphModel;
+        self.nodes = self.graphModel.get('nodes');
+
+        self.nodeCount = ko.computed(function(){
+            return self.nodes().length
+        });
 
         var ontologyClass = params.node().ontologyclass;
 

--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -40,6 +40,7 @@ define([
     viewModel.selectedNode = viewModel.graphModel.get('selectedNode');
 
     viewModel.nodeForm = new NodeFormView({
+        graph: viewModel.graph,
         graphModel: viewModel.graphModel,
         loading: viewModel.contentLoading,
         node: viewModel.selectedNode
@@ -57,6 +58,7 @@ define([
 
     viewModel.graphSettingsViewModel = new GraphSettingsViewModel({
         graph: viewModel.graph,
+        graphModel: viewModel.graphModel,
         ontologyClasses: viewModel.ontologyClasses,
         ontologies: viewModel.ontologies,
         ontologyClass: ko.observable(''),

--- a/arches/app/media/js/views/graph/graph-designer/node-form.js
+++ b/arches/app/media/js/views/graph/graph-designer/node-form.js
@@ -22,10 +22,12 @@ define([
             var self = this;
             _.extend(this, _.pick(options, 'graphModel'));
             this.datatypes = _.keys(this.graphModel.get('datatypelookup'));
-            this.hasOntology = this.graphModel.get('ontology_id') ? true: false;
             this.node = options.node;
+            this.graph = options.graph;
             this.loading = options.loading || ko.observable(false);
-
+            this.hasOntology = ko.computed(function(){
+                return self.graph.ontology_id() === null ? false : true;
+            })
             this.isResourceTopNode = ko.computed(function() {
                 var node = self.node();
                 return self.graphModel.get('isresource') && node && node.istopnode;

--- a/arches/app/media/js/views/graph/graph-designer/node-form.js
+++ b/arches/app/media/js/views/graph/graph-designer/node-form.js
@@ -22,7 +22,7 @@ define([
             var self = this;
             _.extend(this, _.pick(options, 'graphModel'));
             this.datatypes = _.keys(this.graphModel.get('datatypelookup'));
-            this.hasOntolgoy = this.graphModel.get('ontology_id') ? true: false;
+            this.hasOntology = this.graphModel.get('ontology_id') ? true: false;
             this.node = options.node;
             this.loading = options.loading || ko.observable(false);
 

--- a/arches/app/media/js/views/graph/graph-manager/node-form.js
+++ b/arches/app/media/js/views/graph/graph-manager/node-form.js
@@ -25,7 +25,7 @@ define([
             var self = this;
             _.extend(this, _.pick(options, 'graphModel', 'branches'));
             this.datatypes = _.keys(this.graphModel.get('datatypelookup'));
-            this.hasOntolgoy = this.graphModel.get('ontology_id') ? true: false;
+            this.hasOntology = this.graphModel.get('ontology_id') ? true: false;
             this.node = this.graphModel.get('selectedNode');
             this.closeClicked = ko.observable(false);
             this.loading = options.loading || ko.observable(false);

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -536,7 +536,7 @@ class Graph(models.GraphModel):
 
     def clear_ontology_references(self):
         """
-        removes any references to ontolgoy classes and properties in a graph
+        removes any references to ontology classes and properties in a graph
 
         """
 

--- a/arches/app/templates/views/graph/graph-designer/graph-settings.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-settings.htm
@@ -48,7 +48,7 @@
                                 </div>
 
                                 <div class="col-xs-12">
-                                    <select class="design" data-bind="attr: {'disabled': graph.nodes().length > 1 }, value: graph.ontology_id, valueAllowUnset: true, options: ontologies, optionsText: 'name', optionsValue:'ontologyid', optionsCaption: '{% trans "No ontology" %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
+                                    <select class="design" data-bind="attr: {'disabled': graphSettingsViewModel.nodeCount() > 1 }, value: graph.ontology_id, valueAllowUnset: true, options: ontologies, optionsText: 'name', optionsValue:'ontologyid', optionsCaption: '{% trans "No ontology" %}', chosen: {disable_search_threshold: 10, width: '100%'}"></select>
                                 </div>
                             </div>
                         </div>
@@ -60,7 +60,7 @@
                                 </div>
 
                                 <div class="col-xs-12">
-                                    <select class="design" data-bind="attr: {'disabled': graph.nodes().length > 1 }, value: graphSettingsViewModel.ontologyClass, valueAllowUnset: false, options: ontologyClasses, optionsText: 'display', optionsValue:'source', chosen: {disable_search_threshold: 10, width: '100%', search_contains: true}"></select>
+                                    <select class="design" data-bind="attr: {'disabled': graphSettingsViewModel.nodeCount() > 1 }, value: graphSettingsViewModel.ontologyClass, valueAllowUnset: false, options: ontologyClasses, optionsText: 'display', optionsValue:'source', chosen: {disable_search_threshold: 10, width: '100%', search_contains: true}"></select>
                                 </div>
                             </div>
                         </div>

--- a/arches/app/templates/views/graph/graph-designer/node-form.htm
+++ b/arches/app/templates/views/graph/graph-designer/node-form.htm
@@ -22,7 +22,7 @@
                     </div>
                 </div>
 
-                <!-- ko if: hasOntolgoy -->
+                <!-- ko if: hasOntology -->
                 <div class="node-widget-label">
                     <div class="control-label">
                         {% trans "CRM Class" %}

--- a/arches/app/templates/views/graph/graph-manager/node-form.htm
+++ b/arches/app/templates/views/graph/graph-manager/node-form.htm
@@ -48,7 +48,7 @@
                     </div>
                 </div>
 
-                <!-- ko if: hasOntolgoy -->
+                <!-- ko if: hasOntology -->
                 <div class="node-widget-label">
                     <div class="control-label">
                         {% trans "CRM Class" %}


### PR DESCRIPTION
### Types of changes
Fixes the display of ontology options in the node form when a user changes the ontology of the graph settings. Also disables the ontology options in the graph settings form once an ontology is defined for the graph and nodes are added. re #3199, #3202 