### PR TITLE
3385 provisional in new editor

### DIFF
--- a/arches/__init__.py
+++ b/arches/__init__.py
@@ -1,5 +1,5 @@
 from arches.setup import get_version
 
-VERSION = (4, 1, 1, 'final', 0)
+VERSION = (4, 3, 0, 'final', 0)
 
 __version__ = get_version(VERSION)

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -285,6 +285,7 @@ define([
         nodeLookup: createLookup(data.nodes, 'nodeid'),
         graphid: data.graphid,
         graphname: data.graphname,
+        reviewer: data.userisreviewer,
         graphiconclass: data.graphiconclass,
         graph: {
             graphid: data.graphid,

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -244,7 +244,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 widgets: {{widgets_json}},
                 datatypes: {{datatypes_json}},
                 cardComponents: {{card_components_json}},
-                nodegroups: {{nodegroups}}
+                nodegroups: {{nodegroups}},
+                userisreviewer: {{ user_is_reviewer }},
             };
         });{% endautoescape %}
     </script>


### PR DESCRIPTION
### Description of Change
Replaces authoritative data in a tile with a user's provisional data if a user is a provisional user and removes provisional data of other users if a user is provisional. re #3385.

This allows provisional users to see their own edits (and nobody else's) displayed in the resource editor. 

Also updates the Arches version number to 4.3.