### PR TITLE
remove sphinx as all docs now elsewhere

### DIFF
--- a/arches/install/requirements_dev.txt
+++ b/arches/install/requirements_dev.txt
@@ -1,5 +1,3 @@
-sphinx==1.7.0
-sphinx_rtd_theme
 fabric
 livereload
 webtest


### PR DESCRIPTION
Now that we have the documentation in a different repo, we don't need `sphinx` in the dev requirements.txt file.