### PR TITLE
3385 provisional in new editor

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5874,6 +5874,15 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     font-size:13px;
 }
 
+.new-provisional-edit-history.footer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    background-color: inherit;
+    border-bottom: 0px;
+    padding: 0px;
+}
+
 .provisional-edits-list-header {
     display: inline-flex;
     width: 100%;

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5853,8 +5853,13 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     display: flex;
     flex-direction: column;
     border-bottom: solid #f0f0f0 1px;
-    padding: 5px;
-    background-color: #f5f5f5;
+    padding: 5px 15px;
+    background-color: #fcfcfc;
+}
+
+.new-provisional-edit-history.selected-card {
+    color: #454545;
+    background-color: #f0f0f0;
 }
 
 .new-provisional-edit-history:hover {
@@ -5891,6 +5896,31 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     height: 35px;
     margin-top: 0px;
     margin-bottom:1px;
+}
+
+.provisional-edit-history-filter {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.provisional-edit-history-filter .calendar {
+    display: flex;
+    width: 220px;
+    padding-left: 10px;
+    align-items: baseline;
+    justify-content: space-between;
+}
+
+.provisional-edit-history-filter .calendar-label {
+    font-size: 12px;
+    color: inherit;
+    padding: 5px;
+}
+
+
+.ep-edits-body.provisional-edit-history {
+    height: 100%;
 }
 
 .provisional-edits-list-header span {

--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -1,10 +1,12 @@
 define([
+    'jquery',
     'knockout',
+    'underscore',
     'knockout-mapping',
     'moment',
     'arches',
     'views/components/simple-switch'
-], function (ko, koMapping, moment, arches) {
+], function ($, ko, _, koMapping, moment, arches) {
     /**
     * A viewmodel for managing provisional edits
     *
@@ -16,23 +18,23 @@ define([
     var ProvisionalTileViewModel = function(params) {
         var self = this;
         self.card = null;
-        self.edits = ko.observableArray()
-        self.users = []
+        self.edits = ko.observableArray();
+        self.users = [];
         self.declineUnacceptedEdits = ko.observable(true);
         self.loading = params.loading;
         self.selectedForm = params.selectedForm;
-        self.parseProvisionalEdits = function(editsjson){
-            _.each(JSON.parse(editsjson), function(edit, key){
-                    self.users.push(key);
-                    edit.user = key;
-                    edit.timestamp = moment(edit.timestamp).format("MMMM Do YYYY, h:mm a");
-                    edit.username = '';
-                    edit.tileid = self.selectedProvisionalTile().tileid();
-                    self.edits.push(koMapping.fromJS(edit))
+        self.parseProvisionalEdits = function(editsjson) {
+            _.each(JSON.parse(editsjson), function(edit, key) {
+                self.users.push(key);
+                edit.user = key;
+                edit.timestamp = moment(edit.timestamp).format('MMMM Do YYYY, h:mm a');
+                edit.username = '';
+                edit.tileid = self.selectedProvisionalTile().tileid();
+                self.edits.push(koMapping.fromJS(edit));
             });
-        }
+        };
 
-        self.deleteProvisionalEdit = function(val){
+        self.deleteProvisionalEdit = function(val) {
             $.ajax({
                 url: arches.urls.delete_provisional_tile,
                 context: this,
@@ -40,17 +42,17 @@ define([
                 dataType: 'json',
                 data: koMapping.toJS(val)
             })
-            .done(function(data) {
-                self.edits.remove(val);
-                self.form.loadForm(self.selectedForm());
-            })
-            .fail(function(data) {
-                console.log('Related resource request failed', data)
-            });
-        }
+                .done(function(data) {
+                    self.edits.remove(val);
+                    self.form.loadForm(self.selectedForm());
+                })
+                .fail(function(data) {
+                    console.log('Related resource request failed', data);
+                });
+        };
 
         self.deleteAllProvisionalEdits = function() {
-            var edits = koMapping.toJSON({'edits':self.edits()})
+            var edits = koMapping.toJSON({'edits': self.edits()});
             $.ajax({
                 url: arches.urls.delete_provisional_tile,
                 context: this,
@@ -58,16 +60,16 @@ define([
                 dataType: 'json',
                 data: {payload: edits}
             })
-            .done(function(data) {
-                self.edits.removeAll();
-                self.form.loadForm(self.selectedForm());
-            })
-            .fail(function(data) {
-                console.log('Related resource request failed', data)
-            });
-        }
+                .done(function(data) {
+                    self.edits.removeAll();
+                    self.form.loadForm(self.selectedForm());
+                })
+                .fail(function(data) {
+                    console.log('Related resource request failed', data);
+                });
+        };
 
-        self.getUserNames = function(edits){
+        self.getUserNames = function(edits) {
             $.ajax({
                 url: arches.urls.get_user_names,
                 context: this,
@@ -75,59 +77,58 @@ define([
                 data: { userids: this.users },
                 dataType: 'json'
             })
-            .done(function(data) {
-                _.each(this.edits(), function(edit) {
-                    edit.username(data[edit.user()])
+                .done(function(data) {
+                    _.each(this.edits(), function(edit) {
+                        edit.username(data[edit.user()]);
+                    });
                 })
-            })
-            .fail(function(data) {
-                console.log('User name request failed', data)
-            });
-        }
+                .fail(function(data) {
+                    console.log('User name request failed', data);
+                });
+        };
 
-        self.acceptProvisionalEdit = function(val){
+        self.acceptProvisionalEdit = function(val) {
             self.loading(true);
-            this.selectedProvisionalTile().data = val.value
-            var tile = this.selectedProvisionalTile()
-            this.form.saveTile(this.parentTile, this.cardinality, this.selectedProvisionalTile())
-            this.form.on('after-update', function(){
+            this.selectedProvisionalTile().data = val.value;
+            this.form.saveTile(this.parentTile, this.cardinality, this.selectedProvisionalTile());
+            this.form.on('after-update', function() {
                 if (this.declineUnacceptedEdits()) {
                     this.deleteAllProvisionalEdits();
                 } else {
                     this.deleteProvisionalEdit(val);
                 }
                 this.loading(false);
-            }, this)
-        }
+            }, this);
+        };
 
-        self.rejectProvisionalEdit = function(val){
+        self.rejectProvisionalEdit = function(val) {
             self.deleteProvisionalEdit(val);
-        }
+        };
 
-        self.findCard = function(cards, nodegroupid){
+        self.findCard = function(cards, nodegroupid) {
             _.each(cards, function(card) {
-                if (card.get('nodegroup_id') == nodegroupid) {
-                    this.card = card
+                if (card.get('nodegroup_id') === nodegroupid) {
+                    this.card = card;
                 }
                 if (this.card == null) {
-                    self.findCard(card.get('cards')(), nodegroupid)
+                    self.findCard(card.get('cards')(), nodegroupid);
                 }
             }, self);
-        }
+        };
 
-        self.selectedProvisionalTile = params.selectedProvisionalTile
+        self.selectedProvisionalTile = params.selectedProvisionalTile;
         self.selectedProvisionalTile.subscribe(function(val) {
             if (!self.selectedForm()) {
-                self.selectedForm(self.form.formid)
+                self.selectedForm(self.form.formid);
             };
             self.edits.removeAll();
             if (val) {
                 self.card = null;
-                self.findCard(this.cards(), val.nodegroup_id())
+                self.findCard(this.cards(), val.nodegroup_id());
                 this.parseProvisionalEdits(val.provisionaledits());
-                this.getUserNames(self.edits())
+                this.getUserNames(self.edits());
             }
-        }, self)
+        }, self);
     };
 
     return ProvisionalTileViewModel;

--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -47,7 +47,7 @@ define([
                     self.form.loadForm(self.selectedForm());
                 })
                 .fail(function(data) {
-                    console.log('Related resource request failed', data);
+                    console.log('Delete provisional tile request failed', data);
                 });
         };
 
@@ -65,7 +65,7 @@ define([
                     self.form.loadForm(self.selectedForm());
                 })
                 .fail(function(data) {
-                    console.log('Related resource request failed', data);
+                    console.log('Delete provisional tiles request failed', data);
                 });
         };
 

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -46,7 +46,6 @@ define([
         );
     };
 
-
     var TileViewModel = function(params) {
         var CardViewModel = require('viewmodels/card');
         var self = this;
@@ -154,6 +153,7 @@ define([
                 loading(true);
                 delete self.formData.data;
                 if (params.provisionalTileViewModel.selectedProvisionalEdit()) {
+                    self.formData.append('accepted_provisional', JSON.stringify(params.provisionalTileViewModel.selectedProvisionalEdit()));
                     params.provisionalTileViewModel.acceptProvisionalEdit();
                 };
                 self.formData.append(
@@ -163,7 +163,7 @@ define([
                     )
                 );
                 $.ajax({
-                    type: "POST",
+                    type: 'POST',
                     url: arches.urls.tile,
                     processData: false,
                     contentType: false,
@@ -183,7 +183,7 @@ define([
                         selection(self);
                     }
                     if (params.userisreviewer === false && !self.provisionaledits()) {
-                        //If the user is provisional ensure their edits are provisional
+                        // If the user is provisional ensure their edits are provisional
                         self.provisionaledits(self.data);
                     };
                     if (params.userisreviewer === true && params.provisionalTileViewModel.selectedProvisionalEdit()) {

--- a/arches/app/media/js/views/page-view.js
+++ b/arches/app/media/js/views/page-view.js
@@ -49,6 +49,7 @@ define([
                 showConfirmNav: ko.observable(false),
                 navDestination: ko.observable(''),
                 provisionalEdits: ko.observableArray(),
+                urls: arches.urls,
                 navigate: function(url, bypass) {
                     if (!bypass && self.viewModel.dirty()) {
                         self.viewModel.navDestination(url);
@@ -63,7 +64,7 @@ define([
                     self.viewModel.loading(true);
                     window.location = url;
                 },
-                getHelp: function(template){
+                getHelp: function(template) {
                     if (!self.viewModel.helploaded()) {
                         self.viewModel.helploading(true);
                         var el = $('.ep-help-content');
@@ -75,7 +76,7 @@ define([
                                 el.html(data);
                                 self.viewModel.helploaded(true);
                                 self.viewModel.helploading(false);
-                                $('.ep-help-topic-toggle').click(function (){
+                                $('.ep-help-topic-toggle').click(function () {
                                     var sectionEl = $(this).closest('div');
                                     contentEl = $(sectionEl).find('.ep-help-topic-content').first();
                                     contentEl.slideToggle();
@@ -87,25 +88,24 @@ define([
                         });
                     }
                 },
-                getProvisionalHistory: function(){
+                getProvisionalHistory: function() {
                     self.viewModel.helploading(true);
                     self.viewModel.provisionalEdits.removeAll();
                     $.ajax({
-                        type: "GET",
-                        url: arches.urls.tile_history,
-                        success : function(data) {
-                            self.viewModel.helploaded(true);
-                            self.viewModel.helploading(false);
-                            self.viewModel.provisionalEdits(_.map(data, function(edit){
-                                edit.displaytime = moment(edit.lasttimestamp).format('DD-MM-YYYY hh:mm a');
-                                return edit;
-                            }))
-                        }
+                        type: 'GET',
+                        url: arches.urls.tile_history
+                    }).done(function(data) {
+                        self.viewModel.helploaded(true);
+                        self.viewModel.helploading(false);
+                        self.viewModel.provisionalEdits(_.map(data, function(edit) {
+                            edit.displaytime = moment(edit.lasttimestamp).format('DD-MM-YYYY hh:mm a');
+                            return edit;
+                        }));
                     });
                 }
             });
 
-            window.addEventListener("beforeunload", function (event) {
+            window.addEventListener('beforeunload', function(event) {
                 self.viewModel.loading(true);
             });
 

--- a/arches/app/media/js/views/provisional-history-list.js
+++ b/arches/app/media/js/views/provisional-history-list.js
@@ -1,0 +1,131 @@
+define([
+    'jquery',
+    'underscore',
+    'moment',
+    'knockout',
+    'arches',
+    'views/list',
+    'bindings/datepicker',
+    'bindings/chosen',
+    'views/components/simple-switch'
+], function($, _, moment, ko, arches, ListView) {
+    var ProvisionalHistoryList = ListView.extend({
+        /**
+        * A backbone view to manage a list of graph nodes
+        * @augments ListView
+        * @constructor
+        * @name ProvisionalHistoryList
+        */
+
+        single_select: true,
+
+        /**
+        * initializes the view with optional parameters
+        * @memberof ProvisionalHistoryList.prototype
+        * @param {object} options
+        */
+        initialize: function(options) {
+            var self = this;
+            ListView.prototype.initialize.apply(this, arguments);
+
+            this.updateList = function() {
+                self.helploading(true);
+                self.items.removeAll();
+                $.ajax({
+                    type: 'GET',
+                    url: arches.urls.tile_history,
+                    data: {start: this.start(), end: this.end()}
+                }).done(function(data) {
+                    self.helploaded(true);
+                    self.helploading(false);
+                    self.items(_.map(data, function(edit) {
+                        edit.displaytime = moment(edit.lasttimestamp).format('DD-MM-YYYY hh:mm a');
+                        return edit;
+                    }));
+                    if (self.sortAscending() === false) {
+                        self.sortDesc();
+                    }
+                });
+            };
+
+            this.items = options.items;
+            this.helploading = options.helploading;
+            this.helploaded = options.helploaded;
+            this.start = ko.observable();
+            this.end = ko.observable();
+            this.dateRangeType = ko.observable('custom');
+            this.format = 'YYYY-MM-DD';
+            this.dateRangeType = ko.observable();
+            this.fromDate = ko.observable();
+            this.toDate = ko.observable();
+            this.sortAscending = ko.observable(true);
+
+            this.sortAsc = function() {
+                self.items.sort(function(a, b) {
+                    return a.lasttimestamp === b.lasttimestamp ? 0 : (a.lasttimestamp < b.lasttimestamp ? -1 : 1);
+                });
+            };
+
+            this.sortDesc = function() {
+                self.items.sort(function(a, b) {
+                    return a.lasttimestamp === b.lasttimestamp ? 0 : (a.lasttimestamp > b.lasttimestamp ? -1 : 1);
+                });
+            };
+
+            this.sortAscending.subscribe(function(val) {
+                console.log(val);
+                if (val === false) {
+                    self.sortDesc();
+                } else {
+                    self.sortAsc();
+                }
+            });
+
+            this.dateRangeType.subscribe(function(value) {
+                var today = moment();
+                var from = today.format(this.format);
+                var to = today.add(1, 'days').format(this.format);
+                // Note: for DateTimeFields the end (to) date is non-inclusive in a
+                // range query. Therefore the range must be one day longer than would
+                // seem necessary.
+                // (https://docs.djangoproject.com/en/2.0/ref/models/querysets/#range)
+                switch (value) {
+                case 'today':
+                    break;
+                case 'last-7':
+                    from = today.subtract(7, 'days').format(this.format);
+                    break;
+                case 'last-30':
+                    from = today.subtract(30, 'days').format(this.format);
+                    break;
+                case 'this-week':
+                    from = today.day(0).format(this.format);
+                    to = today.day(7).format(this.format);
+                    break;
+                case 'this-month':
+                    from = today.date(1).format(this.format);
+                    to = moment().month(today.month() + 1).date(1).format(this.format);
+                    break;
+                case 'this-quarter':
+                    from = moment().date(1).quarter(today.quarter()).format(this.format);
+                    to = moment().date(1).quarter(today.quarter() + 1).format(this.format);
+                    break;
+                case 'this-year':
+                    var first = today.dayOfYear(1);
+                    from = first.format(this.format);
+                    to = first.add(1, 'years').format(this.format);
+                    break;
+                default:
+                    return;
+                }
+                this.start(from);
+                this.end(to);
+                this.updateList();
+            }, this);
+
+            this.dateRangeType('last-30');
+        }
+
+    });
+    return ProvisionalHistoryList;
+});

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -171,12 +171,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             </a>
                         </div>
 
