### PR TITLE
Filters points on permitted nodegroups, re #2492

### DIFF
--- a/arches/app/media/js/views/search/search-results.js
+++ b/arches/app/media/js/views/search/search-results.js
@@ -103,6 +103,7 @@ define(['jquery',
                 this.total(response.results.hits.total);
                 this.results.removeAll();
                 this.userRequestedNewPage(false);
+                response.results.aggregations.geo_aggs = response.results.aggregations.geo_aggs.inner.buckets[0]
                 this.aggregations(
                     _.extend(response.results.aggregations, {
                         results: response.results.hits.hits


### PR DESCRIPTION
### Description of Change
Filters points on permitted nodegroups so that the search map does not automatically zoom to data a user is not permitted to read. re #2492
