### PR TITLE
update date and urls in 4.2.0 release notes

### DIFF
--- a/releases/4.2.0.md
+++ b/releases/4.2.0.md
@@ -1,6 +1,6 @@
 ### Arches 4.2.0 release notes
 
-May 31, 2018
+June 19, 2018
 
 The Arches team has been busy trying to improve Arches and fix a several bugs as well.
 Below you'll find a listing of all the changes that are included in the latest release.
@@ -32,7 +32,7 @@ python manage.py es index_database
 
 If you have Arches running on a web server such as Apache, be sure to update your static files directory and restart your web server.
 
-As always the documentation can be found at http://arches4.readthedocs.io/en/stable/
+As always the documentation can be found at http://arches.readthedocs.io/en/stable/
 
 
 #### Installing Yarn
@@ -69,9 +69,9 @@ To upgrade your existing project to use Yarn:
 
 Optional project changes you may want to make:
 
-1. In 4.2 users can cache the time wheel to make subsequent loads faster. They can also configure their time wheel to produce fewer date range bins. Refer to [time wheel configuration](http://arches4.readthedocs.io/en/latest/initial-configuration/?highlight=time%20wheel#time-wheel-configuration) for more details on how to modify these settings in your project.
+1. In 4.2 users can cache the time wheel to make subsequent loads faster. They can also configure their time wheel to produce fewer date range bins. Refer to [time wheel configuration](https://arches.readthedocs.io/en/stable/additional-configuration/#time-wheel-configuration) for more details on how to modify these settings in your project.
 
-2. Projects can now use settings from packages. If your project was created with Arches 4.1, you will need to make the following change to your projects settings.py file. This is only necessary if you are loading data from a package and your package contains a [package_settings.py](http://arches4.readthedocs.io/en/latest/initial-configuration/?highlight=package_settings#settings-beyond-the-ui) file.
+2. Projects can now use settings from packages. If your project was created with Arches 4.1, you will need to make the following change to your projects settings.py file. This is only necessary if you are loading data from a package and your package contains a [package_settings.py](https://arches.readthedocs.io/en/stable/settings-beyond-the-ui/) file.
     ```
     try:
         from settings_local import *

--- a/releases/4.2.0.md
+++ b/releases/4.2.0.md
@@ -2,7 +2,7 @@
 
 June 19, 2018
 
-The Arches team has been busy trying to improve Arches and fix a several bugs as well.
+The Arches team has been busy improving Arches and fixing several bugs as well.
 Below you'll find a listing of all the changes that are included in the latest release.
 
 Some of the highlights:


### PR DESCRIPTION
The urls in the documentation links and the release date needed to be updated.