### PR TITLE
4044 file list datatype upload

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -89,14 +89,14 @@ class Resource(models.ResourceInstance):
         Saves and indexes a single resource
 
         """
-        request = kwargs.pop('request', '')
-        user = kwargs.pop('user', '')
+        request = kwargs.pop('request', None)
+        user = kwargs.pop('user', None)
         super(Resource, self).save(*args, **kwargs)
         for tile in self.tiles:
             tile.resourceinstance_id = self.resourceinstanceid
             saved_tile = tile.save(request=request, index=False)
-        if request == '':
-            if user == '':
+        if request is None:
+            if user is None:
                 user = {}
         else:
             user = request.user

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -47,9 +47,12 @@ class Resource(models.ResourceInstance):
         self.tiles = []
 
     def get_descriptor(self, descriptor):
-        module = importlib.import_module('arches.app.functions.primary_descriptors')
-        PrimaryDescriptorsFunction = getattr(module, 'PrimaryDescriptorsFunction')()
-        functionConfig = models.FunctionXGraph.objects.filter(graph_id=self.graph_id, function__functiontype='primarydescriptors')
+        module = importlib.import_module(
+            'arches.app.functions.primary_descriptors')
+        PrimaryDescriptorsFunction = getattr(
+            module, 'PrimaryDescriptorsFunction')()
+        functionConfig = models.FunctionXGraph.objects.filter(
+            graph_id=self.graph_id, function__functiontype='primarydescriptors')
         if len(functionConfig) == 1:
             return PrimaryDescriptorsFunction.get_primary_descriptor_from_nodes(self, functionConfig[0].config[descriptor])
         else:
@@ -107,7 +110,8 @@ class Resource(models.ResourceInstance):
 
         """
         root_ontology_class = None
-        graph_nodes = models.Node.objects.filter(graph_id=self.graph_id).filter(istopnode=True)
+        graph_nodes = models.Node.objects.filter(
+            graph_id=self.graph_id).filter(istopnode=True)
         if len(graph_nodes) > 0:
             root_ontology_class = graph_nodes[0].ontologyclass
 
@@ -119,7 +123,8 @@ class Resource(models.ResourceInstance):
 
         """
 
-        self.tiles = list(models.TileModel.objects.filter(resourceinstance=self))
+        self.tiles = list(
+            models.TileModel.objects.filter(resourceinstance=self))
 
     # # flatten out the nested tiles into a single array
     def get_flattened_tiles(self):
@@ -140,7 +145,8 @@ class Resource(models.ResourceInstance):
 
         se = SearchEngineFactory().create()
         datatype_factory = DataTypeFactory()
-        node_datatypes = {str(nodeid): datatype for nodeid, datatype in models.Node.objects.values_list('nodeid', 'datatype')}
+        node_datatypes = {str(nodeid): datatype for nodeid,
+                          datatype in models.Node.objects.values_list('nodeid', 'datatype')}
         tiles = []
         documents = []
         term_list = []
@@ -155,11 +161,14 @@ class Resource(models.ResourceInstance):
 
         for resource in resources:
             resource.save_edit(edit_type='create')
-            document, terms = resource.get_documents_to_index(fetchTiles=False, datatype_factory=datatype_factory, node_datatypes=node_datatypes)
+            document, terms = resource.get_documents_to_index(
+                fetchTiles=False, datatype_factory=datatype_factory, node_datatypes=node_datatypes)
             document['root_ontology_class'] = resource.get_root_ontology()
-            documents.append(se.create_bulk_item(index='resource', doc_type=document['graph_id'], id=document['resourceinstanceid'], data=document))
+            documents.append(se.create_bulk_item(
+                index='resource', doc_type=document['graph_id'], id=document['resourceinstanceid'], data=document))
             for term in terms:
-                term_list.append(se.create_bulk_item(index='strings', doc_type='term', id=term['_id'], data=term['_source']))
+                term_list.append(se.create_bulk_item(
+                    index='strings', doc_type='term', id=term['_id'], data=term['_source']))
 
         for tile in tiles:
             tile.save_edit(edit_type='tile create', new_value=tile.data)
@@ -175,12 +184,16 @@ class Resource(models.ResourceInstance):
         if unicode(self.graph_id) != unicode(settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID):
             se = SearchEngineFactory().create()
             datatype_factory = DataTypeFactory()
-            node_datatypes = {str(nodeid): datatype for nodeid, datatype in models.Node.objects.values_list('nodeid', 'datatype')}
-            document, terms = self.get_documents_to_index(datatype_factory=datatype_factory, node_datatypes=node_datatypes)
+            node_datatypes = {str(nodeid): datatype for nodeid,
+                              datatype in models.Node.objects.values_list('nodeid', 'datatype')}
+            document, terms = self.get_documents_to_index(
+                datatype_factory=datatype_factory, node_datatypes=node_datatypes)
             document['root_ontology_class'] = self.get_root_ontology()
-            se.index_data('resource', self.graph_id, JSONSerializer().serializeToPython(document), id=self.pk)
+            se.index_data('resource', self.graph_id, JSONSerializer(
+            ).serializeToPython(document), id=self.pk)
             for term in terms:
-                se.index_data('strings', 'term', term['_source'], id=term['_id'])
+                se.index_data('strings', 'term',
+                              term['_source'], id=term['_id'])
 
     def get_documents_to_index(self, fetchTiles=True, datatype_factory=None, node_datatypes=None):
         """
