### PR TITLE
4519 dont create RDF Literals if the tile data is 'None'

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -126,8 +126,9 @@ class StringDataType(BaseDataType):
         # returns an in-memory graph object, containing the domain resource, its
         # type and the string as a string literal
         g = Graph()
-        g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
-        g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty), Literal(str(edge_info['range_tile_data']))))
+        if edge_info['range_tile_data'] is not None:
+            g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
+            g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty), Literal(str(edge_info['range_tile_data']))))
         return g
 
     def from_rdf(self, json_ld_node):
@@ -229,9 +230,10 @@ class BooleanDataType(BaseDataType):
         # returns an in-memory graph object, containing the domain resource, its
         # type and the number as a numeric literal (as this is how it is in the JSON)
         g = Graph()
-        g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
-        g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
-               Literal(edge_info['range_tile_data'])))
+        if edge_info['range_tile_data'] is not None:
+            g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
+            g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
+                       Literal(edge_info['range_tile_data'])))
         return g
 
     def is_a_literal_in_rdf(self):
@@ -321,9 +323,10 @@ class DateDataType(BaseDataType):
         # returns an in-memory graph object, containing the domain resource, its
         # type and the number as a numeric literal (as this is how it is in the JSON)
         g = Graph()
-        g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
-        g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
-               Literal(str(edge_info['range_tile_data']), datatype=XSD.dateTime)))
+        if edge_info['range_tile_data'] is not None:
+            g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
+            g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
+                   Literal(str(edge_info['range_tile_data']), datatype=XSD.dateTime)))
         return g
 
     def from_rdf(self, json_ld_node):
@@ -1352,9 +1355,10 @@ class DomainDataType(BaseDomainDataType):
         # returns an in-memory graph object, containing the domain resource, its
         # type and the number as a numeric literal (as this is how it is in the JSON)
         g = Graph()
-        g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
-        g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
-               Literal(str(self.get_option_text(edge.rangenode, edge_info['range_tile_data'])))))
+        if edge_info['range_tile_data'] is not None:
+            g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
+            g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
+                   Literal(str(self.get_option_text(edge.rangenode, edge_info['range_tile_data'])))))
         return g
 
     def from_rdf(self, json_ld_node):

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -233,7 +233,7 @@ class BooleanDataType(BaseDataType):
         if edge_info['range_tile_data'] is not None:
             g.add((edge_info['d_uri'], RDF.type, URIRef(edge.domainnode.ontologyclass)))
             g.add((edge_info['d_uri'], URIRef(edge.ontologyproperty),
-                       Literal(edge_info['range_tile_data'])))
+                   Literal(edge_info['range_tile_data'])))
         return g
 
     def is_a_literal_in_rdf(self):

--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -160,6 +160,12 @@ class RDFExportTests(ArchesTestCase):
         obj = Literal(edge_info['range_tile_data'])
         self.assertTrue((edge_info['d_uri'], edge.ontologyproperty, obj) in graph)
 
+    def test_rdf_None_string(self):
+        dt = self.DT.get_instance("string")
+        edge_info, edge = mock_edge(1, CIDOC_NS['name'], None, '', None)
+        graph = dt.to_rdf(edge_info, edge)
+        self.assertTrue(len(graph) == 0)  # the graph should be empty
+
     def test_rdf_number(self):
         dt = self.DT.get_instance("number")
         edge_info, edge = mock_edge(1, CIDOC_NS['some_value'], None, '', 42)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Datatypes that have to_rdf() functions which create RDF Literals now do not render out the string 'None' for RDF Literals when not desirable.

### Issues Solved
#4519 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
