### PR TITLE
Support file sync for mobile

### DIFF
--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -70,7 +70,7 @@ define([
                     koMapping.fromJS(this.provisionaledits()[0]['value'], tile.data);
                     this.selectedProvisionalEdit(this.provisionaledits()[0]);
                     tile._tileData.valueHasMutated();
-                } else {
+                } else if (self.selectedProvisionalEdit()) {
                     self.selectedProvisionalEdit(undefined);
                     self.selectedTile().reset();
                 }

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -182,6 +182,7 @@ define([
                         self.tileid = tileData.tileid;
                         self.data = koMapping.fromJS(tileData.data);
                         self.provisionaledits = koMapping.fromJS(tileData.provisionaledits);
+                        self._tileData(koMapping.toJSON(self.data));
                         self.dirty = ko.pureComputed(function() {
                             return self._tileData() !== koMapping.toJSON(self.data);
                         }, self);


### PR DESCRIPTION
### Description of Change
Prevents the dirty state from getting activated after a tile is saved and prevents tile.reset from getting called unnecessarily. re #4301, #4331