### PR TITLE
Adding env var to ES to stop bootstrap checks

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -51,6 +51,7 @@ services:
         - "9200:9200"
         - "9300:9300"
       environment:
+        - discovery.type=single-node
         - TZ=PST
 
     sut_couchdb:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
It causes Elasticsearch to run in a developmental mode, causing some preflight checks to become logged warnings, rather than critical errors. This is to avoid the Elasticsearch service from closing pre-emptively on Docker Hub, as the test host DH uses may have the vm.max_map_count set too low, or a related soft error for a test instance.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#4800 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
