### PR TITLE
3385 provisional in new editor

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5534,6 +5534,15 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     background-color: #ddd;
 }
 
+.new-provisional-edit-entry:hover {
+    border-color: #111;
+    background-color: #ececec;
+}
+
+.new-provisional-edit-entry.selected {
+    background-color: #ececec;
+}
+
 .new-provisional-edit-entry .field {
     padding: 5px
 }

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5516,6 +5516,28 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     margin-top: 0px;
 }
 
+.new-provisional-edits-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0px;
+}
+
+
+.new-provisional-edit-entry {
+    display: flex;
+    flex-direction: row;
+    padding: 3px;
+    margin: 2px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #ccc;
+    background-color: #ddd;
+}
+
+.new-provisional-edit-entry .field {
+    padding: 5px
+}
+
 .provisional-edits-list-header {
     display: inline-flex;
     width: 100%;

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5531,7 +5531,25 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     border-style: solid;
     border-width: 1px;
     border-color: #ccc;
-    background-color: #ddd;
+    background-color: #fafafa;
+    justify-content: space-between;
+}
+
+.new-provisional-edits-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #2f527a;
+}
+
+.new-delete-provisional-edit {
+    color: red;
+    font-size: 16px;
+}
+
+.new-provisional-edits-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 }
 
 .new-provisional-edit-entry:hover {

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -33,7 +33,6 @@
     overflow-x: scroll;
 }
 
-
 /*.navbar-top-links:last-child>li {
     border-right: 1px solid rgba(0,0,0,0.07);
 }*/
@@ -5501,6 +5500,10 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     margin-right: 10px;
     background: #F5BB25;
     color: #fff;
