### PR TITLE
#4278 Remove all image-block css styling

### DIFF
--- a/arches/app/media/css/page_job_inner.css
+++ b/arches/app/media/css/page_job_inner.css
@@ -33,56 +33,6 @@
 	border-top: 1px solid #eee;
 }
 
-/*Image Block
-------------------------------------*/
-.image-block {
-	overflow: hidden;
-	min-height: 200px;
-	position: relative;
-}
-
-.image-block {
-	background: url(../../img/job/slider.jpg) 70% 40% no-repeat;
-}
-
-/*Company Description*/
-.image-block .company-description {
-	max-width: 500px;
-	margin: 40px auto;
-	padding: 35px 25px;	
-	position: relative;
-	text-align: center;
-	background: rgba(255,255,255,0.8);
-}
-
-.image-block .company-description h2 {
-	margin-bottom: 20px;
-	text-transform: uppercase;
-}
-
-.image-block .company-description p {
-	text-align: left;
-}
-
-.image-block .benefits {
-	margin-bottom: 20px;
-}
-
-.image-block .benefits li {
-	margin: 0 7px 10px 0;
-	font-style: italic;
-}
- 
-.image-block .benefits li i {
-	color: #555;
-	min-width: 32px;
-	font-size: 15px;
-	padding: 7px 6px;
-	margin-right: 10px;
-	text-align: center;
-	border: 1px solid #555;
-}
-
 /*Block Description
 ------------------------------------*/
 .block-description {


### PR DESCRIPTION
For #4278 
Remove all image-block css styling: not used, plus `url()` in `line 45` pointed to non-existing file.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Removed all styling for the `.image-block` class, because it was not used anymore and was causing trouble.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
`collectstatic` crashed because this css referred to a non-existing file.