### PR TITLE
v3 - support export of resources to jsonl files with multiprocessing

### DIFF
--- a/arches/app/utils/data_management/resources/exporter.py
+++ b/arches/app/utils/data_management/resources/exporter.py
@@ -21,7 +21,10 @@ class ResourceExporter(object):
     def __init__(self, file_format):
         self.filetypes = {'csv': CsvWriter, 'kml': KmlWriter, 'shp': ShpWriter, 'json': JsonWriter}
         self.format = file_format
-        self.writer = self.filetypes[file_format]()
+        if file_format == "jsonl":
+            self.writer = JsonWriter(jsonl=True)
+        else:
+            self.writer = self.filetypes[file_format]()
 
     def export(self, resources=None, zip=False, search_results=True, dest_dir=None):
         result=None

--- a/arches/app/utils/data_management/resources/formats/archesjson.py
+++ b/arches/app/utils/data_management/resources/formats/archesjson.py
@@ -12,34 +12,85 @@ import json
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 import csv
 
+import time
+from multiprocessing import Pool, TimeoutError, cpu_count
+from django.db import connections
+
+# this wrapper function must be outside of the class to be called during the
+# multiprocessing operations.
+def write_one_resource_wrapper(args):
+    return JsonWriter.write_one_resource(*args)
 
 class JsonWriter(Writer):
 
-    def __init__(self):
+    def __init__(self, jsonl=False):
         super(JsonWriter, self).__init__()
+        self.jsonl = jsonl
+
+    def write_one_resource(self, resource_id):
+
+        a_resource = Resource().get(resource_id)
+        a_resource.form_groups = None
+        jsonres = JSONSerializer().serialize(a_resource, separators=(',',':'))
+        return jsonres
 
     def write_resources(self, dest_dir):
-        cursor = connection.cursor()
-        cursor.execute("""select entitytypeid from data.entity_types where isresource = TRUE""")
-        resource_types = cursor.fetchall()
-        json_resources = []
-        with open(dest_dir, 'w') as f:
-            for resource_type in resource_types:
-                resources = archesmodels.Entities.objects.filter(entitytypeid = resource_type)
-                print "Writing {0} {1} resources".format(len(resources), resource_type[0])
-                errors = []
-                for resource in resources:
-                    try:
-                        a_resource = Resource().get(resource.entityid)
-                        a_resource.form_groups = None
-                        json_resources.append(a_resource)
-                    except Exception as e:
-                        if e not in errors:
-                            errors.append(e)
-                if len(errors) > 0:
-                    print errors[0], ':', len(errors)
-            f.write((JSONSerializer().serialize({'resources':json_resources}, separators=(',',':'))))
 
+        # if JSONL file is desired, use this code to write the resource line by
+        # line, and also introduce multiprocessing to speed things up.
+        if self.jsonl is True:
+
+            process_count = cpu_count()
+            print "number of cores:", cpu_count()
+            print "number of parallel processes:", process_count
+            pool = Pool(cpu_count())
+
+            restypes = [i.entitytypeid for i in archesmodels.EntityTypes.objects.filter(isresource=True)]
+
+            for restype in restypes:
+                start = time.time()
+                resources = archesmodels.Entities.objects.filter(entitytypeid=restype)
+                resids = [r.entityid for r in resources]
+                
+                for conn in connections.all():
+                    conn.close()
+                
+                outfile = dest_dir.replace(".jsonl","-"+restype+".jsonl")
+                with open(outfile, 'w') as f:
+
+                    print "Writing {0} {1} resources".format(len(resids), restype) 
+                    joined_input = [(self,r) for r in resids]
+                    for res in pool.imap(write_one_resource_wrapper, joined_input):
+                        f.write(res+"\n")
+
+                print "elapsed time:", time.time()-start
+
+        # if standard JSON is desired, use the existing JSON export code
+        else:
+            cursor = connection.cursor()
+            cursor.execute("""select entitytypeid from data.entity_types where isresource = TRUE""")
+            resource_types = cursor.fetchall()
+
+            start = time.time()
+            json_resources = []
+            with open(dest_dir, 'w') as f:
+                for resource_type in resource_types:
+                    resources = archesmodels.Entities.objects.filter(entitytypeid = resource_type)
+                    print "Writing {0} {1} resources".format(len(resources), resource_type[0])
+                    errors = []
+                    for resource in resources:
+                        try:
+                            a_resource = Resource().get(resource.entityid)
+                            a_resource.form_groups = None
+                            json_resources.append(a_resource)
+                        except Exception as e:
+                            if e not in errors:
+                                errors.append(e)
+                    if len(errors) > 0:
+                        print errors[0], ':', len(errors)
+                f.write((JSONSerializer().serialize({'resources':json_resources}, separators=(',',':'))))
+            print "elapsed time:", time.time()-start
+        
 
 class JsonReader():
 

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -354,7 +354,11 @@ class Command(BaseCommand):
         """
         Exports resources to archesjson
         """
-        resource_exporter = ResourceExporter('json')
+        if data_dest.endswith(".jsonl"):
+            format = "jsonl"
+        else:
+            format = "json"
+        resource_exporter = ResourceExporter(format)
         resource_exporter.export(search_results=False, dest_dir=data_dest)
         related_resources = [{'RESOURCEID_FROM':rr.entityid1, 'RESOURCEID_TO':rr.entityid2,'RELATION_TYPE':rr.relationshiptype,'START_DATE':rr.datestarted,'END_DATE':rr.dateended,'NOTES':rr.notes} for rr in models.RelatedResource.objects.all()] 
         relations_file = os.path.splitext(data_dest)[0] + '.relations'


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Allows users to export their resources to JSONL format instead of standard JSON. To do so, users just have to use

    python manage.py packages -o export_resources -d output.jsonl

instead of

    python manage.py packages -o export_resources -d output.json

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Related to #4855 , but only addresses v3 which is not really the point of that ticket.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

### Further Comments
This is part of a larger effort to improve the import/export process for resources. In this case it is specifically geared toward improving the v3-v4 workflow.
