### PR TITLE
Fixes missing values in provisional edit log

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -73,7 +73,8 @@ class StringDataType(BaseDataType):
     def validate(self, value, row_number=None, source=None):
         errors = []
         try:
-            value.upper()
+            if value is not None:
+                value.upper()
         except:
             errors.append({
                 'type': 'ERROR',

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -190,12 +190,6 @@ class Tile(models.TileModel):
                 edit = edits[str(user.id)]
         return edit
 
-    def make_provisional_authoritative(self, user):
-        user_id = str(user.id)
-        if user_id in self.provisionaledits:
-            self.data = self.provisionaledits[user_id]['value']
-            self.provisionaledits.pop(user_id, None)
-
     def check_for_missing_nodes(self, request):
         missing_nodes = []
         for nodeid, value in self.data.iteritems():

--- a/arches/management/commands/mobile.py
+++ b/arches/management/commands/mobile.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
             )
         synclog.save()
         print("Syncing {0} from CouchDB to PostgreSQL").format(mobile_survey)
-        mobile_survey.push_edits_to_db(synclog)
+        mobile_survey.push_edits_to_db(synclog, user)
         synclog.save()
 
     def delete_associated_surveys(self):


### PR DESCRIPTION
Simplifies sync so that only the edits of the person syncing are processed and fixes issue of provisional edits not showing up in the tile after sync. re #4619