### PR TITLE
4858 multiprocessing improvements

### DIFF
--- a/arches/app/utils/data_management/resources/importer.py
+++ b/arches/app/utils/data_management/resources/importer.py
@@ -54,7 +54,8 @@ except ImportError:
 def import_one_resource(line):
     """this single resource import function must be outside of the BusinessDataImporter
     class in order for it to be called with multiprocessing"""
-    django.setup()
+
+    connections.close_all()
     reader = ArchesFileReader()
     archesresource = JSONDeserializer().deserialize(line)
     reader.import_business_data({"resources": [archesresource]})
@@ -178,8 +179,8 @@ class BusinessDataImporter(object):
                     lines = openf.readlines()
                     if use_multiprocessing is True:
                         pool = Pool(cpu_count())
-                        connections.close_all()
                         pool.map(import_one_resource, lines)
+                        connections.close_all()
                         reader = ArchesFileReader()
                     else:
                         reader = ArchesFileReader()

--- a/arches/app/utils/data_management/resources/importer.py
+++ b/arches/app/utils/data_management/resources/importer.py
@@ -14,7 +14,7 @@ from multiprocessing import Pool, TimeoutError, cpu_count
 import django
 # django.setup() must be called here to prepare for multiprocessing. specifically,
 # it must be called before any models are imported, otherwise things will crash
-# during an import that uses multiprocessing.
+# during a resource load that uses multiprocessing.
 # see https://stackoverflow.com/a/49461944/3873885
 django.setup()
 from django.db import connection, connections, transaction


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When testing business data import using multiprocessing, I encountered errors when trying to use an installation that had a remote postgres database backend (it was an RDS instance). The errors occurred on the first resource in each multiprocessing pool, but then the loading continued as normal. For example, if I had a machine with 4 cores, then 4 parallel processes would be made, and the first 4 resources would fail.

Adding a `django.db.connections.close_all()` call each individual load process, instead of calling it only once before the `pool` is processed, fixed this issue.

I also determined that calling `django.setup()` in the beginning of each process was unnecessary; it only needs to be called once at the top of the file (where I already had it).
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#4858

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)