### PR TITLE
fix height of .ep-help-body so overflow works on firefox #4031

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -5673,7 +5673,7 @@ ul.jqtree_common li.jqtree-folder {
 }
 
 .ep-help-body {
-    height: 100%;
+    height: calc(100vh - 50px);
     width: 100%;
     overflow-y: auto;
     display: table-row;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The help panel didn't scroll on firefox, this change to the height of the panel fixes that. Note that the 50px in calc() references the height of .ep-help-header which is set at 50px.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#4031

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: GCI
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->
