### PR TITLE
Fixes dirty state when selecting an object in the card or graph trees.

### DIFF
--- a/arches/app/media/js/viewmodels/graph-settings.js
+++ b/arches/app/media/js/viewmodels/graph-settings.js
@@ -46,10 +46,9 @@ define([
             if (self.graph.ontology_id() === undefined) {
                 self.graph.ontology_id(null);
             }
-            var rootNodeDatatype = self.node() === undefined ?  ko.unwrap(self.graph.root.datatype) : ko.unwrap(self.node().datatype);
+
             return JSON.stringify({
                 graph: koMapping.toJS(self.graph),
-                root_node_datatype: rootNodeDatatype,
                 relatable_resource_ids: relatableResourceIds,
                 ontology_class: ontologyClass(),
             });

--- a/arches/app/templates/views/graph/graph-designer/graph-settings.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-settings.htm
@@ -232,7 +232,7 @@
                                 </div>
 
                                 <div class="col-xs-12 crm-selector">
-                                    <select class="design" data-bind="value: graphSettingsViewModel.node().datatype, options: datatypes, optionsCaption: '{% trans "Choose a data type" %}', chosen: {disable_search_threshold: 10, width: '500px'}"></select>
+                                    <select class="design" data-bind="value: graphSettingsViewModel.graph.root.datatype, options: datatypes, optionsCaption: '{% trans "Choose a data type" %}', chosen: {disable_search_threshold: 10, width: '500px'}"></select>
                                 </div>
                             </div>
                         </div>

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -110,7 +110,10 @@ class GraphSettingsView(GraphBaseView):
 
         node = models.Node.objects.get(graph_id=graphid, istopnode=True)
         node.set_relatable_resources(data.get('relatable_resource_ids'))
-        node.datatype = data.get('root_node_datatype')
+        try:
+            node.datatype = data['graph']['root']['datatype']
+        except KeyError as e:
+            print e, 'Cannot find root node datatype'
         node.ontologyclass = data.get('ontology_class') if data.get('graph').get('ontology_id') is not None else None
         node.name = graph.name
         graph.root.name = node.name

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -224,7 +224,7 @@ class GraphManagerViewTests(ArchesTestCase):
         graph = json.loads(response.content)
 
         graph['name'] = 'new graph name'
-        post_data = {'graph': graph, 'relatable_resource_ids': [str(self.ROOT_ID)], 'root_node_datatype': 'semantic'}
+        post_data = {'graph': graph, 'relatable_resource_ids': [str(self.ROOT_ID)]}
         post_data = JSONSerializer().serialize(post_data)
         content_type = 'application/x-www-form-urlencoded'
         response = self.client.post(url, post_data, content_type)


### PR DESCRIPTION
### Issues Solved
Uses graph root node rather than the graph tree's selected node to update a branch's root node datatype. Fixes dirty state when selecting nodes in the card and graph trees. re #3804, #3787
