### PR TITLE
Displays authoritative data in a report when sibling tiles are fully provisional

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -3116,6 +3116,10 @@ ul .collapse li:last-of-type {
     background-color: #f5f5f5;
 }
 
+.resource-report .fullyprovisional {
+    display: none;
+}
+
 .dl-horizontal.provisional {
     border-style: solid;
     margin-right: 25px;

--- a/arches/app/media/js/viewmodels/card.js
+++ b/arches/app/media/js/viewmodels/card.js
@@ -145,10 +145,10 @@ define([
                 });
                 provisionalindex = _.reduce(summary, function(a, b){return a + b;});
                 if (provisionalindex > 0) {
-                    if (provisionalindex % 2 === 0) {
+                    if (_.every(summary, function(val){return val === 2;})) {
                         res = 'fullyprovisional';
                     }
-                    else if (provisionalindex % 2 === 1) {
+                    else {
                         res = 'provisional';
                     }
                 }

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -356,7 +356,7 @@
 <div class="rp-card-section" data-bind="css: card.model.cssclass, visible: card.fullyProvisional() !== 'fullyprovisional'">
     <span class="rp-tile-title" data-bind="text: card.model.get('name')"></span>
     <!-- ko foreach: { data: self.preview ? [card.newTile] : card.tiles, as: 'tile' } -->
-        <div class="rp-card-section" data-bind="css: {'provisional': tile.provisionaledits() !== null && tile.userisreviewer === false}">
+        <div class="rp-card-section" data-bind="css: {'provisional': tile.provisionaledits() !== null && tile.userisreviewer === false, 'fullyprovisional': tile.isfullyprovisional()}">
             <!-- ko if: card.model.get('widgets')().length > 0 -->
                 <div class="rp-report-tile" data-bind="attr: { id: tile.tileid }">
                     <!-- ko if: tile.provisionaledits() !== null && tile.userisreviewer === false -->


### PR DESCRIPTION
Displays authoritative data in a report when sibling tiles are fully provisional. re #3922