### PR TITLE
 #4190 Add flag to disable/enable installing yarn components on Docker startup

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -286,11 +286,21 @@ To develop on Arches Core, ensure you are not already running PostgreSQL and it 
 
 8. See [Running in DEV mode](#running-in-dev-mode) to get exception messages in the browser and to bypass Nginx.  
 
+##### Dependencies
+Any time you change Arches Dependancies, you will need to re-build your Docker Container.  
+The `docker-compose -f .\docker-compose-local.yml build` command will re-build the container for you based upon the `Dockerfile`.  
+*Tip: If your new or updated dependency does not install correctly, you may need to build without cache: `docker-compose -f .\docker-compose-local.yml build --no-cache`*
 
-Any time you change Arches Dependancies, you will need to re-build your Docker Container. The `docker-compose -f .\docker-compose-local.yml build` command will re-build the container for you based upon the `Dockerfile`. If your new or updated dependency does not install correctly, you may need to build without cache: `docker-compose -f .\docker-compose-local.yml build --no-cache`
+##### settings_local.py
+The volume section at **point 4** also mounts a `settings_local.py` into the container.  
+This ensures some important settings, e.g. database and Elasticsearch endpoints, can still be set through environment variables.  
+**This settings file may be overwritten by your own settings file, presuming you are including these settings as well.**
 
-(Note: *The volume section at **point 4** also mounts a settings_local.py into the container. This ensures some important settings, e.g. database and Elasticsearch endpoints, can still be set through environment variables.* **This settings file may be overwritten by your own settings file, presuming you are including these settings as well.**)
+##### Yarn components
+The INSTALL_YARN_COMPONENTS environment variable causes yarn components (static files) to be installed when the container is started.  
+This is necessary, because your volume from `step 4` is laid over the files in your container, thus hiding them. To turn this off and speed up container startup, set this variable to `False`.
 
+##### docker-compose-local.yml
 Here is a link to a working [docker-compose-local.yml](https://gist.github.com/jmunowitch/c63fa39be4651b9bf2f0b1abc69f7479) file
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -28,6 +28,8 @@ DJANGO_PORT=${DJANGO_PORT:-8000}
 COUCHDB_URL="http://$COUCHDB_USER:$COUCHDB_PASS@$COUCHDB_HOST:$COUCHDB_PORT"
 COMPRESS_STATIC_FILES=${COMPRESS_STATIC_FILES:-False}
 STATIC_ROOT=${STATIC_ROOT:-/static_root}
+INSTALL_YARN_COMPONENTS=${INSTALL_YARN_COMPONENTS:-True}
+
 
 cd_web_root() {
 	cd ${WEB_ROOT}
@@ -340,7 +342,10 @@ run_gunicorn_server() {
 run_arches() {
 
 	init_arches
-	install_yarn_components
+
+	if [[ "${INSTALL_YARN_COMPONENTS}" == "True" ]]; then
+		install_yarn_components
+	fi
 
 	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
 		set_dev_mode


### PR DESCRIPTION
For  #4190

- Added env variable `INSTALL_YARN_COMPONENTS`
- Explain in Readme
- Some Readme formatting

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Our Docker entrypoint.sh currently always runs the yarn install command. Since this takes a long time, it is standing in the way of rapid development and deployment.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Slow startup

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] I have added necessary documentation (if appropriate)
