### PR TITLE
Removes check to prevent runaway workflows on reload

### DIFF
--- a/arches/app/media/js/viewmodels/workflow.js
+++ b/arches/app/media/js/viewmodels/workflow.js
@@ -16,11 +16,6 @@ define([
         this.advance = true;
 
         this.restoreStateFromURL = function(){
-            if (Object.keys(self.state.steps).length === 0) {
-                self.advance = false;
-            } else {
-                self.advance = true;
-            }
             var urlparams = new window.URLSearchParams(window.location.search);
             var res = {};
             urlparams.forEach(function(v, k){res[k] = v;});

--- a/arches/app/media/js/views/components/workflows/new-tile-step.js
+++ b/arches/app/media/js/views/components/workflows/new-tile-step.js
@@ -123,7 +123,8 @@ define([
                 }
             });
             self.loading(false);
-            self.complete(!!ko.unwrap(params.tileid));
+            // commented the line below because it causes steps to automatically advance on page reload
+            // self.complete(!!ko.unwrap(params.tileid));
         });
 
         self.saveTile = function(tile, callback) {


### PR DESCRIPTION
Changes logic in new-tile-step instead. re #4821