### PR TITLE
4308 Removed broken if statement from csvfile.py

### DIFF
--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -268,7 +268,7 @@ class TileCsvWriter(Writer):
 
                 if csv_record != {'ResourceID': resourceinstanceid}:
                     csv_records.append(csv_record)
-        
+
         dest = StringIO()
         csvwriter = csv.DictWriter(dest, delimiter=',', fieldnames=csv_header)
         csvwriter.writeheader()
@@ -668,8 +668,8 @@ class CsvReader(Reader):
                     source_data = column_names_to_targetids(row, mapping, row_number)
 
                     row_keys = [list(b) for b in zip(*[a.keys() for a in source_data])]
-                    if len(row_keys) > 0:
-                        missing_display_nodes = [n for n in display_nodes if n not in row_keys]
+
+                    missing_display_nodes = [n for n in display_nodes if n not in row_keys]
                     if len(missing_display_nodes) > 0:
                         errors = []
                         for mdn in missing_display_nodes:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixing issue 4308. Removing an if statement that causes an error when importing business data in csv format. The if condition is not met so the array `missing_display_nodes` is not populated. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#
https://github.com/archesproject/arches/issues/4308

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
