### PR TITLE
Galen consultation prj 38 docx

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -16,7 +16,7 @@ couchdb==1.2
 django-revproxy==0.9.15
 django-cors-headers==2.2.0
 django-oauth-toolkit==1.1.2
-docx2html==0.2.3
+python-docx==0.8.10
 PyLD[requests]==1.0.4
 pyprind==2.11.2
 pycryptodome<4.0.0,>=3.3.1

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -16,6 +16,7 @@ couchdb==1.2
 django-revproxy==0.9.15
 django-cors-headers==2.2.0
 django-oauth-toolkit==1.1.2
+docx2html==0.2.3
 PyLD[requests]==1.0.4
 pyprind==2.11.2
 pycryptodome<4.0.0,>=3.3.1


### PR DESCRIPTION
adds python-docx to requirements.txt (for use of docx library in a file_template view to handle docx templates), re https://github.com/archesproject/consultations-prj/issues/38