### PR TITLE
Allow default values to be saved if a widget is not visible

### DIFF
--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -23,8 +23,7 @@
                 <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.form.selection($data) }, css:{'jstree-clicked': selected, 'child-selected': isChildSelected(), 'filtered-leaf': card.highlight()}">
                     <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits()}"></i>
                     <strong style="margin-right: 10px;">
-                        <!-- ko if: card.widgets().length > 0 -->
-                        <!-- ko if: card.widgets()[0].visible -->
+                        <!-- ko if: card.widgets().length > 0 && card.widgets()[0].visible -->
                         <span data-bind="text: card.widgets()[0].label || card.model.name"></span>:
                         <div style="display: inline;" data-bind="component: {
                             name: self.form.widgetLookup[card.widgets()[0].widget_id()].name,
@@ -39,9 +38,8 @@
                             }
                         }"></div>
                         <!-- /ko -->
-                        <!-- ko if: card.widgets().length === 0 -->
+                        <!-- ko if: card.widgets().length === 0 || !card.widgets()[0].visible -->
                         <span data-bind="text: card.model.name"></span>
-                        <!-- /ko -->
                         <!-- /ko -->
                     </strong>
                 </a>

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -24,6 +24,7 @@
                     <i class="fa fa-file" role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits()}"></i>
                     <strong style="margin-right: 10px;">
                         <!-- ko if: card.widgets().length > 0 -->
+                        <!-- ko if: card.widgets()[0].visible -->
                         <span data-bind="text: card.widgets()[0].label || card.model.name"></span>:
                         <div style="display: inline;" data-bind="component: {
                             name: self.form.widgetLookup[card.widgets()[0].widget_id()].name,
@@ -40,6 +41,7 @@
                         <!-- /ko -->
                         <!-- ko if: card.widgets().length === 0 -->
                         <span data-bind="text: card.model.name"></span>
+                        <!-- /ko -->
                         <!-- /ko -->
                     </strong>
                 </a>
@@ -247,7 +249,6 @@
                 <div data-bind="foreach: {
                         data:card.widgets, as: 'widget'
                     }">
-                    <!-- ko if: widget.visible -->
                     <div data-bind='component: {
                         name: self.form.widgetLookup[widget.widget_id()].name,
                         params: {
@@ -264,8 +265,7 @@
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
-            }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }'></div>
-            <!-- /ko -->
+            }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
                 </div>
             </form>
             <!-- /ko -->

--- a/arches/app/templates/views/graph/graph-designer/widget-configuration.htm
+++ b/arches/app/templates/views/graph/graph-designer/widget-configuration.htm
@@ -35,7 +35,7 @@
                 {% trans "Visible" %}
             </div>
             <div class="pad-no">
-                <div class="pad-top" data-bind="component: { name: 'views/components/simple-switch', params: {value: visible, config:{label: '{% trans "Make Widget Visible" %}', subtitle: '{% trans "Show this widget by default" %}'}}}"></div>
+                <div data-bind="component: { name: 'views/components/simple-switch', params: {value: visible, config:{label: '{% trans "Make Widget Visible" %}', subtitle: '{% trans "Show this widget by default" %}'}}}"></div>
             </div>
         </div>
 


### PR DESCRIPTION
Uses css to hide the widget rather than remove it from the resource editor. This allows a default value to be saved with the tile. re #3065