@@ -195,7 +208,8 @@ class Resource(models.ResourceInstance):
         """
 
         document = JSONSerializer().serializeToPython(self)
-        tiles = list(models.TileModel.objects.filter(resourceinstance=self)) if fetchTiles else self.tiles
+        tiles = list(models.TileModel.objects.filter(
+            resourceinstance=self)) if fetchTiles else self.tiles
         document['tiles'] = tiles
         document['strings'] = []
         document['dates'] = []
@@ -204,7 +218,8 @@ class Resource(models.ResourceInstance):
         document['points'] = []
         document['numbers'] = []
         document['date_ranges'] = []
-        document['provisional_resource'] = 'true' if sum([len(t.data) for t in tiles]) == 0 else 'false'
+        document['provisional_resource'] = 'true' if sum(
+            [len(t.data) for t in tiles]) == 0 else 'false'
 
         terms = []
 
@@ -213,10 +228,13 @@ class Resource(models.ResourceInstance):
                 datatype = node_datatypes[nodeid]
                 if nodevalue != '' and nodevalue != [] and nodevalue != {} and nodevalue is not None:
                     datatype_instance = datatype_factory.get_instance(datatype)
-                    datatype_instance.append_to_document(document, nodevalue, nodeid, tile)
-                    node_terms = datatype_instance.get_search_terms(nodevalue, nodeid)
+                    datatype_instance.append_to_document(
+                        document, nodevalue, nodeid, tile)
+                    node_terms = datatype_instance.get_search_terms(
+                        nodevalue, nodeid)
                     for index, term in enumerate(node_terms):
-                        terms.append({'_id':unicode(nodeid)+unicode(tile.tileid)+unicode(index), '_source': {'value': term, 'nodeid': nodeid, 'nodegroupid': tile.nodegroup_id, 'tileid': tile.tileid, 'resourceinstanceid':tile.resourceinstance_id, 'provisional': False}})
+                        terms.append({'_id': unicode(nodeid)+unicode(tile.tileid)+unicode(index), '_source': {'value': term, 'nodeid': nodeid,
+                                                                                                              'nodegroupid': tile.nodegroup_id, 'tileid': tile.tileid, 'resourceinstanceid': tile.resourceinstance_id, 'provisional': False}})
 
             if tile.provisionaledits is not None:
                 provisionaledits = tile.provisionaledits
@@ -228,12 +246,15 @@ class Resource(models.ResourceInstance):
                             for nodeid, nodevalue in edit['value'].iteritems():
                                 datatype = node_datatypes[nodeid]
                                 if nodevalue != '' and nodevalue != [] and nodevalue != {} and nodevalue is not None:
-                                    datatype_instance = datatype_factory.get_instance(datatype)
-                                    datatype_instance.append_to_document(document, nodevalue, nodeid, tile, True)
-                                    node_terms = datatype_instance.get_search_terms(nodevalue, nodeid)
+                                    datatype_instance = datatype_factory.get_instance(
+                                        datatype)
+                                    datatype_instance.append_to_document(
+                                        document, nodevalue, nodeid, tile, True)
+                                    node_terms = datatype_instance.get_search_terms(
+                                        nodevalue, nodeid)
                                     for index, term in enumerate(node_terms):
-                                        terms.append({'_id':unicode(nodeid)+unicode(tile.tileid)+unicode(index), '_source': {'value': term, 'nodeid': nodeid, 'nodegroupid': tile.nodegroup_id, 'tileid': tile.tileid, 'resourceinstanceid':tile.resourceinstance_id, 'provisional': True}})
-
+                                        terms.append({'_id': unicode(nodeid)+unicode(tile.tileid)+unicode(index), '_source': {'value': term, 'nodeid': nodeid,
+                                                                                                                              'nodegroupid': tile.nodegroup_id, 'tileid': tile.tileid, 'resourceinstanceid': tile.resourceinstance_id, 'provisional': True}})
 
         return document, terms
 
@@ -244,7 +265,6 @@ class Resource(models.ResourceInstance):
         """
 
         permit_deletion = False
