### PR TITLE
Set graph as inactive before deletion #3574

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -384,15 +384,12 @@ class Graph(models.GraphModel):
         deletes all associated resource instances
 
         """
-        activestate = self.isactive
-        self.isactive = False
         if verbose == True:
             bar = pyprind.ProgBar(Resource.objects.filter(graph_id=self.graphid).count())
         for resource in Resource.objects.filter(graph_id=self.graphid):
             resource.delete()
             if verbose == True:
                 bar.update()
-        self.isactive = activestate
         if verbose == True:
             print(bar)
 

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -247,7 +247,10 @@ class GraphManagerView(GraphBaseView):
     def delete(self, request, graphid):
         try:
             graph = Graph.objects.get(graphid=graphid)
-            graph.delete_instances()
+            if graph.isresource:
+                graph.isactive = False
+                graph.save()
+                graph.delete_instances()
             graph.delete()
             return JSONResponse({'success':True})
         except GraphValidationError as e:


### PR DESCRIPTION
To give time to allow all resources to be removed, set the graph as
inactive before starting.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Allow the deletion of a Resource Model with instances associated with it.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3574

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Getty Conservation Institute <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->