### PR TITLE
Changes widget selection status only when status is not true

### DIFF
--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -254,7 +254,8 @@
                             type: "resource-editor"
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered
-                    }, event: { mouseover: function(){ widget.hovered(true) }, mouseout: function(){ widget.hovered(null) } }'></div>
+                }, click: function(data, e) { if (!widget.selected()) {widget.selected(true);}
+                }, event: { mouseover: function(){ widget.hovered(true) }, mouseout: function(){ widget.hovered(null) } }'></div>
                 </div>
             </form>
             <!-- /ko -->


### PR DESCRIPTION
### Description of Change
Changes widget selection status to `true` only when status is not true. Prevents issues with click handlers within a widget. re #3785