-
         if user != {}:
             user_is_reviewer = user.groups.filter(name='Resource Reviewer').exists()
             if user_is_reviewer is False:
@@ -259,19 +279,25 @@ class Resource(models.ResourceInstance):
 
         if permit_deletion is True:
             se = SearchEngineFactory().create()
-            related_resources = self.get_related_resources(lang="en-US", start=0, limit=1000, page=0)
+            related_resources = self.get_related_resources(
+                lang="en-US", start=0, limit=1000, page=0)
             for rr in related_resources['resource_relationships']:
-                models.ResourceXResource.objects.get(pk=rr['resourcexid']).delete()
+                models.ResourceXResource.objects.get(
+                    pk=rr['resourcexid']).delete()
             query = Query(se)
             bool_query = Bool()
-            bool_query.filter(Terms(field='resourceinstanceid', terms=[self.resourceinstanceid]))
+            bool_query.filter(Terms(field='resourceinstanceid',
+                                    terms=[self.resourceinstanceid]))
             query.add_query(bool_query)
-            results = query.search(index='strings', doc_type='term')['hits']['hits']
+            results = query.search(index='strings', doc_type='term')[
+                'hits']['hits']
             for result in results:
                 se.delete(index='strings', doc_type='term', id=result['_id'])
-            se.delete(index='resource', doc_type=str(self.graph_id), id=self.resourceinstanceid)
+            se.delete(index='resource', doc_type=str(
+                self.graph_id), id=self.resourceinstanceid)
 
-            self.save_edit(edit_type='delete', user=user, note=self.displayname)
+            self.save_edit(edit_type='delete', user=user,
+                           note=self.displayname)
             super(Resource, self).delete()
 
         return permit_deletion
