### PR TITLE
Allow filter box and expand/collapse button to remain in header while…

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -10894,10 +10894,11 @@ ul.select2-choices:after {
 .left-panel {
     width: 270px;
     overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .left-panel-overflow {
-    height: 90%;
+    height: calc(90vh - 60px);
     overflow-y: auto;
 }
 

--- a/arches/app/templates/views/graph-designer.htm
+++ b/arches/app/templates/views/graph-designer.htm
@@ -110,7 +110,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 </ul>
             </div>
 
-            <div class="tab-content left-panel-overflow" >
+            <div class="tab-content" >
                 <!-- Summary Card -->
                 <div class="tab-pane fade in" data-bind="css: { active: activeTab() === 'graph' }">
                     <div class="" data-bind="with: graphTree">

--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -1,7 +1,7 @@
 {% load i18n %}
 <!-- ko foreach: { data: [$data], as: 'graphTree' } -->
 <div class="jstree jstree-default">
-    <div class="header">
+    <div class="header" style="padding-bottom: 55px">
         <!-- Layer Filter -->
         <div class="list-filter" data-bind="" style="margin-right: 10px;">
             <input type="text" class="form-control" style="width: 250px;" placeholder="{% trans 'Find a node, datatype, card...' %}" data-bind="textInput: graphTree.filter">
@@ -9,19 +9,22 @@
             <!-- Clear Search -->
             <span class="clear-node-search" data-bind="visible: graphTree.filter().length > 0, click: function() { graphTree.filter(''); }" style="top: 8px;"><i class="fa fa-times-circle"></i></span>
         </div>
-
-        <a data-bind="click: expandAll">Expand all</a>
-        <a data-bind="click: collapseAll" style="padding-left:5px;">Collapse all</a>
+        <div style="text-align: center;">
+            <a data-bind="click: expandAll" style="cursor:pointer;">Expand all</a>
+            <a data-bind="click: collapseAll" style="padding-left:30px; cursor:pointer;">Collapse all</a>
+        </div>
     </div>
-    <!-- <div data-bind="sortable: $data"> -->
-    <ul class="jstree-container-ul jstree-children" aria-expanded="true">
-        <div class="" data-bind="template: {
-            name: 'graph-tree',
-            foreach: graphTree.graphModel.tree,
-            as: 'node'
-        }"></div>
-    </ul>
-    <!-- </div> -->
+    <div class="left-panel-overflow">
+        <!-- <div data-bind="sortable: $data"> -->
+        <ul class="jstree-container-ul jstree-children" aria-expanded="true">
+            <div class="" data-bind="template: {
+                name: 'graph-tree',
+                foreach: graphTree.graphModel.tree,
+                as: 'node'
+            }"></div>
+        </ul>
+        <!-- </div> -->
+    </div>
 </div>
 <!-- /ko -->
 


### PR DESCRIPTION
… scrolling graph tree, re #3436

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Allow filter box and expand/collapse button to remain in header while scrolling graph tree, re #3436

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3436 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
