### PR TITLE
Fix issue where resource editor breadcrumb dropdown was empty when cl…

### DIFF
--- a/arches/app/media/js/views/resource/new-editor.js
+++ b/arches/app/media/js/views/resource/new-editor.js
@@ -39,6 +39,17 @@ define([
             return item.getNewTile();
         }
     });
+    var addableCards = ko.computed(function() {
+        var items = [];
+        if (selectedTile()) {
+            _.each(selectedTile().cards, function(card) {
+                if (card && card.canAdd()) {
+                    items.push(card);
+                }
+            });
+            return items;
+        }
+    });
     var provisionalTileViewModel = new ProvisionalTileViewModel({tile: selectedTile, reviewer: data.user_is_reviewer});
 
     var flattenTree = function(parents, flatList) {
@@ -153,6 +164,7 @@ define([
                 return item;
             }
         }),
+        addableCards: addableCards,
         provisionalTileViewModel: provisionalTileViewModel,
         filter: filter,
         on: function(eventName, handler) {

--- a/arches/app/templates/views/resource/new-editor.htm
+++ b/arches/app/templates/views/resource/new-editor.htm
@@ -191,20 +191,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         </span>
                         <!-- ko if: selectedTile().tileid && selectedTile().cards.length > 0 -->
                         &gt;
+                        <!-- ko if: addableCards().length > 0 -->
                         <span class="dropdown">
                             <a class="dropdown-toggle" href="javascript:void(0)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                                 Add new... <i class="fa fa-caret-down"></i>
                             </a>
                             <ul class="dropdown-menu" style="padding-bottom: 5px;">
-                                <!-- ko foreach: { data: selectedTile().cards, as: 'card' } -->
-                                    <!-- ko if: card.canAdd() -->
+                                <!-- ko foreach: { data: addableCards(), as: 'card' } -->
                                     <li>
                                         <a href="javascript:void(0)" data-bind="text: card.model.name, click: function () { card.selected(true) }"></a>
                                     </li>
-                                    <!-- /ko -->
                                 <!-- /ko -->
                             </ul>
                         </span>
+                        <!-- /ko -->
 
                         <!-- /ko -->
                     </div>


### PR DESCRIPTION
…icking on certain cards, re #3800

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fix issue where resource editor breadcrumb dropdown was empty when clicking on certain cards

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#3800 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
