### PR TITLE
Prevents empty error when saving a node.

### DIFF
--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -88,7 +88,7 @@ define([
                 if (node) {
                     viewModel.loading(true);
                     node.save(function(data) {
-                        if (!data.responseJSON.success) {
+                        if (data.responseJSON.success === false || data.status === 500) {
                             viewModel.alert(new AlertViewModel('ep-alert-red', data.responseJSON.title, data.responseJSON.message));
                         }
                         viewModel.loading(false);


### PR DESCRIPTION
Prevents empty error panel when a user saves a node if the server response does not have a 'success' property. re #3749