### PR TITLE
Map widget config bindings

### DIFF
--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -245,7 +245,7 @@
                             formData: self.tile.formData,
                             tile: self.tile,
                             form: self.form,
-                            config: widget.configJSON(),
+                            config: widget.configJSON,
                             label: widget.label(),
                             value: self.tile.data[widget.node_id()],
                             node: self.form.nodeLookup[widget.node_id()],


### PR DESCRIPTION
### Description of Change
Passes widget configs to the widget instantiation unevaluated so that the binding between config form and widget persists. re #3796 and #3797