### PR TITLE
Catching db errors in the CreateExtension class re #4707

### DIFF
--- a/arches/db/migration_operations/extras.py
+++ b/arches/db/migration_operations/extras.py
@@ -13,10 +13,16 @@ class CreateExtension(Operation):
         pass
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        schema_editor.execute("CREATE EXTENSION IF NOT EXISTS \"%s\"" % self.name)
+        try:
+            schema_editor.execute("CREATE EXTENSION IF NOT EXISTS \"%s\"" % self.name)
+        except:
+            print("INFO: SQL command to create extension \"%s\" failed. Must be executed by Postgres superuser account before running Arches." % self.name)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        schema_editor.execute("DROP EXTENSION IF EXISTS \"%s\"" % self.name)
+        try:
+            schema_editor.execute("DROP EXTENSION IF EXISTS \"%s\"" % self.name)
+        except:
+            print("INFO: SQL command to drop extension \"%s\" failed. Must be executed by Postgres superuser account." % self.name)
 
     def describe(self):
         return "Creates extension %s" % self.name

--- a/arches/db/migration_operations/extras.py
+++ b/arches/db/migration_operations/extras.py
@@ -1,4 +1,7 @@
 from django.db.migrations.operations.base import Operation
+from django.db import Error
+import logging
+
 
 class CreateExtension(Operation):
     """
@@ -8,6 +11,7 @@ class CreateExtension(Operation):
 
     def __init__(self, name):
         self.name = name
+        self.logger = logging.getLogger(__name__)
 
     def state_forwards(self, app_label, state):
         pass
@@ -15,14 +19,16 @@ class CreateExtension(Operation):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         try:
             schema_editor.execute("CREATE EXTENSION IF NOT EXISTS \"%s\"" % self.name)
-        except:
-            print("INFO: SQL command to create extension \"%s\" failed. Must be executed by Postgres superuser account before running Arches." % self.name)
+        except Error as e:
+            self.logger.warning("Operation to create extension \"%s\" failed. Must be executed by Postgres superuser \
+account before running Arches." % self.name)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         try:
             schema_editor.execute("DROP EXTENSION IF EXISTS \"%s\"" % self.name)
-        except:
-            print("INFO: SQL command to drop extension \"%s\" failed. Must be executed by Postgres superuser account." % self.name)
+        except Error as e:
+            self.logger.warning("Operation to drop extension \"%s\" failed. Must be executed by Postgres superuser \
+account." % self.name)
 
     def describe(self):
         return "Creates extension %s" % self.name
@@ -58,8 +64,8 @@ class CreateFunction(Operation):
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         sql = """
-        CREATE FUNCTION %(name)s(%(arguments)s) 
-            RETURNS %(returntype)s 
+        CREATE FUNCTION %(name)s(%(arguments)s)
+            RETURNS %(returntype)s
             LANGUAGE %(language)s
             AS $$
             DECLARE
@@ -69,16 +75,16 @@ class CreateFunction(Operation):
             END;
             $$;
         """
-        sql = sql % {'name': self.name, 'arguments': ', '.join(self.arguments), 
-            'declarations': ';\n\t\t'.join(self.declarations) + ';', 'language': self.language, 
-            'body': self.body, 'returntype': self.returntype}
+        sql = sql % {'name': self.name, 'arguments': ', '.join(self.arguments),
+                     'declarations': ';\n\t\t'.join(self.declarations) + ';', 'language': self.language,
+                     'body': self.body, 'returntype': self.returntype}
         sql = sql.replace(';;', ';')
 
         schema_editor.execute(sql)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         sql = """
-        DROP FUNCTION IF EXISTS %(name)s(%(arguments)s) 
+        DROP FUNCTION IF EXISTS %(name)s(%(arguments)s)
         """
         sql = sql % {'name': self.name, 'arguments': ', '.join(self.arguments)}
 
@@ -87,6 +93,7 @@ class CreateFunction(Operation):
     def describe(self):
         return "Creates a function named %s" % self.name
         return "Creates extension %s" % self.name
+
 
 class CreateAutoPopulateUUIDField(Operation):
 
@@ -99,7 +106,8 @@ class CreateAutoPopulateUUIDField(Operation):
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         for column in self.columns:
-            schema_editor.execute("ALTER TABLE {0} ALTER COLUMN {1} SET DEFAULT uuid_generate_v1mc()".format(self.table, column))
+            schema_editor.execute(
+                "ALTER TABLE {0} ALTER COLUMN {1} SET DEFAULT uuid_generate_v1mc()".format(self.table, column))
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         for column in self.columns:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Catching `django.db.Error`s thrown when the CreateExtension operation is run with a non-superuser postgres user. A warning is logged, but it is intended that the extension will be made available to the non-superuser postgres user through another means (eg template inclusion, or via the `public` schema.)

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#4707

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
