### PR TITLE
3993 refactor update card in card tree

### DIFF
--- a/arches/app/media/js/models/card.js
+++ b/arches/app/media/js/models/card.js
@@ -234,6 +234,7 @@ define([
 
         parseNodes: function(attributes) {
             var widgets = [];
+            console.log('parsing nodes')
             ko.unwrap(this.nodes).forEach(function(node) {
                 // TODO: it would be nice to normalize the nodegroup_id names (right now we have several different versions)
                 if((ko.unwrap(node.nodeGroupId) || ko.unwrap(node.nodegroup_id)) === ko.unwrap(attributes.data.nodegroup_id)){

--- a/arches/app/media/js/models/card.js
+++ b/arches/app/media/js/models/card.js
@@ -234,7 +234,6 @@ define([
 
         parseNodes: function(attributes) {
             var widgets = [];
-            console.log('parsing nodes')
             ko.unwrap(this.nodes).forEach(function(node) {
                 // TODO: it would be nice to normalize the nodegroup_id names (right now we have several different versions)
                 if((ko.unwrap(node.nodeGroupId) || ko.unwrap(node.nodegroup_id)) === ko.unwrap(attributes.data.nodegroup_id)){

--- a/arches/app/media/js/views/graph/graph-designer/card-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/card-tree.js
@@ -221,11 +221,11 @@ define([
                                         if (pw.node_id() === widget.node_id()) {
                                             replacewidget = i;
                                         }
-                                    }, self)
+                                    }, self);
                                     if (replacewidget !== undefined) {
                                         parent.widgets.splice(replacewidget, 1, widget);
                                     } else {
-                                        parent.widgets.push(widget)
+                                        parent.widgets.push(widget);
                                     }
                                 }
                             }

--- a/arches/app/media/js/views/graph/graph-designer/card-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/card-tree.js
@@ -216,14 +216,14 @@ define([
                                         datatype: datatype,
                                         disabled: attributes.data.disabled
                                     });
-                                    var replacewidget;
+                                    var widgetIndex;
                                     _.each(parent.widgets(), function(pw, i){
                                         if (pw.node_id() === widget.node_id()) {
-                                            replacewidget = i;
+                                            widgetIndex = i;
                                         }
                                     }, self);
-                                    if (replacewidget !== undefined) {
-                                        parent.widgets.splice(replacewidget, 1, widget);
+                                    if (widgetIndex !== undefined) {
+                                        parent.widgets.splice(widgetIndex, 1, widget);
                                     } else {
                                         parent.widgets.push(widget);
                                     }

--- a/arches/app/media/js/views/graph/graph-designer/card-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/card-tree.js
@@ -3,13 +3,14 @@ define([
     'underscore',
     'knockout',
     'viewmodels/card',
+    'models/card-widget',
     'arches',
     'graph-designer-data',
     'bindings/sortable',
     'bindings/scrollTo',
     'widgets',
     'card-components'
-], function($, _, ko, CardViewModel, arches, data) {
+], function($, _, ko, CardViewModel, CardWidgetModel, arches, data) {
     var CardTreeViewModel = function(params) {
         var self = this;
         var filter = ko.observable('');
@@ -196,7 +197,40 @@ define([
                 var updatedCards = [];
                 _.each(ko.unwrap(parents), function(parent) {
                     if (parent.nodegroupid === node.nodegroup_id) {
-                        parent.model.parseNodes(parent.model.attributes);
+                        var attributes = parent.model.attributes;
+                        _.each(parent.model.nodes(), function(modelnode){
+                            if (modelnode.nodeid === node.nodeid) {
+                                var datatype = attributes.datatypelookup[ko.unwrap(modelnode.datatype)];
+                                if (!modelnode.nodeDatatypeSubscription) {
+                                    modelnode.nodeDatatypeSubscription = modelnode.datatype.subscribe(function(){
+                                        parent.model._card(JSON.stringify(parent.model.toJSON()));
+                                    }, this);
+                                }
+                                if (datatype.defaultwidget_id) {
+                                    var cardWidgetData = _.find(attributes.data.widgets, function(widget) {
+                                        return widget.node_id === node.nodeid;
+                                    });
+                                    var widget = new CardWidgetModel(cardWidgetData, {
+                                        node: modelnode,
+                                        card: parent.model,
+                                        datatype: datatype,
+                                        disabled: attributes.data.disabled
+                                    });
+                                    var replacewidget;
+                                    _.each(parent.widgets(), function(pw, i){
+                                        if (pw.node_id() === widget.node_id()) {
+                                            replacewidget = i;
+                                        }
+                                    }, self)
+                                    if (replacewidget !== undefined) {
+                                        parent.widgets.splice(replacewidget, 1, widget);
+                                    } else {
+                                        parent.widgets.push(widget)
+                                    }
+                                }
+                            }
+                        });
+                        parent.model._card(JSON.stringify(parent.model.toJSON()));
                     } else {
                         self.updateNode(ko.unwrap(parent.cards), node);
                     }

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -313,8 +313,8 @@ class GraphDataView(View):
                 elif self.action == 'update_node':
                     updated_values = graph.update_node(data)
                     ret = graph
-                    graph.save()
-                    ret = JSONSerializer().serializeToPython(graph)
+                    updated_graph = graph.save()
+                    ret = JSONSerializer().serializeToPython(updated_graph)
                     ret['updated_values'] = updated_values
 
                 elif self.action == 'update_node_layer':

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -312,9 +312,8 @@ class GraphDataView(View):
 
                 elif self.action == 'update_node':
                     updated_values = graph.update_node(data)
-                    ret = graph
-                    updated_graph = graph.save()
-                    ret = JSONSerializer().serializeToPython(updated_graph)
+                    graph.save()
+                    ret = JSONSerializer().serializeToPython(graph)
                     ret['updated_values'] = updated_values
 
                 elif self.action == 'update_node_layer':


### PR DESCRIPTION
### Description of Change
Creates widgets within the card trees update node method rather than using parseNodes. re #3993, #4149 
