### PR TITLE
re: sfp #28 greys out, disables dashboard nav button when not in Sear…

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -61,6 +61,17 @@ dl.inline-flex dd {
     width: 50px;
 }
 
+.nav-item-disabled {
+    background-color: #9eacc1;
+    color: black;
+    pointer-events: none;
+    cursor: default;
+}
+
+.nav-item-disabled i {
+    color: black;
+}
+
 .navbar-header {
     height: 50px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.4);

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -58,6 +58,10 @@ define([
                 window.nifty.window.trigger('resize');
             });
 
+            options.viewModel.inSearch = ko.pureComputed(function() {
+                return window.location.pathname === "/search" || window.location.pathname === "/plugins/c8261a41-a409-4e45-b049-c925c28a57da";
+            });
+
             PageView.prototype.constructor.call(this, options);
             return this;
         }

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -374,7 +374,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
                                         {% for p in plugins %}
                                         <li{% if main_script == "views/plugin" and plugin.pluginid == p.pluginid  %} class="active-sub"{% endif %}>
-                                            {% if p.slug is not None %}
+                                            {% if p.name == "Dashboard" %}
+                                            <a href="{% url 'plugins' p.pluginid %}" data-bind="css: {'nav-item-disabled': !inSearch() }" alt="Click Search to use Dashboard">
+                                            {% elif p.slug is not None %}
                                             <a href="{% url 'plugins' p.slug %}" data-bind="click: navigate.bind(this, '{% url 'plugins' p.slug %}') ">
                                             {% else %}
                                             <a href="{% url 'plugins' p.pluginid %}" data-bind="click: navigate.bind(this, '{% url 'plugins' p.pluginid %}') ">


### PR DESCRIPTION
…ch; specific to dashboard plugin only

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

greys out and disables the dashboard plugin from the nav bar when the user is not in Search. Does not affect other plugins. See sfp ticket: https://github.com/fargeo/sfport-pkg/issues/28