### PR TITLE
3385 provisional in new editor

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -289,6 +289,7 @@ class Tile(models.TileModel):
     def delete(self, *args, **kwargs):
         se = SearchEngineFactory().create()
         request = kwargs.pop('request', None)
+        provisional_edit_log_details = kwargs.pop('provisional_edit_log_details', None)
         for tiles in self.tiles.itervalues():
             for tile in tiles:
                 tile.delete(*args, request=request, **kwargs)
@@ -309,7 +310,11 @@ class Tile(models.TileModel):
                 se.delete(index='strings', doc_type='term', id=result['_id'])
 
             self.__preDelete(request)
-            self.save_edit(user=request.user, edit_type='tile delete', old_value=self.data)
+            self.save_edit(
+                user=request.user,
+                edit_type='tile delete',
+                old_value=self.data,
+                provisional_edit_log_details=provisional_edit_log_details)
             super(Tile, self).delete(*args, **kwargs)
             resource = Resource.objects.get(resourceinstanceid=self.resourceinstance.resourceinstanceid)
             resource.index()

--- a/arches/app/templates/views/provisional-history-list.htm
+++ b/arches/app/templates/views/provisional-history-list.htm
@@ -45,8 +45,13 @@
         <div class="new-provisional-edit-history" data-bind="visible: $data.filtered() == false, click: $parent.selectItem.bind($parent), css:{ 'selected selected-card': $data.selected }">
             {% block listitem %}
             <div class='entry'>
+                <!--ko if: $data.resource_deleted == false -->
                 <a class="resource-edit-link" href='' data-bind="text: '{% trans "Edit" %}', click: function(){$parent.editResource($data.resourceinstanceid)}"></a>
                 <div class="entry-label-resource" data-bind="text: $data.resourcedisplayname"></div>
+                <!--/ko-->
+                <!--ko if: $data.resource_deleted == true -->
+                <div><span class="resource-edit-link" data-bind="text: '{% trans 'Resource has been deleted' %}'"></span></div>
+                <!--/ko-->
             </div>
 
             <div class='entry'><i data-bind="css: $data.resourcemodel.iconclass" style="padding-right: 4px"></i>

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -166,7 +166,13 @@ class TileData(View):
                     if tile.filter_by_perm(request.user, 'delete_nodegroup'):
                         nodegroup = models.NodeGroup.objects.get(pk=tile.nodegroup_id)
                         clean_resource_cache(tile)
-                        tile.delete(request=request)
+                        if tile.is_provisional() is True and len(tile.provisionaledits.keys()) == 1:
+                            provisional_editor_id = tile.provisionaledits.keys()[0]
+                            edit = tile.provisionaledits[provisional_editor_id]
+                            provisional_editor = User.objects.get(pk=provisional_editor_id)
+                            tile.delete(request=request, provisional_edit_log_details={"user": request.user.id, "action": "delete edit", "edit": edit, "provisional_editor": provisional_editor})
+                        else:
+                            tile.delete(request=request)
                         tile.after_update_all()
                         update_system_settings_cache(tile)
                         return JSONResponse(tile)

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -188,6 +188,9 @@ class TileData(View):
             start = request.GET.get('start')
             end = request.GET.get('end')
             edits = EditLog.objects.filter(provisional_userid=request.user.id).filter(timestamp__range=[start, end]).order_by('tileinstanceid', 'timestamp')
+            resourceinstanceids = [e['resourceinstanceid'] for e in edits.values('resourceinstanceid')]
+            deleted_resource_edits = EditLog.objects.filter(resourceinstanceid__in=resourceinstanceids).filter(edittype='delete')
+            deleted_resource_instances = [e['resourceinstanceid'] for e in deleted_resource_edits.values('resourceinstanceid')]
             summary = {}
             for edit in edits:
                 if edit.tileinstanceid not in summary:
@@ -199,6 +202,7 @@ class TileData(View):
                 summary[edit.tileinstanceid]['resourcedisplayname'] = edit.resourcedisplayname
                 summary[edit.tileinstanceid]['resourcemodelid'] = edit.resourceclassid
                 summary[edit.tileinstanceid]['nodegroupid'] = edit.nodegroupid
+                summary[edit.tileinstanceid]['resource_deleted'] = True if edit.resourceinstanceid in deleted_resource_instances else False
                 if edit.provisional_edittype in ['accept edit', 'delete edit']:
                     summary[edit.tileinstanceid]['reviewer'] = edit.user_username
 

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -170,7 +170,8 @@ class TileData(View):
                             provisional_editor_id = tile.provisionaledits.keys()[0]
                             edit = tile.provisionaledits[provisional_editor_id]
                             provisional_editor = User.objects.get(pk=provisional_editor_id)
-                            tile.delete(request=request, provisional_edit_log_details={"user": request.user.id, "action": "delete edit", "edit": edit, "provisional_editor": provisional_editor})
+                            reviewer = request.user
+                            tile.delete(request=request, provisional_edit_log_details={"user": reviewer, "action": "delete edit", "edit": edit, "provisional_editor": provisional_editor})
                         else:
                             tile.delete(request=request)
                         tile.after_update_all()


### PR DESCRIPTION
### Description of Change
Adds provisional edit 'declined' status to the edit history if a reviewer directly deletes a fully provisional tile. Indicates in the provisional history if a resource instance has been deleted, preventing users from navigating to the editor of a deleted instance. Notifies a user with a warning message if they try to save or delete a non-existent tile.