### PR TITLE
Uses provisional values as descriptors

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -252,11 +252,19 @@ class BaseDataType(object):
         """
         return None
 
+    def get_tile_data(self, tile):
+        if tile.data is not None and len(tile.data.keys()) > 0:
+            return tile.data
+        elif tile.provisionaledits is not None and len(tile.provisionaledits.keys()) == 1:
+            userid = tile.provisionaledits.keys()[0]
+            return tile.provisionaledits[userid]['value']
+
     def get_display_value(self, tile, node):
         """
         Returns a list of concept values for a given node
         """
-        return unicode(tile.data[str(node.nodeid)])
+        data = self.get_tile_data(tile)
+        return unicode(data[str(node.nodeid)])
 
     def get_search_terms(self, nodevalue, nodeid=None):
         """

--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -103,10 +103,11 @@ class ConceptDataType(BaseConceptDataType):
         return get_preflabel_from_valueid(nodevalue, lang)['value']
 
     def get_display_value(self, tile, node):
-        if tile.data[str(node.nodeid)] is None or tile.data[str(node.nodeid)].strip() == '':
+        data = self.get_tile_data(tile)
+        if data[str(node.nodeid)] is None or data[str(node.nodeid)].strip() == '':
             return ''
         else:
-            return self.get_value(uuid.UUID(tile.data[str(node.nodeid)])).value
+            return self.get_value(uuid.UUID(data[str(node.nodeid)])).value
 
     def append_search_filters(self, value, node, query, request):
         try:
@@ -270,8 +271,9 @@ class ConceptListDataType(BaseConceptDataType):
 
     def get_display_value(self, tile, node):
         new_values = []
-        if tile.data[str(node.nodeid)]:
-            for val in tile.data[str(node.nodeid)]:
+        data = self.get_tile_data(tile)
+        if data[str(node.nodeid)]:
+            for val in data[str(node.nodeid)]:
                 new_val = self.get_value(uuid.UUID(val))
                 new_values.append(new_val.value)
         return ','.join(new_values)

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1304,7 +1304,8 @@ class DomainDataType(BaseDomainDataType):
             document['strings'].append({'string': domain_text, 'nodegroup_id': tile.nodegroup_id, 'provisional': provisional})
 
     def get_display_value(self, tile, node):
-        return self.get_option_text(node, tile.data[str(node.nodeid)])
+        data = self.get_tile_data(tile)
+        return self.get_option_text(node, data[str(node.nodeid)])
 
     def transform_export_values(self, value, *args, **kwargs):
         ret = ''
@@ -1391,8 +1392,9 @@ class DomainListDataType(BaseDomainDataType):
 
     def get_display_value(self, tile, node):
         new_values = []
-        if tile.data[str(node.nodeid)] is not None:
-            for val in tile.data[str(node.nodeid)]:
+        data = self.get_tile_data(tile)
+        if data[str(node.nodeid)] is not None:
+            for val in data[str(node.nodeid)]:
                 option = self.get_option_text(node, val)
                 new_values.append(option)
         return ','.join(new_values)
@@ -1485,7 +1487,8 @@ class ResourceInstanceDataType(BaseDataType):
         return errors
 
     def get_display_value(self, tile, node):
-        nodevalue = tile.data[str(node.nodeid)]
+        data = self.get_tile_data(tile)
+        nodevalue = data[str(node.nodeid)]
         resource_names = self.get_resource_names(nodevalue)
         return ', '.join(resource_names)
 
@@ -1566,7 +1569,8 @@ class NodeValueDataType(BaseDataType):
     def get_display_value(self, tile, node):
         datatype_factory = DataTypeFactory()
         value_node = models.Node.objects.get(nodeid=node.config['nodeid'])
-        tileid = tile.data[str(node.pk)]
+        data = self.get_tile_data(tile)
+        tileid = data[str(node.pk)]
         if tileid:
             value_tile = models.TileModel.objects.get(tileid=tileid)
             datatype = datatype_factory.get_instance(value_node.datatype)

--- a/arches/app/functions/primary_descriptors.py
+++ b/arches/app/functions/primary_descriptors.py
@@ -4,6 +4,7 @@ from arches.app.models import models
 from arches.app.models.tile import Tile
 from arches.app.datatypes.datatypes import DataTypeFactory
 
+
 class PrimaryDescriptorsFunction(BaseFunction):
 
     def get_primary_descriptor_from_nodes(self, resource, config):
@@ -29,6 +30,6 @@ class PrimaryDescriptorsFunction(BaseFunction):
                             value = datatype.get_display_value(tile, node)
                             config['string_template'] = config['string_template'].replace('<%s>' % node.name, value)
         except ValueError as e:
-            print e, 'invalid nodegroupid participating in descriptor function.'
+            print(e, 'invalid nodegroupid participating in descriptor function.')
 
         return config['string_template']

--- a/arches/app/functions/primary_descriptors.py
+++ b/arches/app/functions/primary_descriptors.py
@@ -11,7 +11,12 @@ class PrimaryDescriptorsFunction(BaseFunction):
             if 'nodegroup_id' in config and config['nodegroup_id'] != '' and config['nodegroup_id'] is not None:
                 for tile in models.TileModel.objects.filter(nodegroup_id=uuid.UUID(config['nodegroup_id']), sortorder=0).filter(resourceinstance_id=resource.resourceinstanceid):
                     for node in models.Node.objects.filter(nodegroup_id=uuid.UUID(config['nodegroup_id'])):
-                        if str(node.nodeid) in tile.data:
+                        if len(tile.data.keys()) > 0:
+                            data = tile.data
+                        elif tile.provisionaledits is not None and len(tile.provisionaledits.keys()) == 1:
+                            userid = tile.provisionaledits.keys()[0]
+                            data = tile.provisionaledits[userid]['value']
+                        if str(node.nodeid) in data:
                             datatype_factory = DataTypeFactory()
                             datatype = datatype_factory.get_instance(node.datatype)
                             value = datatype.get_display_value(tile, node)

--- a/arches/app/functions/primary_descriptors.py
+++ b/arches/app/functions/primary_descriptors.py
@@ -9,7 +9,14 @@ class PrimaryDescriptorsFunction(BaseFunction):
     def get_primary_descriptor_from_nodes(self, resource, config):
         try:
             if 'nodegroup_id' in config and config['nodegroup_id'] != '' and config['nodegroup_id'] is not None:
-                for tile in models.TileModel.objects.filter(nodegroup_id=uuid.UUID(config['nodegroup_id']), sortorder=0).filter(resourceinstance_id=resource.resourceinstanceid):
+                tiles = models.TileModel.objects.filter(
+                        nodegroup_id=uuid.UUID(config['nodegroup_id']),
+                        sortorder=0).filter(resourceinstance_id=resource.resourceinstanceid)
+                if len(tiles) == 0:
+                    tiles = models.TileModel.objects.filter(
+                        nodegroup_id=uuid.UUID(config['nodegroup_id'])).filter(
+                        resourceinstance_id=resource.resourceinstanceid)
+                for tile in tiles:
                     for node in models.Node.objects.filter(nodegroup_id=uuid.UUID(config['nodegroup_id'])):
                         if len(tile.data.keys()) > 0:
                             data = tile.data


### PR DESCRIPTION
### Description of Change
Assigns a provisional value as descriptor when a resource instance's descriptor nodes have no authoritative data. re #3714