### PR TITLE
Prevents activation of card dirty state when a graph is loaded

### DIFF
--- a/arches/app/media/js/models/card.js
+++ b/arches/app/media/js/models/card.js
@@ -183,6 +183,7 @@ define([
                 return w.get('sortorder')() > ww.get('sortorder')();
             });
             this.get('widgets')(widgets);
+            this._card(JSON.stringify(this.toJSON()));
         },
 
         reset: function() {


### PR DESCRIPTION
Updates a cards JSON state after widgets are added to the card so that the dirty state is not activated on load. re #3787
