### PR TITLE
Hides in-app help on page load

### DIFF
--- a/arches/app/media/js/bindings/slide.js
+++ b/arches/app/media/js/bindings/slide.js
@@ -1,28 +1,23 @@
-// Here's a custom Knockout binding that makes elements shown/hidden via jQuery's fadeIn()/fadeOut() methods
-// Could be stored in a separate utility library
 define([
-  'jquery',
-  'knockout',
-], function ($, ko) {
+    'jquery',
+    'knockout',
+], function($, ko) {
     ko.bindingHandlers.slide = {
-        init: function(element, valueAccessor,allBindingsAccessor, viewModel, bindingContent) {
-            var value = valueAccessor();
-            var bindings = allBindingsAccessor();
-            var value = valueAccessor();
+        init: function() {
+            this.initted = true;
         },
-        update: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContent) {
+        update: function(element, valueAccessor, allBindingsAccessor) {
             var value = valueAccessor();
             var bindings = allBindingsAccessor();
-            var duration = bindings.duration;
             var direction = bindings.direction;
             var easing = bindings.easing;
-            var callback = bindings.callback;
-
             if (value() === true) {
                 $(element).toggle(easing, direction);
-            } else {
+            }
+            else if (this.initted === false && value() === false) {
                 $(element).toggle(easing, direction);
             }
+            this.initted = false;
         }
     };
     return ko.bindingHandlers.slide;

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -150,7 +150,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         {% endif %}
 
                         {% if nav.help.0 != '' %}
-                        <a href="javascript:void(0)" class="ep-help-toggle ep-tools ep-tools-right" data-bind="click: function(){ getHelp('{{ help }}'); helpOpen(!helpOpen()) }">
+                        <a href="javascript:void(0)" class="ep-help-toggle ep-tools ep-tools-right" data-bind="click: function(){ getHelp('{{ help }}'); helpOpen(true) }">
                             <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Help" %}'>
                               <i class="ion-help"></i>
                             </div>
@@ -159,7 +159,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     </div>
 
                     <!-- Help Panel -->
-                    <div id="ep-edits-panel" class="ep-edits" style="display:none">
+                    <div id="ep-edits-panel" class="ep-edits" style="display:none;">
                         <div class="ep-edits-header" style="padding-right:0px">
                             <div class="ep-edits-title">
                                 <span>{% trans 'My Edit History' %}</span>
@@ -182,12 +182,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     </div>
 
                     <!-- Help Panel -->
-                    <div id="ep-help-panel" class="ep-help" data-bind="slide: helpOpen, duration: 400, direction: {direction: 'right'}, easing: 'slide'">
+                    <div id="ep-help-panel" class="ep-help" style="display: none" data-bind="slide: helpOpen, duration: 400, direction: {direction: 'right'}, easing: 'slide'">
                         <div class="ep-help-header" style="padding-right:0px">
                             <div class="ep-help-title">
                                 <span>{% trans nav.help.0 %}</span>
                             </div>
-                            <a href="javascript:void(0);" class="ep-help-toggle ep-help-close ep-tools ep-tools-right" style="border:none;" data-bind="click: function(){helpOpen(!helpOpen())}">
+                            <a href="javascript:void(0);" class="ep-help-toggle ep-help-close ep-tools ep-tools-right" style="border:none" data-bind="click: function(){helpOpen(false)}">
                                 <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title='{% trans "Close Help" %}'>
                                   <i class="fa fa-times-circle fa-lg"></i>
                                 </div>


### PR DESCRIPTION
Prevents the 'slide' custom knockout binding from displaying in-app help on page load. re #3712
