### PR TITLE
Keeps resource instance search widget open during multiselect

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -83,6 +83,7 @@ define([
             clickBubble: true,
             multiple: this.multiple,
             placeholder: this.placeholder,
+            closeOnSelect: false,
             allowClear: true,
             disabled: this.disabled,
             ajax: {
@@ -139,7 +140,7 @@ define([
                 }
             },
             id: function(item) {
-                    return item._id;
+                return item._id;
             },
             formatResult: function(item) {
                 if (self.disable(item) === false) {


### PR DESCRIPTION
Prevents resource-instance-search widget from closing when a user selects a resource instance. re #3604