### PR TITLE
add operation for deleting mapbox layer #3526

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('-o', '--operation', action='store', dest='operation', default='setup',
-            choices=['setup', 'install', 'setup_db', 'setup_indexes', 'start_elasticsearch', 'setup_elasticsearch', 'build_permissions', 'load_concept_scheme', 'export_business_data', 'export_graphs', 'add_tileserver_layer', 'delete_tileserver_layer',
+            choices=['setup', 'install', 'setup_db', 'setup_indexes', 'start_elasticsearch', 'setup_elasticsearch', 'build_permissions', 'load_concept_scheme', 'export_business_data', 'export_graphs', 'add_tileserver_layer', 'delete_tileserver_layer','delete_mapbox_layer',
             'create_mapping_file', 'import_reference_data', 'import_graphs', 'import_business_data','import_business_data_relations', 'import_mapping_file', 'save_system_settings', 'add_mapbox_layer', 'seed_resource_tile_cache', 'update_project_templates','load_package', 'create_package', 'update_package', 'export_package_configs', 'import_node_value_data'],
             help='Operation Type; ' +
             '\'setup\'=Sets up Elasticsearch and core database schema and code' +
@@ -195,6 +195,9 @@ class Command(BaseCommand):
 
         if options['operation'] == 'delete_tileserver_layer':
             self.delete_tileserver_layer(options['layer_name'])
+            
+        if options['operation'] == 'delete_mapbox_layer':
+            self.delete_mapbox_layer(options['layer_name'])
 
         if options['operation'] == 'create_mapping_file':
             self.create_mapping_file(options['dest_dir'], options['graphs'])
@@ -1090,7 +1093,15 @@ class Command(BaseCommand):
                 tileserver_layer.map_layer.delete()
                 tileserver_layer.map_source.delete()
                 tileserver_layer.delete()
-
+    
+    def delete_mapbox_layer(self, layer_name=False):
+        if layer_name != False:
+            with transaction.atomic():
+                mapbox_layer = models.MapLayer.objects.get(name=layer_name)
+                for layerdef in mapbox_layer.layerdefinitions:
+                    mapbox_layer_source = models.MapSource.objects.get(name=layerdef['source'])
+                    mapbox_layer_source.delete()
+                mapbox_layer.delete()
 
     def create_mapping_file(self, dest_dir=None, graphs=None):
         if graphs != False:


### PR DESCRIPTION
### Types of changes
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
adds a command line operation to delete mapbox layers, mimicking existing operation for deleting tileserver layer. (these two could be combined in the future.)

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3526 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Legion GIS