### PR TITLE
Permission cards selected when a user selects a node from the graph or card tree.

### DIFF
--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -238,7 +238,6 @@ define([
                             return card.nodegroupid === item.node.nodeGroupId();
                         }
                     });
-                    cardTree.expandToRoot(res);
                 }
                 return res;
 
@@ -258,6 +257,7 @@ define([
             var updateGraphSelection = function() {
                 if (viewModel.activeTab() === 'card') {
                     var matchingNode;
+                    viewModel.graphTree.collapseAll();
                     matchingNode = correspondingNode(viewModel.cardTree.selection(), viewModel.graphTree);
                     viewModel.graphTree.selectItem(matchingNode);
                 }
@@ -273,6 +273,7 @@ define([
                         } else {
                             matchingCard = correspondingCard(graphTreeSelection, viewModel.cardTree);
                             viewModel.cardTree.selection(matchingCard);
+                            viewModel.cardTree.collapseAll();
                             viewModel.cardTree.expandToRoot(viewModel.cardTree.selection());
                         }
                     }
@@ -281,6 +282,8 @@ define([
 
             var updatePermissionCardSelection = function() {
                 var matchingCard = correspondingCard(viewModel.cardTree.selection(), viewModel.permissionTree);
+                viewModel.permissionTree.collapseAll();
+                viewModel.permissionTree.expandToRoot(matchingCard);
                 viewModel.permissionTree.selection.removeAll();
                 matchingCard.selected(true);
             };
@@ -293,7 +296,7 @@ define([
             viewModel.graphTree.selectedItems.subscribe(function(){
                 updateCardSelection();
                 updatePermissionCardSelection();
-            })
+            });
 
             if (viewModel.activeTab() === 'graph') {
                 viewModel.loadGraphSettings();


### PR DESCRIPTION
### Description of Change
Indirectly selects the permission card that corresponds to the selected card tree card or the graph tree node. re #3782 
Also collapses trees when a card is indirectly selected. For example, if a graph node is selected its corresponding permission and card tree cards are expanded, and all other permission cards and card tree cards are collapsed. This prevents somebody from clicking on several graph nodes and then moving to the card tree to find everything expanded without ever having clicked on it anything in that tree.