-                        <!-- help content loaded from contextually referenced template -->
                         <div class="ep-edits-body" style="float:left" data-bind="css: {'loading-mask': helploading()}">
                             <div class="ep-edits-content">
                             <!-- ko foreach: provisionalEdits -->
                             <div class='new-provisional-edit-history'>
-                                <div class='entry'><i data-bind="css: $data.resourcemodel.iconclass" style="padding-right: 4px"></i><div class='entry-label' data-bind="text: $data.resourcemodel.name"></div></div>
+                                <div class='entry'><i data-bind="css: $data.resourcemodel.iconclass" style="padding-right: 4px"></i><div class='entry-label' data-bind="text: $data.resourcemodel.name + ' - '"></div><div class='entry-label' data-bind="text: $data.name || '(name pending approval)'"></div></div>
                                 <div class='entry'><div class='entry-label'>{% trans 'Card: ' %}</div><span data-bind="text: $data.card.name"></span></div>
                                 <div class='entry'><div class='entry-label'>{% trans 'Edited: ' %}</div><span data-bind="text: $data.displaytime"></span></div>
                                 <div class='entry'>
@@ -191,10 +190,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                     <div><span style='color: green'>{% trans 'Approved by: ' %}</span><strong data-bind="text: $data.reviewer"></strong></div>
                                     <!--/ko-->
                                 </div>
