### PR TITLE
Gets valid properties for all ontology classes.

### DIFF
--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -148,7 +148,7 @@ class GraphManagerView(GraphBaseView):
             context['graphs'] = JSONSerializer().serialize(context['graph_models'], exclude=['functions'])
             context['nav']['title'] = 'Arches Designer'
             context['nav']['icon'] = 'fa-bookmark'
-            
+
             context['nav']['help'] = {
                 'title': _('Using the Arches Designer'),
                 'template': 'arches-designer-help',
@@ -272,7 +272,7 @@ class GraphDataView(View):
             ret = graph.get_valid_domain_ontology_classes()
             for r in ret:
                 res.append({'ontology_property': r['ontology_property'], 'ontology_classes': [
-                           c for c in r['ontology_classes'] if c == ontology_class]})
+                           c for c in r['ontology_classes']]})
             return JSONResponse(res)
 
         else:


### PR DESCRIPTION
Gets valid properties for all ontology classes rather than just for the resource model's root node class. re #4040.

This fixes the issue of unavailable properties in the relationship dropdown and ontology classes not appearing in the Ontology Class column of the related resources table.