### PR TITLE
Removes reindexing of resources after addition of the provisional column

### DIFF
--- a/arches/app/models/migrations/2891_adds_tile_provisional_json.py
+++ b/arches/app/models/migrations/2891_adds_tile_provisional_json.py
@@ -18,5 +18,4 @@ class Migration(migrations.Migration):
             name='provisionaledits',
             field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, db_column='provisionaledits', null=True),
         ),
-        migrations.RunPython(index_database.index_resources, index_database.index_resources),
     ]


### PR DESCRIPTION
Removes reindexing of resources after addition provisional column due to a conflict between new and old versions of the graph model re #3199

Users will need to run python manage.py es index_resources to update their resource index with the provisional flag after migration.