### PR TITLE
checks for graph.isactive in tile save()/post() and delete(), re #4937

### DIFF
--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -166,7 +166,7 @@ class TileData(View):
 
                     return JSONResponse(tile)
                 elif is_active is False:
-                    response = {'status': 'false', 'message': [_('Request Failed'), _('Unable to Save. Please verify the model status is active')]}
+                    response = {'status': 'false', 'message': [_('Request Failed'), _('Unable to Save. Verify model status is active')]}
                     return JSONResponse(response, status=500)
                 else:
                     response = {'status': 'false', 'message': [_('Request Failed'), _('Permission Denied')]}
@@ -225,7 +225,7 @@ class TileData(View):
                 except ObjectDoesNotExist:
                     return JSONResponse({'status':'false','message': [_('This tile is no longer available'), _('It was likely already deleted by another user')]}, status=500)
                 user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
-                if (user_is_reviewer or tile.is_provisional() == True) and is_active is True:
+                if (user_is_reviewer or tile.is_provisional() is True) and is_active is True:
                     if tile.filter_by_perm(request.user, 'delete_nodegroup'):
                         nodegroup = models.NodeGroup.objects.get(pk=tile.nodegroup_id)
                         clean_resource_cache(tile)
@@ -243,7 +243,7 @@ class TileData(View):
                     else:
                         return JSONResponse({'status':'false','message': [_('Request Failed'), _('Permission Denied')]}, status=500)
                 elif is_active is False:
-                    response = {'status': 'false', 'message': [_('Request Failed'), _('Unable to delete. Please verify the model status is active')]}
+                    response = {'status': 'false', 'message': [_('Request Failed'), _('Unable to delete. Verify model status is active')]}
                     return JSONResponse(response, status=500)
                 else:
                     return JSONResponse({'status':'false','message': [_('Request Failed'), _('You do not have permissions to delete a tile with authoritative data.')]}, status=500)

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -109,6 +109,8 @@ class TileData(View):
                         message = _('Unable to save. Please verify the model status is active')
                         return JSONResponse({'status': 'false', 'message': [_(e.title), _(str(message))]}, status=500)
                 tile_id = data['tileid']
+                resource_instance = models.ResourceInstance.objects.get(pk=data['resourceinstance_id'])
+                is_active = resource_instance.graph.isactive
                 if tile_id is not None and tile_id != '':
                     try:
                         old_tile = Tile.objects.get(pk=tile_id)
@@ -119,7 +121,7 @@ class TileData(View):
 
                 tile = Tile(data)
 
-                if tile.filter_by_perm(request.user, 'write_nodegroup'):
+                if tile.filter_by_perm(request.user, 'write_nodegroup') and is_active is True:
                     try:
                         with transaction.atomic():
                             try:
@@ -163,6 +165,9 @@ class TileData(View):
                         return self.handle_save_error(e, tile_id)
 
                     return JSONResponse(tile)
+                elif is_active is False:
+                    response = {'status': 'false', 'message': [_('Request Failed'), _('Unable to Save. Please verify the model status is active')]}
+                    return JSONResponse(response, status=500)
                 else:
                     response = {'status': 'false', 'message': [_('Request Failed'), _('Permission Denied')]}
                     return JSONResponse(response, status=500)
@@ -211,6 +216,8 @@ class TileData(View):
         if json != None:
             ret = []
             data = JSONDeserializer().deserialize(json)
+            resource_instance = models.ResourceInstance.objects.get(pk=data['resourceinstance_id'])
+            is_active = resource_instance.graph.isactive
 
             with transaction.atomic():
                 try:
@@ -218,7 +225,7 @@ class TileData(View):
                 except ObjectDoesNotExist:
                     return JSONResponse({'status':'false','message': [_('This tile is no longer available'), _('It was likely already deleted by another user')]}, status=500)
                 user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
-                if user_is_reviewer or tile.is_provisional() == True:
+                if (user_is_reviewer or tile.is_provisional() == True) and is_active is True:
                     if tile.filter_by_perm(request.user, 'delete_nodegroup'):
                         nodegroup = models.NodeGroup.objects.get(pk=tile.nodegroup_id)
                         clean_resource_cache(tile)
@@ -235,6 +242,9 @@ class TileData(View):
                         return JSONResponse(tile)
                     else:
                         return JSONResponse({'status':'false','message': [_('Request Failed'), _('Permission Denied')]}, status=500)
+                elif is_active is False:
+                    response = {'status': 'false', 'message': [_('Request Failed'), _('Unable to delete. Please verify the model status is active')]}
+                    return JSONResponse(response, status=500)
                 else:
                     return JSONResponse({'status':'false','message': [_('Request Failed'), _('You do not have permissions to delete a tile with authoritative data.')]}, status=500)
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



### Issues Solved
Prevents user from creating, updating, or deleting tile data to a resource whose model status is set to inactive. Re #4937 and followup to #4946 
