### PR TITLE
Moves provisional edit panel to the left of it's corresponding card

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5519,24 +5519,38 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 .new-provisional-edits-list {
     display: flex;
     flex-direction: column;
-    margin-top: 0px;
+    margin-top: 26px;
+    width: 165px;
+    padding: 5px;
+    border-color: #ddd;
+    border-right-style: solid;
+    border-width: 1px;
+    height: 100%;
 }
 
+.new-provisional-edit-card-container {
+    display: flex;
+    flex-direction: row;
+}
 
 .new-provisional-edit-entry {
     display: flex;
-    flex-direction: row;
-    padding: 3px;
+    flex-direction: column;
     margin: 2px;
     border-style: solid;
     border-width: 1px;
-    border-color: #ccc;
-    background-color: #fafafa;
+    border-color: #ddd;
+}
+
+.new-provisional-edit-entry .title {
+    display: flex;
+    flex-direction: row;
     justify-content: space-between;
+    background-color: #f1f1f1;
 }
 
 .new-provisional-edits-title {
-    font-size: 16px;
+    font-size: 13px;
     font-weight: 600;
     color: #2f527a;
 }
@@ -5554,15 +5568,27 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 
 .new-provisional-edit-entry:hover {
     border-color: #111;
-    background-color: #ececec;
+    background-color: #fff;
 }
 
 .new-provisional-edit-entry.selected {
-    background-color: #ececec;
+    background-color: #fff;
+    border-color: #729dd2;
+    border-width: 2px;
+}
+
+.new-provisional-edit-entry .field-name {
+    font-weight: 600;
 }
 
 .new-provisional-edit-entry .field {
     padding: 5px
+}
+
+.new-provisional-edits-delete-all {
+    width: auto;
+    padding-left: 0px;
+    margin: 3px;
 }
 
 .provisional-edits-list-header {

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -81,11 +81,7 @@ define([
                 self.selectedProvisionalEdit(val);
                 koMapping.fromJS(val['value'], self.selectedTile().data);
                 self.selectedTile()._tileData.valueHasMutated()
-            }
-            // else if (val['isfullyprovisional'] === false) {
-            //     self.selectedProvisionalEdit(undefined);
-            //     self.selectedTile().reset();
-            // };
+            };
         };
 
         self.updateProvisionalEdits(self.selectedTile);

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -48,15 +48,19 @@ define([
                 var provisionaleditlist = _.map(tile.provisionaledits(), function(edit, key){
                     users.push(key);
                     edit['username'] = ko.observable('');
-                    edit['displaytimestamp'] =  moment(edit.timestamp).format("MMMM Do YYYY, h:mm a");
+                    edit['displaytimestamp'] = moment(edit.timestamp).format("hh:mm");
+                    edit['displaydate'] = moment(edit.timestamp).format("DD-MM-YYYY");
                     edit['user'] = key;
                     return edit;
                 }, this);
                 this.provisionaledits(_.sortBy(provisionaleditlist, function(pe){return moment(pe.timestamp)}));
                 if (data && _.keys(data).length === 0 && tile.provisionaledits()) {
+                    // this.provisionaledits()[0]['isfullyprovisional'] = true;
                     koMapping.fromJS(this.provisionaledits()[0]['value'], tile.data);
-                    this.selectedProvisionalEdit(this.provisionaledits()[0])
-                    tile._tileData.valueHasMutated()
+                    this.selectedProvisionalEdit(this.provisionaledits()[0]);
+                    tile._tileData.valueHasMutated();
+                } else {
+                    self.selectedProvisionalEdit(undefined);
                 };
                 this.getUserNames(this.provisionaleditlist, users);
             };
@@ -68,9 +72,15 @@ define([
         };
 
         self.selectProvisionalEdit = function(val){
-            self.selectedProvisionalEdit(val);
-            koMapping.fromJS(val['value'], self.selectedTile().data);
-            self.selectedTile()._tileData.valueHasMutated()
+            if (self.selectedProvisionalEdit() != val) {
+                self.selectedProvisionalEdit(val);
+                koMapping.fromJS(val['value'], self.selectedTile().data);
+                self.selectedTile()._tileData.valueHasMutated()
+            }
+            // else if (val['isfullyprovisional'] === false) {
+            //     self.selectedProvisionalEdit(undefined);
+            //     self.selectedTile().reset();
+            // };
         };
 
         self.updateProvisionalEdits(self.selectedTile);
@@ -135,11 +145,6 @@ define([
                 this.provisionaledits.remove(this.selectedProvisionalEdit());
                 this.selectedProvisionalEdit(undefined);
             }
-        };
-
-        self.acceptEdit = function(val){
-            this.selectProvisionalEdit(val);
-            this.selectedTile().save();
         };
 
         self.rejectProvisionalEdit = function(val){

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -51,16 +51,21 @@ define([
                     edit['displaytimestamp'] = moment(edit.timestamp).format("hh:mm");
                     edit['displaydate'] = moment(edit.timestamp).format("DD-MM-YYYY");
                     edit['user'] = key;
+                    if (edit.isfullyprovisional === undefined) {
+                        edit['isfullyprovisional'] = ko.observable(false);
+                    };
                     return edit;
                 }, this);
                 this.provisionaledits(_.sortBy(provisionaleditlist, function(pe){return moment(pe.timestamp)}));
-                if (data && _.keys(data).length === 0 && tile.provisionaledits()) {
-                    // this.provisionaledits()[0]['isfullyprovisional'] = true;
+                if ((data && _.keys(data).length === 0 && tile.provisionaledits()) || this.provisionaledits().length > 0 && this.provisionaledits()[0].isfullyprovisional() === true) {
+                    self.selectedProvisionalEdit(undefined);
+                    this.provisionaledits()[0].isfullyprovisional(true);
                     koMapping.fromJS(this.provisionaledits()[0]['value'], tile.data);
                     this.selectedProvisionalEdit(this.provisionaledits()[0]);
                     tile._tileData.valueHasMutated();
                 } else {
                     self.selectedProvisionalEdit(undefined);
+                    self.selectedTile().reset();
                 };
                 this.getUserNames(this.provisionaleditlist, users);
             };

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -210,6 +210,45 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
                 <!-- /ko -->
             </div>
+            <!--ko if: reviewer && provisionalTileViewModel.selectedProvisionalEdit() -->
+            <div>
+            <span>{% trans 'Currently showing edits by' %}</span>
+            <span data-bind="text: provisionalTileViewModel.selectedProvisionalEdit().username() + '.'"></span>
+            <!--ko if: provisionalTileViewModel.selectedProvisionalEdit().isfullyprovisional -->
+            <span>{% trans 'No authoritative data has been saved to this card.' %}</span>
+            <!--/ko-->
+            </div>
+            <!--/ko-->
+            <div class="new-provisional-edit-card-container">
+                <div class="testing-this">
+                <!--ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 -->
+                <div class='new-provisional-edits-list'>
+                    <div class='new-provisional-edits-header'>
+                        <div class='new-provisional-edits-title'>{% trans 'Provisional Edits' %}</div>
+                    </div>
+                    <!--ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
+                    <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
+                        <div class='title'>
+                            <div class='field'>
+                            <span class='field-name'>{%trans 'User: ' %}</span>
+                            <span data-bind="text : pe.username"></span>
+                            </div>
+                            <a href='' class='field fa fa-times-circle new-delete-provisional-edit' data-bind="click : function(){$parent.provisionalTileViewModel.rejectProvisionalEdit(pe)}"></a>
+                        </div>
+                        <div class='field'>
+                            <span class='field-name'>{%trans 'Date: ' %}</span>
+                            <span data-bind="text : pe.displaydate"></span>
+                        </div>
+                        <div class='field'>
+                            <span class='field-name'>{%trans 'Time: ' %}</span>
+                            <span data-bind="text : pe.displaytimestamp"></span>
+                        </div>
+                    </div>
+                    <!-- /ko -->
+                    <div class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all" data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}">{% trans 'Delete all edits' %}</div>
+                </div>
+                <!--/ko-->
+            </div>
             <div data-bind="component: {
                 name: cardComponentLookup[selectedCard().component_id].componentname,
                 params: {
@@ -219,24 +258,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     form: $data
                 }
             }"></div>
+            </div>
             <!-- /ko -->
-            <!--ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 -->
-            <div class='new-provisional-edits-list'>
-            <div class='new-provisional-edits-header'>
-            <div class='new-provisional-edits-title'>{% trans 'Provisional Edits' %}</div>
 
-            <button class="btn btn-shim btn-danger btn-labeled btn-sm fa fa-trash" data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}">{% trans 'Delete All Provisional Edits' %}</button>
-            </div>
-            <!--ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
-            <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
-            <span class='field' data-bind="text : 'User: ' + pe.username()"></span>
-            <span class='field' data-bind="text : 'Edited: ' + pe.displaytimestamp"></span>
-            <a href='' class='field' data-bind="click : function(){$parent.provisionalTileViewModel.acceptEdit(pe)}">Accept</a>
-            <a href='' class='field fa fa-times-circle new-delete-provisional-edit' data-bind="click : function(){$parent.provisionalTileViewModel.rejectProvisionalEdit(pe)}"></a>
-            </div>
-            <!-- /ko -->
-            </div>
-            <!--/ko-->
         </div>
 
     </div>

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -113,7 +113,7 @@ class NewResourceEditorView(MapBaseManagerView):
                             tile.provisionaledits = {str(request.user.id): tile.provisionaledits[str(request.user.id)]}
                             tile.data = tile.provisionaledits[str(request.user.id)]['value']
                         else:
-                            if isfullyprovisional:
+                            if isfullyprovisional == True:
                                 #if the tile IS fully provisional and the current user is not the owner, we don't send that tile back to the client.
                                 append_tile = False
                             else:

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -103,14 +103,24 @@ class NewResourceEditorView(MapBaseManagerView):
 
             provisionaltiles = []
             for tile in tiles:
+                append_tile = True
+                isfullyprovisional = False
                 if tile.provisionaledits is not None:
+                    if len(tile.data) == 0:
+                        isfullyprovisional = True
                     if user_is_reviewer == False:
                         if str(request.user.id) in tile.provisionaledits:
                             tile.provisionaledits = {str(request.user.id): tile.provisionaledits[str(request.user.id)]}
                             tile.data = tile.provisionaledits[str(request.user.id)]['value']
                         else:
-                            tile.provisionaledits = None
-                provisionaltiles.append(tile)
+                            if isfullyprovisional:
+                                #if the tile IS fully provisional and the current user is not the owner, we don't send that tile back to the client.
+                                append_tile = False
+                            else:
+                                #if the tile has authoritaive data and the current user is not the owner, we don't send the provisional data of other users back to the client.
+                                tile.provisionaledits = None
+                if append_tile == True:
+                    provisionaltiles.append(tile)
             tiles = provisionaltiles
 
         map_layers = models.MapLayer.objects.all()


### PR DESCRIPTION
### Description of Change
Moves the provisional edit panel to the left of its card, indicates to the reviewer that a tile is entirely provisional (has no auth data saved to it), and prevents provisional users from seeing the provisional tiles of other provisional users. re #3385.