### PR TITLE
adds validation on import from UI in the tile model via custom except…

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -220,6 +220,9 @@ class Tile(models.TileModel):
             node = models.Node.objects.get(nodeid=nodeid)
             datatype = datatype_factory.get_instance(node.datatype)
             error = datatype.validate(value)
+            for error_instance in error:
+                if error_instance['type']=='ERROR':
+                    raise TileValidationError(_("Your tile: {0} ".format(error_instance["message"])))
             if errors != None:
                 errors += error
         return errors
@@ -269,6 +272,7 @@ class Tile(models.TileModel):
                     if provisional_edit_log_details == None:
                         provisional_edit_log_details={"user": user, "action": "create tile",  "provisional_editor": user}
 
+        self.validate([])
         super(Tile, self).save(*args, **kwargs)
         #We have to save the edit log record after calling save so that the
         #resource's displayname changes are avaliable
@@ -446,3 +450,12 @@ class Tile(models.TileModel):
         ret['tiles'] = self.tiles
 
         return ret
+
+class TileValidationError(Exception):
+    def __init__(self, message, code=None):
+        self.title = _("Tile Validation Error")
+        self.message = message
+        self.code = code
+
+    def __str__(self):
+        return repr(self.message)

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -20,7 +20,7 @@ import uuid, importlib, json as jsonparser
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models import models
 from arches.app.models.resource import Resource
-from arches.app.models.tile import Tile
+from arches.app.models.tile import Tile, TileValidationError
 from arches.app.models.system_settings import settings
 from arches.app.utils.response import JSONResponse
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
@@ -87,6 +87,8 @@ class TileData(View):
                             if accepted_provisional == None:
                                 try:
                                     tile.save(request=request)
+                                except TileValidationError as e:
+                                    return JSONResponse({'status': 'false', 'message': [e.message, _('Unable to Save. Please verify your input is valid')]}, status=500)
                                 except Exception as e:
                                     message = "Unable to save. A {0} has occurred. Arguments: {1!r}".format(type(e).__name__, e.args)
                                     return JSONResponse({'status': 'false', 'message': [message, _('Please contact your system administrator')]}, status=500)


### PR DESCRIPTION
### Description of Change
re: #4451 grabs validation error from invalid UI input and raises custom exception. Inserts validate() method within save() method for tiles, returns a JSON response in the tile view that carries whichever validation error was stored in the exception so that the user can see in the UI what their validation error was.