### PR TITLE
Provisional data in reports

### DIFF
--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -94,6 +94,9 @@ define([
             hasprovisionaledits: ko.computed(function() {
                 return !!self.provisionaledits();
             }, this),
+            isfullyprovisional: ko.pureComputed(function() {
+                return !!self.provisionaledits() && _.keys(koMapping.toJS(this.data)).length === 0;
+            }, this),
             selected: ko.pureComputed({
                 read: function() {
                     return selection() === this;

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -91,7 +91,7 @@ define([
                 });
             }),
             expanded: ko.observable(false),
-            hasprovisionaledits: ko.computed(function() {
+            hasprovisionaledits: ko.pureComputed(function() {
                 return !!self.provisionaledits();
             }, this),
             isfullyprovisional: ko.pureComputed(function() {
@@ -109,7 +109,7 @@ define([
                 owner: this
             }),
             formData: new FormData(),
-            dirty: ko.computed(function() {
+            dirty: ko.pureComputed(function() {
                 return this._tileData() !== koMapping.toJSON(this.data);
             }, this),
             reset: function() {
@@ -226,10 +226,10 @@ define([
                 });
             }
         });
-        this.isChildSelected = ko.computed(function() {
+        this.isChildSelected = ko.pureComputed(function() {
             return isChildSelected(this);
         }, this);
-        this.doesChildHaveProvisionalEdits = ko.computed(function() {
+        this.doesChildHaveProvisionalEdits = ko.pureComputed(function() {
             return doesChildHaveProvisionalEdits(this);
         }, this);
     };

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -355,6 +355,7 @@
     <span class="rp-tile-title" data-bind="text: card.model.get('name')"></span>
     <!-- ko foreach: { data: self.preview ? [card.newTile] : card.tiles, as: 'tile' } -->
         <div class="rp-card-section">
+            <!--ko if: tile.isfullyprovisional() === false -->
             <!-- ko if: card.model.get('widgets')().length > 0 -->
                 <div class="rp-report-tile" data-bind="attr: { id: tile.tileid }">
                     <dl class="dl-horizontal">
@@ -372,7 +373,7 @@
                         <!-- /ko -->
                     </dl>
                 </div>
-            <!-- /ko -->
+                <!-- /ko -->
 
             <div class="rp-report-container-tile" data-bind="visible: card.cards().length > 0">
                 <!-- ko foreach: { data: self.preview ? card.cards : tile.cards, as: 'card' } -->
@@ -386,6 +387,7 @@
                         } --> <!-- /ko -->
                 <!-- /ko -->
             </div>
+            <!-- /ko -->
         </div>
     <!-- /ko -->
 


### PR DESCRIPTION
### Description of Change
Adds isfullyprovisional computed boolean to the tile model in order to filter fully provisional tiles from reports, re #3922 
Also, replaces some computeds with pureComputeds to improve memory management. (http://knockoutjs.com/documentation/component-binding.html#disposal-and-memory-management)