### PR TITLE
Move file list widget fixes to 4.3.x

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -927,20 +927,14 @@ class FileListDataType(BaseDataType):
             previously_saved_data = previously_saved_tile.data
         return previously_saved_data
 
-    def get_current_data(self, user_is_reviewer, user_id, current_tile):
-        if user_is_reviewer is True:
-            current_tile_data = current_tile.data
-        else:
-            current_tile_data = current_tile.provisionaledits[user_id]['value']
-        return current_tile_data
-
     def handle_request(self, current_tile, request, node):
+
         previously_saved_tile = models.TileModel.objects.filter(pk=current_tile.tileid)
         user = request.user
         if hasattr(request.user, 'userprofile') is not True:
             models.UserProfile.objects.create(user=request.user)
         user_is_reviewer = request.user.userprofile.is_reviewer()
-        current_tile_data = self.get_current_data(user_is_reviewer, str(user.id), current_tile)
+        current_tile_data = current_tile.data
         if previously_saved_tile.count() == 1:
             previously_saved_tile_data = self.get_previously_saved_data(user_is_reviewer, str(user.id), previously_saved_tile[0])
             if previously_saved_tile_data[str(node.pk)] is not None:
@@ -957,6 +951,7 @@ class FileListDataType(BaseDataType):
                             print 'file does not exist'
 
         files = request.FILES.getlist('file-list_' + str(node.pk), [])
+
         for file_data in files:
             file_model = models.File()
             file_model.path = file_data

--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -70,7 +70,7 @@ define([
                     koMapping.fromJS(this.provisionaledits()[0]['value'], tile.data);
                     this.selectedProvisionalEdit(this.provisionaledits()[0]);
                     tile._tileData.valueHasMutated();
-                } else {
+                } else if (self.selectedProvisionalEdit()) {
                     self.selectedProvisionalEdit(undefined);
                     self.selectedTile().reset();
                 }

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -182,6 +182,7 @@ define([
                         self.tileid = tileData.tileid;
                         self.data = koMapping.fromJS(tileData.data);
                         self.provisionaledits = koMapping.fromJS(tileData.provisionaledits);
+                        self._tileData(koMapping.toJSON(self.data));
                         self.dirty = ko.pureComputed(function() {
                             return self._tileData() !== koMapping.toJSON(self.data);
                         }, self);

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -225,6 +225,7 @@ class Tile(models.TileModel):
         user_is_reviewer = False
         newprovisionalvalue = None
         oldprovisionalvalue = None
+        self.check_for_missing_nodes(request)
 
         try:
             user = request.user
@@ -258,7 +259,6 @@ class Tile(models.TileModel):
                     if provisional_edit_log_details == None:
                         provisional_edit_log_details={"user": user, "action": "create tile",  "provisional_editor": user}
 
-        self.check_for_missing_nodes(request)
         super(Tile, self).save(*args, **kwargs)
         #We have to save the edit log record after calling save so that the
         #resource's displayname changes are avaliable


### PR DESCRIPTION
Prevents unnecessary tile reset and dirty state bug in the file list widget. re #4331.