### PR TITLE
3811 missing node ontology properties

### DIFF
--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -128,7 +128,7 @@ class Card(models.CardModel):
         with transaction.atomic():
             if self.graph.ontology and self.graph.isresource:
                 edge = self.get_edge_to_parent()
-                edge.ontologyproperty = self.ontologyproperty
+                # edge.ontologyproperty = self.ontologyproperty
                 edge.save()
 
             self.nodegroup.cardinality = self.cardinality

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -128,7 +128,8 @@ class Card(models.CardModel):
         with transaction.atomic():
             if self.graph.ontology and self.graph.isresource:
                 edge = self.get_edge_to_parent()
-                # edge.ontologyproperty = self.ontologyproperty
+                if self.ontologyproperty is not None:
+                    edge.ontologyproperty = self.ontologyproperty
                 edge.save()
 
             self.nodegroup.cardinality = self.cardinality


### PR DESCRIPTION
### Issues Solved
Prevents a node's parent edge ontology property from being saved as `None` when saving a card re #3811 .