### PR TITLE
Handles for cases when a tile's nodegroup is None

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -430,7 +430,7 @@ class Tile(models.TileModel):
 
     def filter_by_perm(self, user, perm):
         if user:
-            if user.has_perm(perm, self.nodegroup):
+            if self.nodegroup_id is not None and user.has_perm(perm, self.nodegroup):
                 self.tiles = filter(lambda tile: tile.filter_by_perm(user, perm), self.tiles)
             else:
                 return None


### PR DESCRIPTION
Handles for cases when a tile's nodegroup is None, re #4383