### PR TITLE
Graph Manager: move delete icon node to far right RE: 3545

### DIFF
--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -24,12 +24,14 @@
             <i data-bind="css: node.iconclass" role="presentation"></i>
             <span style="padding-right: 10px;" data-bind="text: graphTree.getDisplayName(node), css:{filtered: graphTree.filter().length > 0 && !node.filtered()}"></span>
             <!-- ko if: !node.istopnode -->
-            <i class="jstree-node-action-icon fa fa-trash" role="presentation" data-bind="click: graphTree.deleteNode.bind(graphTree)" data-toggle="tooltip" data-original-title="{% trans "Delete Node" %}"></i>
             <i class="jstree-node-action-icon fa fa-arrow-right" role="presentation" data-bind="click: graphTree.exportBranch.bind(graphTree)" data-toggle="tooltip" data-original-title="{% trans "Export Branch" %}"></i>
             <!-- /ko -->
             <i class="jstree-node-action-icon fa fa-plus-circle" role="presentation" data-bind="click: graphTree.addChildNode.bind(graphTree)" data-toggle="tooltip" data-original-title="{% trans "Add Child Node" %}"></i>
             <!-- ko if: node.istopnode && node.graph.get('isresource') -->
             <i class="jstree-node-action-icon ion-merge" role="presentation" data-bind="click: graphTree.toggleBranchList.bind(graphTree)" data-toggle="tooltip" data-original-title="{% trans "Add Branch" %}"></i>
+            <!-- /ko -->
+            <!-- ko if: !node.istopnode -->
+            <i class="jstree-node-action-icon fa fa-trash" role="presentation" data-bind="click: graphTree.deleteNode.bind(graphTree)" data-toggle="tooltip" data-original-title="{% trans "Delete Node" %}"></i>
             <!-- /ko -->
         </a>
         <ul class="jstree-children" aria-expanded="true" data-bind="if: node.children().length > 0">


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Move the delete node icon to the far right on the graph manager node 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3545

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Getty Conservation Institute <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->