### PR TITLE
replaces default Unnamed as survey name with placeholder

### DIFF
--- a/arches/app/templates/views/mobile-survey-designer.htm
+++ b/arches/app/templates/views/mobile-survey-designer.htm
@@ -312,7 +312,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                                 <div class="col-sm-5">
                                                     <div class="form-group">
                                                         <label class="control-label account-label">{% trans 'Survey name' %}</label>
-                                                        <input type="text" class="form-control input-lg account-input" data-bind="value: mobilesurvey.name, valueUpdate: 'keyup'">
+                                                        <input type="text" class="form-control input-lg account-input" placeholder="{% trans 'Survey name' %}" data-bind="value: mobilesurvey.name, valueUpdate: 'keyup'">
                                                     </div>
                                                 </div>
 

--- a/arches/app/views/mobile_survey.py
+++ b/arches/app/views/mobile_survey.py
@@ -200,7 +200,7 @@ class MobileSurveyDesignerView(MapBaseManagerView):
         else:
             survey = MobileSurvey(
                     id=surveyid,
-                    name=_('Unnamed'),
+                    name=_(''),
                     datadownloadconfig={"download": False, "count": 100, "resources": [], "custom": None},
                     onlinebasemaps=settings.MOBILE_DEFAULT_ONLINE_BASEMAP,
                 )


### PR DESCRIPTION

### Description of Change
re: #4516 replaces default "Unnamed" input value for Survey name in MSM survey designer with no value, placeholder.