### PR TITLE
Replaces the add-resource url with an instance's editor url once a tile is saved

### DIFF
--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -201,6 +201,11 @@ define([
     var topCard = vm.topCards[0];
     selection(topCard.tiles().length > 0 ? topCard.tiles()[0] : topCard);
 
+    vm.resourceId.subscribe(function(val){
+        //switches the url from 'create-resource' once the resource id is available
+        history.pushState({}, '', arches.urls.resource_editor + resourceId())
+    })
+
     vm.selectionBreadcrumbs = ko.computed(function () {
         var item = vm.selectedTile()
         var crumbs = [];


### PR DESCRIPTION
### Description of Change
In the resource editor - replaces the add-resource url with an instance's editor url once a tile is saved re #3569