### PR TITLE
Disables related resource node in editor tree until resource instance exists

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -11422,6 +11422,10 @@ a.jstree-anchor strong {
     display:inline;
 }
 
+a.jstree-anchor.disabled {
+    color: #ccc;
+}
+
 .card-summary-section li {
     list-style: none;
 }

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -76,9 +76,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         </ul>
                         <!-- /ko -->
                     </li>
-                    <li role="treeitem" class="jstree-node jstree-open">
+                    <li role="treeitem" class="jstree-node jstree-open"  data-bind="css: {'disabled': resourceId()}">
                         <i class="jstree-icon jstree-ocl" role="presentation"></i>
-                        <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function(){showRelatedResourcesManager()}, css: {'jstree-clicked': manageRelatedResources}">
+                        <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function(){if (resourceId()){showRelatedResourcesManager()}}, css: {'jstree-clicked': manageRelatedResources, 'disabled': resourceId() === ''}">
                             <strong>
                                 <i class="fa fa-link" role="presentation"></i>
                                 <span>{% trans 'Related Resources' %}</span>


### PR DESCRIPTION
### Description of Change
Disables the related resources node in the resource editor's card tree until a user saves a tile (because that's when a resource is create to relate against). re #3604