### PR TITLE
Adds support for alternate authorization header 

### DIFF
--- a/arches/app/models/mobile_survey.py
+++ b/arches/app/models/mobile_survey.py
@@ -198,7 +198,7 @@ class MobileSurvey(models.MobileSurveyModel):
                 singlepart = GeoUtils().convert_multipart_to_singlepart(bounds)
                 ret['bounds'] = singlepart
         except TypeError as e:
-            print 'Could not parse', ret['bounds'], e
+            logger.error('Could not parse {0}, {1}'.format(ret['bounds'], e))
         return ret
 
     def serialize(self, fields=None, exclude=None):

--- a/arches/app/utils/middleware.py
+++ b/arches/app/utils/middleware.py
@@ -24,6 +24,15 @@ class SetAnonymousUser(MiddlewareMixin):
             except:
                 pass
 
+class ModifyAuthorizationHeader(MiddlewareMixin):
+    def process_request(self, request):
+        # for OAuth authentication to work, we must use the standard
+        # HTTP_AUTHORIZATION header. So, if the request has the alternate
+        # HTTP_X_AUTHORIZATION header, update the request to use the standard
+        if request.META.get('HTTP_X_AUTHORIZATION', None) is not None:
+            request.META['HTTP_AUTHORIZATION'] = request.META.get('HTTP_X_AUTHORIZATION')
+            del request.META['HTTP_X_AUTHORIZATION']
+
 
 class JWTAuthenticationMiddleware(MiddlewareMixin):
     """

--- a/arches/app/utils/middleware.py
+++ b/arches/app/utils/middleware.py
@@ -13,6 +13,7 @@ from jose import jwt, jws, JWSError
 
 HTTP_HEADER_ENCODING = 'iso-8859-1'
 
+
 class SetAnonymousUser(MiddlewareMixin):
     def process_request(self, request):
         # for OAuth authentication to work, we can't automatically assign
@@ -21,8 +22,9 @@ class SetAnonymousUser(MiddlewareMixin):
         if request.path != reverse('oauth2:authorize') and request.user.is_anonymous():
             try:
                 request.user = User.objects.get(username='anonymous')
-            except:
+            except Exception:
                 pass
+
 
 class ModifyAuthorizationHeader(MiddlewareMixin):
     def process_request(self, request):

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -124,7 +124,9 @@ class Sync(APIBase):
         can_sync = userCanAccessMobileSurvey(request, surveyid)
         if can_sync:
             try:
+                logger.info("Starting sync for user {0}".format(request.user.username))
                 management.call_command('mobile', operation='sync_survey', id=surveyid, user=request.user.id)
+                logger.info("Sync complete for user {0}".format(request.user.username))
             except Exception:
                 logger.exception(_('Sync Failed'))
 
@@ -136,6 +138,9 @@ class Sync(APIBase):
 class Surveys(APIBase):
 
     def get(self, request, surveyid=None):
+
+        auth_header = request.META.get('HTTP_AUTHORIZATION', None)
+        logger.info("Requesting projects for user: {0}".format(request.user.username))
         try:
             if hasattr(request.user, 'userprofile') is not True:
                 models.UserProfile.objects.create(user=request.user)
@@ -145,7 +150,6 @@ class Surveys(APIBase):
                     get_child_cardids(child_card, cardset)
 
             group_ids = list(request.user.groups.values_list('id', flat=True))
-
             if request.GET.get('status', None) is not None:
                 ret = {}
                 surveys = MobileSurvey.objects.filter(users__in=[request.user]).distinct()
@@ -192,6 +196,7 @@ class Surveys(APIBase):
             logger.exception(_('Unable to fetch collector projects'))
             response = JSONResponse(_('Unable to fetch collector projects'), indent=4)
 
+        logger.info("Returning projects for user: {0}".format(request.user.username))
         return response
 
 

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -296,7 +296,6 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     #'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'arches.app.utils.middleware.ModifyAuthorizationHeader',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -304,6 +303,7 @@ MIDDLEWARE = [
     #'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'arches.app.utils.middleware.ModifyAuthorizationHeader',
     'oauth2_provider.middleware.OAuth2TokenMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     #'arches.app.utils.middleware.JWTAuthenticationMiddleware',

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import inspect
-
+from corsheaders.defaults import default_headers
 
 #########################################
 ###          STATIC SETTINGS          ###
@@ -296,6 +296,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     #'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'arches.app.utils.middleware.ModifyAuthorizationHeader',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -316,6 +317,9 @@ ROOT_URLCONF = 'arches.urls'
 WSGI_APPLICATION = 'arches.wsgi.application'
 
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'x-authorization',
+]
 
 LOGGING = {
     'version': 1,

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -18,7 +18,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import inspect
-from corsheaders.defaults import default_headers
+
+
+try:
+    from corsheaders.defaults import default_headers
+except ImportError:  # unable to import corsheaders prior to installing requirements.txt in setup.py
+    pass
 
 #########################################
 ###          STATIC SETTINGS          ###

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -322,9 +322,13 @@ ROOT_URLCONF = 'arches.urls'
 WSGI_APPLICATION = 'arches.wsgi.application'
 
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_ALLOW_HEADERS = list(default_headers) + [
-    'x-authorization',
-]
+
+try:
+    CORS_ALLOW_HEADERS = list(default_headers) + [
+        'x-authorization',
+    ]
+except Exception as e:
+    print(e)
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
... because iOS strips the 'HTTP_AUTHORIZATION' header in some API requests. re #4717

This allows us to download projects to iOS devices without the Guest user group being assigned to the collector project. 