### PR TITLE
improve check for createdb privileges during setup_db re: #4941

### DIFF
--- a/arches/management/commands/setup_db.py
+++ b/arches/management/commands/setup_db.py
@@ -97,9 +97,13 @@ class Command(BaseCommand):
                       "re-run this same command.")
                 exit()
 
+        cursor = conn.cursor()
+        cursor.execute("SELECT rolcreatedb FROM pg_roles WHERE rolname = '{}'".format(username))
+        cancreate = cursor.fetchone()[0]
+
         # autocommit false
         conn.set_isolation_level(0)
-        return conn
+        return {"connection": conn, "can_create_db": cancreate}
 
     def reset_db(self, cursor):
 
@@ -146,14 +150,12 @@ CREATE DATABASE {}
         WARNING: This will destroy data
         """
 
-        conn = self.get_connection()
+        conninfo = self.get_connection()
+        conn = conninfo['connection']
+        can_create_db = conninfo['can_create_db']
+
         cursor = conn.cursor()
-
-        # figure out if this is a superuser or not
-        cursor.execute("SELECT current_setting('is_superuser')")
-        superuser = True if cursor.fetchone()[0] == "on" else False
-
-        if superuser:
+        if can_create_db is True:
             self.drop_and_recreate_db(cursor)
         else:
             self.reset_db(cursor)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Makes a better check for what type of postgres user Arches is provided with. The impetus for this change is that some hosted PG solutions (like AWS RDS) don't provide users with logins that are technically "superusers". However, the logins do have "CREATE DATABASE" ability, which is all that Arches actually needs when it tries to run the create/drop database operation.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#4941 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Legion GIS
*   Designed by: @mradamcox

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