+}
+
+.has-provisional-edits {
+    color: #F5BB25;
 }
 
 .provisional-edits-list {

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -21,7 +21,7 @@ define([
         self.selectedTile = params.tile;
         self.provisionaledits = ko.observableArray();
         self.declineUnacceptedEdits = ko.observable(true);
-        self.selectedProvisionalTile = ko.observable();
+        self.selectedProvisionalEdit = ko.observable();
 
         self.getUserNames = function(edits, users){
             $.ajax({
@@ -54,14 +54,20 @@ define([
                 this.provisionaledits(_.sortBy(provisionaleditlist, function(pe){return moment(pe.timestamp)}));
                 if (data && _.keys(data).length === 0 && tile.provisionaledits()) {
                     koMapping.fromJS(this.provisionaledits()[0]['value'], tile.data);
+                    this.selectedProvisionalEdit(this.provisionaledits()[0])
                     tile._tileData.valueHasMutated()
                 };
                 this.getUserNames(this.provisionaleditlist, users);
             };
         };
 
-        self.updateProvisionalEdits(self.selectedTile);
+        self.selectProvisionalEdit = function(val){
+            self.selectedProvisionalEdit(val);
+            koMapping.fromJS(val['value'], self.selectedTile().data);
+            self.selectedTile()._tileData.valueHasMutated()
+        };
 
+        self.updateProvisionalEdits(self.selectedTile);
         self.selectedTile.subscribe(self.updateProvisionalEdits, this);
 
 
@@ -103,9 +109,9 @@ define([
 
         // self.acceptProvisionalEdit = function(val){
         //     self.loading(true);
-        //     this.selectedProvisionalTile().data = val.value
-        //     var tile = this.selectedProvisionalTile()
-        //     this.form.saveTile(this.parentTile, this.cardinality, this.selectedProvisionalTile())
+        //     this.selectedProvisionalEdit().data = val.value
+        //     var tile = this.selectedProvisionalEdit()
+        //     this.form.saveTile(this.parentTile, this.cardinality, this.selectedProvisionalEdit())
         //     this.form.on('after-update', function(){
         //         if (this.declineUnacceptedEdits()) {
         //             this.deleteAllProvisionalEdits();
@@ -131,8 +137,8 @@ define([
         //     }, self);
         // }
         //
-        // self.selectedProvisionalTile = params.selectedProvisionalTile
-        // self.selectedProvisionalTile.subscribe(function(val) {
+        // self.selectedProvisionalEdit = params.selectedProvisionalEdit
+        // self.selectedProvisionalEdit.subscribe(function(val) {
         //     if (!self.selectedForm()) {
         //         self.selectedForm(self.form.formid)
         //     };

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -95,23 +95,24 @@ define([
             });
         }
 
-        // self.deleteAllProvisionalEdits = function() {
-        //     var edits = koMapping.toJSON({'edits':self.edits()})
-        //     $.ajax({
-        //         url: arches.urls.delete_provisional_tile,
-        //         context: this,
-        //         method: 'POST',
-        //         dataType: 'json',
-        //         data: {payload: edits}
-        //     })
-        //     .done(function(data) {
-        //         self.edits.removeAll();
-        //         self.form.loadForm(self.selectedForm());
-        //     })
-        //     .fail(function(data) {
-        //         console.log('Related resource request failed', data)
-        //     });
-        // }
+        self.deleteAllProvisionalEdits = function() {
+            var users = _.map(self.provisionaledits(), function(edit){return edit.user});
+            $.ajax({
+                url: arches.urls.delete_provisional_tile,
+                context: this,
+                method: 'POST',
+                dataType: 'json',
+                data: {'users': JSON.stringify(users), 'tileid': this.selectedTile().tileid }
+            })
+            .done(function(data) {
+                self.selectedTile().reset();
+                self.selectedProvisionalEdit(undefined);
+                self.provisionaledits.removeAll();
+            })
+            .fail(function(data) {
+                console.log('request failed', data)
+            });
+        }
 
 
         self.acceptProvisionalEdit = function(){

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -48,6 +48,7 @@ define([
                 var provisionaleditlist = _.map(tile.provisionaledits(), function(edit, key){
                     users.push(key);
                     edit['username'] = ko.observable('');
+                    edit['displaytimestamp'] =  moment(edit.timestamp).format("MMMM Do YYYY, h:mm a");
                     edit['user'] = key;
                     return edit;
                 }, this);

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -75,23 +75,24 @@ define([
         self.updateProvisionalEdits(self.selectedTile);
         self.selectedTile.subscribe(self.updateProvisionalEdits, this);
 
-
         self.deleteProvisionalEdit = function(val){
-            console.log('deleting', val)
-            // $.ajax({
-            //     url: arches.urls.delete_provisional_tile,
-            //     context: this,
-            //     method: 'POST',
-            //     dataType: 'json',
-            //     data: koMapping.toJS(val)
-            // })
-            // .done(function(data) {
-            //     self.edits.remove(val);
-            //     self.form.loadForm(self.selectedForm());
-            // })
-            // .fail(function(data) {
-            //     console.log('Related resource request failed', data)
-            // });
+            $.ajax({
+                url: arches.urls.delete_provisional_tile,
+                context: this,
+                method: 'POST',
+                dataType: 'json',
+                data: {'user': koMapping.toJS(val).user, 'tileid': this.selectedTile().tileid }
+            })
+            .done(function(data) {
+                if (self.selectedProvisionalEdit() === val) {
+                    self.selectedProvisionalEdit(undefined);
+                    self.selectedTile().reset();
+                };
+                self.provisionaledits.remove(val);
+            })
+            .fail(function(data) {
+                console.log('request failed', data)
+            });
         }
 
         // self.deleteAllProvisionalEdits = function() {
@@ -131,49 +132,11 @@ define([
             this.selectedTile().save();
         };
 
-        // self.acceptProvisionalEdit = function(val){
-        //     var provisionaledits = this.selectedTile().provisionaledits();
-        //     if (provisionaledits) {
-        //         delete provisionaledits[val.user]
-        //         if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
-        //             this.selectedTile().provisionaledits(null);
-        //         }
-        //         this.selectProvisionalEdit(val);
-        //         this.selectedTile().save();
-        //         this.selectedProvisionalEdit(undefined);
-        //         this.provisionaledits.remove(val);
-        //     }
-        // }
-        //
         self.rejectProvisionalEdit = function(val){
             console.log('rejecting')
             self.deleteProvisionalEdit(val);
         }
-        //
-        // self.findCard = function(cards, nodegroupid){
-        //     _.each(cards, function(card) {
-        //         if (card.get('nodegroup_id') == nodegroupid) {
-        //             this.card = card
-        //         }
-        //         if (this.card == null) {
-        //             self.findCard(card.get('cards')(), nodegroupid)
-        //         }
-        //     }, self);
-        // }
-        //
-        // self.selectedProvisionalEdit = params.selectedProvisionalEdit
-        // self.selectedProvisionalEdit.subscribe(function(val) {
-        //     if (!self.selectedForm()) {
-        //         self.selectedForm(self.form.formid)
-        //     };
-        //     self.edits.removeAll();
-        //     if (val) {
-        //         self.card = null;
-        //         self.findCard(this.cards(), val.nodegroup_id())
-        //         this.parseProvisionalEdits(val.provisionaledits());
-        //         this.getUserNames(self.edits())
-        //     }
-        // }, self)
+
     };
 
     return ProvisionalTileViewModel;

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -1,0 +1,150 @@
+define([
+    'knockout',
+    'knockout-mapping',
+    'moment',
+    'arches',
+    'views/components/simple-switch'
+], function (ko, koMapping, moment, arches) {
+    /**
+    * A viewmodel for managing provisional edits
+    *
+    * @constructor
+    * @name ProvisionalTileViewModel
+    *
+    * @param  {string} params - a configuration object
+    */
+    var ProvisionalTileViewModel = function(params) {
+        var self = this;
+        self.card = null;
+        self.edits = ko.observableArray()
+        self.users = []
+        self.selectedTile = params.tile;
+        self.provisionaledits = ko.observableArray();
+        self.declineUnacceptedEdits = ko.observable(true);
+        self.selectedProvisionalTile = ko.observable();
+
+        self.getUserNames = function(edits, users){
+            $.ajax({
+                url: arches.urls.get_user_names,
+                context: this,
+                method: 'POST',
+                data: { userids: JSON.stringify(users) },
+                dataType: 'json'
+            })
+            .done(function(data) {
+                _.each(this.provisionaledits(), function(edit) {
+                    edit.username(data[edit.user]);
+                })
+            })
+            .fail(function(data) {
+                console.log('User name request failed', data)
+            });
+        }
+
+        self.updateProvisionalEdits = function(tile) {
+            if (tile.data) {
+                var users = [];
+                var data = koMapping.toJS(tile.data);
+                var provisionaleditlist = _.map(tile.provisionaledits(), function(edit, key){
+                    users.push(key);
+                    edit['username'] = ko.observable('');
+                    edit['user'] = key;
+                    return edit;
+                }, this);
+                this.provisionaledits(_.sortBy(provisionaleditlist, function(pe){return moment(pe.timestamp)}));
+                if (data && _.keys(data).length === 0 && tile.provisionaledits()) {
+                    koMapping.fromJS(this.provisionaledits()[0]['value'], tile.data);
+                    tile._tileData.valueHasMutated()
+                };
+                this.getUserNames(this.provisionaleditlist, users);
+            };
+        };
+
+        self.updateProvisionalEdits(self.selectedTile);
+
+        self.selectedTile.subscribe(self.updateProvisionalEdits, this);
+
+
+
+        // self.deleteProvisionalEdit = function(val){
+        //     $.ajax({
+        //         url: arches.urls.delete_provisional_tile,
+        //         context: this,
+        //         method: 'POST',
+        //         dataType: 'json',
+        //         data: koMapping.toJS(val)
+        //     })
+        //     .done(function(data) {
+        //         self.edits.remove(val);
+        //         self.form.loadForm(self.selectedForm());
+        //     })
+        //     .fail(function(data) {
+        //         console.log('Related resource request failed', data)
+        //     });
+        // }
+
+        // self.deleteAllProvisionalEdits = function() {
+        //     var edits = koMapping.toJSON({'edits':self.edits()})
+        //     $.ajax({
+        //         url: arches.urls.delete_provisional_tile,
+        //         context: this,
+        //         method: 'POST',
+        //         dataType: 'json',
+        //         data: {payload: edits}
+        //     })
+        //     .done(function(data) {
+        //         self.edits.removeAll();
+        //         self.form.loadForm(self.selectedForm());
+        //     })
+        //     .fail(function(data) {
+        //         console.log('Related resource request failed', data)
+        //     });
+        // }
+
+        // self.acceptProvisionalEdit = function(val){
+        //     self.loading(true);
+        //     this.selectedProvisionalTile().data = val.value
+        //     var tile = this.selectedProvisionalTile()
+        //     this.form.saveTile(this.parentTile, this.cardinality, this.selectedProvisionalTile())
+        //     this.form.on('after-update', function(){
+        //         if (this.declineUnacceptedEdits()) {
+        //             this.deleteAllProvisionalEdits();
+        //         } else {
+        //             this.deleteProvisionalEdit(val);
+        //         }
+        //         this.loading(false);
+        //     }, this)
+        // }
+        //
+        // self.rejectProvisionalEdit = function(val){
+        //     self.deleteProvisionalEdit(val);
+        // }
+        //
+        // self.findCard = function(cards, nodegroupid){
+        //     _.each(cards, function(card) {
+        //         if (card.get('nodegroup_id') == nodegroupid) {
+        //             this.card = card
+        //         }
+        //         if (this.card == null) {
+        //             self.findCard(card.get('cards')(), nodegroupid)
+        //         }
+        //     }, self);
+        // }
+        //
+        // self.selectedProvisionalTile = params.selectedProvisionalTile
+        // self.selectedProvisionalTile.subscribe(function(val) {
+        //     if (!self.selectedForm()) {
+        //         self.selectedForm(self.form.formid)
+        //     };
+        //     self.edits.removeAll();
+        //     if (val) {
+        //         self.card = null;
+        //         self.findCard(this.cards(), val.nodegroup_id())
+        //         this.parseProvisionalEdits(val.provisionaledits());
+        //         this.getUserNames(self.edits())
+        //     }
+        // }, self)
+    };
+
+    return ProvisionalTileViewModel;
+});

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -85,11 +85,18 @@ define([
                 data: {'user': koMapping.toJS(val).user, 'tileid': this.selectedTile().tileid }
             })
             .done(function(data) {
+                var user = val.user;
+                var provisionaledits = this.selectedTile().provisionaledits();
+                delete provisionaledits[user]
+                this.selectedTile().provisionaledits(provisionaledits);
                 if (self.selectedProvisionalEdit() === val) {
                     self.selectedProvisionalEdit(undefined);
                     self.selectedTile().reset();
                 };
                 self.provisionaledits.remove(val);
+                if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
+                    this.selectedTile().provisionaledits(null);
+                };
             })
             .fail(function(data) {
                 console.log('request failed', data)
@@ -109,6 +116,7 @@ define([
                 self.selectedTile().reset();
                 self.selectedProvisionalEdit(undefined);
                 self.provisionaledits.removeAll();
+                this.selectedTile().provisionaledits(null);
             })
             .fail(function(data) {
                 console.log('request failed', data)

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -61,6 +61,11 @@ define([
             };
         };
 
+        self.removeSelectedProvisionalEdit = function() {
+            this.provisionaledits.remove(this.selectedProvisionalEdit());
+            this.selectedProvisionalEdit(undefined);
+        };
+
         self.selectProvisionalEdit = function(val){
             self.selectedProvisionalEdit(val);
             koMapping.fromJS(val['value'], self.selectedTile().data);
@@ -71,23 +76,23 @@ define([
         self.selectedTile.subscribe(self.updateProvisionalEdits, this);
 
 
-
-        // self.deleteProvisionalEdit = function(val){
-        //     $.ajax({
-        //         url: arches.urls.delete_provisional_tile,
-        //         context: this,
-        //         method: 'POST',
-        //         dataType: 'json',
-        //         data: koMapping.toJS(val)
-        //     })
-        //     .done(function(data) {
-        //         self.edits.remove(val);
-        //         self.form.loadForm(self.selectedForm());
-        //     })
-        //     .fail(function(data) {
-        //         console.log('Related resource request failed', data)
-        //     });
-        // }
+        self.deleteProvisionalEdit = function(val){
+            console.log('deleting', val)
+            // $.ajax({
+            //     url: arches.urls.delete_provisional_tile,
+            //     context: this,
+            //     method: 'POST',
+            //     dataType: 'json',
+            //     data: koMapping.toJS(val)
+            // })
+            // .done(function(data) {
+            //     self.edits.remove(val);
+            //     self.form.loadForm(self.selectedForm());
+            // })
+            // .fail(function(data) {
+            //     console.log('Related resource request failed', data)
+            // });
+        }
 
         // self.deleteAllProvisionalEdits = function() {
         //     var edits = koMapping.toJSON({'edits':self.edits()})
@@ -107,24 +112,43 @@ define([
         //     });
         // }
 
+
+        self.acceptProvisionalEdit = function(){
+            var provisionaledits = this.selectedTile().provisionaledits();
+            var user = this.selectedProvisionalEdit().user
+            if (provisionaledits) {
+                delete provisionaledits[user]
+                if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
+                    this.selectedTile().provisionaledits(null);
+                }
+                this.provisionaledits.remove(this.selectedProvisionalEdit());
+                this.selectedProvisionalEdit(undefined);
+            }
+        };
+
+        self.acceptEdit = function(val){
+            this.selectProvisionalEdit(val);
+            this.selectedTile().save();
+        };
+
         // self.acceptProvisionalEdit = function(val){
-        //     self.loading(true);
-        //     this.selectedProvisionalEdit().data = val.value
-        //     var tile = this.selectedProvisionalEdit()
-        //     this.form.saveTile(this.parentTile, this.cardinality, this.selectedProvisionalEdit())
-        //     this.form.on('after-update', function(){
-        //         if (this.declineUnacceptedEdits()) {
-        //             this.deleteAllProvisionalEdits();
-        //         } else {
-        //             this.deleteProvisionalEdit(val);
+        //     var provisionaledits = this.selectedTile().provisionaledits();
+        //     if (provisionaledits) {
+        //         delete provisionaledits[val.user]
+        //         if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
+        //             this.selectedTile().provisionaledits(null);
         //         }
-        //         this.loading(false);
-        //     }, this)
+        //         this.selectProvisionalEdit(val);
+        //         this.selectedTile().save();
+        //         this.selectedProvisionalEdit(undefined);
+        //         this.provisionaledits.remove(val);
+        //     }
         // }
         //
-        // self.rejectProvisionalEdit = function(val){
-        //     self.deleteProvisionalEdit(val);
-        // }
+        self.rejectProvisionalEdit = function(val){
+            console.log('rejecting')
+            self.deleteProvisionalEdit(val);
+        }
         //
         // self.findCard = function(cards, nodegroupid){
         //     _.each(cards, function(card) {

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -143,7 +143,6 @@ define([
         };
 
         self.rejectProvisionalEdit = function(val){
-            console.log('rejecting')
             self.deleteProvisionalEdit(val);
         }
 

--- a/arches/app/media/js/views/components/widgets/radio-boolean.js
+++ b/arches/app/media/js/views/components/widgets/radio-boolean.js
@@ -52,7 +52,7 @@ define(['knockout', 'underscore', 'viewmodels/widget'], function (ko, _, WidgetV
             if (self.value() === null && self.defaultValue() !== null) {
                 self.value(self.defaultValue());
             }
-            if (this.tile && this.tile.tileid() == "" && defaultValue != null && defaultValue != "") {
+            if (this.tile && ko.unwrap(this.tile.tileid) == "" && defaultValue != null && defaultValue != "") {
                 this.value(defaultValue);
             }
         },

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -192,6 +192,7 @@ define([
                 _.each(handlers['tile-reset'], function (handler) {
                     handler(tile);
                 });
+                vm.provisionalTileViewModel.selectedProvisionalEdit(undefined);
             },
             getAttributes: function () {
                 var tileData = tile.data ? koMapping.toJS(tile.data) : {};

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -286,7 +286,7 @@ define([
                     parent.tiles.remove(tile);
                     selection(parent);
                 }).fail(function(response) {
-                    console.log('there was an error ', response);
+                    vm.alert(new AlertViewModel('ep-alert-red', response.responseJSON.message[0], response.responseJSON.message[1], null, function(){}));
                 }).always(function(){
                     loading(false);
                 });

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -117,6 +117,13 @@ define([
                     return setupTile(tile, card);
                 })
             ),
+            provisionaleditcount: ko.computed(function(){
+                return _.filter(tiles, function(tile){
+                    return (
+                        parent ? (tile.parenttile_id === parent.tileid) : true
+                    ) && tile.nodegroup_id === card.nodegroup_id && ko.unwrap(tile.provisionaledits);
+                }).length
+            }),
             selected: ko.pureComputed({
                 read: function () {
                     return selection() === this;
@@ -140,6 +147,7 @@ define([
             koMapping.toJSON(tile.data)
         );
         tile.data = koMapping.fromJS(tile.data);
+        tile.provisionaledits = ko.observable(tile.provisionaledits);
 
         tile = _.extend(tile, {
             parent: parent,
@@ -149,6 +157,9 @@ define([
                 return setupCard(_.clone(card), tile);
             }),
             expanded: ko.observable(true),
+            hasprovisionaledits: ko.computed(function () {
+                return !!tile.provisionaledits();
+            }, this),
             selected: ko.pureComputed({
                 read: function () {
                     return selection() === this;
@@ -221,6 +232,12 @@ define([
                         tile.parent.tiles.unshift(tile);
                         tile.parent.expanded(true);
                         vm.selection(tile);
+                    }
+                    if (data.userisreviewer === false && tile.provisionaledits() === null) {
+                        tile.provisionaledits(tile.data);
+                    };
+                    if (data.userisreviewer === true) {
+                        tile.provisionaledits(null);
                     }
                     if (!resourceId()) {
                         tile.resourceinstance_id = tileData.resourceinstance_id;

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -96,6 +96,17 @@ define([
         return childSelected;
     };
 
+    var doesChildHaveProvisionalEdits = function(parent) {
+        var hasEdits = false;
+        var childrenKey = parent.tiles ? 'tiles' : 'cards';
+        ko.unwrap(parent[childrenKey]).forEach(function(child) {
+            if (child.hasprovisionaledits() || doesChildHaveProvisionalEdits(child)){
+                hasEdits = true;
+            }
+        });
+        return hasEdits;
+    };
+
     var setupCard = function (card, parent) {
         card = _.extend(card, {
             parent: parent,
@@ -119,7 +130,7 @@ define([
                     return setupTile(tile, card);
                 })
             ),
-            provisionaleditcount: ko.computed(function(){
+            hasprovisionaledits: ko.computed(function(){
                 return _.filter(tiles, function(tile){
                     return (
                         parent ? (tile.parenttile_id === parent.tileid) : true
@@ -147,6 +158,9 @@ define([
         card.isChildSelected = ko.computed(function() {
             return isChildSelected(card);
         }, this);
+        card.doesChildHaveProvisionalEdits = ko.computed(function() {
+            return doesChildHaveProvisionalEdits(card);
+        });
         return card;
     };
 
@@ -295,6 +309,9 @@ define([
         tile.isChildSelected = ko.computed(function() {
             return isChildSelected(tile);
         }, this);
+        tile.doesChildHaveProvisionalEdits = ko.computed(function() {
+            return doesChildHaveProvisionalEdits(tile);
+        });
         return tile;
     };
 

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -3,15 +3,17 @@ define([
     'underscore',
     'knockout',
     'knockout-mapping',
+    'moment',
     'views/base-manager',
     'viewmodels/alert',
+    'viewmodels/new-provisional-tile',
     'arches',
     'resource-editor-data',
     'bindings/resizable-sidepanel',
     'bindings/sortable',
     'widgets',
     'card-components'
-], function($, _, ko, koMapping, BaseManagerView, AlertViewModel, arches, data) {
+], function($, _, ko, koMapping, moment, BaseManagerView, AlertViewModel, ProvisionalTileViewModel, arches, data) {
     var handlers = {
         'after-update': [],
         'tile-reset': []
@@ -152,6 +154,7 @@ define([
         tile._tileData = ko.observable(
             koMapping.toJSON(tile.data)
         );
+
         tile.data = koMapping.fromJS(tile.data);
         tile.provisionaledits = ko.observable(tile.provisionaledits);
 
@@ -243,7 +246,8 @@ define([
                         tile.parent.expanded(true);
                         vm.selection(tile);
                     }
-                    if (data.userisreviewer === false && tile.provisionaledits() === null) {
+                    if (data.userisreviewer === false && !tile.provisionaledits()) {
+                        //If the user is provisional ensure their edits are provisional
                         tile.provisionaledits(tile.data);
                     };
                     if (data.userisreviewer === true) {
@@ -446,6 +450,7 @@ define([
         }
     };
     var topCard = vm.topCards[0];
+    vm.provisionalTileViewModel = new ProvisionalTileViewModel({tile: vm.selectedTile, reviewer: data.user_is_reviewer});
     selection(topCard.tiles().length > 0 ? topCard.tiles()[0] : topCard);
 
     vm.selectionBreadcrumbs = ko.computed(function () {

--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -195,12 +195,14 @@ define([
             },
             getAttributes: function () {
                 var tileData = tile.data ? koMapping.toJS(tile.data) : {};
+                var tileProvisionalEdits = tile.provisionaledits ? koMapping.toJS(tile.provisionaledits) : {};
                 return {
                     "tileid": tile.tileid,
                     "data": tileData,
                     "nodegroup_id": tile.nodegroup_id,
                     "parenttile_id": tile.parenttile_id,
-                    "resourceinstance_id": tile.resourceinstance_id
+                    "resourceinstance_id": tile.resourceinstance_id,
+                    "provisionaledits": tileProvisionalEdits
                 }
             },
             getData: function () {
@@ -220,6 +222,9 @@ define([
             save: function () {
                 loading(true);
                 delete tile.formData.data;
+                if (vm.provisionalTileViewModel.selectedProvisionalEdit()) {
+                    vm.provisionalTileViewModel.acceptProvisionalEdit();
+                };
                 tile.formData.append(
                     'data',
                     JSON.stringify(
@@ -236,6 +241,7 @@ define([
                 }).done(function(tileData, status, req) {
                     if (tile.tileid) {
                         koMapping.fromJS(tileData.data,tile.data);
+                        koMapping.fromJS(tileData.provisionaledits,tile.provisionaledits);
                     } else {
                         tile.data = koMapping.fromJS(tileData.data);
                     }
@@ -250,9 +256,11 @@ define([
                         //If the user is provisional ensure their edits are provisional
                         tile.provisionaledits(tile.data);
                     };
-                    if (data.userisreviewer === true) {
-                        tile.provisionaledits(null);
-                    }
+                    if (data.userisreviewer === true && vm.provisionalTileViewModel.selectedProvisionalEdit()) {
+                        if (JSON.stringify(vm.provisionalTileViewModel.selectedProvisionalEdit().value) === koMapping.toJSON(tile.data)) {
+                            vm.provisionalTileViewModel.removeSelectedProvisionalEdit();
+                        };
+                    };
                     if (!resourceId()) {
                         tile.resourceinstance_id = tileData.resourceinstance_id;
                         resourceId(tile.resourceinstance_id);

--- a/arches/app/models/migrations/deserialize_provisional_edits.py
+++ b/arches/app/models/migrations/deserialize_provisional_edits.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+
+
+def forwards_func(apps, schema_editor):
+    # We get the model from the versioned app registry;
+    # if we directly import it, it'll be the wrong version
+    TileModel = apps.get_model("models", "TileModel")
+    tiles = TileModel.objects.all()
+    for tile in tiles:
+        if tile.provisionaledits is not None:
+            tile.provisionaledits = JSONDeserializer().deserialize(tile.provisionaledits)
+            tile.save()
+
+def reverse_func(apps, schema_editor):
+    # We get the model from the versioned app registry;
+    # if we directly import it, it'll be the wrong version
+    TileModel = apps.get_model("models", "TileModel")
+    tiles = TileModel.objects.all()
+    for tile in tiles:
+        if tile.provisionaledits is not None:
+            tile.provisionaledits = JSONSerializer().serialize(tile.provisionaledits)
+            tile.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('models', '3201_second_removal_of_node_nodetype_branch'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -170,7 +170,6 @@ class Resource(models.ResourceInstance):
             document, terms = self.get_documents_to_index(datatype_factory=datatype_factory, node_datatypes=node_datatypes)
             document['root_ontology_class'] = self.get_root_ontology()
             se.index_data('resource', self.graph_id, JSONSerializer().serializeToPython(document), id=self.pk)
-
             for term in terms:
                 se.index_data('strings', 'term', term['_source'], id=term['_id'])
 
@@ -211,7 +210,7 @@ class Resource(models.ResourceInstance):
                         terms.append({'_id':unicode(nodeid)+unicode(tile.tileid)+unicode(index), '_source': {'value': term, 'nodeid': nodeid, 'nodegroupid': tile.nodegroup_id, 'tileid': tile.tileid, 'resourceinstanceid':tile.resourceinstance_id, 'provisional': False}})
 
             if tile.provisionaledits is not None:
-                provisionaledits = JSONDeserializer().deserialize(tile.provisionaledits)
+                provisionaledits = tile.provisionaledits
                 if len(provisionaledits) > 0:
                     if document['provisional_resource'] == 'false':
                         document['provisional_resource'] = 'partial'

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -125,7 +125,7 @@ class Tile(models.TileModel):
                 result = False
         return result
 
-    def apply_provisional_edit(self, user, data, action='create', status='review'):
+    def apply_provisional_edit(self, user, data, action='create', status='review', existing_model=None):
         """
         Creates or updates the json stored in a tile's provisionaledits db_column
 
@@ -141,8 +141,8 @@ class Tile(models.TileModel):
                 "reviewtimestamp": None
             }
 
-            if self.provisionaledits is not None:
-                provisionaledits = JSONDeserializer().deserialize(self.provisionaledits)
+            if existing_model and existing_model.provisionaledits is not None:
+                provisionaledits = JSONDeserializer().deserialize(existing_model.provisionaledits)
                 provisionaledits[str(user.id)] = provisionaledit
             else:
                 provisionaledits = {
@@ -234,7 +234,8 @@ class Tile(models.TileModel):
 
         if user is not None:
             if user_is_reviewer == False and creating_new_tile == False:
-                self.apply_provisional_edit(user, self.data, action='update')
+                self.apply_provisional_edit(user, self.data, action='update', existing_model=existing_model)
+                print self.provisionaledits
                 newprovisionalvalue = self.data
                 oldprovisional = self.get_provisional_edit(existing_model, user)
                 if oldprovisional is not None:
@@ -262,7 +263,6 @@ class Tile(models.TileModel):
 
         for tiles in self.tiles.itervalues():
             for tile in tiles:
-                # print tile.provisionaledits, tile.tileid
                 tile.resourceinstance = self.resourceinstance
                 tile.parenttile = self
                 tile.save(*args, request=request, index=index, **kwargs)

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -234,7 +234,6 @@ class Tile(models.TileModel):
         if user is not None:
             if user_is_reviewer == False and creating_new_tile == False:
                 self.apply_provisional_edit(user, self.data, action='update', existing_model=existing_model)
-                print self.provisionaledits
                 newprovisionalvalue = self.data
                 oldprovisional = self.get_provisional_edit(existing_model, user)
                 if oldprovisional is not None:

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -172,7 +172,7 @@ class Tile(models.TileModel):
         if self.provisionaledits is None:
             return False
         else:
-            return str(user.id) in JSONDeserializer().deserialize(self.provisionaledits)
+            return str(user.id) in self.provisionaledits
 
     def get_provisional_edit(self, tile, user):
         edit = None

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -137,18 +137,18 @@ class Tile(models.TileModel):
                 "status": status,
                 "action": action,
                 "reviewer": None,
-                "timestamp": timezone.now(),
+                "timestamp": unicode(timezone.now()),
                 "reviewtimestamp": None
             }
 
             if existing_model and existing_model.provisionaledits is not None:
-                provisionaledits = JSONDeserializer().deserialize(existing_model.provisionaledits)
+                provisionaledits = existing_model.provisionaledits
                 provisionaledits[str(user.id)] = provisionaledit
             else:
                 provisionaledits = {
                     user.id: provisionaledit
                     }
-            self.provisionaledits = JSONSerializer().serialize(provisionaledits)
+            self.provisionaledits = provisionaledits
 
     def is_provisional(self):
         """
@@ -178,7 +178,7 @@ class Tile(models.TileModel):
     def get_provisional_edit(self, tile, user):
         edit = None
         if tile.provisionaledits is not None:
-            edits = json.loads(tile.provisionaledits)
+            edits = tile.provisionaledits
             if str(user.id) in edits:
                 edit = edits[str(user.id)]
         return edit

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -140,13 +140,12 @@ class Tile(models.TileModel):
                 "timestamp": unicode(timezone.now()),
                 "reviewtimestamp": None
             }
-
             if existing_model and existing_model.provisionaledits is not None:
                 provisionaledits = existing_model.provisionaledits
-                provisionaledits[user.id] = provisionaledit
+                provisionaledits[str(user.id)] = provisionaledit
             else:
                 provisionaledits = {
-                    user.id: provisionaledit
+                    str(user.id): provisionaledit
                     }
             self.provisionaledits = provisionaledits
 

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -143,7 +143,7 @@ class Tile(models.TileModel):
 
             if existing_model and existing_model.provisionaledits is not None:
                 provisionaledits = existing_model.provisionaledits
-                provisionaledits[str(user.id)] = provisionaledit
+                provisionaledits[user.id] = provisionaledit
             else:
                 provisionaledits = {
                     user.id: provisionaledit

--- a/arches/app/search/mappings.py
+++ b/arches/app/search/mappings.py
@@ -126,7 +126,8 @@ def prepare_search_index(resource_model_id, create=False):
                             'tileid' : {'type': 'keyword'},
                             'nodegroup_id' : {'type': 'keyword'},
                             'parenttile_id' : {'type': 'keyword'},
-                            'resourceinstanceid_id' : {'type': 'keyword'}
+                            'resourceinstanceid_id' : {'type': 'keyword'},
+                            'provisionaledits': {'enabled': False}
                         }
                     },
                     'strings' : {

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -81,7 +81,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 <li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0}">
                     <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}"></i>
                     <a class="jstree-anchor" href="#" tabindex="-1" data-bind="css:{'jstree-clicked': card.selected, 'child-selected': card.isChildSelected()}">
-                        <i class="fa fa-file-o" role="presentation"></i>
+                        <i class="fa fa-file-o" role="presentation" data-bind="css:{'has-provisional-edits fa-file': card.provisionaleditcount() > 0 }"></i>
                         <span style="padding-right: 5px;" data-bind="text: card.name, css:{'filtered': card.highlight()}"></span>
                         <!-- ko if: card.cardinality === 'n' || card.tiles().length === 0 -->
                         <i class="fa fa-plus-circle add-new-tile" role="presentation" data-bind="click: function () { self.selection(card) }, css:{'jstree-clicked': card.selected}" data-toggle="tooltip" data-original-title="{% trans "Add New" %}"></i>
@@ -96,7 +96,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0}">
                                 <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){expanded(!expanded())}"></i>
                                 <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.selection($data) }, css:{'jstree-clicked': selected, 'child-selected': isChildSelected()}">
-                                    <i class="fa fa-file" role="presentation"></i>
+                                    <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': $data.hasprovisionaledits }"></i>
                                     <strong style="margin-right: 10px;" data-bind="css:{'filtered': card.highlight()}">
                                         <!-- ko if: card.widgets.length > 0 -->
                                         <span data-bind="text: card.widgets[0].label"></span>:

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -96,7 +96,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0}">
                                 <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){expanded(!expanded())}"></i>
                                 <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.selection($data) }, css:{'jstree-clicked': selected, 'child-selected': isChildSelected()}">
-                                    <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits()}"></i>
+                                    <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits()}"></i>
                                     <strong style="margin-right: 10px;" data-bind="css:{'filtered': card.highlight()}">
                                         <!-- ko if: card.widgets.length > 0 -->
                                         <span data-bind="text: card.widgets[0].label"></span>:

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -223,7 +223,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!--ko if: reviewer -->
             <div class='new-provisional-edits-list'>
             <!--ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
-            <div class='new-provisional-edit-entry'>
+            <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
             <span class='field' data-bind="text : pe.username"></span>
             <span class='field' data-bind="text : pe.timestamp"></span>
             </div>

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -226,6 +226,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
             <span class='field' data-bind="text : pe.username"></span>
             <span class='field' data-bind="text : pe.timestamp"></span>
+            <a href='' class='field' data-bind="click : function(){$parent.provisionalTileViewModel.acceptEdit(pe)}">Accept</a>
+            <a href='' class='field' data-bind="click : function(){$parent.provisionalTileViewModel.rejectProvisionalEdit(pe)}">Delete</a>
             </div>
             <!-- /ko -->
             </div>

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -81,7 +81,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 <li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0}">
                     <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}"></i>
                     <a class="jstree-anchor" href="#" tabindex="-1" data-bind="css:{'jstree-clicked': card.selected, 'child-selected': card.isChildSelected()}, click: function () { card.canAdd() ? self.selection(card) : self.selection(card.tiles()[0]) },">
-                        <i class="fa fa-file-o" role="presentation" data-bind="css:{'has-provisional-edits fa-file': card.provisionaleditcount() > 0 }"></i>
+                        <i class="fa fa-file-o" role="presentation" data-bind="css:{'has-provisional-edits fa-file': card.doesChildHaveProvisionalEdits()}"></i>
                         <span style="padding-right: 5px;" data-bind="text: card.name, css:{'filtered': card.highlight()}"></span>
                         <!-- ko if: card.canAdd() -->
                         <i class="fa fa-plus-circle add-new-tile" role="presentation" data-bind="css:{'jstree-clicked': card.selected}" data-toggle="tooltip" data-original-title="{% trans "Add New" %}"></i>
@@ -96,7 +96,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0}">
                                 <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){expanded(!expanded())}"></i>
                                 <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.selection($data) }, css:{'jstree-clicked': selected, 'child-selected': isChildSelected()}">
-                                    <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': $data.hasprovisionaledits }"></i>
+                                    <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits()}"></i>
                                     <strong style="margin-right: 10px;" data-bind="css:{'filtered': card.highlight()}">
                                         <!-- ko if: card.widgets.length > 0 -->
                                         <span data-bind="text: card.widgets[0].label"></span>:
@@ -220,7 +220,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 }
             }"></div>
             <!-- /ko -->
-            <!--ko if: reviewer -->
+            <!--ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 -->
             <div class='new-provisional-edits-list'>
             <div class='new-provisional-edits-header'>
             <div class='new-provisional-edits-title'>{% trans 'Provisional Edits' %}</div>

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -220,7 +220,18 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 }
             }"></div>
             <!-- /ko -->
+            <!--ko if: reviewer -->
+            <div class='new-provisional-edits-list'>
+            <!--ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
+            <div class='new-provisional-edit-entry'>
+            <span class='field' data-bind="text : pe.username"></span>
+            <span class='field' data-bind="text : pe.timestamp"></span>
+            </div>
+            <!-- /ko -->
+            </div>
+            <!--/ko-->
         </div>
+
     </div>
 </div>
 {% endblock main_content %}

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -222,14 +222,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!-- /ko -->
             <!--ko if: reviewer -->
             <div class='new-provisional-edits-list'>
-            <div>Provisional Edits</div>
-            <div data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}">Delete All</div>
+            <div class='new-provisional-edits-header'>
+            <div class='new-provisional-edits-title'>{% trans 'Provisional Edits' %}</div>
+
+            <button class="btn btn-shim btn-danger btn-labeled btn-sm fa fa-trash" data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}">{% trans 'Delete All Provisional Edits' %}</button>
+            </div>
             <!--ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
             <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
-            <span class='field' data-bind="text : pe.username"></span>
-            <span class='field' data-bind="text : pe.timestamp"></span>
+            <span class='field' data-bind="text : 'User: ' + pe.username()"></span>
+            <span class='field' data-bind="text : 'Edited: ' + pe.displaytimestamp"></span>
             <a href='' class='field' data-bind="click : function(){$parent.provisionalTileViewModel.acceptEdit(pe)}">Accept</a>
-            <a href='' class='field' data-bind="click : function(){$parent.provisionalTileViewModel.rejectProvisionalEdit(pe)}">Delete</a>
+            <a href='' class='field fa fa-times-circle new-delete-provisional-edit' data-bind="click : function(){$parent.provisionalTileViewModel.rejectProvisionalEdit(pe)}"></a>
             </div>
             <!-- /ko -->
             </div>

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -222,6 +222,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!-- /ko -->
             <!--ko if: reviewer -->
             <div class='new-provisional-edits-list'>
+            <div>Provisional Edits</div>
+            <div data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}">Delete All</div>
             <!--ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
             <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
             <span class='field' data-bind="text : pe.username"></span>

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -104,9 +104,12 @@ class NewResourceEditorView(MapBaseManagerView):
             provisionaltiles = []
             for tile in tiles:
                 if tile.provisionaledits is not None:
-                    if str(request.user.id) in tile.provisionaledits:
-                        tile.provisionaledits = tile.provisionaledits[str(request.user.id)]
-                        tile.data = tile.provisionaledits['value']
+                    if user_is_reviewer == False:
+                        if str(request.user.id) in tile.provisionaledits:
+                            tile.provisionaledits = tile.provisionaledits[str(request.user.id)]
+                            tile.data = tile.provisionaledits['value']
+                        else:
+                            tile.provisionaledits = None
                 provisionaltiles.append(tile)
             tiles = provisionaltiles
 

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -104,14 +104,9 @@ class NewResourceEditorView(MapBaseManagerView):
             provisionaltiles = []
             for tile in tiles:
                 if tile.provisionaledits is not None:
-                    edits = json.loads(tile.provisionaledits)
-                    if user_is_reviewer == True:
-                        tile.provisionaledits = edits
-                    else:
-                        if str(request.user.id) in edits:
-                            edit = edits[str(request.user.id)]
-                            tile.provisionaledits = edit
-                            tile.data = edit['value']
+                    if str(request.user.id) in tile.provisionaledits:
+                        tile.provisionaledits = tile.provisionaledits[str(request.user.id)]
+                        tile.data = tile.provisionaledits['value']
                 provisionaltiles.append(tile)
             tiles = provisionaltiles
 

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -106,8 +106,8 @@ class NewResourceEditorView(MapBaseManagerView):
                 if tile.provisionaledits is not None:
                     if user_is_reviewer == False:
                         if str(request.user.id) in tile.provisionaledits:
-                            tile.provisionaledits = tile.provisionaledits[str(request.user.id)]
-                            tile.data = tile.provisionaledits['value']
+                            tile.provisionaledits = {str(request.user.id): tile.provisionaledits[str(request.user.id)]}
+                            tile.data = tile.provisionaledits[str(request.user.id)]['value']
                         else:
                             tile.provisionaledits = None
                 provisionaltiles.append(tile)

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -100,7 +100,7 @@ class TileData(View):
                         update_system_settings_cache(tile)
 
                     if tile.provisionaledits is not None and request.user.id in tile.provisionaledits:
-                        tile.data = tile.provisionaledits[request.user.id]
+                        tile.data = tile.provisionaledits[request.user.id]['value']
 
                     return JSONResponse(tile)
                 else:

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -99,11 +99,10 @@ class TileData(View):
                         clean_resource_cache(tile)
                         update_system_settings_cache(tile)
 
-                    if tile.provisionaledits is not None:
-                        if str(request.user.id) in tile.provisionaledits:
-                            edit = tile.provisionaledits[str(request.user.id)]
-                            tile.provisionaledits = edit
-                            tile.data = edit['value']
+                    if tile.provisionaledits is not None and request.user.id in tile.provisionaledits:
+                        edit = tile.provisionaledits[request.user.id]
+                        tile.provisionaledits = edit
+                        tile.data = edit['value']
 
                     return JSONResponse(tile)
                 else:

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -100,9 +100,7 @@ class TileData(View):
                         update_system_settings_cache(tile)
 
                     if tile.provisionaledits is not None and request.user.id in tile.provisionaledits:
-                        edit = tile.provisionaledits[request.user.id]
-                        tile.provisionaledits = edit
-                        tile.data = edit['value']
+                        tile.data = tile.provisionaledits[request.user.id]
 
                     return JSONResponse(tile)
                 else:

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -93,14 +93,14 @@ class TileData(View):
                                             tile_json['_rev'] = row.doc['_rev']
                                             db.save(tile_json)
 
+                            if tile.provisionaledits is not None and str(request.user.id) in tile.provisionaledits:
+                                tile.data = tile.provisionaledits[str(request.user.id)]['value']
+
                         except ValidationError as e:
                             return JSONResponse({'status':'false','message':e.args}, status=500)
                         tile.after_update_all()
                         clean_resource_cache(tile)
                         update_system_settings_cache(tile)
-
-                    if tile.provisionaledits is not None and request.user.id in tile.provisionaledits:
-                        tile.data = tile.provisionaledits[request.user.id]['value']
 
                     return JSONResponse(tile)
                 else:

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -122,16 +122,15 @@ class TileData(View):
         if self.action == 'delete_provisional_tile':
             user = request.POST.get('user', None)
             tileid = request.POST.get('tileid', None)
-            if 'tileid' is not None:
+            users = request.POST.get('users', None)
+            if tileid is not None and user is not None:
                 provisionaledits = self.delete_provisional_edit(tileid, user)
                 return JSONResponse(provisionaledits)
 
-            else:
-                payload = data.get('payload', None)
-                if payload is not None:
-                    edits = jsonparser.loads(payload)
-                    for edit in edits['edits']:
-                        provisionaledits = self.delete_provisional_edit(edit, request)
+            elif tileid is not None and users is not None:
+                users = jsonparser.loads(users)
+                for user in users:
+                    self.delete_provisional_edit(tileid, user)
                 return JSONResponse({'result':'success'})
 
         return HttpResponseNotFound()

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -98,6 +98,13 @@ class TileData(View):
                         tile.after_update_all()
                         clean_resource_cache(tile)
                         update_system_settings_cache(tile)
+
+                    if tile.provisionaledits is not None:
+                        if str(request.user.id) in tile.provisionaledits:
+                            edit = tile.provisionaledits[str(request.user.id)]
+                            tile.provisionaledits = edit
+                            tile.data = edit['value']
+
                     return JSONResponse(tile)
                 else:
                     return JSONResponse({'status':'false','message': [_('Request Failed'), _('Permission Denied')]}, status=500)

--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -104,7 +104,6 @@ class UserManagerView(BaseManagerView):
             if self.request.user.is_authenticated() and request.user.groups.filter(name='Resource Reviewer').exists():
                 userids = json.loads(request.POST.get('userids', '[]'))
                 data = {u.id:u.username for u in User.objects.filter(id__in=userids)}
-                print userids, data
                 return JSONResponse(data)
 
         if self.request.user.is_authenticated() and self.request.user.username != 'anonymous':

--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
 
+import json
 from datetime import datetime
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User, Group
@@ -101,8 +102,9 @@ class UserManagerView(BaseManagerView):
         if self.action == 'get_user_names':
             data = {}
             if self.request.user.is_authenticated() and request.user.groups.filter(name='Resource Reviewer').exists():
-                userids = [str(id) for id in request.POST.get('userids[]', [])]
+                userids = json.loads(request.POST.get('userids', '[]'))
                 data = {u.id:u.username for u in User.objects.filter(id__in=userids)}
+                print userids, data
                 return JSONResponse(data)
 
         if self.request.user.is_authenticated() and self.request.user.username != 'anonymous':

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -281,7 +281,7 @@ class TileTests(ArchesTestCase):
         provisional_tile.save(index=False, request=request)
         tiles = Tile.objects.filter(resourceinstance_id="40000000-0000-0000-0000-000000000000")
 
-        provisionaledits = JSONDeserializer().deserialize(provisional_tile.provisionaledits)
+        provisionaledits = provisional_tile.provisionaledits
         self.assertEqual(tiles.count(), 2)
         self.assertEqual(provisional_tile.data["72048cb3-adbc-11e6-9ccf-14109fd34195"], 'AUTHORITATIVE')
         self.assertEqual(provisionaledits[str(self.user.id)]['action'], 'update')
@@ -310,7 +310,7 @@ class TileTests(ArchesTestCase):
         request.user = user
         provisional_tile.save(index=False, request=request)
         provisional_tile.apply_provisional_edit(user, {"test":"test"}, 'update')
-        provisionaledits = JSONDeserializer().deserialize(provisional_tile.provisionaledits)
+        provisionaledits = provisional_tile.provisionaledits
         userid = str(user.id)
         self.assertEqual(provisionaledits[userid]['action'], 'update')
         self.assertEqual(provisionaledits[userid]['reviewer'], None)


### PR DESCRIPTION
### Description of Change
Implements provisional edit management in the new resource editor and casts provisional edit data as true json in the database and elasticsearch rather than a string with json within it. re #3385