### PR TITLE
Provisional edit bug fixes

### DIFF
--- a/arches/app/models/mobile_survey.py
+++ b/arches/app/models/mobile_survey.py
@@ -359,7 +359,7 @@ class MobileSurvey(models.MobileSurveyModel):
                                         except KeyError:
                                             pass
 
-                            tile.save()
+                            tile.save(user=user)
                             self.save_revision_log(row.doc, synclog, action)
                             print('Tile {0} Saved'.format(row.doc['tileid']))
                             db.compact()

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -231,6 +231,7 @@ class Tile(models.TileModel):
     def save(self, *args, **kwargs):
         request = kwargs.pop('request', None)
         index = kwargs.pop('index', True)
+        user = kwargs.pop('user', None)
         log = kwargs.pop('log', True)
         provisional_edit_log_details = kwargs.pop('provisional_edit_log_details', None)
         self.__preSave(request)
@@ -242,8 +243,9 @@ class Tile(models.TileModel):
         self.check_for_missing_nodes(request)
 
         try:
-            user = request.user
-            user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+            if user is None and request is not None:
+                user = request.user
+            user_is_reviewer = user.groups.filter(name='Resource Reviewer').exists()
         except AttributeError: #no user - probably importing data
             user = None
 

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -397,10 +397,10 @@
                     {% block report_widgets %}
                     <!-- ko if: card.model.get('widgets')().length > 0 -->
                         <div class="rp-report-tile" data-bind="attr: { id: tile.tileid }">
-                            <!-- ko if: tile.provisionaledits() !== null && tile.userisreviewer === false -->
+                            <!-- ko if: ko.unwrap(tile.provisionaledits) !== null && tile.userisreviewer === false -->
                             <div class="report-card-provisional-flag">{% trans 'These data are provisional and pending review' %}</div>
                             <!--/ko-->
-                            <dl class="dl-horizontal" data-bind="css: {'provisional': tile.provisionaledits() !== null && tile.userisreviewer === false}">
+                            <dl class="dl-horizontal" data-bind="css: {'provisional': ko.unwrap(tile.provisionaledits) !== null && tile.userisreviewer === false}">
                                 <!-- ko foreach: { data: card.model.get('widgets'), as: 'widget' } -->
                                     <!-- ko if: widget.visible -->
                                     <!-- ko component: {


### PR DESCRIPTION
Fixes missing records in edit history when edits were made from mobile by passing user into tile save during sync. Also fixes missing records in edit history when edits were made from mobile re #4619, #4621