+                            <div class='new-provisional-edit-history footer'>
+                                <div>
+                                    <a data-bind="attr: {'href': $parent.urls.resource_editor + $data.resourceinstanceid}">{% trans 'Edit' %}</a>
+                                </div>
+                                <div>
+                                    <a data-bind="attr: {'href': $parent.urls.resource_report + $data.resourceinstanceid}">{% trans 'Report' %}</a>
+                                </div>
+                            </div>
                             </div>
                             <!--/ko-->
                             </div>
                         </div>
+
+
+
                     </div>
 
                     <!-- Help Panel -->

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -162,6 +162,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <div id="ep-edits-panel" class="ep-edits" style="display:none">
                         <div class="ep-edits-header" style="padding-right:0px">
                             <div class="ep-edits-title">
+                                <span>{% trans 'Edit History' %}</span>
                             </div>
                             <a href="javascript:void(0);" class="ep-edits-toggle ep-edits-close ep-tools ep-tools-right" style="border:none;">
                                 <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Close" %}'>

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -171,35 +171,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             </a>
                         </div>
 
-                        <div class="ep-edits-body" style="float:left" data-bind="css: {'loading-mask': helploading()}">
+                        <div class="ep-edits-body provisional-edit-history" style="float:left" data-bind="css: {'loading-mask': helploading()}">
                             <div class="ep-edits-content">
