### PR TITLE
Remove restrictions on appending graphs to non-resource nodes, re #3397

### DIFF
--- a/arches/app/media/js/models/graph.js
+++ b/arches/app/media/js/models/graph.js
@@ -373,30 +373,6 @@ define(['arches',
         },
 
         /**
-         * isType - does this graph contain a card, a collection of cards, or no cards
-         * @memberof GraphModel.prototype
-         * @return  {string} - either 'card', 'card_collector', or 'undefined'
-         */
-        isType: function(){
-            var nodegroups = [];
-            this.get('nodes')().forEach(function (node) {
-                if(node.isCollector()){
-                    nodegroups.push(node);
-                }
-            });
-            switch(nodegroups.length) {
-                case 0:
-                    return 'undefined';
-                    break;
-                case 1:
-                    return 'card'
-                    break;
-                default:
-                    return 'card_collector'
-            }
-        },
-
-        /**
          * canAppend - test to see whether or not a graph can be appened to this graph at a specific location
          * @memberof GraphModel.prototype
          * @param  {object} graphToAppend - the {@link GraphModel} to test appending on to this graph
@@ -405,7 +381,6 @@ define(['arches',
          */
         canAppend: function(graphToAppend, nodeToAppendTo){
             nodeToAppendTo = nodeToAppendTo ? nodeToAppendTo : this.get('selectedNode')();
-            var typeOfGraphToAppend = graphToAppend.isType();
 
             if(!!this.get('ontology_id') && !!graphToAppend.get('ontology_id')){
                 var found = !!_.find(graphToAppend.get('domain_connections'), function(domain_connection){
@@ -415,42 +390,6 @@ define(['arches',
                 }, this);
                 if(!found){
                     return false;
-                }
-            }
-
-            if(this.get('isresource')){
-                if(typeOfGraphToAppend === 'undefined'){
-                    return false;
-                }
-            }else{ // this graph is a Graph
-                switch(this.isType()) {
-                    case 'undefined':
-                        return false;
-                        break;
-                    case 'card':
-                        if(typeOfGraphToAppend === 'card'){
-                            if(nodeToAppendTo.nodeid === this.get('root').nodeid){
-                                if(!(this.isGroupSemantic(nodeToAppendTo))){
-                                    return false;
-                                }
-                            }else{
-                                return false;
-                            }
-                        }
-                        else if(typeOfGraphToAppend === 'card_collector'){
-                            return false;
-                        }
-                        break;
-                    case 'card_collector':
-                        if(typeOfGraphToAppend === 'card_collector'){
-                            return false;
-                        }
-                        if(this.isNodeInChildGroup(nodeToAppendTo)){
-                            if(typeOfGraphToAppend === 'card'){
-                                return false;
-                            }
-                        }
-                        break;
                 }
             }
 

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -871,8 +871,6 @@ class Graph(models.GraphModel):
 
         """
 
-        typeOfGraphToAppend = graphToAppend.is_type()
-
         found = False
         if self.ontology is not None and graphToAppend.ontology is None:
             raise GraphValidationError(_('The graph you wish to append needs to define an ontology'))
@@ -889,46 +887,7 @@ class Graph(models.GraphModel):
 
             if not found:
                 raise GraphValidationError(_('Ontology rules don\'t allow this graph to be appended'))
-        if self.isresource:
-            if typeOfGraphToAppend == 'undefined':
-                raise GraphValidationError(_('Can\'t append an undefined graph to a resource graph'))
-        else: # self graph is a Graph
-            graph_type = self.is_type()
-            if graph_type == 'undefined':
-                raise GraphValidationError(_('Can\'t append any graph to an undefined graph'))
-            elif graph_type == 'card':
-                if typeOfGraphToAppend == 'card':
-                    if nodeToAppendTo == self.root:
-                        if not self.is_group_semantic(nodeToAppendTo):
-                            raise GraphValidationError(_('Can only append a card type graph to a semantic group'))
-                    else:
-                        raise GraphValidationError(_('Can only append to the root of the graph'))
-                elif typeOfGraphToAppend == 'card_collector':
-                    raise GraphValidationError(_('Can\'t append a card collector type graph to a card type graph'))
-            elif graph_type == 'card_collector':
-                if typeOfGraphToAppend == 'card_collector':
-                    raise GraphValidationError(_('Can\'t append a card collector type graph to a card collector type graph'))
-                if self.is_node_in_child_group(nodeToAppendTo):
-                    if typeOfGraphToAppend == 'card':
-                        raise GraphValidationError(_('Can only append an undefined type graph to a child within a card collector type graph'))
         return True
-
-    def is_type(self):
-        """
-        does this graph contain a card, a collection of cards, or no cards
-
-        returns either 'card', 'card_collector', or 'undefined'
-
-        """
-
-        count = self.get_nodegroups()
-
-        if len(count) == 0:
-            return 'undefined'
-        elif len(count) == 1:
-            return 'card'
-        else:
-            return 'card_collector'
 
     def get_parent_node(self, nodeid):
         """

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1316,7 +1316,7 @@ class Graph(models.GraphModel):
                             raise GraphValidationError(_("Your graph isn't semantically valid. Entity domain '{0}' and Entity range '{1}' can not be related via Property '{2}'.").format(edge.domainnode.ontologyclass, edge.rangenode.ontologyclass, edge.ontologyproperty), 1003)
 
                 if not property_found:
-                    raise GraphValidationError(_("'{0}' is not a valid {1} ontology property").format(edge.ontologyproperty, self.ontology.name), 1004)
+                    raise GraphValidationError(_("'{0}' is not found in the {1} ontology or is not a valid ontology property for Entity domain '{2}'.").format(edge.ontologyproperty, self.ontology.name, edge.domainnode.ontologyclass), 1004)
         else:
             for node_id, node in self.nodes.iteritems():
                 if node.ontologyclass is not None:

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -1039,3 +1039,34 @@ class GraphTests(ArchesTestCase):
             graph.save()
         the_exception = cm.exception
         self.assertEqual(the_exception.code, 1005)
+
+    def test_appending_a_branch_with_an_invalid_ontology_property(self):
+        graph = Graph.objects.get(graphid=self.NODE_NODETYPE_GRAPHID)
+        graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P43_has_dimension', graphid=self.NODE_NODETYPE_GRAPHID)
+
+        with self.assertRaises(GraphValidationError) as cm:
+            graph.save()
+
+    def test_appending_a_branch_with_an_invalid_ontology_class(self):
+        graph = Graph.new()
+        graph.name = "TEST GRAPH"
+        graph.subtitle = "ARCHES TEST GRAPH"
+        graph.author = "Arches"
+        graph.description = "ARCHES TEST GRAPH"
+        graph.ontology = models.Ontology.objects.get(pk="e6e8db47-2ccf-11e6-927e-b8f6b115d7dd")
+        graph.version = "v1.0.0"
+        graph.isactive = False
+        graph.iconclass = "fa fa-building"
+        graph.nodegroups = []
+
+        graph.root.name = 'ROOT NODE'
+        graph.root.description = 'Test Root Node'
+        graph.root.ontologyclass = 'http://www.cidoc-crm.org/cidoc-crm/E21_Person'
+        graph.root.datatype = 'semantic'
+
+        graph.save()
+
+        graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P43_has_dimension', graphid=self.NODE_NODETYPE_GRAPHID)
+
+        with self.assertRaises(GraphValidationError) as cm:
+            graph.save()

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -468,53 +468,14 @@ class GraphTests(ArchesTestCase):
         graph.isresource = True
         self.assertIsNotNone(graph.append_branch('http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as', graphid=self.NODE_NODETYPE_GRAPHID))
 
-        # try to append a non-grouped graph
-        with self.assertRaises(GraphValidationError):
-            graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by', graphid=self.SINGLE_NODE_GRAPHID)
-
-
-        graph = Graph.objects.get(graphid=self.SINGLE_NODE_GRAPHID)
-        # test that we can't append a single non-grouped node to a graph that is a single non grouped node
-        with self.assertRaises(GraphValidationError):
-            graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by', graphid=self.SINGLE_NODE_GRAPHID)
-
         graph = Graph.new()
         graph.root.datatype = 'string'
         graph.update_node(JSONSerializer().serializeToPython(graph.root))
-
-        # test that we can't append a card to a graph that is a card that at it's root is not semantic
-        with self.assertRaises(GraphValidationError):
-            graph.append_branch('http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as', graphid=self.NODE_NODETYPE_GRAPHID)
-
-        # test that we can't append a card as a child to another card
-        graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by', graphid=self.SINGLE_NODE_GRAPHID)
-        for node in graph.nodes.itervalues():
-            if node != graph.root:
-                with self.assertRaises(GraphValidationError):
-                    graph.append_branch('http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as', graphid=self.NODE_NODETYPE_GRAPHID, nodeid=node.nodeid)
-
 
         # create card collector graph to use for appending on to other graphs
         collector_graph = Graph.new()
         collector_graph.append_branch('http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as', graphid=self.NODE_NODETYPE_GRAPHID)
         collector_graph.save()
-
-        # test that we can't append a card collector on to a graph that is a card
-        graph = Graph.new()
-        with self.assertRaises(GraphValidationError):
-            graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by', graphid=collector_graph.graphid)
-
-        # test that we can't append a card collector to another card collector
-
-        collector_copy = collector_graph.copy()['copy']
-        with self.assertRaises(GraphValidationError):
-            collector_copy.append_branch('http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by', graphid=collector_graph.graphid)
-
-        # test that we can't append a card to a node in a child card within a card collector
-        for node in collector_graph.nodes.itervalues():
-            if node != collector_graph.root:
-                with self.assertRaises(GraphValidationError):
-                    collector_graph.append_branch('http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by', graphid=graph.graphid, nodeid=node.nodeid)
 
     def test_node_update(self):
         """
@@ -628,8 +589,6 @@ class GraphTests(ArchesTestCase):
         # test moving a branch to another branch
         # this branch should NOT be grouped with it's new parent nodegroup
         branch_two_rootnodeid = branch_two.root.nodeid
-        with self.assertRaises(GraphValidationError):
-            graph.move_node(branch_one_rootnodeid, 'http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as', branch_two_rootnodeid)
         graph.move_node(branch_one_rootnodeid, 'http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as', branch_two_rootnodeid, skip_validation=True)
         self.assertEqual(len(graph.edges), 5)
         self.assertEqual(len(graph.nodes), 6)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Remove restrictions on appending graphs to non-resource nodes


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3397 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