@@ -281,8 +307,10 @@ class Resource(models.ResourceInstance):
         Returns an object that lists the related resources, the relationship types, and a reference to the current resource
 
         """
-        graphs = models.GraphModel.objects.all().exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID).exclude(isresource=False)
-        graph_lookup = {str(graph.graphid): {'name':graph.name, 'iconclass': graph.iconclass, 'fillColor': graph.color} for graph in graphs}
+        graphs = models.GraphModel.objects.all().exclude(
+            pk=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID).exclude(isresource=False)
+        graph_lookup = {str(graph.graphid): {
+            'name': graph.name, 'iconclass': graph.iconclass, 'fillColor': graph.color} for graph in graphs}
         ret = {
             'resource_instance': self,
             'resource_relationships': [],
@@ -298,18 +326,22 @@ class Resource(models.ResourceInstance):
         def get_relations(resourceinstanceid, start, limit):
             query = Query(se, start=start, limit=limit)
             bool_filter = Bool()
-            bool_filter.should(Terms(field='resourceinstanceidfrom', terms=resourceinstanceid))
-            bool_filter.should(Terms(field='resourceinstanceidto', terms=resourceinstanceid))
+            bool_filter.should(
+                Terms(field='resourceinstanceidfrom', terms=resourceinstanceid))
+            bool_filter.should(
+                Terms(field='resourceinstanceidto', terms=resourceinstanceid))
             query.add_query(bool_filter)
             return query.search(index='resource_relations', doc_type='all')
 
-        resource_relations = get_relations(self.resourceinstanceid, start, limit)
+        resource_relations = get_relations(
+            self.resourceinstanceid, start, limit)
         ret['total'] = resource_relations['hits']['total']
         instanceids = set()
 
         for relation in resource_relations['hits']['hits']:
             try:
-                preflabel = get_preflabel_from_valueid(relation['_source']['relationshiptype'], lang)
+                preflabel = get_preflabel_from_valueid(
+                    relation['_source']['relationshiptype'], lang)
                 relation['_source']['relationshiptype_label'] = preflabel['value']
             except:
                 relation['_source']['relationshiptype_label'] = relation['_source']['relationshiptype']
@@ -321,7 +353,8 @@ class Resource(models.ResourceInstance):
             instanceids.remove(str(self.resourceinstanceid))
 
         if len(instanceids) > 0:
-            related_resources = se.search(index='resource', doc_type='_all', id=list(instanceids))
+            related_resources = se.search(
+                index='resource', doc_type='_all', id=list(instanceids))
             if related_resources:
                 for resource in related_resources['docs']:
                     relations = get_relations(resource['_id'], 0, 0)

--- a/tests/fixtures/data/csv/file_list_datatype_import.csv
+++ b/tests/fixtures/data/csv/file_list_datatype_import.csv
@@ -1,0 +1,2 @@
+ResourceID,File-list
+9fa643a7-2dde-4092-8f5b-aab3ba06a57a,moo.jpg

--- a/tests/fixtures/data/csv/file_list_datatype_import.mapping
+++ b/tests/fixtures/data/csv/file_list_datatype_import.mapping
@@ -1,0 +1,13 @@
+{
+    "resource_model_id": "69008234-e13c-11e8-9f60-f23c91527491", 
+    "resource_model_name": "Graph_with_filelist", 
+    "nodes": [
+        {
+            "arches_nodeid": "763698ee-e13c-11e8-acbb-f23c91527491", 
+            "arches_node_name": "File-list", 
+            "file_field_name": "File-list", 
+            "data_type": "file-list", 
+            "export": false
+        }
+    ]
+}

--- a/tests/fixtures/data/json/cardinality_test_data/file-list.json
+++ b/tests/fixtures/data/json/cardinality_test_data/file-list.json
@@ -1,0 +1,121 @@
+{
+    "graph": [
+        {
+            "author": " ", 
+            "cards": [
+                {
+                    "active": true, 
+                    "cardid": "7636ff3c-e13c-11e8-acbb-f23c91527491", 
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
+                    "config": null, 
+                    "cssclass": null, 
+                    "description": null, 
+                    "graph_id": "69008234-e13c-11e8-9f60-f23c91527491", 
+                    "helpenabled": false, 
+                    "helptext": null, 
+                    "helptitle": null, 
+                    "instructions": null, 
+                    "is_editable": true, 
+                    "name": "New Node", 
+                    "nodegroup_id": "763698ee-e13c-11e8-acbb-f23c91527491", 
+                    "sortorder": null, 
+                    "visible": true
+                }
+            ], 
+            "cards_x_nodes_x_widgets": [], 
+            "color": null, 
+            "config": {}, 
+            "deploymentdate": null, 
+            "deploymentfile": null, 
+            "description": "", 
+            "edges": [
+                {
+                    "description": null, 
+                    "domainnode_id": "69007820-e13c-11e8-9f60-f23c91527491", 
+                    "edgeid": "7637824a-e13c-11e8-acbb-f23c91527491", 
+                    "graph_id": "69008234-e13c-11e8-9f60-f23c91527491", 
+                    "name": null, 
+                    "ontologyproperty": null, 
+                    "rangenode_id": "763698ee-e13c-11e8-acbb-f23c91527491"
+                }
+            ], 
+            "functions_x_graphs": [], 
+            "graphid": "69008234-e13c-11e8-9f60-f23c91527491", 
+            "iconclass": "", 
+            "is_editable": true, 
+            "isactive": true, 
+            "isresource": true, 
+            "jsonldcontext": null, 
+            "name": "Graph_with_filelist", 
+            "nodegroups": [
+                {
+                    "cardinality": "1", 
+                    "legacygroupid": null, 
+                    "nodegroupid": "763698ee-e13c-11e8-acbb-f23c91527491", 
+                    "parentnodegroup_id": null
+                }
+            ], 
+            "nodes": [
+                {
+                    "config": null, 
+                    "datatype": "semantic", 
+                    "description": "", 
+                    "graph_id": "69008234-e13c-11e8-9f60-f23c91527491", 
+                    "is_collector": false, 
+                    "isrequired": false, 
+                    "issearchable": true, 
+                    "istopnode": true, 
+                    "name": "Graph_with_filelist", 
+                    "nodegroup_id": null, 
+                    "nodeid": "69007820-e13c-11e8-9f60-f23c91527491", 
+                    "ontologyclass": null, 
+                    "parentproperty": "", 
+                    "sortorder": 0
+                }, 
+                {
+                    "config": null, 
+                    "datatype": "file-list", 
+                    "description": null, 
+                    "graph_id": "69008234-e13c-11e8-9f60-f23c91527491", 
+                    "is_collector": true, 
+                    "isrequired": false, 
+                    "issearchable": true, 
+                    "istopnode": false, 
+                    "name": "File-list", 
+                    "nodegroup_id": "763698ee-e13c-11e8-acbb-f23c91527491", 
+                    "nodeid": "763698ee-e13c-11e8-acbb-f23c91527491", 
+                    "ontologyclass": null, 
+                    "parentproperty": null, 
+                    "sortorder": 0
+                }
+            ], 
+            "ontology_id": null, 
+            "relatable_resource_model_ids": [], 
+            "resource_2_resource_constraints": [], 
+            "root": {
+                "config": null, 
+                "datatype": "semantic", 
+                "description": "", 
+                "graph_id": "69008234-e13c-11e8-9f60-f23c91527491", 
+                "is_collector": false, 
+                "isrequired": false, 
+                "issearchable": true, 
+                "istopnode": true, 
+                "name": "Graph_with_filelist", 
+                "nodegroup_id": null, 
+                "nodeid": "69007820-e13c-11e8-9f60-f23c91527491", 
+                "ontologyclass": null, 
+                "sortorder": 0
+            }, 
+            "subtitle": "", 
+            "template_id": "50000000-0000-0000-0000-000000000001", 
+            "version": ""
+        }
+    ], 
+    "metadata": {
+        "db": "PostgreSQL 9.6.9 on x86_64-pc-linux-gnu (Ubuntu 9.6.9-2.pgdg16.04+1), compiled by gcc (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609, 64-bit", 
+        "git hash": "b84a92b 2018-10-31 03:14:36 +0000", 
+        "os": "Linux", 
+        "os version": "4.15.13-x86_64-linode106"
+    }
+}

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -54,6 +54,10 @@ class mappedCSVFileImportTests(ArchesTestCase):
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile['graph'])
 
+        with open(os.path.join('tests/fixtures/data/json/cardinality_test_data/file-list.json'), 'rU') as f:
+            archesfile = JSONDeserializer().deserialize(f)
+        ResourceGraphImporter(archesfile['graph'])
+
     @classmethod
     def tearDownClass(cls):
         pass
@@ -134,3 +138,10 @@ class mappedCSVFileImportTests(ArchesTestCase):
         new_tile_count = TileModel.objects.count()
         tile_difference = new_tile_count - og_tile_count
         self.assertEqual(tile_difference, 0)
+
+    def test_file_list_datatype_import(self):
+        og_tile_count = TileModel.objects.count()
+        BusinessDataImporter('tests/fixtures/data/csv/file_list_datatype_import.csv').import_business_data()
+        new_tile_count = TileModel.objects.count()
+        tile_difference = new_tile_count - og_tile_count
+        self.assertEqual(tile_difference, 1)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Use a default value of None for the 'request' and 'user' keyword args to Resource.save(), allowing for graceful exclusion of view code when resource import is carried out by a management command or other serverside code.

### Issues Solved
#4044 
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Getty Conservation Institute and Legion GIS
*   Found by: @ryan86 
*   Tested by: @beatboxchad 
*   Designed by: @beatboxchad 

### Further comments


Now that I think of it, my fix is redundant with these lines: 

```
        request = kwargs.pop('request', None)
        user = kwargs.pop('user', None)
```

(They're already `None`.)

I'm not sure what all parts of the code rely on the `request` or `user`, and this code still ends up setting the user to an empty dictionary, but in Django the "cleanest" approach seems to be dispensing with "view code" entirely unless the relevant data `is not None`. Just wrap it in a `if request is not None:` block rather than coercing it to a default value. But maybe Arches does this for a specific reason.

Anyway, for now, a file-list datatype'd node imports without error. So here's this!