-                            <!-- ko foreach: provisionalEdits -->
-                            <div class='new-provisional-edit-history'>
-                                <div class='entry'><i data-bind="css: $data.resourcemodel.iconclass" style="padding-right: 4px"></i><div class='entry-label' data-bind="text: $data.resourcemodel.name + ' - '"></div><div class='entry-label' data-bind="text: $data.name || '(name pending approval)'"></div></div>
-                                <div class='entry'><div class='entry-label'>{% trans 'Card: ' %}</div><span data-bind="text: $data.card.name"></span></div>
-                                <div class='entry'><div class='entry-label'>{% trans 'Edited: ' %}</div><span data-bind="text: $data.displaytime"></span></div>
-                                <div class='entry'>
-                                    <div class='entry-label'>{% trans 'Status: ' %}</div>
-                                    <!--ko if: $data.pending -->
-                                    <span style='color: #F5BB25'>{% trans 'Pending Review' %}</span>
-                                    <!--/ko-->
-                                    <!--ko if: $data.lastedittype === 'delete edit' -->
-                                    <div><span style='color: red'>{% trans 'Declined by: ' %}</span><strong data-bind="text: $data.reviewer"></strong></div>
-                                    <!--/ko-->
-                                    <!--ko if: $data.lastedittype === 'accept edit' -->
-                                    <div><span style='color: green'>{% trans 'Approved by: ' %}</span><strong data-bind="text: $data.reviewer"></strong></div>
-                                    <!--/ko-->
-                                </div>
-                            <div class='new-provisional-edit-history footer'>
-                                <div>
-                                    <a data-bind="attr: {'href': $parent.urls.resource_editor + $data.resourceinstanceid}">{% trans 'Edit' %}</a>
-                                </div>
-                                <div>
-                                    <a data-bind="attr: {'href': $parent.urls.resource_report + $data.resourceinstanceid}">{% trans 'Report' %}</a>
-                                </div>
-                            </div>
-                            </div>
-                            <!--/ko-->
+                                {% include 'views/provisional-history-list.htm' %}
                             </div>
                         </div>
 

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -273,16 +273,16 @@
             <!-- /ko -->
             <div class="install-buttons">
                 <!-- ko if: tile.tileid -->
