### PR TITLE
Fixes dirty state of card container for prov users 

### DIFF
--- a/arches/app/media/js/views/resource/editor/form.js
+++ b/arches/app/media/js/views/resource/editor/form.js
@@ -358,6 +358,9 @@ define([
                                 } else {
                                     updatedData = koMapping.toJS(provisionaledit)
                                 }
+                                if (updatedData === null && savingParentTile === true) {
+                                    updatedData = koMapping.toJS(tile.data)
+                                }
                                 tile._data(JSON.stringify(updatedData));
                                 tile.modified(true);
                             }


### PR DESCRIPTION
Fixes dirty state when provisional user saves an edit to a card in a card container, re #3481