### PR TITLE
Runs handle request on tile.data before it's moved into provisionaledits

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -929,20 +929,14 @@ class FileListDataType(BaseDataType):
             previously_saved_data = previously_saved_tile.data
         return previously_saved_data
 
-    def get_current_data(self, user_is_reviewer, user_id, current_tile):
-        if user_is_reviewer is True:
-            current_tile_data = current_tile.data
-        else:
-            current_tile_data = current_tile.provisionaledits[user_id]['value']
-        return current_tile_data
-
     def handle_request(self, current_tile, request, node):
+
         previously_saved_tile = models.TileModel.objects.filter(pk=current_tile.tileid)
         user = request.user
         if hasattr(request.user, 'userprofile') is not True:
             models.UserProfile.objects.create(user=request.user)
         user_is_reviewer = request.user.userprofile.is_reviewer()
-        current_tile_data = self.get_current_data(user_is_reviewer, str(user.id), current_tile)
+        current_tile_data = current_tile.data
         if previously_saved_tile.count() == 1:
             previously_saved_tile_data = self.get_previously_saved_data(user_is_reviewer, str(user.id), previously_saved_tile[0])
             if previously_saved_tile_data[str(node.pk)] is not None:
@@ -959,6 +953,7 @@ class FileListDataType(BaseDataType):
                             print 'file does not exist'
 
         files = request.FILES.getlist('file-list_' + str(node.pk), [])
+
         for file_data in files:
             file_model = models.File()
             file_model.path = file_data

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -229,6 +229,7 @@ class Tile(models.TileModel):
         user_is_reviewer = False
         newprovisionalvalue = None
         oldprovisionalvalue = None
+        self.check_for_missing_nodes(request)
 
         try:
             user = request.user
@@ -262,7 +263,6 @@ class Tile(models.TileModel):
                     if provisional_edit_log_details == None:
                         provisional_edit_log_details={"user": user, "action": "create tile",  "provisional_editor": user}
 
-        self.check_for_missing_nodes(request)
         super(Tile, self).save(*args, **kwargs)
         #We have to save the edit log record after calling save so that the
         #resource's displayname changes are avaliable


### PR DESCRIPTION
### Description of Change
Previously the check for missing nodes before tile.data is processed into provisional data. re #4331