-                <button class="btn btn-shim btn-warning btn-labeled btn-lg fa fa-trash" data-bind="click: function () { self.form.deleteTile(tile); }">Delete this record</button>
+                <button class="btn btn-shim btn-warning btn-labeled btn-lg fa fa-trash" data-bind="click: function () { self.form.deleteTile(tile); }">{% trans 'Delete this record' %}</button>
                 <!-- /ko -->
                 <!-- ko if: tile.dirty() -->
-                <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: tile.reset">Cancel edit</button>
+                <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: tile.reset">{% trans 'Cancel edit' %}</button>
                     <!-- ko if: tile.tileid -->
-                    <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: function () { self.form.saveTile(tile); }">Save edit</button>
+                    <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: function () { self.form.saveTile(tile); }">{% trans 'Save edit' %}</button>
                     <!-- /ko -->
                 <!-- /ko -->
                 <!-- ko if: !tile.tileid -->
-                <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: function () { self.form.saveTile(tile); }">Add</button>
+                <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: function () { self.form.saveTile(tile); }">{% trans 'Add'  %}</button>
                 <!-- /ko -->
             </div>
 

--- a/arches/app/templates/views/list.htm
+++ b/arches/app/templates/views/list.htm
@@ -29,13 +29,11 @@
 <div class="list-wrapper">
 <div class="grid" class="grid-list">
 
