### PR TITLE
3385 provisional in new editor

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5843,6 +5843,10 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     margin-top: -10px;
 }
 
+.ep-edits-body.provisional-edit-history {
+    overflow: visible;
+}
+
 .new-provisional-edits-header .new-provisional-edits-delete-all {
     width: 100%;
     padding: 3px 0px;

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5909,6 +5909,13 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     margin-bottom:1px;
 }
 
+.grid-list.provisional-edit-history {
+    height: 100%;
+    position: absolute;
+    width: 100%;
+    overflow-y: scroll;
+}
+
 .provisional-edit-history-filter {
     display: flex;
     justify-content: space-between;

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5746,6 +5746,12 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     padding: 15px 25px;
 }
 
+.edit-message-container .reset-authoritative {
+    float: right;
+    color: white;
+}
+
+
 .edit-message-container.approved {
     background: #C8F89A;
     border-bottom: 1px solid #9CEC4F;

--- a/arches/app/media/js/bindings/chosen.js
+++ b/arches/app/media/js/bindings/chosen.js
@@ -19,6 +19,10 @@ define([
             var defaults = {
                 search_contains: true
             };
+            
+            if (options.disabled === true) {
+                $element.attr('disabled', true);
+            }
 
             if (allBindings.has('placeholder')){
                 var prop = allBindings.get('placeholder');

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -91,6 +91,11 @@ define([
             }
         };
 
+        self.resetAuthoritative = function(){
+            self.selectedProvisionalEdit(undefined);
+            self.selectedTile().reset();
+        };
+
         self.tileIsFullyProvisional = ko.computed(function() {
             return self.selectedProvisionalEdit() && self.selectedProvisionalEdit().isfullyprovisional() === true;
         });

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -1,10 +1,12 @@
 define([
+    'jquery',
+    'underscore',
     'knockout',
     'knockout-mapping',
     'moment',
     'arches',
     'views/components/simple-switch'
-], function (ko, koMapping, moment, arches) {
+], function($, _, ko, koMapping, moment, arches) {
     /**
     * A viewmodel for managing provisional edits
     *
@@ -15,8 +17,8 @@ define([
     */
     var ProvisionalTileViewModel = function(params) {
         var self = this;
-        self.edits = ko.observableArray()
-        self.users = []
+        self.edits = ko.observableArray();
+        self.users = [];
         self.selectedTile = params.tile;
         self.provisionaledits = ko.observableArray();
         self.declineUnacceptedEdits = ko.observable(true);
@@ -30,15 +32,15 @@ define([
                 data: { userids: JSON.stringify(users) },
                 dataType: 'json'
             })
-            .done(function(data) {
-                _.each(this.provisionaledits(), function(edit) {
-                    edit.username(data[edit.user]);
+                .done(function(data) {
+                    _.each(this.provisionaledits(), function(edit) {
+                        edit.username(data[edit.user]);
+                    });
                 })
-            })
-            .fail(function(data) {
-                // console.log('User name request failed', data)
-            });
-        }
+                .fail(function() {
+                    // console.log('User name request failed', data)
+                });
+        };
 
         self.updateProvisionalEdits = function(tile) {
             var isfullyprovisional;
@@ -53,15 +55,15 @@ define([
                     edit['user'] = key;
                     if (edit.isfullyprovisional === undefined) {
                         edit['isfullyprovisional'] = ko.observable(false);
-                    };
+                    }
                     return edit;
                 }, this);
-                this.provisionaledits(_.sortBy(provisionaleditlist, function(pe){return moment(pe.timestamp)}));
+                this.provisionaledits(_.sortBy(provisionaleditlist, function(pe){return moment(pe.timestamp);}));
                 if (this.provisionaledits().length > 0) {
                     if (ko.unwrap(this.provisionaledits()[0].isfullyprovisional) === true) {
                         isfullyprovisional = true;
-                    };
-                };
+                    }
+                }
                 if ((data && _.keys(data).length === 0 && tile.provisionaledits()) ||  isfullyprovisional) {
                     self.selectedProvisionalEdit(undefined);
                     this.provisionaledits()[0].isfullyprovisional(true);
@@ -71,9 +73,9 @@ define([
                 } else {
                     self.selectedProvisionalEdit(undefined);
                     self.selectedTile().reset();
-                };
+                }
                 this.getUserNames(this.provisionaleditlist, users);
-            };
+            }
         };
 
         self.removeSelectedProvisionalEdit = function() {
@@ -85,8 +87,8 @@ define([
             if (self.selectedProvisionalEdit() != val) {
                 self.selectedProvisionalEdit(val);
                 koMapping.fromJS(val['value'], self.selectedTile().data);
-                self.selectedTile()._tileData.valueHasMutated()
-            };
+                self.selectedTile()._tileData.valueHasMutated();
+            }
         };
 
         self.tileIsFullyProvisional = ko.computed(function() {
@@ -104,32 +106,32 @@ define([
                 dataType: 'json',
                 data: {'user': koMapping.toJS(val).user, 'tileid': this.selectedTile().tileid }
             })
-            .done(function(data) {
-                if (data.result === 'delete') {
-                    this.selectedTile().deleteTile()
-                } else {
-                    var user = val.user;
-                    var provisionaledits = this.selectedTile().provisionaledits();
-                    delete provisionaledits[user]
-                    this.selectedTile().provisionaledits(provisionaledits);
-                    if (self.selectedProvisionalEdit() === val) {
-                        self.selectedProvisionalEdit(undefined);
-                        self.selectedTile().reset();
-                    };
-                    self.provisionaledits.remove(val);
-                    if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
-                        this.selectedTile().provisionaledits(null);
-                    };
-                }
-                self.selectedTile()._tileData.valueHasMutated();
-            })
-            .fail(function(data) {
-                console.log('request failed', data)
-            });
-        }
+                .done(function(data) {
+                    if (data.result === 'delete') {
+                        this.selectedTile().deleteTile();
+                    } else {
+                        var user = val.user;
+                        var provisionaledits = this.selectedTile().provisionaledits();
+                        delete provisionaledits[user];
+                        this.selectedTile().provisionaledits(provisionaledits);
+                        if (self.selectedProvisionalEdit() === val) {
+                            self.selectedProvisionalEdit(undefined);
+                            self.selectedTile().reset();
+                        }
+                        self.provisionaledits.remove(val);
+                        if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
+                            this.selectedTile().provisionaledits(null);
+                        }
+                    }
+                    self.selectedTile()._tileData.valueHasMutated();
+                })
+                .fail(function(data) {
+                    console.log('request failed', data);
+                });
+        };
 
         self.deleteAllProvisionalEdits = function() {
-            var users = _.map(self.provisionaledits(), function(edit){return edit.user});
+            var users = _.map(self.provisionaledits(), function(edit){return edit.user;});
             $.ajax({
                 url: arches.urls.delete_provisional_tile,
                 context: this,
@@ -137,27 +139,27 @@ define([
                 dataType: 'json',
                 data: {'users': JSON.stringify(users), 'tileid': this.selectedTile().tileid }
             })
-            .done(function(data) {
-                if (data.result === 'delete') {
-                    this.selectedTile().deleteTile()
-                } else {
-                    self.selectedTile().reset();
-                    self.selectedProvisionalEdit(undefined);
-                    self.provisionaledits.removeAll();
-                    this.selectedTile().provisionaledits(null);
-                };
-            })
-            .fail(function(data) {
-                console.log('request failed', data)
-            });
-        }
+                .done(function(data) {
+                    if (data.result === 'delete') {
+                        this.selectedTile().deleteTile();
+                    } else {
+                        self.selectedTile().reset();
+                        self.selectedProvisionalEdit(undefined);
+                        self.provisionaledits.removeAll();
+                        this.selectedTile().provisionaledits(null);
+                    }
+                })
+                .fail(function(data) {
+                    console.log('request failed', data);
+                });
+        };
 
 
         self.acceptProvisionalEdit = function(){
             var provisionaledits = this.selectedTile().provisionaledits();
-            var user = this.selectedProvisionalEdit().user
+            var user = this.selectedProvisionalEdit().user;
             if (provisionaledits) {
-                delete provisionaledits[user]
+                delete provisionaledits[user];
                 if (_.keys(this.selectedTile().provisionaledits()).length === 0) {
                     this.selectedTile().provisionaledits(null);
                 }
@@ -168,7 +170,7 @@ define([
 
         self.rejectProvisionalEdit = function(val){
             self.deleteProvisionalEdit(val);
-        }
+        };
 
     };
 

--- a/arches/app/media/js/viewmodels/new-provisional-tile.js
+++ b/arches/app/media/js/viewmodels/new-provisional-tile.js
@@ -89,6 +89,10 @@ define([
             };
         };
 
+        self.tileIsFullyProvisional = ko.computed(function() {
+            return self.selectedProvisionalEdit() && self.selectedProvisionalEdit().isfullyprovisional() === true;
+        });
+
         self.updateProvisionalEdits(self.selectedTile);
         self.selectedTile.subscribe(self.updateProvisionalEdits, this);
 

--- a/arches/app/media/js/views/provisional-history-list.js
+++ b/arches/app/media/js/views/provisional-history-list.js
@@ -42,8 +42,8 @@ define([
                         edit.displaytime = moment(edit.lasttimestamp).format('DD-MM-YYYY hh:mm a');
                         return edit;
                     }));
-                    if (self.sortAscending() === false) {
-                        self.sortDesc();
+                    if (self.sortDescending() === false) {
+                        self.sortAsc();
                     }
                 });
             };
@@ -58,7 +58,7 @@ define([
             this.dateRangeType = ko.observable();
             this.fromDate = ko.observable();
             this.toDate = ko.observable();
-            this.sortAscending = ko.observable(true);
+            this.sortDescending = ko.observable(true);
 
             this.sortAsc = function() {
                 self.items.sort(function(a, b) {
@@ -72,9 +72,8 @@ define([
                 });
             };
 
-            this.sortAscending.subscribe(function(val) {
-                console.log(val);
-                if (val === false) {
+            this.sortDescending.subscribe(function(val) {
+                if (val === true) {
                     self.sortDesc();
                 } else {
                     self.sortAsc();

--- a/arches/app/media/js/views/provisional-history-list.js
+++ b/arches/app/media/js/views/provisional-history-list.js
@@ -72,6 +72,10 @@ define([
                 });
             };
 
+            this.editResource = function(resourceinstanceid){
+                window.open(arches.urls.resource_editor + resourceinstanceid);
+            },
+
             this.sortDescending.subscribe(function(val) {
                 if (val === true) {
                     self.sortDesc();

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -167,9 +167,11 @@
     </div>
     <!--/ko-->
 
-    <div class="new-provisional-edit-card-container">
 
+
+    <div class="new-provisional-edit-card-container">
         <!--ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 -->
+        <!--ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
         <div class='new-provisional-edits-list'>
             <div class='new-provisional-edits-header'>
                 <div class='new-provisional-edits-title'>{% trans 'Provisional Edits' %}</div>
@@ -189,8 +191,8 @@
                 </div>
             </div>
             <!-- /ko -->
-
         </div>
+        <!--/ko-->
         <!--/ko-->
 
 

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -155,8 +155,9 @@
     <div class="edit-message-container">
         <span>{% trans 'Currently showing edits by' %}</span>
         <span class="edit-message-container-user" data-bind="text: provisionalTileViewModel.selectedProvisionalEdit().username() + '.'"></span>
+        <!--ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
         <a class="reset-authoritative" href='' data-bind="click: function(){provisionalTileViewModel.resetAuthoritative();}">{% trans 'Return to approved edits' %}</a>
-
+        <!--/ko-->
         <!--ko if: provisionalTileViewModel.selectedProvisionalEdit().isfullyprovisional -->
         <span>{% trans ' This is a new contribution by a provisional editor.' %}</span>
         <!--/ko-->
@@ -280,7 +281,9 @@
                 <button class="btn btn-shim btn-warning btn-labeled btn-lg fa fa-trash" data-bind="click: function () { self.form.deleteTile(tile); }">{% trans 'Delete this record' %}</button>
                 <!-- /ko -->
                 <!-- ko if: tile.dirty() -->
+                <!-- ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
                 <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: tile.reset">{% trans 'Cancel edit' %}</button>
+                <!-- /ko -->
                     <!-- ko if: tile.tileid -->
                     <button class="btn btn-shim btn-mint btn-labeled btn-lg fa fa-plus" data-bind="click: function () { self.form.saveTile(tile); }">{% trans 'Save edit' %}</button>
                     <!-- /ko -->

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -155,6 +155,8 @@
     <div class="edit-message-container">
         <span>{% trans 'Currently showing edits by' %}</span>
         <span class="edit-message-container-user" data-bind="text: provisionalTileViewModel.selectedProvisionalEdit().username() + '.'"></span>
+        <a class="reset-authoritative" href='' data-bind="click: function(){provisionalTileViewModel.resetAuthoritative();}">{% trans 'Return to approved edits' %}</a>
+
         <!--ko if: provisionalTileViewModel.selectedProvisionalEdit().isfullyprovisional -->
         <span>{% trans ' This is a new contribution by a provisional editor.' %}</span>
         <!--/ko-->

--- a/arches/app/templates/views/provisional-history-list.htm
+++ b/arches/app/templates/views/provisional-history-list.htm
@@ -10,7 +10,7 @@
     <!-- Date Selector -->
     <div class="provisional-edit-history-filter">
         <div class="calendar">
-            <select id="" class="resources" placeholder="Select" tabindex="-1" data-bind="value: dateRangeType, chosen:{ width: '100%', disabled: items().length > 0}">
+            <select id="" class="resources" placeholder="Select" tabindex="-1" data-bind="value: dateRangeType, chosen:{ width: '100%'}">
                 <!-- <option value="custom">{% trans "Custom date range" %}</option> -->
                 <option value="today">{% trans "Today" %}</option>
                 <option value="last-7">{% trans "Last 7 days" %}</option>
@@ -22,7 +22,7 @@
             </select>
         </div>
 
-        <div data-bind="css: {'disabled': items().length === 0}, component: { name: 'views/components/simple-switch', params: {value: sortDescending, config:{ label: '{% trans "Youngest to oldest" %}', subtitle: '', disabled: items().length === 0}}}"></div>
+        <div data-bind="component: { name: 'views/components/simple-switch', params: {value: sortDescending, config:{ label: '{% trans "Youngest to oldest" %}', subtitle: ''}}}"></div>
     </div>
     <!-- /ko -->
     {% endblock %}
@@ -33,7 +33,7 @@
 
 {% block list_wrapper %}
 <div class="list-wrapper">
-    <div class="grid-list">
+    <div class="grid-list provisional-edit-history">
         <!--ko with: provisionalHistoryList -->
         <!-- ko if: items().length === 0 -->
         <div class="new-provisional-edit-history">

--- a/arches/app/templates/views/provisional-history-list.htm
+++ b/arches/app/templates/views/provisional-history-list.htm
@@ -45,7 +45,7 @@
         <div class="new-provisional-edit-history" data-bind="visible: $data.filtered() == false, click: $parent.selectItem.bind($parent), css:{ 'selected selected-card': $data.selected }">
             {% block listitem %}
             <div class='entry'>
-                <a class="resource-edit-link" data-bind="attr: {'href': $root.urls.resource_editor + $data.resourceinstanceid}">{% trans 'Edit' %}</a>
+                <a class="resource-edit-link" href='' data-bind="text: '{% trans "Edit" %}', click: function(){$parent.editResource($data.resourceinstanceid)}"></a>
                 <div class="entry-label-resource" data-bind="text: $data.resourcedisplayname"></div>
             </div>
 

--- a/arches/app/templates/views/provisional-history-list.htm
+++ b/arches/app/templates/views/provisional-history-list.htm
@@ -4,13 +4,13 @@
 
 <!-- Title -->
 <span>
-    
+
     <!--ko with: provisionalHistoryList -->
-    
+
     <!-- Date Selector -->
     <div class="provisional-edit-history-filter">
         <div class="calendar">
-            <select id="" class="resources" placeholder="Select" tabindex="-1" data-bind="value: dateRangeType, chosen:{ width: '100%' }">
+            <select id="" class="resources" placeholder="Select" tabindex="-1" data-bind="value: dateRangeType, chosen:{ width: '100%', disabled: items().length > 0}">
                 <!-- <option value="custom">{% trans "Custom date range" %}</option> -->
                 <option value="today">{% trans "Today" %}</option>
                 <option value="last-7">{% trans "Last 7 days" %}</option>
@@ -22,22 +22,8 @@
             </select>
         </div>
 
-        <div data-bind="component: { name: 'views/components/simple-switch', params: {value: sortAscending, config:{ label: '{% trans "Oldest to youngest" %}', subtitle: ''}}}"></div>
+        <div data-bind="css: {'disabled': items().length === 0}, component: { name: 'views/components/simple-switch', params: {value: sortDescending, config:{ label: '{% trans "Youngest to oldest" %}', subtitle: '', disabled: items().length === 0}}}"></div>
     </div>
-    <!-- <div class="calendar">
-        <h3 class="search-label">{% trans "From" %}</h3>
-        <div id="search-from-c">
-            <input placeholder="" class="form-control input-lg" data-bind="value: fromDate, datepicker: {format: format, keepInvalid: true}, attr:{'placeholder': format}, disable: dateRangeType() !== 'custom'">
-        </div>
-    </div>
-
-    <div class="calendar">
-        <h3 class="search-label">{% trans "To" %}</h3>
-        <div id="search-from-b">
-            <input placeholder="" class="form-control input-lg" data-bind="value: toDate, datepicker: {format: format, keepInvalid: true}, attr:{'placeholder': format}, disable: dateRangeType() !== 'custom'">
-        </div>
-    </div> -->
-    
     <!-- /ko -->
     {% endblock %}
 
@@ -49,6 +35,12 @@
 <div class="list-wrapper">
     <div class="grid-list">
         <!--ko with: provisionalHistoryList -->
+        <!-- ko if: items().length === 0 -->
+        <div class="new-provisional-edit-history">
+            {% trans 'You have not yet edited any data within the specified time period. Once you edit a resource, your edit history will display here.' %}
+        </div>
+        <!-- /ko -->
+        <!-- ko if: items().length > 0 -->
         <!-- ko foreach: items -->
         <div class="new-provisional-edit-history" data-bind="visible: $data.filtered() == false, click: $parent.selectItem.bind($parent), css:{ 'selected selected-card': $data.selected }">
             {% block listitem %}
@@ -56,21 +48,21 @@
                 <a class="resource-edit-link" data-bind="attr: {'href': $root.urls.resource_editor + $data.resourceinstanceid}">{% trans 'Edit' %}</a>
                 <div class="entry-label-resource" data-bind="text: $data.resourcedisplayname"></div>
             </div>
-            
+
             <div class='entry'><i data-bind="css: $data.resourcemodel.iconclass" style="padding-right: 4px"></i>
                 <div class='entry-label' data-bind="text: $data.resourcemodel.name"></div>
             </div>
-            
+
             <div class='entry'>
                 <div class='entry-label'>{% trans 'Card: ' %}</div>
                 <span data-bind="text: $data.card.name"></span>
             </div>
-            
+
             <div class='entry'>
                 <div class='entry-label'>{% trans 'Edited: ' %}</div>
                 <span data-bind="text: $data.displaytime"></span>
             </div>
-            
+
             <div class='entry'>
                 <!--ko if: $data.pending -->
                 <span class="provisional-review-pending">{% trans 'pending review' %}</span>
@@ -85,6 +77,7 @@
 
             {% endblock %}
         </div>
+        <!-- /ko -->
         <!-- /ko -->
         <!-- /ko -->
 

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -35,7 +35,6 @@ from django.views.generic import View
 from django.db import transaction
 from arches.app.models.resource import EditLog
 
-
 @method_decorator(can_edit_resource_instance(), name='dispatch')
 class TileData(View):
     action = 'update_tile'
@@ -217,9 +216,7 @@ class TileData(View):
                     v['card'].pop('nodegroup_id')
                 chronological_summary.append(v)
 
-            sorted(chronological_summary, key=lambda k: k['lasttimestamp'])
-
-            return JSONResponse(JSONSerializer().serialize(sorted(chronological_summary, key=lambda k: k['lasttimestamp'])))
+            return JSONResponse(JSONSerializer().serialize(sorted(chronological_summary, key=lambda k: k['lasttimestamp'], reverse=True)))
 
 
 


### PR DESCRIPTION
### Description of Change
Changes sort order of provisional history, hides provisional edit panel in fully provisional tiles, allows reviewers to return to authoritative data after selecting a provisional edit, fixes edit link and other css issues in the provisional history panel. re #3385 