### PR TITLE
Add ability to scroll graph tree in graph manager without graph and c…

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -10884,6 +10884,11 @@ ul.select2-choices:after {
 
 .left-panel {
     width: 270px;
+    overflow-x: auto;
+}
+
+.left-panel-overflow {
+    height: 90%;
     overflow-y: auto;
 }
 

--- a/arches/app/templates/views/graph-designer.htm
+++ b/arches/app/templates/views/graph-designer.htm
@@ -103,7 +103,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 </ul>
             </div>
 
-            <div class="tab-content" >
+            <div class="tab-content left-panel-overflow" >
                 <!-- Summary Card -->
                 <div class="tab-pane fade in" data-bind="css: { active: activeTab() === 'graph' }">
                     <div class="" data-bind="with: graphTree">


### PR DESCRIPTION
…ard header disappearing, re #3436

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Allow 'graph/card' header to show on graph tree panel when scrolling down the graph tree.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3436 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