-    <!-- Card -->
     <!-- ko foreach: $data.items -->
         <div class="library-card" data-bind="visible: $data.filtered() == false, click: $parent.selectItem.bind($parent), css:{ 'selected selected-card': $data.selected }">
             {% block listitem %}{% endblock %}
         </div>
     <!-- /ko -->
-
 
 </div>
 </div>

--- a/arches/app/templates/views/provisional-history-list.htm
+++ b/arches/app/templates/views/provisional-history-list.htm
@@ -1,0 +1,87 @@
+{% load staticfiles %}
+{% load i18n %}
+{% block header %}
+
+<!-- Title -->
+<span>
+    <h4 class="title-block-title">{% block title %}{% endblock %}</h4>
+    <!--ko with: provisionalHistoryList -->
+    <!-- ko if: $data.filter_function -->
+    <!-- Date Selector -->
+    <div class="provisional-edit-history-filter">
+    <div class="calendar">
+        <div class="calendar-label">{% trans "Within" %}</div>
+        <select id="" class="resources" placeholder="Select" tabindex="-1" data-bind="value: dateRangeType, chosen:{ width: '100%' }">
+            <!-- <option value="custom">{% trans "Custom date range" %}</option> -->
+            <option value="today">{% trans "Today" %}</option>
+            <option value="last-7">{% trans "Last 7 days" %}</option>
+            <option value="last-30">{% trans "Last 30 days" %}</option>
+            <option value="this-week">{% trans "This week" %}</option>
+            <option value="this-month">{% trans "This month" %}</option>
+            <option value="this-quarter">{% trans "This quarter" %}</option>
+            <option value="this-year">{% trans "This year" %}</option>
+        </select>
+    </div>
+
+    <div data-bind="component: { name: 'views/components/simple-switch', params: {value: sortAscending, config:{ label: '{% trans "Sorted Ascending" %}', subtitle: ''}}}"></div>
+    </div>
+    <!-- <div class="calendar">
+        <h3 class="search-label">{% trans "From" %}</h3>
+        <div id="search-from-c">
+            <input placeholder="" class="form-control input-lg" data-bind="value: fromDate, datepicker: {format: format, keepInvalid: true}, attr:{'placeholder': format}, disable: dateRangeType() !== 'custom'">
+        </div>
+    </div>
+
+    <div class="calendar">
+        <h3 class="search-label">{% trans "To" %}</h3>
+        <div id="search-from-b">
+            <input placeholder="" class="form-control input-lg" data-bind="value: toDate, datepicker: {format: format, keepInvalid: true}, attr:{'placeholder': format}, disable: dateRangeType() !== 'custom'">
+        </div>
+    </div> -->
+    <!-- /ko -->
+    <!-- /ko -->
+    {% endblock %}
+
+    {% block filter %}
+    {% endblock %}
+</span>
+
+{% block list_wrapper %}
+<div class="list-wrapper">
+<div class="grid" class="grid-list">
+    <!--ko with: provisionalHistoryList -->
+    <!-- ko foreach: items -->
+    <div class="new-provisional-edit-history" data-bind="visible: $data.filtered() == false, click: $parent.selectItem.bind($parent), css:{ 'selected selected-card': $data.selected }">
+            {% block listitem %}
+                <div class='entry'><i data-bind="css: $data.resourcemodel.iconclass" style="padding-right: 4px"></i><div class='entry-label' data-bind="text: $data.resourcemodel.name"></div></div>
+                <div class='entry'><div class='entry-label'>{% trans 'Resource: ' %}</div><span data-bind="text: $data.resourcedisplayname"></span></div>
+                <div class='entry'><div class='entry-label'>{% trans 'Card: ' %}</div><span data-bind="text: $data.card.name"></span></div>
+                <div class='entry'><div class='entry-label'>{% trans 'Edited: ' %}</div><span data-bind="text: $data.displaytime"></span></div>
+                <div class='entry'>
+                    <div class='entry-label'>{% trans 'Status: ' %}</div>
+                    <!--ko if: $data.pending -->
+                    <span style='color: #F5BB25'>{% trans 'Pending Review' %}</span>
+                    <!--/ko-->
+                    <!--ko if: $data.lastedittype === 'delete edit' -->
+                    <div><span style='color: red'>{% trans 'Declined by: ' %}</span><strong data-bind="text: $data.reviewer"></strong></div>
+                    <!--/ko-->
+                    <!--ko if: $data.lastedittype === 'accept edit' -->
+                    <div><span style='color: green'>{% trans 'Approved by: ' %}</span><strong data-bind="text: $data.reviewer"></strong></div>
+                    <!--/ko-->
+                </div>
+            <div class='new-provisional-edit-history footer'>
+                <div>
+                    <a data-bind="attr: {'href': $root.urls.resource_editor + $data.resourceinstanceid}">{% trans 'Edit' %}</a>
+                </div>
+                <div>
+                    <a data-bind="attr: {'href': $root.urls.resource_report + $data.resourceinstanceid}">{% trans 'Report' %}</a>
+                </div>
+            </div>
+            {% endblock %}
+        </div>
+        <!-- /ko -->
+    <!-- /ko -->
+
+</div>
+</div>
+{% endblock list_wrapper %}

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -180,7 +180,9 @@ class TileData(View):
 
     def get(self, request):
         if self.action == 'tile_history':
