### PR TITLE
set z-index for class .create-resource-instance-card-component, re co…

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -13713,6 +13713,7 @@ a.jstree-anchor.permissions-widget {
 .create-resource-instance-card-component {
   position: absolute;
   background: white;
+  z-index: 3;
 }
 
 .indent {


### PR DESCRIPTION
…nsultations-prj #45

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
ensures that the pseudo-modal to enter a new resource instance shows on top of the card widget, not behind, re original ticket https://github.com/archesproject/arches/issues/4664 and more recent ticket https://github.com/archesproject/consultations-prj/issues/45
