### PR TITLE
Enables styling an entire provisional tile in the resource editor report (for provisional users)

### DIFF
--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -356,7 +356,7 @@
 <div class="rp-card-section" data-bind="css: card.model.cssclass, visible: card.fullyProvisional() !== 'fullyprovisional'">
     <span class="rp-tile-title" data-bind="text: card.model.get('name')"></span>
     <!-- ko foreach: { data: self.preview ? [card.newTile] : card.tiles, as: 'tile' } -->
-        <div class="rp-card-section">
+        <div class="rp-card-section" data-bind="css: {'provisional': tile.provisionaledits() !== null && tile.userisreviewer === false}">
             <!-- ko if: card.model.get('widgets')().length > 0 -->
                 <div class="rp-report-tile" data-bind="attr: { id: tile.tileid }">
                     <!-- ko if: tile.provisionaledits() !== null && tile.userisreviewer === false -->


### PR DESCRIPTION
Adds provisional class to the rp-card-section containing a provisional tile for provisional users. re #3922