-            edits = EditLog.objects.filter(provisional_userid=request.user.id).order_by('tileinstanceid', 'timestamp')
+            start = request.GET.get('start')
+            end = request.GET.get('end')
+            edits = EditLog.objects.filter(provisional_userid=request.user.id).filter(timestamp__range=[start, end]).order_by('tileinstanceid', 'timestamp')
             summary = {}
             for edit in edits:
                 if edit.tileinstanceid not in summary:
@@ -189,6 +191,7 @@ class TileData(View):
                 summary[edit.tileinstanceid]['lastedittype'] = edit.provisional_edittype
                 summary[edit.tileinstanceid]['reviewer'] = ''
                 summary[edit.tileinstanceid]['resourceinstanceid'] = edit.resourceinstanceid
+                summary[edit.tileinstanceid]['resourcedisplayname'] = edit.resourcedisplayname
                 summary[edit.tileinstanceid]['resourcemodelid'] = edit.resourceclassid
                 summary[edit.tileinstanceid]['nodegroupid'] = edit.nodegroupid
                 if edit.provisional_edittype in ['accept edit', 'delete edit']:

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -214,7 +214,7 @@ class TileData(View):
                     v['card'].pop('nodegroup_id')
                 chronological_summary.append(v)
 
-            print sorted(chronological_summary, key=lambda k: k['lasttimestamp'])
+            sorted(chronological_summary, key=lambda k: k['lasttimestamp'])
 
             return JSONResponse(JSONSerializer().serialize(sorted(chronological_summary, key=lambda k: k['lasttimestamp'])))
 


### PR DESCRIPTION
### Description of Change
Makes the provisional edit history filterable and sortable by date. Adds the instance display name to each edit, and adds the reviewer status if a reviewer approves an edit by directly saving the card. re #3385