### PR TITLE
Fix data grouping problems in v3v4 migration

### DIFF
--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -33,7 +33,7 @@ class DataValueConverter():
         # doesn't exist, but "test_arches" does.
         except OperationalError:
             db_conn = "dbname = {} user = {} host = {} password = {} port = {}".format(
-            "test_"+db['NAME'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
+                      "test_"+db['NAME'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
             conn = psycopg2.connect(db_conn)
 
         self.dbcursor = conn.cursor()

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -170,10 +170,6 @@ def get_nodegroup_tilegroup(v4_node_name, nodes, resource_id, verbose=False):
     v4_node = nodes.get(name=v4_node_name)
     ng_tile = Tile().get_blank_tile(v4_node.nodegroup_id, resourceid=resource_id)
 
-    if verbose:
-        print "  ", ng_tile.data
-        print "  ", ng_tile.tiles
-
     # if there are child tiles, then the ng_tile.tileid needs to be set
     # (not sure why this is the case, but it is)
     if ng_tile.tileid is None:

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -242,17 +242,14 @@ class v3PreparedResource:
         def get_group_branches(entity, outgroups=[]):
             """ get the group branches from the entity based on v3 mergenodes """
 
-            # iterate the children of this entity
-            for child in entity['child_entities']:
+            look_further = any([child['entitytypeid'] in self.mergenodes for
+                               child in entity['child_entities']])
 
-                # if one of the GRANDCHILDREN is a mergenode, then the recursion
-                # must continue. otherwise, this child is its own group.
-                look_further = any([gc['entitytypeid'] in self.mergenodes for
-                                   gc in child['child_entities']])
-                if look_further:
+            if look_further or entity['entitytypeid'] in self.mergenodes:
+                for child in entity['child_entities']:
                     get_group_branches(child, outgroups=outgroups)
-                else:
-                    outgroups.append(child)
+            else:
+                outgroups.append(entity)
 
             return outgroups
 

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -6,6 +6,7 @@ import psycopg2
 from mimetypes import MimeTypes
 from rdflib import Graph as RDFGraph, Namespace, RDF, URIRef, Literal
 from rdflib.namespace import DCTERMS, SKOS, FOAF, NamespaceManager
+from django.db.utils import OperationalError
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.db.models.functions import MakeValid
 from arches.app.models.graph import Graph
@@ -26,7 +27,14 @@ class DataValueConverter():
         db = settings.DATABASES['default']
         db_conn = "dbname = {} user = {} host = {} password = {} port = {}".format(
             db['NAME'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
-        conn = psycopg2.connect(db_conn)
+        try:
+            conn = psycopg2.connect(db_conn)
+        # this is just for handling during test running where the "arches" database
+        # doesn't exist, but "test_arches" does.
+        except OperationalError:
+            db_conn = "dbname = {} user = {} host = {} password = {} port = {}".format(
+            "test_"+db['NAME'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
+            conn = psycopg2.connect(db_conn)
 
         self.dbcursor = conn.cursor()
 

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -143,25 +143,6 @@ class DataValueConverter():
         return value
 
 
-def duplicate_tile_json(tilejson):
-    """returns a duplicate of the tilejson that is passed in, but
-    with all data values set to None."""
-
-    newtile = {
-        "resourceinstance_id": tilejson['resourceinstance_id'],
-        "provisionaledits": tilejson['provisionaledits'],
-        "parenttile_id": tilejson['parenttile_id'],
-        "nodegroup_id": tilejson['nodegroup_id'],
-        "sortorder": tilejson['sortorder'],
-        "data": {},
-        "tileid": uuid.uuid4(),
-    }
-    for k in tilejson['data'].keys():
-        newtile['data'][k] = None
-
-    return newtile
-
-
 class v3PreparedResource:
     """ Used to convert data for a single v3 resource into corresponding set
     of v4 json. """

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -373,8 +373,11 @@ class v3PreparedResource:
                             print("-- coercing to previous group because parent cardinality is 1 --")
 
                 if self.verbose:
-                    print("v3 value: {}".format(dp[1]))
-                    print("v4 value: {}".format(value))
+                    try:
+                        print("v3 value: {}".format(dp[1]))
+                        print("v4 value: {}".format(value))
+                    except UnicodeEncodeError:
+                        print "v3/v4 value: error encoding to ascii for print statement"
 
                 # find the tile that will hold the value
                 for tile in tilegroup_json:

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -389,12 +389,24 @@ class v3PreparedResource:
                 # now get the UUID of the v4 target node
                 v4_uuid = self.node_lookup[dp[0]]['v4_uuid']
 
+                # figure out if the parent of this tilegroup has cardinality of 1.
+                # use the last tile in line to find the parent nodegroup, this is because
+                # in some cases the first tile in line represents the parent (and therefore
+                # has no parent itself) but not reliably.
+                single_parent = False
+                last_ng = NodeGroup.objects.get(nodegroupid=tilegroup_json[-1]['nodegroup_id'])
+                if last_ng.parentnodegroup_id is not None:
+                    parent_ng = NodeGroup.objects.get(nodegroupid=last_ng.parentnodegroup_id)
+                    if parent_ng.cardinality == "1":
+                        single_parent = True
+
                 # if this node is part of a new group, break the for loop and start the while loop over
                 if group_num != last_group:
                     last_group = group_num
-                    if self.verbose:
-                        print "<< breaking the loop because this node has a new group number >>"
-                    break
+                    if single_parent is False:
+                        if self.verbose:
+                            print "<< breaking the loop because this node has a new group number >>"
+                        break
                 last_group = group_num
 
                 # break the for loop (and subsequently, restart the while loop)

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -119,7 +119,13 @@ class DataValueConverter():
                 exit()
 
             # construct the full json needed to define a file-list node in a tile
-            stats = os.stat(fullpath)
+            try:
+                stats = os.stat(fullpath)
+                lastModified = stats.st_mtime
+                size = stats.st_size
+            except Exception as e:
+                lastModified = None
+                size = None
             ftype = MimeTypes().guess_type(fullpath)[0]
             value = [{
                 "name": filename,
@@ -127,11 +133,11 @@ class DataValueConverter():
                 "url": str(file_obj.path.url).replace("files/", "files/uploadedfiles/"),
                 "status": 'uploaded',
                 "index": 0,
-                "lastModified": stats.st_mtime,
+                "lastModified": lastModified,
                 "height": None,
                 "width": None,
                 "type": ftype,
-                "size": stats.st_size,
+                "size": size,
                 # "content":"blob:http://localhost:8000/24dd8daa-da29-49ec-805a-3dd8a683162c",
                 "accepted": True
             }]

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -267,18 +267,16 @@ class v3PreparedResource:
             data = dict([(k, v) for k, v in tile['data'].items() if v is not None])
             tile['data'] = data
 
-    def put_primary_name_last(self):
-        """ this method ensures that the Primary name is placed at the end of
+    def reorder_tiles_by_value(self, nodeid=None, valueid=None):
+        """ this method can ensure that the Primary name is placed at the end of
         the tile list. this is necessary to ensure that the Primary name is
         used for the "get resource descriptors" function."""
 
         p_name_index = None
         for index, tile in enumerate(self.tiles):
             try:
-                # currently, these hard-coded uuids work for hku models, but
-                # should be refactored way back to the rm_configs.json file
-                name_type = tile['data']["185b9091-943d-11e8-8c9e-94659cf754d0"]
-                if name_type == "a4c88313-52c5-4b6a-9579-3fc5aad17335":
+                node_value = tile['data'][nodeid]
+                if node_value == valueid:
                     p_name_index = index
                     break
             except KeyError:
@@ -436,7 +434,16 @@ class v3PreparedResource:
         self.strip_empty_tile_values()
         self.put_primary_name_last()
 
-    def get_json(self):
+        # reorder tiles so that the correct name and/or description are first in line
+        # and therefore used by the display resource descriptors function.
+        # THIS IS NOT CURRENTLY IMPLEMENTED
+        # the reason being that the Value uuid for "primary" is RDM-specific, and the
+        # Name Type nodeid is resource model-specific. All of the plumbing is not yet
+        # in place to pass those uuids to this function at this time.
+        if True is False:
+            self.reorder_tiles_by_value()
+
+    def get_resource_json(self):
         """ returns the full v4 json for this resource. note that self.process()
         must be run before this method is called, otherwise self.tiles will be
         empty. """

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -293,10 +293,11 @@ class v3PreparedResource:
         while len(resource_data):
 
             if self.verbose:
+                fp = resource_data[0][0]
                 print("\nSTARTING WHILE LOOP")
                 print("###################")
                 print("resource_data current length: {}".format(len(resource_data)))
-                print("first in line: {} {}".format(resource_data[0][0], self.node_lookup[resource_data[0][0]]['v4_uuid']))
+                print("first in line: {} {}".format(fp, self.node_lookup[fp]['v4_uuid']))
                 print("group number of first in line: {}".format(resource_data[0][2]))
 
             # get the v4 name of the first node in the resource list
@@ -304,7 +305,7 @@ class v3PreparedResource:
 
             # obtain a blank tile for the nodegroup that contains the corresponding
             tilegroup_json = v3utils.get_nodegroup_tilegroup(v4_name, v4_nodes, self.resourceid,
-                                                     verbose=self.verbose)
+                                                             verbose=self.verbose)
 
             # get a list of all the node UUIDs in this tile and its children
             all_node_options = []
@@ -317,8 +318,8 @@ class v3PreparedResource:
             # begin iterating resource_data, and trying to fill tile['data'] values
             # in the current tile group. if a node in the iteration doesn't fit
             # in any of the tiles, assume this is a new branch, break the for loop,
-            # and restart the while loop to get the next tile group. remove any
-            # nodes from resource_data whose value has been placed in a tile.
+            # and restart the while loop to get the next tile group. at the end, remove any
+            # nodes from resource_data whose values have been placed in a tile.
             if self.verbose:
                 print("\nSTARTING FOR LOOP")
                 print("=================")

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -162,44 +162,6 @@ def duplicate_tile_json(tilejson):
     return newtile
 
 
-def get_nodegroup_tilegroup(v4_node_name, nodes, resource_id, verbose=False):
-
-    # get the corresponding v4 node and then get the tile for its nodegroup
-    v4_node = nodes.get(name=v4_node_name)
-    ng_tile = Tile().get_blank_tile(v4_node.nodegroup_id, resourceid=resource_id)
-
-    # if there are child tiles, then the ng_tile.tileid needs to be set
-    # (not sure why this is the case, but it is)
-    if ng_tile.tileid is None:
-        ng_tile.tileid = uuid.uuid4()
-
-    # create a raw json representation of the node group tile and its children
-    # and put these into a flat list of tiles that is returned
-    tile_json = {
-        "resourceinstance_id": resource_id,
-        "provisionaledits": None,
-        "parenttile_id": ng_tile.parenttile_id,
-        "nodegroup_id": ng_tile.nodegroup_id,
-        "sortorder": 0,
-        "data": ng_tile.data,
-        "tileid": ng_tile.tileid,
-    }
-    output_tiles = [tile_json]
-    for tile in ng_tile.tiles:
-        child_tile_json = {
-            "tileid": tile.tileid,
-            "resourceinstance_id": resource_id,
-            "nodegroup_id": tile.nodegroup_id,
-            "sortorder": 0,
-            "provisionaledits": None,
-            "parenttile_id": ng_tile.tileid,
-            "data": tile.data,
-        }
-        output_tiles.append(child_tile_json)
-
-    return output_tiles
-
-
 class v3PreparedResource:
     """ Used to convert data for a single v3 resource into corresponding set
     of v4 json. """
@@ -360,7 +322,7 @@ class v3PreparedResource:
             v4_name = self.node_lookup[resource_data[0][0]]['v4_name']
 
             # obtain a blank tile for the nodegroup that contains the corresponding
-            tilegroup_json = get_nodegroup_tilegroup(v4_name, v4_nodes, self.resourceid,
+            tilegroup_json = v3utils.get_nodegroup_tilegroup(v4_name, v4_nodes, self.resourceid,
                                                      verbose=self.verbose)
 
             # get a list of all the node UUIDs in this tile and its children

--- a/arches/app/utils/v3migration.py
+++ b/arches/app/utils/v3migration.py
@@ -26,16 +26,8 @@ class DataValueConverter():
         self.skip_file_check = skip_file_check
         db = settings.DATABASES['default']
         db_conn = "dbname = {} user = {} host = {} password = {} port = {}".format(
-            db['NAME'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
-        try:
-            conn = psycopg2.connect(db_conn)
-        # this is just for handling during test running where the "arches" database
-        # doesn't exist, but "test_arches" does.
-        except OperationalError:
-            db_conn = "dbname = {} user = {} host = {} password = {} port = {}".format(
-                      "test_"+db['NAME'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
-            conn = psycopg2.connect(db_conn)
-
+            db['POSTGIS_TEMPLATE'], db['USER'], db['HOST'], db['PASSWORD'], db['PORT'])
+        conn = psycopg2.connect(db_conn)
         self.dbcursor = conn.cursor()
 
     def fix_v3_value(self, value, v4nodeinfo):

--- a/arches/app/utils/v3utils.py
+++ b/arches/app/utils/v3utils.py
@@ -42,6 +42,37 @@ def get_nodegroup_tilegroup(v4_node_name, nodes, resource_id, verbose=False):
     return output_tiles
 
 
+def duplicate_tile_json(tilejson):
+    """returns a duplicate of the tilejson that is passed in, but
+    with all data values set to None."""
+
+    newtile = {
+        "resourceinstance_id": tilejson['resourceinstance_id'],
+        "provisionaledits": tilejson['provisionaledits'],
+        "parenttile_id": tilejson['parenttile_id'],
+        "nodegroup_id": tilejson['nodegroup_id'],
+        "sortorder": tilejson['sortorder'],
+        "data": {},
+        "tileid": uuid.uuid4(),
+    }
+    for k in tilejson['data'].keys():
+        newtile['data'][k] = None
+
+    return newtile
+
+
+def set_tile_data(tile, v4_uuid, datatype, value):
+
+    if datatype == "concept-list":
+        if tile['data'][v4_uuid] is None:
+            tile['data'][v4_uuid] = [value]
+        else:
+            tile['data'][v4_uuid].append(value)
+    else:
+        tile['data'][v4_uuid] = value
+    return tile
+
+
 def get_v3_config_info(v3_data_dir, v4_graph_name=None):
 
     conf_file = os.path.join(v3_data_dir, "rm_configs.json")

--- a/arches/management/commands/v3.py
+++ b/arches/management/commands/v3.py
@@ -276,8 +276,7 @@ class Command(BaseCommand):
                         onlyids.append(line.rstrip())
                 only = onlyids
         except Exception as e:
-            print e
-            exit()
+            pass
 
         if len(only) > 0:
             print("  processing {} resources".format(len(only)))

--- a/arches/management/commands/v3.py
+++ b/arches/management/commands/v3.py
@@ -304,9 +304,9 @@ class Command(BaseCommand):
                 output_file = os.path.join(package_dir, 'business_data', outfilename)
 
                 if ext == ".json":
-                    output = importer.write_v4_json(output_file, verbose=verbose)
+                    output = importer.write_v4_json(output_file)
                 elif ext == ".jsonl":
-                    output = importer.write_v4_jsonl(output_file, verbose=verbose)
+                    output = importer.write_v4_jsonl(output_file)
 
                 if output is not False:
                     sources.append(output_file)

--- a/arches/management/commands/v3.py
+++ b/arches/management/commands/v3.py
@@ -69,19 +69,19 @@ class Command(BaseCommand):
             try:
                 dir_path = settings.PACKAGE_DIR
                 if not os.path.isdir(dir_path):
-                    print "\nCurrent PACKAGE_DIR value: "+settings.PACKAGE_DIR
-                    print "This directory does not exist."
+                    print("\nCurrent PACKAGE_DIR value: "+settings.PACKAGE_DIR)
+                    print("This directory does not exist.")
                     raise AttributeError
             except AttributeError:
-                print "\nYou must correctly set PACKAGE_DIR in your project's "\
-                    "settings.py file, or use the -t/--target argument to indicate"\
-                    " the location of your package."
+                print("\nYou must correctly set PACKAGE_DIR in your project's "
+                      "settings.py file, or use the -t/--target argument to indicate "
+                      "the location of your package.")
                 exit()
         else:
             dir_path = os.path.abspath(options['target'])
             if not os.path.isdir(dir_path):
-                print "\nInvalid -t/--target value: "+options['target']+"\n"\
-                    "This must be a directory."
+                print("\nInvalid -t/--target value: "+options['target']+"\n"
+                      "This must be a directory.")
                 exit()
 
         op = options['operation']
@@ -114,7 +114,7 @@ class Command(BaseCommand):
                     try:
                         graph = Graph.objects.get(name=rm)
                     except Graph.DoesNotExist:
-                        print "invalid resource model name:", rm
+                        print("invalid resource model name: {}".format(rm))
                         exit()
                 models = resource_models
 
@@ -149,21 +149,21 @@ class Command(BaseCommand):
             try:
                 shutil.rmtree(v3_dir)
             except Exception as e:
-                print e
+                print(e)
                 exit()
         elif os.path.isfile(v3_dir) and overwrite:
             try:
                 os.remove(v3_dir)
             except Exception as e:
-                print e
+                print(e)
                 exit()
         elif os.path.isdir(v3_dir) or os.path.isfile(v3_dir):
-            print "The v3data directory already exists at this location:\n    "\
-                + v3_dir + "\nEither change your path, or re-run command with "\
-                "--overwrite to replace the existing file or directory."
+            print("The v3data directory already exists at this location:\n    "
+                  + v3_dir + "\nEither change your path, or re-run command with "
+                  "--overwrite to replace the existing file or directory.")
             exit()
 
-        print "making directory"
+        print("making directory")
 
         os.mkdir(v3_dir)
         os.mkdir(os.path.join(v3_dir, 'business_data'))
@@ -201,8 +201,8 @@ class Command(BaseCommand):
         for rm, config in configs.iteritems():
             v3_type = config['v3_entitytypeid']
             if v3_type.startswith("<") or v3_type.endswith(">"):
-                print "you must fill out the 'v3_entitytypeid' attribute "\
-                    "for every resource model listed in your v3 configs."
+                print("you must fill out the 'v3_entitytypeid' attribute "
+                      "for every resource model listed in your v3 configs.")
                 exit()
         csv_dir = os.path.join(path, 'v3data', 'graph_data')
 
@@ -210,9 +210,9 @@ class Command(BaseCommand):
             v3_type = config['v3_entitytypeid']
             csv_file = os.path.join(csv_dir, "{}_nodes.csv".format(v3_type))
             if not os.path.isfile(csv_file):
-                print "\nCan't find nodes CSV file for {}. Expected name is:"\
-                    "\n\n  {}".format(v3_type, csv_file)
-                print "\n  -- Have you transferred your v3 nodes files yet?"
+                print("\nCan't find nodes CSV file for {}. Expected name is:"
+                      "\n\n  {}".format(v3_type, csv_file))
+                print("\n  -- Have you transferred your v3 nodes files yet?")
                 exit()
 
             v3_business_nodes = []
@@ -245,12 +245,12 @@ class Command(BaseCommand):
         v3_data_dir = os.path.join(package_dir, "v3data")
         errors = v3utils.test_rm_configs(v3_data_dir)
         if len(errors) > 0:
-            print "FAIL"
+            print("FAIL")
             for e in errors:
-                print e
+                print(e)
             exit()
 
-        print "PASS"
+        print("PASS")
 
     def write_v4_json(self, package_dir, resource_models,
                       direct_import=False, truncate=None, verbose=False, exclude=[], only=[],
@@ -264,7 +264,7 @@ class Command(BaseCommand):
         v3_files = glob(os.path.join(package_dir, 'v3data', 'business_data', '*.json*'))
 
         if len(v3_files) == 0:
-            print "\nThere is no v3 data to import. Put v3 json or jsonl in {}".format(v3_data_dir)
+            print("\nThere is no v3 data to import. Put v3 json or jsonl in {}".format(v3_data_dir))
             exit()
 
         try:
@@ -321,9 +321,9 @@ class Command(BaseCommand):
                                         )
 
         else:
-            print endmsg+"\n"
+            print(endmsg+"\n")
 
-        print "elapsed time:", datetime.now() - start
+        print("elapsed time: {}".format(datetime.now() - start))
 
     def write_v4_relations(self, package_dir, direct_import=False):
 
@@ -332,15 +332,15 @@ class Command(BaseCommand):
         v3_relations_files = glob(os.path.join(v3_business_dir, '*.relations'))
 
         if len(v3_relations_files) == 0:
-            print "\nThere are no v3 relations to import. Put v3 .relations "\
-                "file in {}".format(v3_business_dir)
+            print("\nThere are no v3 relations to import. Put v3 .relations "
+                  "file in {}".format(v3_business_dir))
             exit()
 
         v3_relations = v3_relations_files[0]
 
         if len(v3_relations_files) > 1:
-            print "\nOnly one v3 relations file can be imported. This file will be used"\
-                ":\n\n  {}".format(v3_relations)
+            print("\nOnly one v3 relations file can be imported. This file will be used"
+                  ":\n\n  {}".format(v3_relations))
 
         v4_relations = os.path.join(package_dir, "business_data", "relations", "all.relations")
 
@@ -361,11 +361,11 @@ class Command(BaseCommand):
                                     source=v4_relations
                                     )
         else:
-            print '\n  -- You can load these resources later with:\n'\
-                '\n  python manage.py packages -o import_business_data_relations -s '\
-                '"{}"'.format(v4_relations)
+            print('\n  -- You can load these resources later with:\n'
+                  '\n  python manage.py packages -o import_business_data_relations -s '
+                  '"{}"'.format(v4_relations))
 
-        print "elapsed time:", datetime.now() - start
+        print("elapsed time: {}".format(datetime.now() - start))
 
     def convert_v3_skos(self, package_dir, direct_import=False, verbose=False):
 
@@ -390,16 +390,16 @@ class Command(BaseCommand):
 
         v3_skos_files = glob(os.path.join(v3_ref_dir, '*.xml'))
         if len(v3_skos_files) == 0:
-            print "\nThere is no v3 data to import. Export your concept scheme"\
-                " from v3 and place it in {}".format(v3_ref_dir)
+            print("\nThere is no v3 data to import. Export your concept scheme"
+                  " from v3 and place it in {}".format(v3_ref_dir))
             exit()
 
         if len(v3_skos_files) > 0:
             skos_file = v3_skos_files[0]
 
         if len(v3_skos_files) > 1:
-            print "\nOnly one v3 file can be converted. This file will be used"\
-                ":\n\n  {}".format(skos_file)
+            print("\nOnly one v3 file can be converted. This file will be used"
+                  ":\n\n  {}".format(skos_file))
 
         skos_importer = v3SkosConverter(skos_file,
                                         name_space=settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT,

--- a/arches/management/commands/v3.py
+++ b/arches/management/commands/v3.py
@@ -250,6 +250,7 @@ class Command(BaseCommand):
     def write_v4_json(self, package_dir, resource_models,
                       direct_import=False, truncate=None, verbose=False, exclude=[], only=[]):
 
+        start = datetime.now()
         v3_data_dir = os.path.join(package_dir, "v3data")
         endmsg = "\n  -- You can load these resources later with:\n"
 
@@ -299,8 +300,11 @@ class Command(BaseCommand):
         else:
             print endmsg+"\n"
 
+        print "elapsed time:", datetime.now() - start
+
     def write_v4_relations(self, package_dir, direct_import=False):
 
+        start = datetime.now()
         v3_business_dir = os.path.join(package_dir, 'v3data', 'business_data')
         v3_relations_files = glob(os.path.join(v3_business_dir, '*.relations'))
 
@@ -337,6 +341,8 @@ class Command(BaseCommand):
             print '\n  -- You can load these resources later with:\n'\
                 '\n  python manage.py packages -o import_business_data_relations -s '\
                 '"{}"'.format(v4_relations)
+
+        print "elapsed time:", datetime.now() - start
 
     def convert_v3_skos(self, package_dir, direct_import=False, verbose=False):
 

--- a/arches/management/commands/v3.py
+++ b/arches/management/commands/v3.py
@@ -10,7 +10,7 @@ from arches.app.models.graph import Graph
 from arches.app.models.models import TileModel, Node
 from arches.app.utils.skos import SKOSReader
 from arches.app.utils import v3utils
-from arches.app.utils.v3migration import v3Importer, v3SkosConverter
+from arches.app.utils.v3migration import v3Importer, v3SkosConverter, DataValueConverter
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.models.system_settings import settings
 
@@ -273,6 +273,8 @@ class Command(BaseCommand):
             for rm in resource_models:
 
                 print("looking for "+rm+" resources...")
+                value_converter = DataValueConverter(skip_file_check=skipfilecheck)
+
                 importer = v3Importer(v3_data_dir, rm, v3_resource_file=v3_file,
                                       truncate=truncate, exclude=exclude, only=only)
 

--- a/arches/management/commands/v3.py
+++ b/arches/management/commands/v3.py
@@ -159,8 +159,8 @@ class Command(BaseCommand):
                 exit()
         elif os.path.isdir(v3_dir) or os.path.isfile(v3_dir):
             print("The v3data directory already exists at this location:\n    "
-                  + v3_dir + "\nEither change your path, or re-run command with "
-                  "--overwrite to replace the existing file or directory.")
+                  "{}\nEither change your path, or re-run command with "
+                  "--overwrite to replace the existing file or directory.".format(v3_dir))
             exit()
 
         print("making directory")

--- a/tests/fixtures/v3migration-pkg/graphs/resource_models/Historic District.json
+++ b/tests/fixtures/v3migration-pkg/graphs/resource_models/Historic District.json
@@ -5,20 +5,20 @@
             "cards": [
                 {
                     "active": true, 
-                    "cardid": "2bf4eb21-943c-11e8-a95e-94659cf754d0", 
+                    "cardid": "e0e70d21-943b-11e8-92da-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
-                    "description": "Represents a single node in a graph", 
+                    "description": "Describes the conditions, threats, and disturbances affecting a Heritage Resource or Heritage Resource Group. Additional information may include a management recommendation, a condition image, the data the condition was assessed and a description of the condition.", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "Enter the date resource was evaluated.", 
+                    "instructions": "One assessment of condition at a particular point in time. ", 
                     "is_editable": true, 
-                    "name": "Evaluation Date", 
-                    "nodegroup_id": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
-                    "sortorder": 0, 
+                    "name": "Condition Assessment", 
+                    "nodegroup_id": "e0e70d1f-943b-11e8-86e1-94659cf754d0", 
+                    "sortorder": null, 
                     "visible": true
                 }, 
                 {
@@ -51,7 +51,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the eligibility requirements that the resource meets.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Eligibility Requirements", 
                     "nodegroup_id": "2bf53943-943c-11e8-82e5-94659cf754d0", 
                     "sortorder": 4, 
@@ -59,19 +59,19 @@
                 }, 
                 {
                     "active": true, 
-                    "cardid": "3676e3f1-943c-11e8-8ebd-94659cf754d0", 
+                    "cardid": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
-                    "description": "Generic branch for capturing free-form written descriptive information.\nIntended to be evolution from v3 description branch from HIP 3. Created semantic description node with description string and description type hanging off of it. Description (semantic node) becomes a grouping node (type and string).  \n\nThis branch meets technical business rules for CRM compliance but CRM experts have said that this is an inappropriate implementation of E62.\n\nConnects to all resources with P140i", 
+                    "description": "Used to hold identifiers necessary to link a given resource to records in an external (perhaps legacy) system.", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "Enter a description and description type for the resource.", 
-                    "is_editable": true, 
-                    "name": "Description", 
-                    "nodegroup_id": "3676e3ef-943c-11e8-8654-94659cf754d0", 
+                    "instructions": "Enter information for identifiers of the resource from other external sources.", 
+                    "is_editable": false, 
+                    "name": "External Identifier", 
+                    "nodegroup_id": "0077a5ef-943c-11e8-8c17-94659cf754d0", 
                     "sortorder": null, 
                     "visible": true
                 }, 
@@ -87,7 +87,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": null, 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Resource Type Classification", 
                     "nodegroup_id": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
                     "sortorder": null, 
@@ -105,10 +105,28 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": null, 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Place", 
                     "nodegroup_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0", 
                     "sortorder": null, 
+                    "visible": true
+                }, 
+                {
+                    "active": true, 
+                    "cardid": "e6802821-943b-11e8-a7e3-94659cf754d0", 
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
+                    "config": null, 
+                    "cssclass": null, 
+                    "description": "", 
+                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                    "helpenabled": false, 
+                    "helptext": null, 
+                    "helptitle": null, 
+                    "instructions": "Define the resource's designation or protection status.", 
+                    "is_editable": false, 
+                    "name": "Designation or Protection", 
+                    "nodegroup_id": "e6800110-943b-11e8-b9d9-94659cf754d0", 
+                    "sortorder": 0, 
                     "visible": true
                 }, 
                 {
@@ -123,7 +141,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Enter the address of the location.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Address", 
                     "nodegroup_id": "1d8a6d81-943c-11e8-85f8-94659cf754d0", 
                     "sortorder": 1, 
@@ -141,7 +159,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Enter the resource name and its respective type.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Name", 
                     "nodegroup_id": "eeaaea81-943b-11e8-8181-94659cf754d0", 
                     "sortorder": null, 
@@ -159,7 +177,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Describe the location of the resource.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Description Location", 
                     "nodegroup_id": "1d8a9492-943c-11e8-bcaf-94659cf754d0", 
                     "sortorder": 4, 
@@ -177,7 +195,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "For Historic Resources only, define the setting of the historic resource.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Setting Type", 
                     "nodegroup_id": "1d8a9495-943c-11e8-8c3a-94659cf754d0", 
                     "sortorder": 3, 
@@ -195,7 +213,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the administrative/governmental subdivision name and type.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Administration Subdivision", 
                     "nodegroup_id": "1d8a9498-943c-11e8-8d67-94659cf754d0", 
                     "sortorder": 2, 
@@ -213,7 +231,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Define the spatial location.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Spatial Location", 
                     "nodegroup_id": "1d8a949b-943c-11e8-af7a-94659cf754d0", 
                     "sortorder": 0, 
@@ -231,7 +249,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Enter the cadastral reference number.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Cadastral Reference", 
                     "nodegroup_id": "1d8a949e-943c-11e8-9845-94659cf754d0", 
                     "sortorder": 5, 
@@ -239,19 +257,19 @@
                 }, 
                 {
                     "active": true, 
-                    "cardid": "e6802821-943b-11e8-a7e3-94659cf754d0", 
+                    "cardid": "2bf4eb21-943c-11e8-a95e-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
-                    "description": "", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "Define the resource's designation or protection status.", 
-                    "is_editable": true, 
-                    "name": "Designation or Protection", 
-                    "nodegroup_id": "e6800110-943b-11e8-b9d9-94659cf754d0", 
+                    "instructions": "Enter the date resource was evaluated.", 
+                    "is_editable": false, 
+                    "name": "Evaluation Date", 
+                    "nodegroup_id": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
                     "sortorder": 0, 
                     "visible": true
                 }, 
@@ -267,7 +285,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": null, 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Right", 
                     "nodegroup_id": "e6802822-943b-11e8-a821-94659cf754d0", 
                     "sortorder": null, 
@@ -285,28 +303,10 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the resource status based on the evaluation.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Status", 
                     "nodegroup_id": "2bf53940-943c-11e8-879c-94659cf754d0", 
                     "sortorder": 5, 
-                    "visible": true
-                }, 
-                {
-                    "active": true, 
-                    "cardid": "e0e70d21-943b-11e8-92da-94659cf754d0", 
-                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
-                    "config": null, 
-                    "cssclass": null, 
-                    "description": "Describes the conditions, threats, and disturbances affecting a Heritage Resource or Heritage Resource Group. Additional information may include a management recommendation, a condition image, the data the condition was assessed and a description of the condition.", 
-                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "helpenabled": false, 
-                    "helptext": null, 
-                    "helptitle": null, 
-                    "instructions": "One assessment of condition at a particular point in time. ", 
-                    "is_editable": true, 
-                    "name": "Condition Assessment", 
-                    "nodegroup_id": "e0e70d1f-943b-11e8-86e1-94659cf754d0", 
-                    "sortorder": null, 
                     "visible": true
                 }, 
                 {
@@ -321,7 +321,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the criteria type used for evaluation.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Evaluation Criteria", 
                     "nodegroup_id": "2bf4eb22-943c-11e8-bc7f-94659cf754d0", 
                     "sortorder": 1, 
@@ -339,7 +339,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Define the period of significance that is being used for evaluation. ", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Period of Significance", 
                     "nodegroup_id": "2bf5122f-943c-11e8-b94f-94659cf754d0", 
                     "sortorder": 2, 
@@ -357,7 +357,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "This card ties together a Related/Acillary Features and Use Type with timeframe based on cultural period or actual dates.  For a separate combination Related/Ancillary Features and Use Type, create a separate entry.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Related/Ancillary Feature", 
                     "nodegroup_id": "d8b4d0b1-943b-11e8-99ff-94659cf754d0", 
                     "sortorder": 2, 
@@ -375,7 +375,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": null, 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Evaluation", 
                     "nodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
                     "sortorder": null, 
@@ -393,7 +393,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the type of integrity that the resource maintains. ", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Integrity", 
                     "nodegroup_id": "2bf51235-943c-11e8-97ea-94659cf754d0", 
                     "sortorder": 3, 
@@ -411,7 +411,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Describe the reasons for the evaluated resource's status.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Reasons", 
                     "nodegroup_id": "2bf51238-943c-11e8-9189-94659cf754d0", 
                     "sortorder": 6, 
@@ -419,19 +419,19 @@
                 }, 
                 {
                     "active": true, 
-                    "cardid": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
+                    "cardid": "3676e3f1-943c-11e8-8ebd-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
-                    "description": "Used to hold identifiers necessary to link a given resource to records in an external (perhaps legacy) system.", 
+                    "description": "Generic branch for capturing free-form written descriptive information.\nIntended to be evolution from v3 description branch from HIP 3. Created semantic description node with description string and description type hanging off of it. Description (semantic node) becomes a grouping node (type and string).  \n\nThis branch meets technical business rules for CRM compliance but CRM experts have said that this is an inappropriate implementation of E62.\n\nConnects to all resources with P140i", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "Enter information for identifiers of the resource from other external sources.", 
-                    "is_editable": true, 
-                    "name": "External Identifier", 
-                    "nodegroup_id": "0077a5ef-943c-11e8-8c17-94659cf754d0", 
+                    "instructions": "Enter a description and description type for the resource.", 
+                    "is_editable": false, 
+                    "name": "Description", 
+                    "nodegroup_id": "3676e3ef-943c-11e8-8654-94659cf754d0", 
                     "sortorder": null, 
                     "visible": true
                 }, 
@@ -447,7 +447,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "This card ties together a Heritage Group Style and Use Type with timeframe based on cultural period or actual dates.  For a separate combination Style and Use Type, create a separate entry.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Style", 
                     "nodegroup_id": "d8b4d0b4-943b-11e8-b400-94659cf754d0", 
                     "sortorder": 1, 
@@ -465,7 +465,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select keywords associated with the resource.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Keyword", 
                     "nodegroup_id": "13e455c1-943c-11e8-9bea-94659cf754d0", 
                     "sortorder": null, 
@@ -501,7 +501,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "This card ties together a Heritage Group Type and Use Type with timeframe based on cultural period or actual dates.  For a separate combination Group Type and Use Type, create a separate entry.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Heritage Resource Group/Use Type", 
                     "nodegroup_id": "d8b4f7c2-943b-11e8-bfc5-94659cf754d0", 
                     "sortorder": 0, 
@@ -519,7 +519,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": null, 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Heritage Resource Group Phase Type", 
                     "nodegroup_id": "d8b4f7c5-943b-11e8-93bb-94659cf754d0", 
                     "sortorder": null, 
@@ -527,45 +527,6 @@
                 }
             ], 
             "cards_x_nodes_x_widgets": [
-                {
-                    "card_id": "3b2c7cc3-943c-11e8-b12b-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Measurement Value", 
-                        "max": "", 
-                        "min": "", 
-                        "placeholder": "Enter value", 
-                        "precision": "", 
-                        "prefix": "", 
-                        "step": "", 
-                        "suffix": "", 
-                        "width": "100%"
-                    }, 
-                    "id": "3b2ca3d5-943c-11e8-9312-94659cf754d0", 
-                    "label": "Measurement Value", 
-                    "node_id": "3b2ca3d1-943c-11e8-906a-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000008"
-                }, 
-                {
-                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature From Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "d8b51eda-943b-11e8-ba7e-94659cf754d0", 
-                    "label": "Ancillary Feature From Date", 
-                    "node_id": "d8b4f7ca-943b-11e8-a64b-94659cf754d0", 
-                    "sortorder": 3, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
                 {
                     "card_id": "3676e3f1-943c-11e8-8ebd-94659cf754d0", 
                     "config": {
@@ -578,6 +539,102 @@
                     "label": "Description Type", 
                     "node_id": "3676e3f2-943c-11e8-81bf-94659cf754d0", 
                     "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Start Date of Existence", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "31bf9d78-943c-11e8-8ba5-94659cf754d0", 
+                    "label": "Start Date of Existence", 
+                    "node_id": "31bf9d77-943c-11e8-a434-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Source of Identifier", 
+                        "options": [], 
+                        "placeholder": "Select the source of the indentifier"
+                    }, 
+                    "id": "0077cd03-943c-11e8-a105-94659cf754d0", 
+                    "label": "Source of Identifier", 
+                    "node_id": "0077cd00-943c-11e8-b4ca-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000015"
+                }, 
+                {
+                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "End Date of Existence", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "31bf9d7b-943c-11e8-b5cd-94659cf754d0", 
+                    "label": "End Date of Existence", 
+                    "node_id": "31bf9d72-943c-11e8-9ec9-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "3676e3f1-943c-11e8-8ebd-94659cf754d0", 
+                    "config": {
+                        "label": "Description", 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "3676e3f4-943c-11e8-ae12-94659cf754d0", 
+                    "label": "Description", 
+                    "node_id": "3676e3f3-943c-11e8-b62a-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                }, 
+                {
+                    "card_id": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "External Identifier", 
+                        "maxLength": null, 
+                        "placeholder": "Enter indentifier", 
+                        "width": "100%"
+                    }, 
+                    "id": "0077cd02-943c-11e8-a244-94659cf754d0", 
+                    "label": "External Identifier", 
+                    "node_id": "0077a5ef-943c-11e8-8c17-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }, 
+                {
+                    "card_id": "2bf51237-943c-11e8-b64a-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Integrity Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "686723b1-a96d-11e9-b4b2-94659cf754d0", 
+                    "label": "Integrity Type", 
+                    "node_id": "2bf51235-943c-11e8-97ea-94659cf754d0", 
+                    "sortorder": null, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 }, 
@@ -827,91 +884,17 @@
                     "widget_id": "10000000-0000-0000-0000-000000000012"
                 }, 
                 {
-                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Start Date of Existence", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "31bf9d78-943c-11e8-8ba5-94659cf754d0", 
-                    "label": "Start Date of Existence", 
-                    "node_id": "31bf9d77-943c-11e8-a434-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
+                    "card_id": "2bf5122e-943c-11e8-9413-94659cf754d0", 
                     "config": {
                         "defaultValue": "", 
-                        "label": "Source of Identifier", 
+                        "label": "Evaluation Criteria Type", 
                         "options": [], 
-                        "placeholder": "Select the source of the indentifier"
-                    }, 
-                    "id": "0077cd03-943c-11e8-a105-94659cf754d0", 
-                    "label": "Source of Identifier", 
-                    "node_id": "0077cd00-943c-11e8-b4ca-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000015"
-                }, 
-                {
-                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "End Date Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "393e8c52-11c9-4163-8670-8680c895e8f3", 
-                                "id": "9697e0bd-15ea-476f-94fb-092a351418d9", 
-                                "sortorder": "", 
-                                "text": "Death Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "edf1336f-df77-48ad-a992-a27111031404", 
-                                "id": "6449c50e-289c-425d-aac1-50e2ce070100", 
-                                "sortorder": "", 
-                                "text": "Demolition Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0af60c1e-947c-4e9b-80ce-96a8d76ebf5b", 
-                                "id": "f21fd154-a96d-4b50-9fa9-dbab3c54d441", 
-                                "sortorder": "", 
-                                "text": "Destruction Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0f24c72b-c065-42b6-869f-ba107440376f", 
-                                "id": "24807451-df89-4cf1-99a2-18967b43fe40", 
-                                "sortorder": "", 
-                                "text": "Dissolution Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0f0126f2-1f26-431f-b0f3-06fcbd172162", 
-                                "id": "2195c931-95b0-4c91-9a1d-7607d56d1377", 
-                                "sortorder": "", 
-                                "text": "End Date"
-                            }
-                        ], 
                         "placeholder": "Select an option"
                     }, 
-                    "id": "31bf9d7a-943c-11e8-8357-94659cf754d0", 
-                    "label": "End Date Type", 
-                    "node_id": "31bf9d70-943c-11e8-ba58-94659cf754d0", 
-                    "sortorder": 3, 
+                    "id": "5f034511-a96d-11e9-ab8e-94659cf754d0", 
+                    "label": "Evaluation Criteria Type", 
+                    "node_id": "2bf4eb22-943c-11e8-bc7f-94659cf754d0", 
+                    "sortorder": null, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 }, 
@@ -932,124 +915,101 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 }, 
                 {
-                    "card_id": "f946d3f3-943b-11e8-ae46-94659cf754d0", 
+                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
                     "config": {
                         "defaultValue": "", 
-                        "label": "Resource Type Classification", 
+                        "label": "Ancillary Feature Cultural Period(s)", 
                         "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5db4ab60-0936-4841-b164-d4b55be9ddb5", 
-                                "id": "e675887c-23e3-4c60-9036-c7c864b4272f", 
-                                "sortorder": "1", 
-                                "text": "Building"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "033220d0-79fe-4742-8c0e-e83266d843b1", 
-                                "id": "3cf28c22-7271-4bd8-a7da-6e6c45ca4c13", 
-                                "sortorder": "2", 
-                                "text": "Structure"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3f700bb6-a858-41e0-bb48-67a0308d2997", 
-                                "id": "5d3a1585-0a65-4a4c-85dc-f894fa17ec0d", 
-                                "sortorder": "3", 
-                                "text": "Object"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "68a6772d-c431-42fa-8772-e76a14992139", 
-                                "id": "e4699732-efee-46c0-87e1-3f0a930a43db", 
-                                "sortorder": "4", 
-                                "text": "Site"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "258e6aeb-ff2b-4f18-8c82-0b593b3112ed", 
-                                "id": "acfee644-090f-4ed6-8424-df82f3560807", 
-                                "sortorder": "5", 
-                                "text": "District"
-                            }, 
                             {
                                 "children": [
                                     {
                                         "children": [], 
                                         "collector": "", 
-                                        "conceptid": "4abd862f-43be-4783-9dd0-92e0d6ee516b", 
-                                        "id": "7cd6cd34-b423-40d2-bb40-d68879b116dc", 
-                                        "sortorder": "10", 
-                                        "text": "District Potential Contributor"
+                                        "conceptid": "e4b33c2e-31c8-4819-89dd-0bd46f3c4e8a", 
+                                        "id": "dbd86244-343f-4ffd-8e53-c8a9c74d130f", 
+                                        "sortorder": "302", 
+                                        "text": "Early"
                                     }, 
                                     {
                                         "children": [], 
                                         "collector": "", 
-                                        "conceptid": "e52e931a-797e-4833-8f07-bf24c546271e", 
-                                        "id": "eb7a8bec-2a12-4f5b-a11f-9c200954fb10", 
-                                        "sortorder": "11", 
-                                        "text": "Planning District"
+                                        "conceptid": "aca5fe20-aba4-454e-a224-77b4e1379751", 
+                                        "id": "13c21698-fa98-4ff4-a2c6-aa12b3494164", 
+                                        "sortorder": "303", 
+                                        "text": "Milling Stone"
                                     }, 
                                     {
                                         "children": [], 
                                         "collector": "", 
-                                        "conceptid": "789ab887-b19e-4252-8e74-60e85c284b5c", 
-                                        "id": "c3d9af83-4af1-4554-b9e9-09fb59ca03a6", 
-                                        "sortorder": "7", 
-                                        "text": "District Contributor"
+                                        "conceptid": "c4db511f-2c60-4078-9ba0-8ebf715a3121", 
+                                        "id": "376dcdeb-09dd-43da-8ce1-ea768363fdf0", 
+                                        "sortorder": "304", 
+                                        "text": "Intermediate"
                                     }, 
                                     {
                                         "children": [], 
                                         "collector": "", 
-                                        "conceptid": "a5486051-7c1d-446c-923f-270937443b2c", 
-                                        "id": "8dfdaa13-5073-4ee8-894c-01a68c08dff0", 
-                                        "sortorder": "8", 
-                                        "text": "District Non-Contributor"
+                                        "conceptid": "e7624242-8d70-4aaf-a0a4-8601ebdb45e2", 
+                                        "id": "4515c692-2c65-40ab-acde-156576797afb", 
+                                        "sortorder": "305", 
+                                        "text": "Late"
                                     }, 
                                     {
                                         "children": [], 
                                         "collector": "", 
-                                        "conceptid": "6db901b2-2e82-4c5b-8aae-05231b938c20", 
-                                        "id": "e0229b20-46f2-44a8-9a89-85015e953d89", 
-                                        "sortorder": "9", 
-                                        "text": "District Altered Contributor"
+                                        "conceptid": "42a0c455-d3ec-49ae-8635-0bdbc3cb103a", 
+                                        "id": "cbe164b4-3358-46ce-a532-3e04da2ed294", 
+                                        "sortorder": "306", 
+                                        "text": "Spanish Colonial / Mission"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "834e1aad-5ec5-4a2e-807c-14098e54c7dc", 
+                                        "id": "b42673bc-9223-4f8c-a286-619e39bac2cd", 
+                                        "sortorder": "307", 
+                                        "text": "Mexican"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1b277d9e-0006-4556-b05c-e6bfc0f7fdbe", 
+                                        "id": "cb08fe06-dece-4064-a65e-23a729edcc73", 
+                                        "sortorder": "308", 
+                                        "text": "American"
                                     }
                                 ], 
-                                "collector": "collector", 
-                                "conceptid": "5d787426-4110-4b4f-8c9e-60be8d701013", 
-                                "sortorder": "6", 
-                                "text": "District Element"
+                                "collector": "", 
+                                "conceptid": "ae6299ad-fa18-4fc5-92ab-95880248fe66", 
+                                "id": "5d8554b5-c69c-4fbf-bd98-2835f80dcebb", 
+                                "sortorder": "301", 
+                                "text": "CULTURAL PERIODS - California"
                             }
                         ], 
-                        "placeholder": "Select an option"
+                        "placeholder": "Select zero or multiple Cultural Periods"
                     }, 
-                    "id": "f946d3f4-943b-11e8-9f5b-94659cf754d0", 
-                    "label": "Resource Type Classification", 
-                    "node_id": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
-                    "sortorder": 0, 
+                    "id": "d8b51ed9-943b-11e8-8ded-94659cf754d0", 
+                    "label": "Ancillary Feature Cultural Period(s)", 
+                    "node_id": "d8b4f7cb-943b-11e8-9345-94659cf754d0", 
+                    "sortorder": 2, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 }, 
                 {
-                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
+                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
                     "config": {
                         "dateFormat": "YYYY-MM-DD", 
                         "defaultValue": "", 
-                        "label": "End Date of Existence", 
+                        "label": "Ancillary Feature From Date", 
                         "maxDate": false, 
                         "minDate": false, 
                         "placeholder": "Enter date", 
                         "viewMode": "days"
                     }, 
-                    "id": "31bf9d7b-943c-11e8-b5cd-94659cf754d0", 
-                    "label": "End Date of Existence", 
-                    "node_id": "31bf9d72-943c-11e8-9ec9-94659cf754d0", 
-                    "sortorder": 2, 
+                    "id": "d8b51eda-943b-11e8-ba7e-94659cf754d0", 
+                    "label": "Ancillary Feature From Date", 
+                    "node_id": "d8b4f7ca-943b-11e8-a64b-94659cf754d0", 
+                    "sortorder": 3, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000004"
                 }, 
@@ -1069,20 +1029,19 @@
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 }, 
                 {
-                    "card_id": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
+                    "card_id": "2bf5ae70-943c-11e8-87c5-94659cf754d0", 
                     "config": {
                         "defaultValue": "", 
-                        "label": "External Identifier", 
-                        "maxLength": null, 
-                        "placeholder": "Enter indentifier", 
-                        "width": "100%"
+                        "label": "Eligibility Requirement Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
                     }, 
-                    "id": "0077cd02-943c-11e8-a244-94659cf754d0", 
-                    "label": "External Identifier", 
-                    "node_id": "0077a5ef-943c-11e8-8c17-94659cf754d0", 
-                    "sortorder": 0, 
+                    "id": "7b6d92af-a8e0-11e9-82de-94659cf754d0", 
+                    "label": "Eligibility Requirement Type", 
+                    "node_id": "2bf53943-943c-11e8-82e5-94659cf754d0", 
+                    "sortorder": null, 
                     "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 }, 
                 {
                     "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
@@ -1294,6 +1253,392 @@
                     "sortorder": 6, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "3b2c7cc3-943c-11e8-b12b-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Measurement Value", 
+                        "max": "", 
+                        "min": "", 
+                        "placeholder": "Enter value", 
+                        "precision": "", 
+                        "prefix": "", 
+                        "step": "", 
+                        "suffix": "", 
+                        "width": "100%"
+                    }, 
+                    "id": "3b2ca3d5-943c-11e8-9312-94659cf754d0", 
+                    "label": "Measurement Value", 
+                    "node_id": "3b2ca3d1-943c-11e8-906a-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000008"
+                }, 
+                {
+                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Ancilary Feature To Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "d8b51edb-943b-11e8-8d93-94659cf754d0", 
+                    "label": "Ancilary Feature To Date", 
+                    "node_id": "d8b4f7c9-943b-11e8-a062-94659cf754d0", 
+                    "sortorder": 4, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "3b2c7cc3-943c-11e8-b12b-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Measurement Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "2d152d1d-17e5-4fed-ac36-919f823be256", 
+                                "id": "857d8806-0e0f-4f7d-aed6-fad250ef97ea", 
+                                "sortorder": "", 
+                                "text": "breadth"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "99e96cb3-21ec-499b-9536-2ed69754d2c5", 
+                                "id": "8a3fe0fe-3c5f-4a8e-a08d-b2fe4ad95653", 
+                                "sortorder": "", 
+                                "text": "depth"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5e0124cc-c308-4fec-ab60-08a39ba1f643", 
+                                "id": "db42d2f8-d2d7-465f-b1b2-189f433a6b7c", 
+                                "sortorder": "", 
+                                "text": "height"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "8a0cf26a-2184-4af4-9df4-5ee5dc4879b0", 
+                                "id": "88f2a040-48c0-4240-a9e2-75312a6dd04d", 
+                                "sortorder": "", 
+                                "text": "length"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "26980537-8582-4bdb-8aea-38d60202face", 
+                                        "id": "5d6a0c6c-40b0-409c-a88f-3378761c5562", 
+                                        "sortorder": "", 
+                                        "text": "tonnage"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "32a94c6d-d55f-4019-9f56-3ac7934b59a3", 
+                                "id": "a9bfce58-2a2f-4c48-a8fe-88f1b24463d6", 
+                                "sortorder": "", 
+                                "text": "weight"
+                            }
+                        ], 
+                        "placeholder": "Select type"
+                    }, 
+                    "id": "3b2ca3d6-943c-11e8-b952-94659cf754d0", 
+                    "label": "Measurement Type", 
+                    "node_id": "3b2ca3d2-943c-11e8-9ca7-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Ancillary Feature Use Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "bf41125b-36de-4f67-b5ce-e081496546c3", 
+                                "id": "98fb7f40-6653-4ad8-800f-398fa8c3f976", 
+                                "sortorder": "", 
+                                "text": "Current"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9ba23d13-6c60-4d38-acae-ea76aff931a0", 
+                                "id": "f4d86944-36e8-442a-b863-d5cc206a66b0", 
+                                "sortorder": "", 
+                                "text": "Historic"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "d8b51ed7-943b-11e8-b605-94659cf754d0", 
+                    "label": "Ancillary Feature Use Type", 
+                    "node_id": "d8b51ed4-943b-11e8-a499-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000013"
+                }, 
+                {
+                    "card_id": "eeab1190-943b-11e8-89ab-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Name Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "86708338-1305-459e-9cff-7ee0db2a40e4", 
+                                "id": "ecb20ae9-a457-4011-83bf-1c936e2d6b6a", 
+                                "sortorder": "", 
+                                "text": "Alternative"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "884b086e-50a0-4524-a927-4897f0c7452b", 
+                                        "id": "11e60ad2-7dca-47ef-81ff-24561bc45cd6", 
+                                        "sortorder": "", 
+                                        "text": "California Historic Landmark"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "de9d5536-4860-4821-9419-4f66b0897c8f", 
+                                        "id": "0ad1919d-48ed-4957-9c51-6e3ec439323d", 
+                                        "sortorder": "", 
+                                        "text": "California Point of Historical Interest"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cd4c796f-73f8-4cba-8cdc-8cc069c7bcfb", 
+                                        "id": "3d2ef9d9-e2f1-4286-8922-1b153504e6f5", 
+                                        "sortorder": "", 
+                                        "text": "California Register of Historic Resources"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3a6db05d-6897-4021-a087-0d4989faaa06", 
+                                        "id": "726d46f0-5780-422d-8116-fd25e5dd5aee", 
+                                        "sortorder": "", 
+                                        "text": "Los Angeles Historic Cultural Monument"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a7bc4fa3-73d2-498b-a604-ecbc0e18bf55", 
+                                        "id": "26f8294c-98ff-452c-ac3f-a78eb430df93", 
+                                        "sortorder": "", 
+                                        "text": "Los Angeles Historic Preservation Overlay Zone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6821ec06-03a5-4773-8190-496d41564e70", 
+                                        "id": "14dfac42-ed63-4a51-aa99-d846a0e2f9cf", 
+                                        "sortorder": "", 
+                                        "text": "National Historic Landmark"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f1cece23-e8bc-4a54-93b8-2c609d915287", 
+                                        "id": "53af5a29-e5e5-4893-b5a3-432b19c10440", 
+                                        "sortorder": "", 
+                                        "text": "National Monument"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b800a93f-1429-4fee-a3b6-e1fa55e12c9b", 
+                                        "id": "f7aecc0c-9022-440f-a934-7c9456281fd1", 
+                                        "sortorder": "", 
+                                        "text": "National Register of Historic Places"
+                                    }
+                                ], 
+                                "collector": "collector", 
+                                "conceptid": "163cd597-6848-4109-a7b0-56ca98003f85", 
+                                "sortorder": "", 
+                                "text": "Designation Names"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b193cf22-36fc-4024-ae66-fb1a387c6db0", 
+                                "id": "7ad76f8c-ffae-4773-b415-899fbf2a6ffd", 
+                                "sortorder": "", 
+                                "text": "Historic"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "866e8d3b-e00a-4559-bf23-dc1812c27e1f", 
+                                "id": "81dd62d2-6701-4195-b74b-8057456bba4b", 
+                                "sortorder": "", 
+                                "text": "Primary"
+                            }
+                        ], 
+                        "placeholder": "Select a name type "
+                    }, 
+                    "id": "eeab1192-943b-11e8-b0d2-94659cf754d0", 
+                    "label": "Name Type", 
+                    "node_id": "eeab1191-943b-11e8-85d6-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "3b2c7cc3-943c-11e8-b12b-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Measurement Unit", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0e492db2-a026-4d6b-81f5-e409775be21f", 
+                                "id": "5509b823-7ace-4253-a3e5-0ebb5b976392", 
+                                "sortorder": "1", 
+                                "text": "inches"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "14923c78-a07a-478f-9d5b-d054de6d98e4", 
+                                "id": "b7611b55-55e2-4889-b923-687a89765c02", 
+                                "sortorder": "10", 
+                                "text": "meters"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ef64d304-a3c8-450a-a4cd-4462bbd00262", 
+                                "id": "928219af-a567-40c0-a9ad-8640c8afc800", 
+                                "sortorder": "11", 
+                                "text": "kilometers"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5a2383f4-10d8-41d8-8a2b-c66b4919b955", 
+                                "id": "d7a48024-8240-40b9-b8db-dce1067721fa", 
+                                "sortorder": "12", 
+                                "text": "grams"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "67ffe1c8-3399-481c-87c8-65a0b61bf868", 
+                                "id": "1064db18-7c59-4e02-9080-d1664bb3742e", 
+                                "sortorder": "13", 
+                                "text": "kilograms"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "73f04aea-6da6-4b06-aa2e-332126f3a240", 
+                                "id": "04705f94-7f76-4021-8490-12546cd323f9", 
+                                "sortorder": "2", 
+                                "text": "feet"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "00d2586d-0739-45f5-8812-993ae25a540e", 
+                                "id": "9eb07bbd-70d6-4929-8d0f-fdd2ffdbf616", 
+                                "sortorder": "3", 
+                                "text": "yards"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "bf2c2b08-9a80-4a01-b063-2cac9fb16eac", 
+                                "id": "b555a5f5-4ac5-43c9-b6f0-8582e06bd2b1", 
+                                "sortorder": "4", 
+                                "text": "miles"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "a65d1d4a-04b9-4ae5-9ee6-be8cba3da3f0", 
+                                "id": "fda6e884-8eae-4c13-8490-1ff30b6c8246", 
+                                "sortorder": "5", 
+                                "text": "ounces"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ce8628de-2c44-48ca-a2ee-40375a27c5d5", 
+                                "id": "b9214765-3e1f-4a25-a57e-dfb8af66ad6d", 
+                                "sortorder": "6", 
+                                "text": "pounds"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "701743e7-595b-4a8b-9576-3d46fa52b14c", 
+                                "id": "ccd30536-474c-496b-a617-538750c5a714", 
+                                "sortorder": "7", 
+                                "text": "tons"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "a048b03a-f279-454b-baa3-253891cf47bb", 
+                                "id": "bd87e569-754e-4738-ad22-887be1feb92b", 
+                                "sortorder": "8", 
+                                "text": "millimeters"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5884d60d-1b8c-40fc-99c8-055bca602fa7", 
+                                "id": "41722438-4e84-45ed-a3b5-f12e04dcfd5c", 
+                                "sortorder": "9", 
+                                "text": "centimeters"
+                            }
+                        ], 
+                        "placeholder": "Select unit"
+                    }, 
+                    "id": "3b2ca3d7-943c-11e8-8d53-94659cf754d0", 
+                    "label": "Measurement Unit", 
+                    "node_id": "3b2ca3d4-943c-11e8-ba3c-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Date Condition Assessed", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "e0e7343c-943b-11e8-8f8d-94659cf754d0", 
+                    "label": "Date Condition Assessed", 
+                    "node_id": "e0e73430-943b-11e8-b7b1-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
                 }, 
                 {
                     "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
@@ -1539,6 +1884,706 @@
                     "sortorder": 5, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "2bf5123a-943c-11e8-afa6-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Reasons", 
+                        "maxLength": null, 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "639417d0-a96d-11e9-b753-94659cf754d0", 
+                    "label": "Reasons", 
+                    "node_id": "2bf51238-943c-11e8-9189-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }, 
+                {
+                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Ancillary Feature Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d60111e0-5238-40b0-a7a3-9f3c98d48761", 
+                                "id": "e5a395d3-ce0e-4772-aa83-a8ee1c9ea98e", 
+                                "sortorder": "", 
+                                "text": "Ancillary Building"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "e2c31776-7df1-479e-bc25-c396d6023a71", 
+                                "id": "efbace5d-53e5-48cb-ae1b-f44e03b210ec", 
+                                "sortorder": "", 
+                                "text": "Art"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "003cdc06-5ab5-4335-85d7-dc9e0fb1ab24", 
+                                "id": "858ee54a-3d40-42e9-b52e-140851a1a4b2", 
+                                "sortorder": "", 
+                                "text": "Barn"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5f26ada7-70d9-40a8-b9bb-ef5666db5f28", 
+                                "id": "74a29b86-c62c-48cb-974f-41daf571b61b", 
+                                "sortorder": "", 
+                                "text": "Carriage House"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "1805e84e-07df-48fb-ab6d-d552c0733905", 
+                                "id": "ea8ebc85-c71d-4aa2-ac5d-283a476ebbcf", 
+                                "sortorder": "", 
+                                "text": "Fence, Perimeter"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3842f87a-1b94-48ce-abe4-6632521a244e", 
+                                "id": "cbd5b635-8387-44ff-822d-bb8e43f93ec5", 
+                                "sortorder": "", 
+                                "text": "Fountain"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ba05a1f7-c9cb-400b-9e59-19342f6bf795", 
+                                "id": "4478cdad-5c19-480a-8960-6e980e487f5b", 
+                                "sortorder": "", 
+                                "text": "Garage, Detached"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "6b430629-ac8d-40f1-a5a8-0fb1cfbd88a3", 
+                                "id": "4c811862-a10b-48a3-be6d-653709cd4ff3", 
+                                "sortorder": "", 
+                                "text": "Garden"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b546c145-cf70-4a9c-8b63-5e73a4442852", 
+                                "id": "7657425e-87e9-463e-aa3a-5f1a1461f231", 
+                                "sortorder": "", 
+                                "text": "Historic tree(s)"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "bb1b86b3-7287-47d1-be2c-f90281baf4ff", 
+                                "id": "e129161a-3c96-4b6c-b1da-afdd25b91aeb", 
+                                "sortorder": "", 
+                                "text": "Landscape, Designed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5f96abad-3472-4ee1-8530-62d1940cd1be", 
+                                "id": "f3866c39-2c24-48b3-8795-8a65173bf265", 
+                                "sortorder": "", 
+                                "text": "Lawn"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d7acf149-052b-4586-b1c8-4c2516837598", 
+                                "id": "a7628642-d9a7-49d2-84fd-0912b3c526d4", 
+                                "sortorder": "", 
+                                "text": "Mature vegetation"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "39096be2-5108-46c6-9258-c6b60cdf8584", 
+                                "id": "aa1da8db-c8a2-4b01-91a6-470e75949dd3", 
+                                "sortorder": "", 
+                                "text": "Mural"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "845d4184-9db7-4976-89fd-fa9fd048fae3", 
+                                "id": "662c4fae-89ed-401c-aa61-3e9d25c96e0a", 
+                                "sortorder": "", 
+                                "text": "Parking Lot"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "afad0e1c-5861-4adf-864c-bf4dc0ac39d7", 
+                                "id": "1cf68304-8538-4f25-b465-c88423ea6de4", 
+                                "sortorder": "", 
+                                "text": "Pergola"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "18aad1e6-0464-41bb-92db-ea189861eac3", 
+                                "id": "545d9a25-a018-4cfa-a036-a0b6dcd2ef7b", 
+                                "sortorder": "", 
+                                "text": "Pond/lake"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "438ccb51-8186-4045-a232-a647d4473067", 
+                                "id": "73295b67-1af6-4359-ac6b-305b85fbc677", 
+                                "sortorder": "", 
+                                "text": "Sculpture"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "c0aa48d3-7405-4674-9ada-1546c5b9f1d0", 
+                                "id": "f481ecb9-1d09-4780-89d4-6c769d366650", 
+                                "sortorder": "", 
+                                "text": "Shed, Storage"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "783c6a82-d4f0-49c9-acd8-13b222fe389e", 
+                                "id": "46293817-2fd1-40e3-a994-693512e3d33d", 
+                                "sortorder": "", 
+                                "text": "Signage"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "c53617b7-91a7-4810-86e2-9fe5f1f014e0", 
+                                "id": "78d0c00c-08b4-4051-8b30-9f2cc31aaf7e", 
+                                "sortorder": "", 
+                                "text": "Steps, Concrete"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "c5d8c95e-7bb0-4668-a782-fe35e51e141e", 
+                                "id": "9f17c461-1ead-4651-ba86-fdb3142d9da5", 
+                                "sortorder": "", 
+                                "text": "Steps, Wood"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "36710495-83bc-4657-9132-c3477ccb17b4", 
+                                "id": "97067ed2-56cf-4b2e-be0e-3cc508a52316", 
+                                "sortorder": "", 
+                                "text": "Streetlight, Parkway"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d7a75e3f-2984-4f9b-a6fd-fcd8e21a061e", 
+                                "id": "93627470-0522-444d-b968-4607718431a2", 
+                                "sortorder": "", 
+                                "text": "Swimming Pool"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ed64777d-c5b6-437a-970d-5be4e554e691", 
+                                "id": "806696f3-1178-43cb-b73a-c29fa21a5dc8", 
+                                "sortorder": "", 
+                                "text": "Tennis Court"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0ce01858-6f1b-4296-8cff-36fcd642384e", 
+                                "id": "7d306aa9-7070-4aed-ae6b-90195ed9ceb7", 
+                                "sortorder": "", 
+                                "text": "Tree, Historic"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "94acf3c8-1682-4a9b-b6c1-deb6b42bfa90", 
+                                "id": "ad27e990-7c47-48cf-952b-8b58f1c8dd99", 
+                                "sortorder": "", 
+                                "text": "Walkway"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "17c3455e-755f-4bc5-9192-18b41cc3e460", 
+                                "id": "62c86421-0dfd-4599-98d5-2979d56cb6f8", 
+                                "sortorder": "", 
+                                "text": "Wall, Perimeter"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "7c6fc21b-0a87-4303-8e0b-e1bffb54311f", 
+                                "id": "2306acbc-0f53-4729-af3a-b334a0f92307", 
+                                "sortorder": "", 
+                                "text": "Wall, Retaining"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "d8b51ed8-943b-11e8-ad6d-94659cf754d0", 
+                    "label": "Ancillary Feature Type", 
+                    "node_id": "d8b51ed5-943b-11e8-88c1-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "1d8a949d-943c-11e8-9b61-94659cf754d0", 
+                    "config": {
+                        "basemap": "streets", 
+                        "bearing": 0, 
+                        "centerX": 114.18901637599998, 
+                        "centerY": 4.214945686958913, 
+                        "defaultValue": "", 
+                        "defaultValueType": 0, 
+                        "featureColor": "rgba(255,197,61,1)", 
+                        "featureLineWidth": 1, 
+                        "featurePointSize": 3, 
+                        "geocodePlaceholder": "Search", 
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
+                        "geocoderVisible": true, 
+                        "geometryTypes": [
+                            {
+                                "id": "Point", 
+                                "text": "Point"
+                            }, 
+                            {
+                                "id": "Line", 
+                                "text": "Line"
+                            }, 
+                            {
+                                "id": "Polygon", 
+                                "text": "Polygon"
+                            }
+                        ], 
+                        "label": "Spatial Coordinates Geometry", 
+                        "maxZoom": 20, 
+                        "minZoom": 0, 
+                        "overlayConfigs": [], 
+                        "overlayOpacity": 0, 
+                        "pitch": 0, 
+                        "rerender": true, 
+                        "zoom": 0
+                    }, 
+                    "id": "c5bbd503-cbfa-11e8-9b34-027f111c8e34", 
+                    "label": "Spatial Coordinates Geometry", 
+                    "node_id": "1d8a949b-943c-11e8-af7a-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000007"
+                }, 
+                {
+                    "card_id": "1d8a9494-943c-11e8-870f-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Place Description", 
+                        "maxLength": null, 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "4edd3610-aa70-11e9-9e24-94659cf754d0", 
+                    "label": "Place Description", 
+                    "node_id": "1d8abb9e-943c-11e8-8187-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }, 
+                {
+                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Start Date Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "226bb292-4def-484f-8c6b-6eab8dd48c03", 
+                                "id": "73e5204c-0635-478b-a369-91d5cde5c68f", 
+                                "sortorder": "", 
+                                "text": "Birth Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "cf3683e1-6969-47b4-8cda-c61753819ec7", 
+                                "id": "29adbea8-891a-44bf-b0c5-8912d118f629", 
+                                "sortorder": "", 
+                                "text": "Built Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "11303e6e-9ea1-4b4c-8e2d-c0fa7c9db390", 
+                                "id": "cf4d3fee-1c66-499c-a087-13eb3a069807", 
+                                "sortorder": "", 
+                                "text": "Creation Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0560b41b-123e-413b-ac75-eeb09d7b9de7", 
+                                "id": "af52d238-b9ce-47bd-ba71-585d007d090b", 
+                                "sortorder": "", 
+                                "text": "Formation Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9963003a-f6ae-4792-ad5d-44e4b04da1ea", 
+                                "id": "af8e248f-28c9-4c97-b57b-add942b8e009", 
+                                "sortorder": "", 
+                                "text": "Start Date"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "31bf9d79-943c-11e8-9150-94659cf754d0", 
+                    "label": "Start Date Type", 
+                    "node_id": "31bf9d74-943c-11e8-ae1b-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "f946d3f3-943b-11e8-ae46-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Resource Type Classification", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5db4ab60-0936-4841-b164-d4b55be9ddb5", 
+                                "id": "e675887c-23e3-4c60-9036-c7c864b4272f", 
+                                "sortorder": "1", 
+                                "text": "Building"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "033220d0-79fe-4742-8c0e-e83266d843b1", 
+                                "id": "3cf28c22-7271-4bd8-a7da-6e6c45ca4c13", 
+                                "sortorder": "2", 
+                                "text": "Structure"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3f700bb6-a858-41e0-bb48-67a0308d2997", 
+                                "id": "5d3a1585-0a65-4a4c-85dc-f894fa17ec0d", 
+                                "sortorder": "3", 
+                                "text": "Object"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "68a6772d-c431-42fa-8772-e76a14992139", 
+                                "id": "e4699732-efee-46c0-87e1-3f0a930a43db", 
+                                "sortorder": "4", 
+                                "text": "Site"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "258e6aeb-ff2b-4f18-8c82-0b593b3112ed", 
+                                "id": "acfee644-090f-4ed6-8424-df82f3560807", 
+                                "sortorder": "5", 
+                                "text": "District"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4abd862f-43be-4783-9dd0-92e0d6ee516b", 
+                                        "id": "7cd6cd34-b423-40d2-bb40-d68879b116dc", 
+                                        "sortorder": "10", 
+                                        "text": "District Potential Contributor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e52e931a-797e-4833-8f07-bf24c546271e", 
+                                        "id": "eb7a8bec-2a12-4f5b-a11f-9c200954fb10", 
+                                        "sortorder": "11", 
+                                        "text": "Planning District"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "789ab887-b19e-4252-8e74-60e85c284b5c", 
+                                        "id": "c3d9af83-4af1-4554-b9e9-09fb59ca03a6", 
+                                        "sortorder": "7", 
+                                        "text": "District Contributor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a5486051-7c1d-446c-923f-270937443b2c", 
+                                        "id": "8dfdaa13-5073-4ee8-894c-01a68c08dff0", 
+                                        "sortorder": "8", 
+                                        "text": "District Non-Contributor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6db901b2-2e82-4c5b-8aae-05231b938c20", 
+                                        "id": "e0229b20-46f2-44a8-9a89-85015e953d89", 
+                                        "sortorder": "9", 
+                                        "text": "District Altered Contributor"
+                                    }
+                                ], 
+                                "collector": "collector", 
+                                "conceptid": "5d787426-4110-4b4f-8c9e-60be8d701013", 
+                                "sortorder": "6", 
+                                "text": "District Element"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "f946d3f4-943b-11e8-9f5b-94659cf754d0", 
+                    "label": "Resource Type Classification", 
+                    "node_id": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "End Date Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "393e8c52-11c9-4163-8670-8680c895e8f3", 
+                                "id": "9697e0bd-15ea-476f-94fb-092a351418d9", 
+                                "sortorder": "", 
+                                "text": "Death Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "edf1336f-df77-48ad-a992-a27111031404", 
+                                "id": "6449c50e-289c-425d-aac1-50e2ce070100", 
+                                "sortorder": "", 
+                                "text": "Demolition Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0af60c1e-947c-4e9b-80ce-96a8d76ebf5b", 
+                                "id": "f21fd154-a96d-4b50-9fa9-dbab3c54d441", 
+                                "sortorder": "", 
+                                "text": "Destruction Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0f24c72b-c065-42b6-869f-ba107440376f", 
+                                "id": "24807451-df89-4cf1-99a2-18967b43fe40", 
+                                "sortorder": "", 
+                                "text": "Dissolution Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0f0126f2-1f26-431f-b0f3-06fcbd172162", 
+                                "id": "2195c931-95b0-4c91-9a1d-7607d56d1377", 
+                                "sortorder": "", 
+                                "text": "End Date"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "31bf9d7a-943c-11e8-8357-94659cf754d0", 
+                    "label": "End Date Type", 
+                    "node_id": "31bf9d70-943c-11e8-ba58-94659cf754d0", 
+                    "sortorder": 3, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Type of Identifier", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "21ab0b62-809b-47da-a48c-ab1cd13f0db2", 
+                                "id": "d796303e-5075-4a57-ad9c-226775cf1f4f", 
+                                "sortorder": "", 
+                                "text": "ARK"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "72d3b085-2d10-4f9e-8697-20744299bacf", 
+                                "id": "61bc441a-dad2-4cdb-9c9b-f0112c352731", 
+                                "sortorder": "", 
+                                "text": "DOI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "818b9221-78f2-4c25-84cf-686c21eff8e3", 
+                                "id": "24bcc5d3-ba51-42bd-a9c6-44d5bd6ed681", 
+                                "sortorder": "", 
+                                "text": "HANDLE"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "7ca60d3f-6f3c-4d19-8914-e5800fb805ca", 
+                                "id": "5c340034-fa93-4131-ade8-f670da714bad", 
+                                "sortorder": "", 
+                                "text": "ISBN"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "01251c2a-8e5a-49e5-a389-20b4637c4c76", 
+                                "id": "c8d1e199-ccfc-4882-b551-8d85c37c04e6", 
+                                "sortorder": "", 
+                                "text": "ISSN"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "67b17fc8-d205-471b-bdf5-a361f032e545", 
+                                "id": "77569746-6bf0-4c73-949d-496115fc9cea", 
+                                "sortorder": "", 
+                                "text": "POI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "02c09240-a9a3-4cd5-98cd-c2fbafc9173b", 
+                                "id": "fb795aad-a09c-4fd0-87ce-3012c2f3d631", 
+                                "sortorder": "", 
+                                "text": "PURL"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0a4ce957-d837-4595-8320-8d142af864ab", 
+                                "id": "acab77ad-dbee-4448-8ce9-8e7dd2ec1651", 
+                                "sortorder": "", 
+                                "text": "SICI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "eaa19556-fcfa-40c8-9696-0d89804ad895", 
+                                "id": "f39679be-899b-4472-9484-df377e43d776", 
+                                "sortorder": "", 
+                                "text": "URI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d8f00076-3b8e-4984-8ab9-152cc21ebc40", 
+                                "id": "763105f1-757f-431b-90ff-a0511d2ba900", 
+                                "sortorder": "", 
+                                "text": "URL"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ec9e80e3-ae93-4aed-97a6-f61b0f93da43", 
+                                "id": "b411a4a6-1db0-4745-a67a-e74cf586193e", 
+                                "sortorder": "", 
+                                "text": "URN"
+                            }
+                        ], 
+                        "placeholder": "Select the type of identifier"
+                    }, 
+                    "id": "0077cd04-943c-11e8-b5e0-94659cf754d0", 
+                    "label": "Type of Identifier", 
+                    "node_id": "0077cd01-943c-11e8-b7df-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000009"
+                }, 
+                {
+                    "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Condition", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "16a462cb-cf4c-4959-8991-8d46c041dd6c", 
+                                "id": "5c459cec-0e3f-4f5f-99e5-e4608530508b", 
+                                "sortorder": "1", 
+                                "text": "good"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "863baf30-f9c1-4762-a1fc-57d400294bb4", 
+                                "id": "44dbe54e-0bf2-4ee9-9ae1-ad7ddd0a53a6", 
+                                "sortorder": "2", 
+                                "text": "fair"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3bcf52dc-f8c8-4cb3-9240-44abb7d11c94", 
+                                "id": "4e4e7fbf-d0f6-4f86-8005-b1b52de0aa14", 
+                                "sortorder": "3", 
+                                "text": "poor"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b33f47c0-f0db-4c79-bc71-deae8813e2ce", 
+                                "id": "6df218a4-1056-4c7d-8519-b013a80384c4", 
+                                "sortorder": "4", 
+                                "text": "very bad"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "e0e7343a-943b-11e8-b922-94659cf754d0", 
+                    "label": "Condition", 
+                    "node_id": "e0e73437-943b-11e8-a165-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000009"
+                }, 
+                {
+                    "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
+                    "config": {
+                        "acceptedFiles": "", 
+                        "label": "Images or Documents", 
+                        "maxFilesize": "200", 
+                        "rerender": true
+                    }, 
+                    "id": "e0e7343b-943b-11e8-9fa5-94659cf754d0", 
+                    "label": "Images or Documents", 
+                    "node_id": "e0e73432-943b-11e8-b76c-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000019"
                 }, 
                 {
                     "card_id": "13e455c3-943c-11e8-8297-94659cf754d0", 
@@ -9019,972 +10064,6 @@
                     "sortorder": 0, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "3676e3f1-943c-11e8-8ebd-94659cf754d0", 
-                    "config": {
-                        "label": "Description", 
-                        "placeholder": "Enter text", 
-                        "width": "100%"
-                    }, 
-                    "id": "3676e3f4-943c-11e8-ae12-94659cf754d0", 
-                    "label": "Description", 
-                    "node_id": "3676e3f3-943c-11e8-b62a-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000005"
-                }, 
-                {
-                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature Use Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "bf41125b-36de-4f67-b5ce-e081496546c3", 
-                                "id": "98fb7f40-6653-4ad8-800f-398fa8c3f976", 
-                                "sortorder": "", 
-                                "text": "Current"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9ba23d13-6c60-4d38-acae-ea76aff931a0", 
-                                "id": "f4d86944-36e8-442a-b863-d5cc206a66b0", 
-                                "sortorder": "", 
-                                "text": "Historic"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "d8b51ed7-943b-11e8-b605-94659cf754d0", 
-                    "label": "Ancillary Feature Use Type", 
-                    "node_id": "d8b51ed4-943b-11e8-a499-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000013"
-                }, 
-                {
-                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d60111e0-5238-40b0-a7a3-9f3c98d48761", 
-                                "id": "e5a395d3-ce0e-4772-aa83-a8ee1c9ea98e", 
-                                "sortorder": "", 
-                                "text": "Ancillary Building"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "e2c31776-7df1-479e-bc25-c396d6023a71", 
-                                "id": "efbace5d-53e5-48cb-ae1b-f44e03b210ec", 
-                                "sortorder": "", 
-                                "text": "Art"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "003cdc06-5ab5-4335-85d7-dc9e0fb1ab24", 
-                                "id": "858ee54a-3d40-42e9-b52e-140851a1a4b2", 
-                                "sortorder": "", 
-                                "text": "Barn"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5f26ada7-70d9-40a8-b9bb-ef5666db5f28", 
-                                "id": "74a29b86-c62c-48cb-974f-41daf571b61b", 
-                                "sortorder": "", 
-                                "text": "Carriage House"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "1805e84e-07df-48fb-ab6d-d552c0733905", 
-                                "id": "ea8ebc85-c71d-4aa2-ac5d-283a476ebbcf", 
-                                "sortorder": "", 
-                                "text": "Fence, Perimeter"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3842f87a-1b94-48ce-abe4-6632521a244e", 
-                                "id": "cbd5b635-8387-44ff-822d-bb8e43f93ec5", 
-                                "sortorder": "", 
-                                "text": "Fountain"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ba05a1f7-c9cb-400b-9e59-19342f6bf795", 
-                                "id": "4478cdad-5c19-480a-8960-6e980e487f5b", 
-                                "sortorder": "", 
-                                "text": "Garage, Detached"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "6b430629-ac8d-40f1-a5a8-0fb1cfbd88a3", 
-                                "id": "4c811862-a10b-48a3-be6d-653709cd4ff3", 
-                                "sortorder": "", 
-                                "text": "Garden"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b546c145-cf70-4a9c-8b63-5e73a4442852", 
-                                "id": "7657425e-87e9-463e-aa3a-5f1a1461f231", 
-                                "sortorder": "", 
-                                "text": "Historic tree(s)"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "bb1b86b3-7287-47d1-be2c-f90281baf4ff", 
-                                "id": "e129161a-3c96-4b6c-b1da-afdd25b91aeb", 
-                                "sortorder": "", 
-                                "text": "Landscape, Designed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5f96abad-3472-4ee1-8530-62d1940cd1be", 
-                                "id": "f3866c39-2c24-48b3-8795-8a65173bf265", 
-                                "sortorder": "", 
-                                "text": "Lawn"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d7acf149-052b-4586-b1c8-4c2516837598", 
-                                "id": "a7628642-d9a7-49d2-84fd-0912b3c526d4", 
-                                "sortorder": "", 
-                                "text": "Mature vegetation"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "39096be2-5108-46c6-9258-c6b60cdf8584", 
-                                "id": "aa1da8db-c8a2-4b01-91a6-470e75949dd3", 
-                                "sortorder": "", 
-                                "text": "Mural"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "845d4184-9db7-4976-89fd-fa9fd048fae3", 
-                                "id": "662c4fae-89ed-401c-aa61-3e9d25c96e0a", 
-                                "sortorder": "", 
-                                "text": "Parking Lot"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "afad0e1c-5861-4adf-864c-bf4dc0ac39d7", 
-                                "id": "1cf68304-8538-4f25-b465-c88423ea6de4", 
-                                "sortorder": "", 
-                                "text": "Pergola"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "18aad1e6-0464-41bb-92db-ea189861eac3", 
-                                "id": "545d9a25-a018-4cfa-a036-a0b6dcd2ef7b", 
-                                "sortorder": "", 
-                                "text": "Pond/lake"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "438ccb51-8186-4045-a232-a647d4473067", 
-                                "id": "73295b67-1af6-4359-ac6b-305b85fbc677", 
-                                "sortorder": "", 
-                                "text": "Sculpture"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "c0aa48d3-7405-4674-9ada-1546c5b9f1d0", 
-                                "id": "f481ecb9-1d09-4780-89d4-6c769d366650", 
-                                "sortorder": "", 
-                                "text": "Shed, Storage"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "783c6a82-d4f0-49c9-acd8-13b222fe389e", 
-                                "id": "46293817-2fd1-40e3-a994-693512e3d33d", 
-                                "sortorder": "", 
-                                "text": "Signage"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "c53617b7-91a7-4810-86e2-9fe5f1f014e0", 
-                                "id": "78d0c00c-08b4-4051-8b30-9f2cc31aaf7e", 
-                                "sortorder": "", 
-                                "text": "Steps, Concrete"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "c5d8c95e-7bb0-4668-a782-fe35e51e141e", 
-                                "id": "9f17c461-1ead-4651-ba86-fdb3142d9da5", 
-                                "sortorder": "", 
-                                "text": "Steps, Wood"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "36710495-83bc-4657-9132-c3477ccb17b4", 
-                                "id": "97067ed2-56cf-4b2e-be0e-3cc508a52316", 
-                                "sortorder": "", 
-                                "text": "Streetlight, Parkway"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d7a75e3f-2984-4f9b-a6fd-fcd8e21a061e", 
-                                "id": "93627470-0522-444d-b968-4607718431a2", 
-                                "sortorder": "", 
-                                "text": "Swimming Pool"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ed64777d-c5b6-437a-970d-5be4e554e691", 
-                                "id": "806696f3-1178-43cb-b73a-c29fa21a5dc8", 
-                                "sortorder": "", 
-                                "text": "Tennis Court"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0ce01858-6f1b-4296-8cff-36fcd642384e", 
-                                "id": "7d306aa9-7070-4aed-ae6b-90195ed9ceb7", 
-                                "sortorder": "", 
-                                "text": "Tree, Historic"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "94acf3c8-1682-4a9b-b6c1-deb6b42bfa90", 
-                                "id": "ad27e990-7c47-48cf-952b-8b58f1c8dd99", 
-                                "sortorder": "", 
-                                "text": "Walkway"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "17c3455e-755f-4bc5-9192-18b41cc3e460", 
-                                "id": "62c86421-0dfd-4599-98d5-2979d56cb6f8", 
-                                "sortorder": "", 
-                                "text": "Wall, Perimeter"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "7c6fc21b-0a87-4303-8e0b-e1bffb54311f", 
-                                "id": "2306acbc-0f53-4729-af3a-b334a0f92307", 
-                                "sortorder": "", 
-                                "text": "Wall, Retaining"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "d8b51ed8-943b-11e8-ad6d-94659cf754d0", 
-                    "label": "Ancillary Feature Type", 
-                    "node_id": "d8b51ed5-943b-11e8-88c1-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "31bf7664-943c-11e8-ad8b-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Start Date Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "226bb292-4def-484f-8c6b-6eab8dd48c03", 
-                                "id": "73e5204c-0635-478b-a369-91d5cde5c68f", 
-                                "sortorder": "", 
-                                "text": "Birth Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "cf3683e1-6969-47b4-8cda-c61753819ec7", 
-                                "id": "29adbea8-891a-44bf-b0c5-8912d118f629", 
-                                "sortorder": "", 
-                                "text": "Built Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "11303e6e-9ea1-4b4c-8e2d-c0fa7c9db390", 
-                                "id": "cf4d3fee-1c66-499c-a087-13eb3a069807", 
-                                "sortorder": "", 
-                                "text": "Creation Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0560b41b-123e-413b-ac75-eeb09d7b9de7", 
-                                "id": "af52d238-b9ce-47bd-ba71-585d007d090b", 
-                                "sortorder": "", 
-                                "text": "Formation Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9963003a-f6ae-4792-ad5d-44e4b04da1ea", 
-                                "id": "af8e248f-28c9-4c97-b57b-add942b8e009", 
-                                "sortorder": "", 
-                                "text": "Start Date"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "31bf9d79-943c-11e8-9150-94659cf754d0", 
-                    "label": "Start Date Type", 
-                    "node_id": "31bf9d74-943c-11e8-ae1b-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "1d8a949d-943c-11e8-9b61-94659cf754d0", 
-                    "config": {
-                        "basemap": "streets", 
-                        "bearing": 0, 
-                        "centerX": 114.18901637599998, 
-                        "centerY": 4.21495724756123, 
-                        "defaultValue": "", 
-                        "defaultValueType": 0, 
-                        "featureColor": "rgba(255,197,61,1)", 
-                        "featureLineWidth": 1, 
-                        "featurePointSize": 3, 
-                        "geocodePlaceholder": "Search", 
-                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
-                        "geocoderVisible": true, 
-                        "geometryTypes": [
-                            {
-                                "id": "Point", 
-                                "text": "Point"
-                            }, 
-                            {
-                                "id": "Line", 
-                                "text": "Line"
-                            }, 
-                            {
-                                "id": "Polygon", 
-                                "text": "Polygon"
-                            }
-                        ], 
-                        "label": "Spatial Coordinates Geometry", 
-                        "maxZoom": 20, 
-                        "minZoom": 0, 
-                        "overlayConfigs": [], 
-                        "overlayOpacity": 0, 
-                        "pitch": 0, 
-                        "zoom": 0
-                    }, 
-                    "id": "c5bbd503-cbfa-11e8-9b34-027f111c8e34", 
-                    "label": "Spatial Coordinates Geometry", 
-                    "node_id": "1d8a949b-943c-11e8-af7a-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000007"
-                }, 
-                {
-                    "card_id": "eeab1190-943b-11e8-89ab-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Name Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "86708338-1305-459e-9cff-7ee0db2a40e4", 
-                                "id": "ecb20ae9-a457-4011-83bf-1c936e2d6b6a", 
-                                "sortorder": "", 
-                                "text": "Alternative"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "884b086e-50a0-4524-a927-4897f0c7452b", 
-                                        "id": "11e60ad2-7dca-47ef-81ff-24561bc45cd6", 
-                                        "sortorder": "", 
-                                        "text": "California Historic Landmark"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "de9d5536-4860-4821-9419-4f66b0897c8f", 
-                                        "id": "0ad1919d-48ed-4957-9c51-6e3ec439323d", 
-                                        "sortorder": "", 
-                                        "text": "California Point of Historical Interest"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cd4c796f-73f8-4cba-8cdc-8cc069c7bcfb", 
-                                        "id": "3d2ef9d9-e2f1-4286-8922-1b153504e6f5", 
-                                        "sortorder": "", 
-                                        "text": "California Register of Historic Resources"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3a6db05d-6897-4021-a087-0d4989faaa06", 
-                                        "id": "726d46f0-5780-422d-8116-fd25e5dd5aee", 
-                                        "sortorder": "", 
-                                        "text": "Los Angeles Historic Cultural Monument"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a7bc4fa3-73d2-498b-a604-ecbc0e18bf55", 
-                                        "id": "26f8294c-98ff-452c-ac3f-a78eb430df93", 
-                                        "sortorder": "", 
-                                        "text": "Los Angeles Historic Preservation Overlay Zone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6821ec06-03a5-4773-8190-496d41564e70", 
-                                        "id": "14dfac42-ed63-4a51-aa99-d846a0e2f9cf", 
-                                        "sortorder": "", 
-                                        "text": "National Historic Landmark"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f1cece23-e8bc-4a54-93b8-2c609d915287", 
-                                        "id": "53af5a29-e5e5-4893-b5a3-432b19c10440", 
-                                        "sortorder": "", 
-                                        "text": "National Monument"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b800a93f-1429-4fee-a3b6-e1fa55e12c9b", 
-                                        "id": "f7aecc0c-9022-440f-a934-7c9456281fd1", 
-                                        "sortorder": "", 
-                                        "text": "National Register of Historic Places"
-                                    }
-                                ], 
-                                "collector": "collector", 
-                                "conceptid": "163cd597-6848-4109-a7b0-56ca98003f85", 
-                                "sortorder": "", 
-                                "text": "Designation Names"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b193cf22-36fc-4024-ae66-fb1a387c6db0", 
-                                "id": "7ad76f8c-ffae-4773-b415-899fbf2a6ffd", 
-                                "sortorder": "", 
-                                "text": "Historic"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "866e8d3b-e00a-4559-bf23-dc1812c27e1f", 
-                                "id": "81dd62d2-6701-4195-b74b-8057456bba4b", 
-                                "sortorder": "", 
-                                "text": "Primary"
-                            }
-                        ], 
-                        "placeholder": "Select a name type "
-                    }, 
-                    "id": "eeab1192-943b-11e8-b0d2-94659cf754d0", 
-                    "label": "Name Type", 
-                    "node_id": "eeab1191-943b-11e8-85d6-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "3b2c7cc3-943c-11e8-b12b-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Measurement Unit", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0e492db2-a026-4d6b-81f5-e409775be21f", 
-                                "id": "5509b823-7ace-4253-a3e5-0ebb5b976392", 
-                                "sortorder": "1", 
-                                "text": "inches"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "14923c78-a07a-478f-9d5b-d054de6d98e4", 
-                                "id": "b7611b55-55e2-4889-b923-687a89765c02", 
-                                "sortorder": "10", 
-                                "text": "meters"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ef64d304-a3c8-450a-a4cd-4462bbd00262", 
-                                "id": "928219af-a567-40c0-a9ad-8640c8afc800", 
-                                "sortorder": "11", 
-                                "text": "kilometers"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5a2383f4-10d8-41d8-8a2b-c66b4919b955", 
-                                "id": "d7a48024-8240-40b9-b8db-dce1067721fa", 
-                                "sortorder": "12", 
-                                "text": "grams"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "67ffe1c8-3399-481c-87c8-65a0b61bf868", 
-                                "id": "1064db18-7c59-4e02-9080-d1664bb3742e", 
-                                "sortorder": "13", 
-                                "text": "kilograms"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "73f04aea-6da6-4b06-aa2e-332126f3a240", 
-                                "id": "04705f94-7f76-4021-8490-12546cd323f9", 
-                                "sortorder": "2", 
-                                "text": "feet"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "00d2586d-0739-45f5-8812-993ae25a540e", 
-                                "id": "9eb07bbd-70d6-4929-8d0f-fdd2ffdbf616", 
-                                "sortorder": "3", 
-                                "text": "yards"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "bf2c2b08-9a80-4a01-b063-2cac9fb16eac", 
-                                "id": "b555a5f5-4ac5-43c9-b6f0-8582e06bd2b1", 
-                                "sortorder": "4", 
-                                "text": "miles"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "a65d1d4a-04b9-4ae5-9ee6-be8cba3da3f0", 
-                                "id": "fda6e884-8eae-4c13-8490-1ff30b6c8246", 
-                                "sortorder": "5", 
-                                "text": "ounces"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ce8628de-2c44-48ca-a2ee-40375a27c5d5", 
-                                "id": "b9214765-3e1f-4a25-a57e-dfb8af66ad6d", 
-                                "sortorder": "6", 
-                                "text": "pounds"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "701743e7-595b-4a8b-9576-3d46fa52b14c", 
-                                "id": "ccd30536-474c-496b-a617-538750c5a714", 
-                                "sortorder": "7", 
-                                "text": "tons"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "a048b03a-f279-454b-baa3-253891cf47bb", 
-                                "id": "bd87e569-754e-4738-ad22-887be1feb92b", 
-                                "sortorder": "8", 
-                                "text": "millimeters"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5884d60d-1b8c-40fc-99c8-055bca602fa7", 
-                                "id": "41722438-4e84-45ed-a3b5-f12e04dcfd5c", 
-                                "sortorder": "9", 
-                                "text": "centimeters"
-                            }
-                        ], 
-                        "placeholder": "Select unit"
-                    }, 
-                    "id": "3b2ca3d7-943c-11e8-8d53-94659cf754d0", 
-                    "label": "Measurement Unit", 
-                    "node_id": "3b2ca3d4-943c-11e8-ba3c-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "0077a5f1-943c-11e8-9e85-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Type of Identifier", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "21ab0b62-809b-47da-a48c-ab1cd13f0db2", 
-                                "id": "d796303e-5075-4a57-ad9c-226775cf1f4f", 
-                                "sortorder": "", 
-                                "text": "ARK"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "72d3b085-2d10-4f9e-8697-20744299bacf", 
-                                "id": "61bc441a-dad2-4cdb-9c9b-f0112c352731", 
-                                "sortorder": "", 
-                                "text": "DOI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "818b9221-78f2-4c25-84cf-686c21eff8e3", 
-                                "id": "24bcc5d3-ba51-42bd-a9c6-44d5bd6ed681", 
-                                "sortorder": "", 
-                                "text": "HANDLE"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "7ca60d3f-6f3c-4d19-8914-e5800fb805ca", 
-                                "id": "5c340034-fa93-4131-ade8-f670da714bad", 
-                                "sortorder": "", 
-                                "text": "ISBN"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "01251c2a-8e5a-49e5-a389-20b4637c4c76", 
-                                "id": "c8d1e199-ccfc-4882-b551-8d85c37c04e6", 
-                                "sortorder": "", 
-                                "text": "ISSN"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "67b17fc8-d205-471b-bdf5-a361f032e545", 
-                                "id": "77569746-6bf0-4c73-949d-496115fc9cea", 
-                                "sortorder": "", 
-                                "text": "POI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "02c09240-a9a3-4cd5-98cd-c2fbafc9173b", 
-                                "id": "fb795aad-a09c-4fd0-87ce-3012c2f3d631", 
-                                "sortorder": "", 
-                                "text": "PURL"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0a4ce957-d837-4595-8320-8d142af864ab", 
-                                "id": "acab77ad-dbee-4448-8ce9-8e7dd2ec1651", 
-                                "sortorder": "", 
-                                "text": "SICI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "eaa19556-fcfa-40c8-9696-0d89804ad895", 
-                                "id": "f39679be-899b-4472-9484-df377e43d776", 
-                                "sortorder": "", 
-                                "text": "URI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d8f00076-3b8e-4984-8ab9-152cc21ebc40", 
-                                "id": "763105f1-757f-431b-90ff-a0511d2ba900", 
-                                "sortorder": "", 
-                                "text": "URL"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ec9e80e3-ae93-4aed-97a6-f61b0f93da43", 
-                                "id": "b411a4a6-1db0-4745-a67a-e74cf586193e", 
-                                "sortorder": "", 
-                                "text": "URN"
-                            }
-                        ], 
-                        "placeholder": "Select the type of identifier"
-                    }, 
-                    "id": "0077cd04-943c-11e8-b5e0-94659cf754d0", 
-                    "label": "Type of Identifier", 
-                    "node_id": "0077cd01-943c-11e8-b7df-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000009"
-                }, 
-                {
-                    "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Condition", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "16a462cb-cf4c-4959-8991-8d46c041dd6c", 
-                                "id": "5c459cec-0e3f-4f5f-99e5-e4608530508b", 
-                                "sortorder": "1", 
-                                "text": "good"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "863baf30-f9c1-4762-a1fc-57d400294bb4", 
-                                "id": "44dbe54e-0bf2-4ee9-9ae1-ad7ddd0a53a6", 
-                                "sortorder": "2", 
-                                "text": "fair"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3bcf52dc-f8c8-4cb3-9240-44abb7d11c94", 
-                                "id": "4e4e7fbf-d0f6-4f86-8005-b1b52de0aa14", 
-                                "sortorder": "3", 
-                                "text": "poor"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b33f47c0-f0db-4c79-bc71-deae8813e2ce", 
-                                "id": "6df218a4-1056-4c7d-8519-b013a80384c4", 
-                                "sortorder": "4", 
-                                "text": "very bad"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "e0e7343a-943b-11e8-b922-94659cf754d0", 
-                    "label": "Condition", 
-                    "node_id": "e0e73437-943b-11e8-a165-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000009"
-                }, 
-                {
-                    "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
-                    "config": {
-                        "acceptedFiles": "", 
-                        "label": "Images or Documents", 
-                        "maxFilesize": "200"
-                    }, 
-                    "id": "e0e7343b-943b-11e8-9fa5-94659cf754d0", 
-                    "label": "Images or Documents", 
-                    "node_id": "e0e73432-943b-11e8-b76c-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000019"
-                }, 
-                {
-                    "card_id": "e0e70d21-943b-11e8-92da-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Date Condition Assessed", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "e0e7343c-943b-11e8-8f8d-94659cf754d0", 
-                    "label": "Date Condition Assessed", 
-                    "node_id": "e0e73430-943b-11e8-b7b1-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "3b2c7cc3-943c-11e8-b12b-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Measurement Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "2d152d1d-17e5-4fed-ac36-919f823be256", 
-                                "id": "857d8806-0e0f-4f7d-aed6-fad250ef97ea", 
-                                "sortorder": "", 
-                                "text": "breadth"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "99e96cb3-21ec-499b-9536-2ed69754d2c5", 
-                                "id": "8a3fe0fe-3c5f-4a8e-a08d-b2fe4ad95653", 
-                                "sortorder": "", 
-                                "text": "depth"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5e0124cc-c308-4fec-ab60-08a39ba1f643", 
-                                "id": "db42d2f8-d2d7-465f-b1b2-189f433a6b7c", 
-                                "sortorder": "", 
-                                "text": "height"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "8a0cf26a-2184-4af4-9df4-5ee5dc4879b0", 
-                                "id": "88f2a040-48c0-4240-a9e2-75312a6dd04d", 
-                                "sortorder": "", 
-                                "text": "length"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "26980537-8582-4bdb-8aea-38d60202face", 
-                                        "id": "5d6a0c6c-40b0-409c-a88f-3378761c5562", 
-                                        "sortorder": "", 
-                                        "text": "tonnage"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "32a94c6d-d55f-4019-9f56-3ac7934b59a3", 
-                                "id": "a9bfce58-2a2f-4c48-a8fe-88f1b24463d6", 
-                                "sortorder": "", 
-                                "text": "weight"
-                            }
-                        ], 
-                        "placeholder": "Select type"
-                    }, 
-                    "id": "3b2ca3d6-943c-11e8-b952-94659cf754d0", 
-                    "label": "Measurement Type", 
-                    "node_id": "3b2ca3d2-943c-11e8-9ca7-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature Cultural Period(s)", 
-                        "options": [
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e4b33c2e-31c8-4819-89dd-0bd46f3c4e8a", 
-                                        "id": "dbd86244-343f-4ffd-8e53-c8a9c74d130f", 
-                                        "sortorder": "302", 
-                                        "text": "Early"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "aca5fe20-aba4-454e-a224-77b4e1379751", 
-                                        "id": "13c21698-fa98-4ff4-a2c6-aa12b3494164", 
-                                        "sortorder": "303", 
-                                        "text": "Milling Stone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c4db511f-2c60-4078-9ba0-8ebf715a3121", 
-                                        "id": "376dcdeb-09dd-43da-8ce1-ea768363fdf0", 
-                                        "sortorder": "304", 
-                                        "text": "Intermediate"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e7624242-8d70-4aaf-a0a4-8601ebdb45e2", 
-                                        "id": "4515c692-2c65-40ab-acde-156576797afb", 
-                                        "sortorder": "305", 
-                                        "text": "Late"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "42a0c455-d3ec-49ae-8635-0bdbc3cb103a", 
-                                        "id": "cbe164b4-3358-46ce-a532-3e04da2ed294", 
-                                        "sortorder": "306", 
-                                        "text": "Spanish Colonial / Mission"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "834e1aad-5ec5-4a2e-807c-14098e54c7dc", 
-                                        "id": "b42673bc-9223-4f8c-a286-619e39bac2cd", 
-                                        "sortorder": "307", 
-                                        "text": "Mexican"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1b277d9e-0006-4556-b05c-e6bfc0f7fdbe", 
-                                        "id": "cb08fe06-dece-4064-a65e-23a729edcc73", 
-                                        "sortorder": "308", 
-                                        "text": "American"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "ae6299ad-fa18-4fc5-92ab-95880248fe66", 
-                                "id": "5d8554b5-c69c-4fbf-bd98-2835f80dcebb", 
-                                "sortorder": "301", 
-                                "text": "CULTURAL PERIODS - California"
-                            }
-                        ], 
-                        "placeholder": "Select zero or multiple Cultural Periods"
-                    }, 
-                    "id": "d8b51ed9-943b-11e8-8ded-94659cf754d0", 
-                    "label": "Ancillary Feature Cultural Period(s)", 
-                    "node_id": "d8b4f7cb-943b-11e8-9345-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "d8b4d0b3-943b-11e8-981a-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Ancilary Feature To Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "d8b51edb-943b-11e8-8d93-94659cf754d0", 
-                    "label": "Ancilary Feature To Date", 
-                    "node_id": "d8b4f7c9-943b-11e8-a062-94659cf754d0", 
-                    "sortorder": 4, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
                 }
             ], 
             "color": "rgba(255,197,61,1)", 
@@ -10244,12 +10323,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "31bf9d71-943c-11e8-9382-94659cf754d0", 
-                    "edgeid": "31bfc482-943c-11e8-83c5-94659cf754d0", 
+                    "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
+                    "edgeid": "2bf84682-943c-11e8-8dbe-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
-                    "rangenode_id": "31bf9d73-943c-11e8-978d-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by", 
+                    "rangenode_id": "2bf4eb22-943c-11e8-bc7f-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10280,12 +10359,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0", 
-                    "edgeid": "1d8b09c5-943c-11e8-85b1-94659cf754d0", 
+                    "domainnode_id": "fad0563a-b8f8-11e6-84a5-026d961c88e6", 
+                    "edgeid": "13e455c5-943c-11e8-b1d5-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
-                    "rangenode_id": "1d8a9495-943c-11e8-8c3a-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
+                    "rangenode_id": "13e455c1-943c-11e8-9bea-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10307,12 +10386,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "1d8a9498-943c-11e8-8d67-94659cf754d0", 
-                    "edgeid": "1d8b09c9-943c-11e8-a138-94659cf754d0", 
+                    "domainnode_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0", 
+                    "edgeid": "1d8b09c8-943c-11e8-b622-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by", 
-                    "rangenode_id": "1d8abba2-943c-11e8-9264-94659cf754d0"
+                    "rangenode_id": "1d8a949e-943c-11e8-9845-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10595,12 +10674,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "fad0563a-b8f8-11e6-84a5-026d961c88e6", 
-                    "edgeid": "13e455c5-943c-11e8-b1d5-94659cf754d0", 
+                    "domainnode_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0", 
+                    "edgeid": "1d8b09c5-943c-11e8-85b1-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
-                    "rangenode_id": "13e455c1-943c-11e8-9bea-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "rangenode_id": "1d8a9495-943c-11e8-8c3a-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10632,20 +10711,20 @@
                 {
                     "description": null, 
                     "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "edgeid": "2bf84687-943c-11e8-9baa-94659cf754d0", 
+                    "edgeid": "2bf84686-943c-11e8-a487-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned", 
-                    "rangenode_id": "2bf53940-943c-11e8-879c-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note", 
+                    "rangenode_id": "2bf51238-943c-11e8-9189-94659cf754d0"
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0", 
-                    "edgeid": "1d8b09c8-943c-11e8-b622-94659cf754d0", 
+                    "domainnode_id": "1d8a9498-943c-11e8-8d67-94659cf754d0", 
+                    "edgeid": "1d8b09c9-943c-11e8-a138-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by", 
-                    "rangenode_id": "1d8a949e-943c-11e8-9845-94659cf754d0"
+                    "rangenode_id": "1d8abba2-943c-11e8-9264-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10658,21 +10737,21 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "31bf7662-943c-11e8-8818-94659cf754d0", 
-                    "edgeid": "31bfc480-943c-11e8-a11d-94659cf754d0", 
+                    "domainnode_id": "2bf5122f-943c-11e8-b94f-94659cf754d0", 
+                    "edgeid": "2bf84681-943c-11e8-97e2-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P115i_is_finished_by", 
-                    "rangenode_id": "31bf9d71-943c-11e8-9382-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
+                    "rangenode_id": "2bf5d580-943c-11e8-9209-94659cf754d0"
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "edgeid": "2bf84682-943c-11e8-8dbe-94659cf754d0", 
+                    "domainnode_id": "31bf9d71-943c-11e8-9382-94659cf754d0", 
+                    "edgeid": "31bfc482-943c-11e8-83c5-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by", 
-                    "rangenode_id": "2bf4eb22-943c-11e8-bc7f-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
+                    "rangenode_id": "31bf9d73-943c-11e8-978d-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10685,12 +10764,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "edgeid": "2bf84683-943c-11e8-bb50-94659cf754d0", 
+                    "domainnode_id": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
+                    "edgeid": "2bf84684-943c-11e8-8454-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
-                    "rangenode_id": "2bf5122f-943c-11e8-b94f-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
+                    "rangenode_id": "2bf5fc8f-943c-11e8-8a25-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10703,12 +10782,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "edgeid": "2bf84685-943c-11e8-bbcc-94659cf754d0", 
+                    "domainnode_id": "31bf9d76-943c-11e8-987e-94659cf754d0", 
+                    "edgeid": "31bfc486-943c-11e8-9922-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by", 
-                    "rangenode_id": "2bf51235-943c-11e8-97ea-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
+                    "rangenode_id": "31bf9d77-943c-11e8-a434-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10757,12 +10836,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "2bf5122f-943c-11e8-b94f-94659cf754d0", 
-                    "edgeid": "2bf84681-943c-11e8-97e2-94659cf754d0", 
+                    "domainnode_id": "31bf7662-943c-11e8-8818-94659cf754d0", 
+                    "edgeid": "31bfc480-943c-11e8-a11d-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
-                    "rangenode_id": "2bf5d580-943c-11e8-9209-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P115i_is_finished_by", 
+                    "rangenode_id": "31bf9d71-943c-11e8-9382-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10775,12 +10854,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
-                    "edgeid": "2bf84684-943c-11e8-8454-94659cf754d0", 
+                    "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
+                    "edgeid": "2bf84683-943c-11e8-bb50-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
-                    "rangenode_id": "2bf5fc8f-943c-11e8-8a25-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
+                    "rangenode_id": "2bf5122f-943c-11e8-b94f-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -10793,21 +10872,21 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "31bf9d76-943c-11e8-987e-94659cf754d0", 
-                    "edgeid": "31bfc486-943c-11e8-9922-94659cf754d0", 
+                    "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
+                    "edgeid": "2bf84685-943c-11e8-bbcc-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
-                    "rangenode_id": "31bf9d77-943c-11e8-a434-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by", 
+                    "rangenode_id": "2bf51235-943c-11e8-97ea-94659cf754d0"
                 }, 
                 {
                     "description": null, 
                     "domainnode_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "edgeid": "2bf84686-943c-11e8-a487-94659cf754d0", 
+                    "edgeid": "2bf84687-943c-11e8-9baa-94659cf754d0", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note", 
-                    "rangenode_id": "2bf51238-943c-11e8-9189-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned", 
+                    "rangenode_id": "2bf53940-943c-11e8-879c-94659cf754d0"
                 }
             ], 
             "functions_x_graphs": [
@@ -10829,12 +10908,12 @@
                     }, 
                     "function_id": "60000000-0000-0000-0000-000000000001", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "id": "f3c99a21-fe4e-11e8-863c-94659cf754d0"
+                    "id": "1a3ecd0f-a8ae-11e9-a7dc-94659cf754d0"
                 }
             ], 
             "graphid": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
             "iconclass": "fa fa-th", 
-            "is_editable": true, 
+            "is_editable": false, 
             "isactive": true, 
             "isresource": true, 
             "jsonldcontext": null, 
@@ -10847,7 +10926,7 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "e6802822-943b-11e8-a821-94659cf754d0", 
                     "parentnodegroup_id": null
@@ -10859,7 +10938,7 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
                     "parentnodegroup_id": null
@@ -10889,7 +10968,7 @@
                     "parentnodegroup_id": "e6802822-943b-11e8-a821-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1d8a9492-943c-11e8-bcaf-94659cf754d0", 
                     "parentnodegroup_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0"
@@ -10907,7 +10986,7 @@
                     "parentnodegroup_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1d8a949b-943c-11e8-af7a-94659cf754d0", 
                     "parentnodegroup_id": "1d8a948f-943c-11e8-ae9c-94659cf754d0"
@@ -10925,7 +11004,7 @@
                     "parentnodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "2bf4eb22-943c-11e8-bc7f-94659cf754d0", 
                     "parentnodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0"
@@ -10961,13 +11040,13 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "2bf51235-943c-11e8-97ea-94659cf754d0", 
                     "parentnodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "2bf51238-943c-11e8-9189-94659cf754d0", 
                     "parentnodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0"
@@ -10997,7 +11076,7 @@
                     "parentnodegroup_id": "d8b4f7c5-943b-11e8-93bb-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "d8b4f7c5-943b-11e8-93bb-94659cf754d0", 
                     "parentnodegroup_id": null
@@ -11101,6 +11180,24 @@
                     "sortorder": 0
                 }, 
                 {
+                    "config": {
+                        "rdmCollection": "9d24d5c2-d14b-4f3d-9761-4e1a96d214fa"
+                    }, 
+                    "datatype": "concept", 
+                    "description": "Represents a single node in a graph", 
+                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                    "is_collector": true, 
+                    "isrequired": false, 
+                    "issearchable": true, 
+                    "istopnode": false, 
+                    "name": "Status", 
+                    "nodegroup_id": "2bf53940-943c-11e8-879c-94659cf754d0", 
+                    "nodeid": "2bf53940-943c-11e8-879c-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned", 
+                    "sortorder": 0
+                }, 
+                {
                     "config": null, 
                     "datatype": "semantic", 
                     "description": "", 
@@ -11184,20 +11281,20 @@
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "9d24d5c2-d14b-4f3d-9761-4e1a96d214fa"
+                        "rdmCollection": "3f9aefea-a1c0-4e22-8d6a-604de6be1dc4"
                     }, 
                     "datatype": "concept", 
-                    "description": "Represents a single node in a graph", 
+                    "description": "", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": true, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Status", 
-                    "nodegroup_id": "2bf53940-943c-11e8-879c-94659cf754d0", 
-                    "nodeid": "2bf53940-943c-11e8-879c-94659cf754d0", 
+                    "name": "Resource Type Classification", 
+                    "nodegroup_id": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
+                    "nodeid": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
                     "sortorder": 0
                 }, 
                 {
@@ -11219,35 +11316,21 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": null, 
-                    "datatype": "semantic", 
-                    "description": "Represents a single node in a graph", 
-                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "is_collector": true, 
-                    "isrequired": false, 
-                    "issearchable": true, 
-                    "istopnode": false, 
-                    "name": "Evaluation Time Span", 
-                    "nodegroup_id": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
-                    "nodeid": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
-                    "sortorder": 0
-                }, 
-                {
-                    "config": null, 
-                    "datatype": "string", 
+                    "config": {
+                        "rdmCollection": "81db59da-2e5c-4e7a-87a2-7e425b072749"
+                    }, 
+                    "datatype": "concept", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Administrative Subdivision Name", 
-                    "nodegroup_id": "1d8a9498-943c-11e8-8d67-94659cf754d0", 
-                    "nodeid": "1d8abba2-943c-11e8-9264-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by", 
+                    "name": "Geometry Qualifier", 
+                    "nodegroup_id": "1d8a949b-943c-11e8-af7a-94659cf754d0", 
+                    "nodeid": "1d8abba1-943c-11e8-be20-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
                     "sortorder": 0
                 }, 
                 {
@@ -11305,17 +11388,17 @@
                 {
                     "config": null, 
                     "datatype": "semantic", 
-                    "description": "Represents a single node in a graph", 
+                    "description": "", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Beginning of Existence Time Span", 
+                    "name": "Beginning of Existence", 
                     "nodegroup_id": "31bf7662-943c-11e8-8818-94659cf754d0", 
-                    "nodeid": "31bf9d76-943c-11e8-987e-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
+                    "nodeid": "31bf9d75-943c-11e8-a8c8-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P116i_is_started_by", 
                     "sortorder": 0
                 }, 
                 {
@@ -11437,39 +11520,35 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": {
-                        "rdmCollection": "81db59da-2e5c-4e7a-87a2-7e425b072749"
-                    }, 
-                    "datatype": "concept", 
-                    "description": "Represents a single node in a graph", 
+                    "config": null, 
+                    "datatype": "semantic", 
+                    "description": "", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
-                    "istopnode": false, 
-                    "name": "Geometry Qualifier", 
-                    "nodegroup_id": "1d8a949b-943c-11e8-af7a-94659cf754d0", 
-                    "nodeid": "1d8abba1-943c-11e8-be20-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "istopnode": true, 
+                    "name": "Historic District", 
+                    "nodegroup_id": null, 
+                    "nodeid": "fad0563a-b8f8-11e6-84a5-026d961c88e6", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E27_Site", 
+                    "parentproperty": "", 
                     "sortorder": 0
                 }, 
                 {
-                    "config": {
-                        "rdmCollection": "fb5e737c-2008-480a-9650-7b126ff5dd6f"
-                    }, 
-                    "datatype": "concept-list", 
+                    "config": null, 
+                    "datatype": "string", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Ancillary Feature Use Type", 
-                    "nodegroup_id": "d8b4d0b1-943b-11e8-99ff-94659cf754d0", 
-                    "nodeid": "d8b51ed4-943b-11e8-a499-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned", 
+                    "name": "Administrative Subdivision Name", 
+                    "nodegroup_id": "1d8a9498-943c-11e8-8d67-94659cf754d0", 
+                    "nodeid": "1d8abba2-943c-11e8-9264-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by", 
                     "sortorder": 0
                 }, 
                 {
@@ -11572,9 +11651,9 @@
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "0522bc04-85d0-4aa6-9f93-0fc24f1a5548"
+                        "rdmCollection": null
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
@@ -11606,9 +11685,9 @@
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "74b2f2fc-7c47-4bd6-b946-3c6cbdf97bb5"
+                        "rdmCollection": null
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
@@ -11656,25 +11735,25 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "number", 
+                    "datatype": "date", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Measurement Value", 
-                    "nodegroup_id": "3b2c7cc1-943c-11e8-a774-94659cf754d0", 
-                    "nodeid": "3b2ca3d1-943c-11e8-906a-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E60_Number", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P90_has_value", 
+                    "name": "Style From Date", 
+                    "nodegroup_id": "d8b4d0b4-943b-11e8-b400-94659cf754d0", 
+                    "nodeid": "d8b4f7d0-943b-11e8-901e-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E49_Time_Appellation", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
                     "sortorder": 0
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "ff359101-00b3-4d49-bb3e-1b47f612fdea"
+                        "rdmCollection": null
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
@@ -11690,20 +11769,20 @@
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "de85aea8-36b5-4b1e-bbaa-36e3be6a9bf7"
+                        "rdmCollection": "0522bc04-85d0-4aa6-9f93-0fc24f1a5548"
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Measurement Type", 
-                    "nodegroup_id": "3b2c7cc1-943c-11e8-a774-94659cf754d0", 
-                    "nodeid": "3b2ca3d2-943c-11e8-9ca7-94659cf754d0", 
+                    "name": "Style Cultural Period", 
+                    "nodegroup_id": "d8b4d0b4-943b-11e8-b400-94659cf754d0", 
+                    "nodeid": "d8b4f7d2-943b-11e8-a13e-94659cf754d0", 
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned", 
                     "sortorder": 0
                 }, 
                 {
@@ -11790,6 +11869,38 @@
                     "nodeid": "3676e3f3-943c-11e8-b62a-94659cf754d0", 
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E62_String", 
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note", 
+                    "sortorder": 0
+                }, 
+                {
+                    "config": null, 
+                    "datatype": "semantic", 
+                    "description": "Represents a single node in a graph", 
+                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                    "is_collector": false, 
+                    "isrequired": false, 
+                    "issearchable": true, 
+                    "istopnode": false, 
+                    "name": "Condition Description Assignment", 
+                    "nodegroup_id": "e0e70d1f-943b-11e8-86e1-94659cf754d0", 
+                    "nodeid": "e0e73434-943b-11e8-91a0-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by", 
+                    "sortorder": 0
+                }, 
+                {
+                    "config": null, 
+                    "datatype": "semantic", 
+                    "description": "Represents a single node in a graph", 
+                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                    "is_collector": false, 
+                    "isrequired": false, 
+                    "issearchable": true, 
+                    "istopnode": false, 
+                    "name": "Measurement", 
+                    "nodegroup_id": "3b2c7cc1-943c-11e8-a774-94659cf754d0", 
+                    "nodeid": "3b2ca3d3-943c-11e8-8e47-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E54_Dimension", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P40_observed_dimension", 
                     "sortorder": 0
                 }, 
                 {
@@ -11926,18 +12037,18 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "file-list", 
-                    "description": "Represents a single node in a graph", 
+                    "datatype": "semantic", 
+                    "description": "", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "is_collector": false, 
+                    "is_collector": true, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Condition Image", 
-                    "nodegroup_id": "e0e70d1f-943b-11e8-86e1-94659cf754d0", 
-                    "nodeid": "e0e73432-943b-11e8-b76c-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E38_Image", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P138i_has_representation", 
+                    "name": "Evaluation Assignment", 
+                    "nodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
+                    "nodeid": "2bf51232-943c-11e8-b578-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced", 
                     "sortorder": 0
                 }, 
                 {
@@ -12061,33 +12172,33 @@
                 {
                     "config": null, 
                     "datatype": "semantic", 
-                    "description": "", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "is_collector": false, 
+                    "is_collector": true, 
                     "isrequired": false, 
                     "issearchable": true, 
-                    "istopnode": true, 
-                    "name": "Historic District", 
-                    "nodegroup_id": null, 
-                    "nodeid": "fad0563a-b8f8-11e6-84a5-026d961c88e6", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E27_Site", 
-                    "parentproperty": "", 
+                    "istopnode": false, 
+                    "name": "Evaluation Time Span", 
+                    "nodegroup_id": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
+                    "nodeid": "2bf4eb1f-943c-11e8-a5f5-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
                     "sortorder": 0
                 }, 
                 {
                     "config": null, 
                     "datatype": "semantic", 
-                    "description": "", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Beginning of Existence", 
+                    "name": "Beginning of Existence Time Span", 
                     "nodegroup_id": "31bf7662-943c-11e8-8818-94659cf754d0", 
-                    "nodeid": "31bf9d75-943c-11e8-a8c8-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P116i_is_started_by", 
+                    "nodeid": "31bf9d76-943c-11e8-987e-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
                     "sortorder": 0
                 }, 
                 {
@@ -12126,18 +12237,18 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "date", 
+                    "datatype": "number", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Style From Date", 
-                    "nodegroup_id": "d8b4d0b4-943b-11e8-b400-94659cf754d0", 
-                    "nodeid": "d8b4f7d0-943b-11e8-901e-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E49_Time_Appellation", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
+                    "name": "Measurement Value", 
+                    "nodegroup_id": "3b2c7cc1-943c-11e8-a774-94659cf754d0", 
+                    "nodeid": "3b2ca3d1-943c-11e8-906a-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E60_Number", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P90_has_value", 
                     "sortorder": 0
                 }, 
                 {
@@ -12157,19 +12268,21 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": null, 
-                    "datatype": "semantic", 
+                    "config": {
+                        "rdmCollection": "de85aea8-36b5-4b1e-bbaa-36e3be6a9bf7"
+                    }, 
+                    "datatype": "concept", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Measurement", 
+                    "name": "Measurement Type", 
                     "nodegroup_id": "3b2c7cc1-943c-11e8-a774-94659cf754d0", 
-                    "nodeid": "3b2ca3d3-943c-11e8-8e47-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E54_Dimension", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P40_observed_dimension", 
+                    "nodeid": "3b2ca3d2-943c-11e8-9ca7-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
                     "sortorder": 0
                 }, 
                 {
@@ -12311,24 +12424,6 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": {
-                        "rdmCollection": "3f9aefea-a1c0-4e22-8d6a-604de6be1dc4"
-                    }, 
-                    "datatype": "concept", 
-                    "description": "", 
-                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "is_collector": true, 
-                    "isrequired": false, 
-                    "issearchable": true, 
-                    "istopnode": false, 
-                    "name": "Resource Type Classification", 
-                    "nodegroup_id": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
-                    "nodeid": "f946d3f1-943b-11e8-9e06-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
-                    "sortorder": 0
-                }, 
-                {
                     "config": null, 
                     "datatype": "semantic", 
                     "description": "", 
@@ -12361,24 +12456,6 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": {
-                        "rdmCollection": "0522bc04-85d0-4aa6-9f93-0fc24f1a5548"
-                    }, 
-                    "datatype": "concept-list", 
-                    "description": "Represents a single node in a graph", 
-                    "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "is_collector": false, 
-                    "isrequired": false, 
-                    "issearchable": true, 
-                    "istopnode": false, 
-                    "name": "Style Cultural Period", 
-                    "nodegroup_id": "d8b4d0b4-943b-11e8-b400-94659cf754d0", 
-                    "nodeid": "d8b4f7d2-943b-11e8-a13e-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned", 
-                    "sortorder": 0
-                }, 
-                {
                     "config": null, 
                     "datatype": "semantic", 
                     "description": "", 
@@ -12396,18 +12473,18 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "semantic", 
-                    "description": "", 
+                    "datatype": "file-list", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
-                    "is_collector": true, 
+                    "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Evaluation Assignment", 
-                    "nodegroup_id": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "nodeid": "2bf51232-943c-11e8-b578-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced", 
+                    "name": "Condition Image", 
+                    "nodegroup_id": "e0e70d1f-943b-11e8-86e1-94659cf754d0", 
+                    "nodeid": "e0e73432-943b-11e8-b76c-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E38_Image", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P138i_has_representation", 
                     "sortorder": 0
                 }, 
                 {
@@ -12463,26 +12540,28 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": null, 
-                    "datatype": "semantic", 
+                    "config": {
+                        "rdmCollection": "fb5e737c-2008-480a-9650-7b126ff5dd6f"
+                    }, 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Condition Description Assignment", 
-                    "nodegroup_id": "e0e70d1f-943b-11e8-86e1-94659cf754d0", 
-                    "nodeid": "e0e73434-943b-11e8-91a0-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P140i_was_attributed_by", 
+                    "name": "Ancillary Feature Use Type", 
+                    "nodegroup_id": "d8b4d0b1-943b-11e8-99ff-94659cf754d0", 
+                    "nodeid": "d8b51ed4-943b-11e8-a499-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned", 
                     "sortorder": 0
                 }, 
                 {
                     "config": {
                         "rdmCollection": "6166c080-653f-4e7a-9a7a-9cf1a163136d"
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
@@ -12514,7 +12593,15 @@
                 }
             ], 
             "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd", 
-            "relatable_resource_model_ids": [], 
+            "relatable_resource_model_ids": [
+                "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                "f5624ce7-b66c-11e6-84a5-026d961c88e6", 
+                "3caf329f-b8f7-11e6-84a5-026d961c88e6", 
+                "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                "243f8689-b8f6-11e6-84a5-026d961c88e6", 
+                "ccbd1537-ac5e-11e6-84a5-026d961c88e6"
+            ], 
             "resource_2_resource_constraints": [], 
             "root": {
                 "config": null, 
@@ -12531,6 +12618,7 @@
                 "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E27_Site", 
                 "sortorder": 0
             }, 
+            "slug": null, 
             "subtitle": "Describes heritage resource groups which are groupings of heritage resources.", 
             "template_id": "50000000-0000-0000-0000-000000000002", 
             "version": ""

--- a/tests/fixtures/v3migration-pkg/graphs/resource_models/Historic Resource.json
+++ b/tests/fixtures/v3migration-pkg/graphs/resource_models/Historic Resource.json
@@ -23,6 +23,24 @@
                 }, 
                 {
                     "active": true, 
+                    "cardid": "1c421994-943d-11e8-862a-94659cf754d0", 
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
+                    "config": null, 
+                    "cssclass": null, 
+                    "description": "Represents a single node in a graph", 
+                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                    "helpenabled": false, 
+                    "helptext": null, 
+                    "helptitle": null, 
+                    "instructions": "Select the eligibility requirements that the resource meets.", 
+                    "is_editable": false, 
+                    "name": "Eligibility Requirements", 
+                    "nodegroup_id": "1c421992-943d-11e8-ae0a-94659cf754d0", 
+                    "sortorder": 4, 
+                    "visible": true
+                }, 
+                {
+                    "active": true, 
                     "cardid": "40609ef0-943d-11e8-86f7-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
@@ -37,24 +55,6 @@
                     "name": "Condition Assessment", 
                     "nodegroup_id": "406077e2-943d-11e8-93f7-94659cf754d0", 
                     "sortorder": null, 
-                    "visible": true
-                }, 
-                {
-                    "active": true, 
-                    "cardid": "1c41f28f-943d-11e8-ac56-94659cf754d0", 
-                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
-                    "config": null, 
-                    "cssclass": null, 
-                    "description": "Represents a single node in a graph", 
-                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "helpenabled": false, 
-                    "helptext": null, 
-                    "helptitle": null, 
-                    "instructions": "Select the type of integrity that the resource maintains. ", 
-                    "is_editable": true, 
-                    "name": "Integrity", 
-                    "nodegroup_id": "1c41f28d-943d-11e8-a0a5-94659cf754d0", 
-                    "sortorder": 3, 
                     "visible": true
                 }, 
                 {
@@ -95,20 +95,20 @@
                 }, 
                 {
                     "active": true, 
-                    "cardid": "086dce52-943d-11e8-b3f1-94659cf754d0", 
+                    "cardid": "1c41f283-943d-11e8-a265-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
-                    "description": "", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "This card ties together a Related/Acillary Features and Use Type with timeframe based on cultural period or actual dates.  For a separate combination Related/Ancillary Features and Use Type, create a separate entry.", 
+                    "instructions": "Enter the date resource was evaluated.", 
                     "is_editable": false, 
-                    "name": "Related/Ancillary Feature", 
-                    "nodegroup_id": "086dce50-943d-11e8-93c6-94659cf754d0", 
-                    "sortorder": 2, 
+                    "name": "Evaluation Date", 
+                    "nodegroup_id": "1c41f281-943d-11e8-a9dd-94659cf754d0", 
+                    "sortorder": 0, 
                     "visible": true
                 }, 
                 {
@@ -123,7 +123,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the criteria type used for evaluation.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Evaluation Criteria", 
                     "nodegroup_id": "1c41f284-943d-11e8-8ef9-94659cf754d0", 
                     "sortorder": 1, 
@@ -141,10 +141,28 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Define the period of significance that is being used for evaluation. ", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Period of Significance", 
                     "nodegroup_id": "1c41f287-943d-11e8-aa40-94659cf754d0", 
                     "sortorder": 2, 
+                    "visible": true
+                }, 
+                {
+                    "active": true, 
+                    "cardid": "0cebb552-943d-11e8-8a58-94659cf754d0", 
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
+                    "config": null, 
+                    "cssclass": null, 
+                    "description": "Describes the modification of a Heritage Resource.\n\nConnects to Heritage Resource (E18) via P12i", 
+                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                    "helpenabled": false, 
+                    "helptext": null, 
+                    "helptitle": null, 
+                    "instructions": "Describe modification or alteration to the resource.", 
+                    "is_editable": false, 
+                    "name": "Modification Event", 
+                    "nodegroup_id": "0cebb550-943d-11e8-8001-94659cf754d0", 
+                    "sortorder": null, 
                     "visible": true
                 }, 
                 {
@@ -159,7 +177,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": null, 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Evaluation", 
                     "nodegroup_id": "1c41f28a-943d-11e8-9c6d-94659cf754d0", 
                     "sortorder": null, 
@@ -167,7 +185,7 @@
                 }, 
                 {
                     "active": true, 
-                    "cardid": "1c421994-943d-11e8-862a-94659cf754d0", 
+                    "cardid": "1c41f28f-943d-11e8-ac56-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
@@ -176,11 +194,11 @@
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "Select the eligibility requirements that the resource meets.", 
-                    "is_editable": true, 
-                    "name": "Eligibility Requirements", 
-                    "nodegroup_id": "1c421992-943d-11e8-ae0a-94659cf754d0", 
-                    "sortorder": 4, 
+                    "instructions": "Select the type of integrity that the resource maintains. ", 
+                    "is_editable": false, 
+                    "name": "Integrity", 
+                    "nodegroup_id": "1c41f28d-943d-11e8-a0a5-94659cf754d0", 
+                    "sortorder": 3, 
                     "visible": true
                 }, 
                 {
@@ -213,7 +231,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Select the resource status based on the evaluation.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Status", 
                     "nodegroup_id": "1c42198f-943d-11e8-a86a-94659cf754d0", 
                     "sortorder": 5, 
@@ -231,7 +249,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Describe the reasons for the evaluated resource's status.", 
-                    "is_editable": true, 
+                    "is_editable": false, 
                     "name": "Reasons", 
                     "nodegroup_id": "1c41f290-943d-11e8-a80a-94659cf754d0", 
                     "sortorder": 6, 
@@ -249,7 +267,7 @@
                     "helptext": null, 
                     "helptitle": null, 
                     "instructions": "Capture the measurements associated to this resource.", 
-                    "is_editable": false, 
+                    "is_editable": true, 
                     "name": "Measurement", 
                     "nodegroup_id": "54188890-943d-11e8-897e-94659cf754d0", 
                     "sortorder": null, 
@@ -325,24 +343,6 @@
                     "name": "Keyword", 
                     "nodegroup_id": "4c2d1922-943d-11e8-9449-94659cf754d0", 
                     "sortorder": null, 
-                    "visible": true
-                }, 
-                {
-                    "active": true, 
-                    "cardid": "1c41f283-943d-11e8-a265-94659cf754d0", 
-                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
-                    "config": null, 
-                    "cssclass": null, 
-                    "description": "Represents a single node in a graph", 
-                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "helpenabled": false, 
-                    "helptext": null, 
-                    "helptitle": null, 
-                    "instructions": "Enter the date resource was evaluated.", 
-                    "is_editable": true, 
-                    "name": "Evaluation Date", 
-                    "nodegroup_id": "1c41f281-943d-11e8-a9dd-94659cf754d0", 
-                    "sortorder": 0, 
                     "visible": true
                 }, 
                 {
@@ -491,20 +491,20 @@
                 }, 
                 {
                     "active": true, 
-                    "cardid": "0cebb552-943d-11e8-8a58-94659cf754d0", 
+                    "cardid": "086dce52-943d-11e8-b3f1-94659cf754d0", 
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea", 
                     "config": null, 
                     "cssclass": null, 
-                    "description": "Describes the modification of a Heritage Resource.\n\nConnects to Heritage Resource (E18) via P12i", 
+                    "description": "", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "helpenabled": false, 
                     "helptext": null, 
                     "helptitle": null, 
-                    "instructions": "Describe modification or alteration to the resource.", 
+                    "instructions": "This card ties together a Related/Acillary Features and Use Type with timeframe based on cultural period or actual dates.  For a separate combination Related/Ancillary Features and Use Type, create a separate entry.", 
                     "is_editable": false, 
-                    "name": "Modification Event", 
-                    "nodegroup_id": "0cebb550-943d-11e8-8001-94659cf754d0", 
-                    "sortorder": null, 
+                    "name": "Related/Ancillary Feature", 
+                    "nodegroup_id": "086dce50-943d-11e8-93c6-94659cf754d0", 
+                    "sortorder": 2, 
                     "visible": true
                 }, 
                 {
@@ -564,951 +564,6 @@
             ], 
             "cards_x_nodes_x_widgets": [
                 {
-                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature From Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "ccb6b781-dc6e-11e8-91bd-94659cf754d0", 
-                    "label": "Ancillary Feature From Date", 
-                    "node_id": "086df561-943d-11e8-a0e0-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature Cultural Period", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "ccb86531-dc6e-11e8-9087-94659cf754d0", 
-                    "label": "Ancillary Feature Cultural Period", 
-                    "node_id": "086df562-943d-11e8-a4c9-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature Use Type", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "ccb9016f-dc6e-11e8-9aa8-94659cf754d0", 
-                    "label": "Ancillary Feature Use Type", 
-                    "node_id": "086df564-943d-11e8-9803-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Ancilary Feature To Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "ccb9c4c1-dc6e-11e8-b987-94659cf754d0", 
-                    "label": "Ancilary Feature To Date", 
-                    "node_id": "086df565-943d-11e8-86d5-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Ancillary Feature Type", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "ccba8810-dc6e-11e8-b1e7-94659cf754d0", 
-                    "label": "Ancillary Feature Type", 
-                    "node_id": "086df566-943d-11e8-ba38-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Heritage Resource Type Cultural Period", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "bcd74d1f-dc6e-11e8-9d5d-94659cf754d0", 
-                    "label": "Heritage Resource Type Cultural Period", 
-                    "node_id": "086df567-943d-11e8-a111-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Heritage Resource Type To Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "bcd97001-dc6e-11e8-8bac-94659cf754d0", 
-                    "label": "Heritage Resource Type To Date", 
-                    "node_id": "086df569-943d-11e8-ad82-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Heritage Resource Use Type", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "bcda0c41-dc6e-11e8-8c57-94659cf754d0", 
-                    "label": "Heritage Resource Use Type", 
-                    "node_id": "086df56a-943d-11e8-bb62-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Heritage Resource Type", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "bcdb1db0-dc6e-11e8-9c12-94659cf754d0", 
-                    "label": "Heritage Resource Type", 
-                    "node_id": "086df56b-943d-11e8-9f46-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Heritage Resource Type From Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "bcdbe101-dc6e-11e8-b1e3-94659cf754d0", 
-                    "label": "Heritage Resource Type From Date", 
-                    "node_id": "086df56c-943d-11e8-aecb-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Style From Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "c9737362-dc6e-11e8-a8cf-94659cf754d0", 
-                    "label": "Style From Date", 
-                    "node_id": "086df56e-943d-11e8-b150-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Style", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "c974fa01-dc6e-11e8-9731-94659cf754d0", 
-                    "label": "Style", 
-                    "node_id": "086df56f-943d-11e8-b0fe-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Style Cultural Period", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "c975bd4f-dc6e-11e8-be86-94659cf754d0", 
-                    "label": "Style Cultural Period", 
-                    "node_id": "086df570-943d-11e8-8ebb-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Style Use Type", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "c97680a2-dc6e-11e8-801e-94659cf754d0", 
-                    "label": "Style Use Type", 
-                    "node_id": "086e1c70-943d-11e8-9026-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Style To Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "c9771ce2-dc6e-11e8-94e1-94659cf754d0", 
-                    "label": "Style To Date", 
-                    "node_id": "086e1c71-943d-11e8-9185-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "0cebb552-943d-11e8-8a58-94659cf754d0", 
-                    "config": {
-                        "label": "Modification/Alteration Description", 
-                        "placeholder": "Enter text", 
-                        "width": "100%"
-                    }, 
-                    "id": "0cebdc63-943d-11e8-aa10-94659cf754d0", 
-                    "label": "Modification/Alteration Description", 
-                    "node_id": "0cebdc5e-943d-11e8-bccc-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000005"
-                }, 
-                {
-                    "card_id": "0cebb552-943d-11e8-8a58-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Modification/Alteration Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "0cebdc64-943d-11e8-bcc1-94659cf754d0", 
-                    "label": "Modification/Alteration Date", 
-                    "node_id": "0cebdc61-943d-11e8-8e54-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "0cebb552-943d-11e8-8a58-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Modification/Alteration Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "722d9ff4-c470-466c-8e96-d8037979d5ba", 
-                                "id": "496d7001-5912-48c4-b9b1-5a60d8afec27", 
-                                "sortorder": "", 
-                                "text": "Addition to primary elevation"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "2e234b26-d24a-4cf3-99f4-f8c355f8b9be", 
-                                "id": "9e416521-dc78-4690-b658-1e128ce81ec2", 
-                                "sortorder": "", 
-                                "text": "Addition to rear/side elevation"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3674c32c-d89f-45a6-bff8-eef76bee4d50", 
-                                "id": "07adc1d8-2f7a-4799-ac2b-371b593d6be6", 
-                                "sortorder": "", 
-                                "text": "Addition to upper story"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ab586613-9ec2-4a7f-931f-e4cc4633081f", 
-                                "id": "711fc7aa-7e53-4b3d-9c76-951a6bf0d020", 
-                                "sortorder": "", 
-                                "text": "Appears to be unaltered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b103fec3-bbcf-4b76-b817-42c3a769d11d", 
-                                "id": "28c9f8c7-9c5d-4d8d-8781-dc51d12a0614", 
-                                "sortorder": "", 
-                                "text": "Awnings added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "76dea51c-0f17-474c-a1d5-c5bfebecf53f", 
-                                "id": "068f4791-4845-41bd-8d09-f49769c8344e", 
-                                "sortorder": "", 
-                                "text": "Balcony added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "19fea997-ca00-4c00-a25d-25d1590b7b66", 
-                                "id": "eeea1e2e-ba3b-4007-9a40-35a78ab40115", 
-                                "sortorder": "", 
-                                "text": "Balcony altered or enclosed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9c9c5138-f4a4-459a-97fb-1e59980c2f2b", 
-                                "id": "a7fcd074-00fc-49bd-b213-e128d95ec53a", 
-                                "sortorder": "", 
-                                "text": "Brickwork/stone painted"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "4c9cb8ef-7afe-4f4b-adcc-948f6f02a6ee", 
-                                "id": "ff6dba95-bae6-4289-927d-20bfc9683a0b", 
-                                "sortorder": "", 
-                                "text": "Carport added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "8a6bd560-b494-4dab-ab91-9566dbc52d08", 
-                                "id": "7da367ed-379c-4b17-a1bb-b9b47895a215", 
-                                "sortorder": "", 
-                                "text": "Carport altered or enclosed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9c6235e2-f5f1-456c-b136-7ebb5be4dd9e", 
-                                "id": "b1ca9c93-c368-41c0-b5a8-4ef4a5eb07a0", 
-                                "sortorder": "", 
-                                "text": "Carport removed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "a3c50729-179a-4bf5-94b7-137df07b6eb5", 
-                                "id": "e84b812c-4e6d-4d97-8b18-64394c5344cb", 
-                                "sortorder": "", 
-                                "text": "Chimney altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "e7571328-ab5b-4083-8c30-66cf41ac4316", 
-                                "id": "d84e1720-027d-48a4-b947-36a6b22d9eee", 
-                                "sortorder": "", 
-                                "text": "Completely altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ece925a3-8bf6-475e-a63f-8cc30eefbe32", 
-                                "id": "df0ad63d-c926-4d32-bf7d-c600fca1d950", 
-                                "sortorder": "", 
-                                "text": "Decorative elements added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d8c9c16d-21ad-4213-9c9f-b05c9cc0eb2b", 
-                                "id": "93b76072-816e-47cd-9371-7c5d5668fe2f", 
-                                "sortorder": "", 
-                                "text": "Decorative elements removed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "66e0a7ba-bf49-4f48-b40e-1d78f45a2bd7", 
-                                "id": "97a82c25-8acc-4546-8adb-ac2b8152f0ef", 
-                                "sortorder": "", 
-                                "text": "Door (primary) opening or entrance altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "afdd437d-b7d3-430c-b71a-3173a12f9818", 
-                                "id": "76e75d2e-b9db-43b9-a114-9430f8da9b80", 
-                                "sortorder": "", 
-                                "text": "Door (primary) replaced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "1a60452a-4a58-4027-b872-f1c407ae08d8", 
-                                "id": "e06c79e4-629a-4a00-b1f9-3bd2d7f256ee", 
-                                "sortorder": "", 
-                                "text": "Door/entrance added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "7c5db7f1-e3a4-4b41-9631-39580343136d", 
-                                "id": "6e8e64cd-480a-436e-acbf-b303865a1b32", 
-                                "sortorder": "", 
-                                "text": "Exterior staircases added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "f2b24e50-4df0-452f-a1cf-9802a80829f6", 
-                                "id": "f3850419-758e-45f0-8264-d1c8f53b6fd1", 
-                                "sortorder": "", 
-                                "text": "Garage altered or replaced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "4ad2324d-20c2-40d7-b790-d768045f20e4", 
-                                "id": "eb87fd5d-3bf4-4aba-9465-1766b920280f", 
-                                "sortorder": "", 
-                                "text": "Garage door replaced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "64138cf0-9c32-4a72-834b-7b56c01b32d8", 
-                                "id": "6ca711c4-5f1f-4153-b0e9-c4ea177d055d", 
-                                "sortorder": "", 
-                                "text": "Garage postdates residence"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0f916134-f57f-46c1-93b3-e1c9ebcf1ac6", 
-                                "id": "d64c28ba-b418-4aca-ae99-1b346e74788b", 
-                                "sortorder": "", 
-                                "text": "Landscape/hardscape altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "bdbf4fd0-2233-487c-b0d4-ac65a31aae47", 
-                                "id": "18310916-7403-4f31-a8ef-600363ff4b5f", 
-                                "sortorder": "", 
-                                "text": "No major alterations"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "fb01e551-3d33-4d20-849a-7587e060f527", 
-                                "id": "7786d45a-ae12-421b-b267-994c1f82d373", 
-                                "sortorder": "", 
-                                "text": "Parapet altered or removed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "78a5445b-3086-4cbe-9a1a-c8f127f4b7aa", 
-                                "id": "42db092d-b3dd-4813-9869-99ba3db8cc46", 
-                                "sortorder": "", 
-                                "text": "Perimeter fence or wall added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "a9d3ccb1-0db7-48d2-a3c7-3d90f1d1146e", 
-                                "id": "9d114895-8a59-4cf1-bd39-34dbabfe0497", 
-                                "sortorder": "", 
-                                "text": "Porch added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "e9e11871-1b1f-489e-a38b-0ed2c1b90363", 
-                                "id": "e702213d-08ce-4078-ac3b-685112a09d94", 
-                                "sortorder": "", 
-                                "text": "Porch altered or enclosed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "30b7a498-9959-4269-96eb-800d77d9b3a1", 
-                                "id": "8f3e61e4-80f0-41ba-9318-4c8333402ea5", 
-                                "sortorder": "", 
-                                "text": "Porch rails altered or replaced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "4a6219ac-dba5-430c-9926-ed6dbfbf50c7", 
-                                "id": "37a83a92-a962-495f-9d54-28672a54a92c", 
-                                "sortorder": "", 
-                                "text": "Porch removed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "476aee69-8ca9-4960-971d-9bb0b2a6f299", 
-                                "id": "8e13bbe2-2b90-43ba-bc60-4cbe1ee3bde5", 
-                                "sortorder": "", 
-                                "text": "Porte cochere added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "e67906a5-24a4-4914-8d2f-2ba109d32a6d", 
-                                "id": "dcd817dc-64ee-48d0-be7f-44149e709876", 
-                                "sortorder": "", 
-                                "text": "Porte cochere altered or removed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "dfed084f-fe7f-45c3-84ac-80f52bd7335b", 
-                                "id": "673f762d-4444-485a-9660-bc6237518f06", 
-                                "sortorder": "", 
-                                "text": "Roof dormer added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "38653962-7965-41c7-ad45-d5e5c50c0918", 
-                                "id": "3803442d-4c31-4bd0-9f69-62f5ff512d2a", 
-                                "sortorder": "", 
-                                "text": "Roof dormer altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "153cfd84-7208-499e-9575-c131a96984fe", 
-                                "id": "38e69e10-b953-4200-8c09-7e9c0ce8736f", 
-                                "sortorder": "", 
-                                "text": "Roof replaced with incompatible materials"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9fc0b4c5-5df7-450b-93d1-3768be234f0a", 
-                                "id": "9bc61bd7-d09b-4c13-97a0-ceee3e02be46", 
-                                "sortorder": "", 
-                                "text": "Roofline altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d6cf0af7-d58e-4a24-8684-88dec3b1961a", 
-                                "id": "77b7ce4c-a645-4687-acdb-e6aec563cb40", 
-                                "sortorder": "", 
-                                "text": "Security door(s) added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "91d7c00f-4ca3-444a-9e32-8d16ffea4697", 
-                                "id": "b8ebcd34-5d07-4e93-87d9-e95ce9fda9a6", 
-                                "sortorder": "", 
-                                "text": "Security window bars added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "78f80db2-2f21-4089-9473-bb35df779c3f", 
-                                "id": "5bfa94f0-fd1b-4fe4-8217-086598188890", 
-                                "sortorder": "", 
-                                "text": "Seismic anchor plates added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "e0f8be08-2153-4574-a6b9-483a0e0c4c0f", 
-                                "id": "947a9561-b189-4fb5-9758-23d0e05f594e", 
-                                "sortorder": "", 
-                                "text": "Signage added"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b0101c83-6c3d-4627-9f64-e6e87ee7052a", 
-                                "id": "c817866f-ed07-4347-b26e-ddfa2250c317", 
-                                "sortorder": "", 
-                                "text": "Signage altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9d7434a7-598a-4d9c-b479-ad23f008d924", 
-                                "id": "d2c71e8a-4b5a-437b-b3ed-a24aba8d4b5b", 
-                                "sortorder": "", 
-                                "text": "Signage removed"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "1583eae9-7145-4148-bf64-35b744e5b13c", 
-                                "id": "43e85383-11e4-4f76-9ad4-8f00d454e298", 
-                                "sortorder": "", 
-                                "text": "Single-family converted to multi-family"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "a0f1b60a-8022-4bca-920e-3efe18901acc", 
-                                "id": "01423229-dd8b-4506-ad4d-dd914ef3c697", 
-                                "sortorder": "", 
-                                "text": "Stonework painted"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "12358bc8-0ef0-474e-a34a-93fc96eaf3ae", 
-                                "id": "3cb10e8d-15a2-4574-9f44-b62b11d2d364", 
-                                "sortorder": "", 
-                                "text": "Storefront altered or replaced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "c684bb1d-45a8-4971-8f4f-c0910216ab08", 
-                                "id": "bccaa536-01eb-452f-ada3-65b196718646", 
-                                "sortorder": "", 
-                                "text": "Unknown/not visible"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "01e9e313-04aa-4e19-bd4f-d349ec8f6afe", 
-                                "id": "063ddb6f-953f-4a3e-bf72-652d60ba050f", 
-                                "sortorder": "", 
-                                "text": "Wall cladding replaced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3b955768-3358-4f1d-96dd-7095a737778d", 
-                                "id": "8f5203c5-8ef9-4be8-941a-2362b36dc8e5", 
-                                "sortorder": "", 
-                                "text": "Window openings altered"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "6be61848-32c4-4039-b9bf-ce621c679fa7", 
-                                "id": "80e412a8-d0f2-423a-a755-05563a300450", 
-                                "sortorder": "", 
-                                "text": "Window openings infilled"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "31323cf4-4bb7-4559-a6bf-f267f086d7fd", 
-                                "id": "97a5ee2b-e899-4194-9817-d8004df3ca16", 
-                                "sortorder": "", 
-                                "text": "Windows boarded up"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "bf8c90b3-5536-422a-93fe-6873b7a437cb", 
-                                "id": "9f1f3e67-dca3-4f5e-b020-da5ac4c25c46", 
-                                "sortorder": "", 
-                                "text": "Windows replaced - all"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "458cd156-e2fa-4f1c-bbef-aa6c7c27358d", 
-                                "id": "639a237c-f79e-4831-a17d-af8773873ed2", 
-                                "sortorder": "", 
-                                "text": "Windows replaced - some"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "0cebdc65-943d-11e8-92da-94659cf754d0", 
-                    "label": "Modification/Alteration Type", 
-                    "node_id": "0cebdc62-943d-11e8-b47c-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "13e63510-943d-11e8-8bc5-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Description Type", 
-                        "options": [], 
-                        "placeholder": "Select a description type"
-                    }, 
-                    "id": "13e63514-943d-11e8-98a0-94659cf754d0", 
-                    "label": "Description Type", 
-                    "node_id": "13e63511-943d-11e8-984c-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "13e63510-943d-11e8-8bc5-94659cf754d0", 
-                    "config": {
-                        "label": "Description", 
-                        "placeholder": "Enter text", 
-                        "width": "100%"
-                    }, 
-                    "id": "13e63513-943d-11e8-a7b4-94659cf754d0", 
-                    "label": "Description", 
-                    "node_id": "13e63512-943d-11e8-ab12-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000005"
-                }, 
-                {
-                    "card_id": "185b9090-943d-11e8-aeb7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Name", 
-                        "maxLength": null, 
-                        "placeholder": "Enter name here", 
-                        "width": "100%"
-                    }, 
-                    "id": "185b9093-943d-11e8-b3f7-94659cf754d0", 
-                    "label": "Name", 
-                    "node_id": "185b6981-943d-11e8-8310-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
-                }, 
-                {
-                    "card_id": "185b9090-943d-11e8-aeb7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Name Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "86708338-1305-459e-9cff-7ee0db2a40e4", 
-                                "id": "ecb20ae9-a457-4011-83bf-1c936e2d6b6a", 
-                                "sortorder": "", 
-                                "text": "Alternative"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "884b086e-50a0-4524-a927-4897f0c7452b", 
-                                        "id": "11e60ad2-7dca-47ef-81ff-24561bc45cd6", 
-                                        "sortorder": "", 
-                                        "text": "California Historic Landmark"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "de9d5536-4860-4821-9419-4f66b0897c8f", 
-                                        "id": "0ad1919d-48ed-4957-9c51-6e3ec439323d", 
-                                        "sortorder": "", 
-                                        "text": "California Point of Historical Interest"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cd4c796f-73f8-4cba-8cdc-8cc069c7bcfb", 
-                                        "id": "3d2ef9d9-e2f1-4286-8922-1b153504e6f5", 
-                                        "sortorder": "", 
-                                        "text": "California Register of Historic Resources"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3a6db05d-6897-4021-a087-0d4989faaa06", 
-                                        "id": "726d46f0-5780-422d-8116-fd25e5dd5aee", 
-                                        "sortorder": "", 
-                                        "text": "Los Angeles Historic Cultural Monument"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a7bc4fa3-73d2-498b-a604-ecbc0e18bf55", 
-                                        "id": "26f8294c-98ff-452c-ac3f-a78eb430df93", 
-                                        "sortorder": "", 
-                                        "text": "Los Angeles Historic Preservation Overlay Zone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6821ec06-03a5-4773-8190-496d41564e70", 
-                                        "id": "14dfac42-ed63-4a51-aa99-d846a0e2f9cf", 
-                                        "sortorder": "", 
-                                        "text": "National Historic Landmark"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f1cece23-e8bc-4a54-93b8-2c609d915287", 
-                                        "id": "53af5a29-e5e5-4893-b5a3-432b19c10440", 
-                                        "sortorder": "", 
-                                        "text": "National Monument"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b800a93f-1429-4fee-a3b6-e1fa55e12c9b", 
-                                        "id": "f7aecc0c-9022-440f-a934-7c9456281fd1", 
-                                        "sortorder": "", 
-                                        "text": "National Register of Historic Places"
-                                    }
-                                ], 
-                                "collector": "collector", 
-                                "conceptid": "163cd597-6848-4109-a7b0-56ca98003f85", 
-                                "sortorder": "", 
-                                "text": "Designation Names"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b193cf22-36fc-4024-ae66-fb1a387c6db0", 
-                                "id": "7ad76f8c-ffae-4773-b415-899fbf2a6ffd", 
-                                "sortorder": "", 
-                                "text": "Historic"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "866e8d3b-e00a-4559-bf23-dc1812c27e1f", 
-                                "id": "81dd62d2-6701-4195-b74b-8057456bba4b", 
-                                "sortorder": "", 
-                                "text": "Primary"
-                            }
-                        ], 
-                        "placeholder": "Select a name type "
-                    }, 
-                    "id": "185b9092-943d-11e8-ad30-94659cf754d0", 
-                    "label": "Name Type", 
-                    "node_id": "185b9091-943d-11e8-8c9e-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "1c421991-943d-11e8-83ad-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Status", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "b7a58f5f-dc82-11e8-9619-94659cf754d0", 
-                    "label": "Status", 
-                    "node_id": "1c42198f-943d-11e8-a86a-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "1c421994-943d-11e8-862a-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Eligibility Requirement Type", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "b396bddf-dc82-11e8-8e2c-94659cf754d0", 
-                    "label": "Eligibility Requirement Type", 
-                    "node_id": "1c421992-943d-11e8-ae0a-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "1f816613-943d-11e8-bd5d-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Type of Designation or Protection", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "de2838ef-dc81-11e8-b4ae-94659cf754d0", 
-                    "label": "Type of Designation or Protection", 
-                    "node_id": "1f818d22-943d-11e8-9a3c-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "1f816613-943d-11e8-bd5d-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Designation or Protection To Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "de1f5f4f-dc81-11e8-bd64-94659cf754d0", 
-                    "label": "Designation or Protection To Date", 
-                    "node_id": "1f818d24-943d-11e8-b16e-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "1f816613-943d-11e8-bd5d-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Designation or Protection From Date", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "de26160f-dc81-11e8-a06e-94659cf754d0", 
-                    "label": "Designation or Protection From Date", 
-                    "node_id": "1f818d25-943d-11e8-bfa9-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
                     "card_id": "26733342-943d-11e8-8e7c-94659cf754d0", 
                     "config": {
                         "basemap": "streets", 
@@ -1543,6 +598,7 @@
                         "overlayConfigs": [], 
                         "overlayOpacity": 0, 
                         "pitch": 0, 
+                        "rerender": true, 
                         "zoom": 0
                     }, 
                     "id": "19422fe7-cbfb-11e8-9b34-027f111c8e34", 
@@ -1551,950 +607,6 @@
                     "sortorder": null, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000007"
-                }, 
-                {
-                    "card_id": "26733342-943d-11e8-8e7c-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Geometry Qualifier", 
-                        "options": [], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "19422fe9-cbfb-11e8-9b34-027f111c8e34", 
-                    "label": "Geometry Qualifier", 
-                    "node_id": "26733349-943d-11e8-be82-94659cf754d0", 
-                    "sortorder": null, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "End Date Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "393e8c52-11c9-4163-8670-8680c895e8f3", 
-                                "id": "9697e0bd-15ea-476f-94fb-092a351418d9", 
-                                "sortorder": "", 
-                                "text": "Death Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "edf1336f-df77-48ad-a992-a27111031404", 
-                                "id": "6449c50e-289c-425d-aac1-50e2ce070100", 
-                                "sortorder": "", 
-                                "text": "Demolition Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0af60c1e-947c-4e9b-80ce-96a8d76ebf5b", 
-                                "id": "f21fd154-a96d-4b50-9fa9-dbab3c54d441", 
-                                "sortorder": "", 
-                                "text": "Destruction Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0f24c72b-c065-42b6-869f-ba107440376f", 
-                                "id": "24807451-df89-4cf1-99a2-18967b43fe40", 
-                                "sortorder": "", 
-                                "text": "Dissolution Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0f0126f2-1f26-431f-b0f3-06fcbd172162", 
-                                "id": "2195c931-95b0-4c91-9a1d-7607d56d1377", 
-                                "sortorder": "", 
-                                "text": "End Date"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "3c5799d5-943d-11e8-9f5d-94659cf754d0", 
-                    "label": "End Date Type", 
-                    "node_id": "3c5772c4-943d-11e8-aad6-94659cf754d0", 
-                    "sortorder": 3, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "End Date of Existence", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "3c5799d6-943d-11e8-b18c-94659cf754d0", 
-                    "label": "End Date of Existence", 
-                    "node_id": "3c5772c6-943d-11e8-8ca6-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Start Date Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "226bb292-4def-484f-8c6b-6eab8dd48c03", 
-                                "id": "73e5204c-0635-478b-a369-91d5cde5c68f", 
-                                "sortorder": "", 
-                                "text": "Birth Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "cf3683e1-6969-47b4-8cda-c61753819ec7", 
-                                "id": "29adbea8-891a-44bf-b0c5-8912d118f629", 
-                                "sortorder": "", 
-                                "text": "Built Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "11303e6e-9ea1-4b4c-8e2d-c0fa7c9db390", 
-                                "id": "cf4d3fee-1c66-499c-a087-13eb3a069807", 
-                                "sortorder": "", 
-                                "text": "Creation Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0560b41b-123e-413b-ac75-eeb09d7b9de7", 
-                                "id": "af52d238-b9ce-47bd-ba71-585d007d090b", 
-                                "sortorder": "", 
-                                "text": "Formation Date"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "9963003a-f6ae-4792-ad5d-44e4b04da1ea", 
-                                "id": "af8e248f-28c9-4c97-b57b-add942b8e009", 
-                                "sortorder": "", 
-                                "text": "Start Date"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "3c5799d4-943d-11e8-8896-94659cf754d0", 
-                    "label": "Start Date Type", 
-                    "node_id": "3c5799cf-943d-11e8-a34b-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Start Date of Existence", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "3c5799d3-943d-11e8-b3ac-94659cf754d0", 
-                    "label": "Start Date of Existence", 
-                    "node_id": "3c5799d2-943d-11e8-874e-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Recommendations", 
-                        "options": [
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a3157c46-7c4f-4de3-a355-11d68d6788e6", 
-                                        "id": "6d52b780-1091-4b14-b5b2-796f1068bb2a", 
-                                        "sortorder": "2", 
-                                        "text": "archaeological survey"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6d912f16-890e-4176-98db-95b99284e639", 
-                                        "id": "b44cf8f0-0558-4f90-83fa-1e216320df26", 
-                                        "sortorder": "3", 
-                                        "text": "excavation"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e0fa5826-6ddd-404b-b409-32a22475ea54", 
-                                        "id": "1ac24a75-7ea5-4dbf-9a95-dc4e2d612cf9", 
-                                        "sortorder": "4", 
-                                        "text": "salvage recording"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "88975b48-71d5-4c78-9c64-3687123dbc28", 
-                                "id": "305040c0-a87b-42bd-875f-ee13a95f7890", 
-                                "sortorder": "1", 
-                                "text": "archaeological intervention"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7a742a3f-fe28-4b33-8adf-5630e09358b9", 
-                                        "id": "50faa45c-d5f2-4fad-ba3f-b2d9005004ed", 
-                                        "sortorder": "11", 
-                                        "text": "aerial photograph interpretation"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "63404be1-f395-4cd8-b448-e2c8a796331a", 
-                                        "id": "68b09c5c-59ac-460b-8a0a-8467bf92dc36", 
-                                        "sortorder": "12", 
-                                        "text": "desk based assessment"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "96d1444f-2203-43b0-b7ec-40ce0f004574", 
-                                        "id": "d4b35ecb-16cd-4d42-9bed-fe2c94e75c3e", 
-                                        "sortorder": "13", 
-                                        "text": "environmental impact assessment"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7bce9ef8-5801-4291-a407-a7823326b2ee", 
-                                        "id": "d5edc2b2-4736-4cd3-9568-08beeb8420ab", 
-                                        "sortorder": "14", 
-                                        "text": "historic landscape characterisation"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "0fbc093b-e558-465e-9bfe-9aaee4a879ee", 
-                                        "id": "a5696559-4ca3-444a-9233-8d9a5edc7c23", 
-                                        "sortorder": "15", 
-                                        "text": "in-depth condition assessment"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "22d7b0cc-fc6e-47da-82a9-664b2875f94b", 
-                                "id": "fb224913-b29e-4aee-9a29-5e5e5e6d4fe7", 
-                                "sortorder": "10", 
-                                "text": "heritage assessment"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "e87f8cf5-b3ec-43bf-b296-960959a6edaa", 
-                                "id": "f9bdbc6a-e219-46cb-9eb9-9d7ac6e7855d", 
-                                "sortorder": "16", 
-                                "text": "remote sensing"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "0bdcd50f-a701-439f-a455-9fe8c1c596e4", 
-                                        "id": "a9f9afe9-5333-45b3-85fc-53205266223e", 
-                                        "sortorder": "18", 
-                                        "text": "conservation intervention"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "eab3dba2-19ab-4d20-81cc-cd9bfca00cc0", 
-                                        "id": "df81de3c-4cd5-45a9-a083-f8f2c7ec1c3e", 
-                                        "sortorder": "19", 
-                                        "text": "reburial"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "63234c3f-4674-4518-85de-73b84694c6d9", 
-                                        "id": "792b7faa-8cc0-446e-9b9c-3dad85822013", 
-                                        "sortorder": "20", 
-                                        "text": "fencing"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1e0afd30-d5a1-42e0-a02f-3754df3418d6", 
-                                        "id": "3889503a-2524-4edd-920c-f1ac7d4675cd", 
-                                        "sortorder": "21", 
-                                        "text": "fire mitigation"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7022ec05-d669-49be-a000-27a717923023", 
-                                        "id": "e4649da0-95d0-4638-8f14-53f781900943", 
-                                        "sortorder": "22", 
-                                        "text": "designation"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "64d21cb1-444b-4b3b-990d-cbf7c5a03e50", 
-                                "id": "2c29727d-b17c-4311-9d8c-ffa125a90ab2", 
-                                "sortorder": "17", 
-                                "text": "management intervention"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "dc1873f7-49c5-42a2-9863-6a950cd6f3d4", 
-                                        "id": "e6db97a7-a719-4dc6-82dc-fd4aa42e2881", 
-                                        "sortorder": "6", 
-                                        "text": "architectural survey"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9b46acbe-50d1-4870-bb46-55981d2178cd", 
-                                        "id": "57396bb2-b47b-4f53-a2e7-e7d936b55696", 
-                                        "sortorder": "7", 
-                                        "text": "measured survey"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4764910d-3d9e-45bc-a390-147d58b400c7", 
-                                        "id": "93de3278-3a37-455c-8216-ff939f87cf27", 
-                                        "sortorder": "8", 
-                                        "text": "photographic recording"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2b1660dd-b47e-479a-95ae-9e656418acb2", 
-                                        "id": "98aa7952-8775-49c1-b5ce-8ad53d99f3a9", 
-                                        "sortorder": "9", 
-                                        "text": "topographic survey"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "6c1ea4a0-fa6c-4bd3-815a-f57239680abb", 
-                                "id": "de6d7318-929b-4a7a-9e17-69035e16b48a", 
-                                "sortorder": "5", 
-                                "text": "field survey"
-                            }
-                        ], 
-                        "placeholder": "Choose as many or as few recommendations as are relevant to this assessment."
-                    }, 
-                    "id": "40609efd-943d-11e8-8154-94659cf754d0", 
-                    "label": "Recommendations", 
-                    "node_id": "40609ef1-943d-11e8-a59f-94659cf754d0", 
-                    "sortorder": 6, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "dateFormat": "YYYY-MM-DD", 
-                        "defaultValue": "", 
-                        "label": "Date Condition Assessed", 
-                        "maxDate": false, 
-                        "minDate": false, 
-                        "placeholder": "Enter date", 
-                        "viewMode": "days"
-                    }, 
-                    "id": "40609f00-943d-11e8-978d-94659cf754d0", 
-                    "label": "Date Condition Assessed", 
-                    "node_id": "40609ef4-943d-11e8-821f-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000004"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Threats", 
-                        "options": [
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9935c53c-dac4-4e1a-b4a7-a425b777a48b", 
-                                        "id": "51684806-5519-46ef-92e1-b04c8167c975", 
-                                        "sortorder": "2", 
-                                        "text": "storm"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f906108c-b848-4eea-8f7f-0294b4aeb174", 
-                                        "id": "c58a80fe-49b7-45ee-81b6-9cb574c10c7b", 
-                                        "sortorder": "3", 
-                                        "text": "fire induced by lightning"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "6fcc5949-bffc-46f8-93eb-c1f93fc2ef89", 
-                                "id": "3ef4850d-292d-41c7-9c44-bc2376d979ee", 
-                                "sortorder": "1", 
-                                "text": "meteorological"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "76b1670c-2eff-40bb-a0c5-a83f4c7331a1", 
-                                        "id": "73c3928a-c12b-4552-833c-3ae40b70fe25", 
-                                        "sortorder": "13", 
-                                        "text": "pest infestation"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "728e6ada-189a-466c-b5f6-725366036b5d", 
-                                        "id": "4fe7b71e-068d-4a7b-bb98-8bcac148da66", 
-                                        "sortorder": "14", 
-                                        "text": "plant growth"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "0e132db9-a8e9-4998-bbfd-ee696d6c2c97", 
-                                "id": "e33709ec-bc10-45d4-9080-515a337d826d", 
-                                "sortorder": "12", 
-                                "text": "biological"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8e662c34-bf7f-4471-9693-63d4bc7715b3", 
-                                        "id": "061adf90-03f6-4a49-b647-100c4f590898", 
-                                        "sortorder": "16", 
-                                        "text": "fire"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ec543f7c-1470-4f73-b702-35dbc78a55cc", 
-                                        "id": "74a1e963-60fe-4b7d-8d99-42a51fffb4c1", 
-                                        "sortorder": "17", 
-                                        "text": "explosion"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c8303ac1-508c-4cc1-adf6-dba6dc621842", 
-                                        "id": "4efb3606-bf24-40c4-8761-0f7b14ed0fa9", 
-                                        "sortorder": "18", 
-                                        "text": "pollution"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "05bf6c79-b08e-4b4b-82df-f40c3436cd6d", 
-                                        "id": "8153e584-886c-4e57-a79b-b1ff13a2f369", 
-                                        "sortorder": "19", 
-                                        "text": "violence and conflict"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f064f439-5b81-4db4-879a-62a3dac35c0c", 
-                                        "id": "5f8357e8-a0e2-4e9f-bd3e-8931218a3ba2", 
-                                        "sortorder": "20", 
-                                        "text": "looting/theft"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5acbf219-dec2-42ce-a6fa-4da7c4590f4a", 
-                                        "id": "69d53378-1179-49c5-9188-c318850808ae", 
-                                        "sortorder": "21", 
-                                        "text": "vandalism"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "41bc559e-8c0e-4036-aec0-c57d6380d7fb", 
-                                        "id": "cf9635be-b655-47f2-b74c-31f806d9062d", 
-                                        "sortorder": "22", 
-                                        "text": "infrastructure failure"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bb6939ab-57a9-4c4e-94b2-a0d24895890e", 
-                                        "id": "ee67684f-f413-44b5-af99-a746ec93658e", 
-                                        "sortorder": "23", 
-                                        "text": "agriculture"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "61541316-b2e2-4c1e-be6c-9ae2501c71fb", 
-                                        "id": "1176e6a0-1d9b-4653-b733-cd5eb7759c0d", 
-                                        "sortorder": "24", 
-                                        "text": "mining"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "56dcb2d4-0be1-475e-ad09-2fbe4496ea68", 
-                                        "id": "7b474f48-036e-491a-b322-ba52bb33b77a", 
-                                        "sortorder": "25", 
-                                        "text": "construction"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6f046e96-5995-4015-acb9-ebabeac6e4e8", 
-                                        "id": "09d58c58-7a27-4ff1-b6d1-0c9f3723e298", 
-                                        "sortorder": "26", 
-                                        "text": "inappropriate use"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ed6bfcc4-1f2c-4cce-94ba-b304225c279b", 
-                                        "id": "23de2ea6-2e66-4f07-9cbb-7a5492da05e2", 
-                                        "sortorder": "27", 
-                                        "text": "lack of maintenance"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "f2440185-a80e-4ced-8b34-53789882ae3f", 
-                                "id": "26f0ead7-3243-40d0-af5e-c7c8c4c5e4cd", 
-                                "sortorder": "15", 
-                                "text": "human-induced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "380ec64b-2e69-41da-afb9-48ab90caa2d9", 
-                                "id": "b7d1f3fc-3ccf-43a5-98e2-f81e6c5ec528", 
-                                "sortorder": "28", 
-                                "text": "climate change"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "0a0156cc-98fe-4f16-867b-55dfb2dacf9f", 
-                                        "id": "ef34616d-c9d1-4fdc-b787-827d31784025", 
-                                        "sortorder": "5", 
-                                        "text": "flood"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1bdcc469-7f36-4de9-8a6f-802451119dc9", 
-                                        "id": "c3a47bbe-d2e7-4030-a6a7-62dad44e4dc7", 
-                                        "sortorder": "6", 
-                                        "text": "tsunami"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "9167de08-93e7-4080-ac71-2fbe7e6841de", 
-                                "id": "4e44ac6e-98ae-4bc5-96de-fe03ef87a7a9", 
-                                "sortorder": "4", 
-                                "text": "hydrological"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "247a6447-9235-4265-8a5e-a6a77a11bcd2", 
-                                        "id": "809b66b1-014a-42d4-9a38-e2f1f58738de", 
-                                        "sortorder": "10", 
-                                        "text": "mass movement"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "aaae19f4-7164-442e-a3ec-b1562614214a", 
-                                        "id": "4b7d04ef-be4c-4c59-8d98-e5470a8cfa8b", 
-                                        "sortorder": "11", 
-                                        "text": "erosion"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a1370bda-8706-4a80-abc5-412db82a8dd3", 
-                                        "id": "c7e98c6a-22ef-4024-9021-913c80746e26", 
-                                        "sortorder": "8", 
-                                        "text": "volcanic"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "55bc684d-1888-4e78-952a-c417e6418921", 
-                                        "id": "9c35a534-8245-4c87-a511-90b13cbda8f6", 
-                                        "sortorder": "9", 
-                                        "text": "seismic"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "fa6d7f18-f3bf-4bef-86d3-90a1cd13a7df", 
-                                "id": "429d8ca0-7b98-41ea-8452-d9cde03969e5", 
-                                "sortorder": "7", 
-                                "text": "geological"
-                            }
-                        ], 
-                        "placeholder": "Threats are potential future disturbances.  Choose as many or as few threats are you can identify in this assessment."
-                    }, 
-                    "id": "40609f01-943d-11e8-b33e-94659cf754d0", 
-                    "label": "Threats", 
-                    "node_id": "40609ef5-943d-11e8-9cce-94659cf754d0", 
-                    "sortorder": 4, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "acceptedFiles": "", 
-                        "label": "Images or Documents", 
-                        "maxFilesize": "200"
-                    }, 
-                    "id": "40609eff-943d-11e8-8c7a-94659cf754d0", 
-                    "label": "Images or Documents", 
-                    "node_id": "40609ef6-943d-11e8-9259-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000019"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Disturbances", 
-                        "options": [
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "544ec937-13e3-4994-bdc5-fdcd6bf06279", 
-                                        "id": "8eec3bc8-958f-4ed4-9855-d07af708b263", 
-                                        "sortorder": "2", 
-                                        "text": "storm"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cc68a4b0-636e-48e0-be8c-140eb1f54bf7", 
-                                        "id": "d370f3ab-0797-429c-9858-66d60bc66075", 
-                                        "sortorder": "3", 
-                                        "text": "fire induced by lightning"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "46aff001-3c08-4594-aa83-83ffdac5a655", 
-                                "id": "1fed9701-826b-4307-bd10-4ec63d6e5cda", 
-                                "sortorder": "1", 
-                                "text": "meteorological"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "330f950f-72d6-4659-b661-7c87f52b7de1", 
-                                        "id": "5b282deb-5f56-4745-894c-5cdaad712628", 
-                                        "sortorder": "13", 
-                                        "text": "pest infestation"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ffe3693c-a037-4778-9410-a8b05e185778", 
-                                        "id": "9b07b311-d62f-4a50-81a5-19479d61fe5f", 
-                                        "sortorder": "14", 
-                                        "text": "plant growth"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "9c82a674-ecfb-43a1-bf75-aa03b76e583f", 
-                                "id": "3faa99ac-4d1d-4e97-abff-b561dbc863d2", 
-                                "sortorder": "12", 
-                                "text": "biological"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "963c1c77-2cbc-4b8d-9f58-6da04c45e9c5", 
-                                        "id": "5d66180e-91a3-4440-8864-7a863ebdcf4c", 
-                                        "sortorder": "16", 
-                                        "text": "fire"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cfcde299-e99b-49fe-8766-653cf2343338", 
-                                        "id": "ea8b9180-67f7-4fe7-956c-aca0560e7d7e", 
-                                        "sortorder": "17", 
-                                        "text": "explosion"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1b671d35-1742-4213-a012-51c511f395d9", 
-                                        "id": "383af24d-ab74-45e5-a78b-efa60849c5a4", 
-                                        "sortorder": "18", 
-                                        "text": "pollution"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d80c0f5b-40d4-40d2-8825-9b71a3ccbbab", 
-                                        "id": "760b4781-d1a6-42c6-8d32-568e0a8aff74", 
-                                        "sortorder": "19", 
-                                        "text": "violence and conflict"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5d30fb29-00cc-4e5d-a08b-cf7fc6fe1480", 
-                                        "id": "af817166-615a-440c-9447-50e94502b410", 
-                                        "sortorder": "20", 
-                                        "text": "looting/theft"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bbd387fa-f649-44c9-80d4-3441bf262b0b", 
-                                        "id": "680ff8aa-9bec-4b33-bb6e-59137948af72", 
-                                        "sortorder": "21", 
-                                        "text": "vandalism"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d070d967-c62c-4da7-9de7-a5052b24b575", 
-                                        "id": "f1cc4602-894b-474d-89b6-8b67966cc3a5", 
-                                        "sortorder": "22", 
-                                        "text": "infrastructure failure"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "eb267f56-abe1-4693-af3d-a1c031db0a78", 
-                                        "id": "9d1b6e8b-4f7e-449e-8815-d9cdd5639e26", 
-                                        "sortorder": "23", 
-                                        "text": "agriculture"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "17c5dc2b-f47f-44a9-9725-28bb33252daa", 
-                                        "id": "e51c13b8-767c-44d0-b458-86f85fcc61a0", 
-                                        "sortorder": "24", 
-                                        "text": "mining"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9e705c53-b6d5-4e0d-9f2a-f27ca121efde", 
-                                        "id": "e1b51147-4de0-44ed-9dc7-bc9c63c902ed", 
-                                        "sortorder": "25", 
-                                        "text": "construction"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ad073c4a-2bc0-4d40-bb5e-002c945c08f6", 
-                                        "id": "ee4f40ac-a7f0-420a-9800-e2c0777b5ee3", 
-                                        "sortorder": "26", 
-                                        "text": "inappropriate use"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "fab93209-6488-4e54-9cdc-250d6933d2c6", 
-                                        "id": "331cfd47-782d-4aea-b0bc-97eaba1aa875", 
-                                        "sortorder": "27", 
-                                        "text": "lack of maintenance"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "0ff63bf4-3130-4a2c-be8e-c1d5948576d7", 
-                                "id": "149b6f47-ed55-4862-8264-4915106b24f3", 
-                                "sortorder": "15", 
-                                "text": "human-induced"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "8440dd1e-cdbf-4197-a1f3-bd69c3a0df34", 
-                                "id": "b2eaf961-ccb4-40a9-997d-792f6ccc5aca", 
-                                "sortorder": "28", 
-                                "text": "climate change"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "98d5654e-3acf-4b0e-abba-5dbe9efeb40e", 
-                                        "id": "5f34df21-b0e4-4b3f-92b9-d5dddf0256a2", 
-                                        "sortorder": "5", 
-                                        "text": "flood"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5440dd24-d7b3-4789-aa19-581547435cd3", 
-                                        "id": "17199483-e13b-495b-a436-adde83e420dc", 
-                                        "sortorder": "6", 
-                                        "text": "tsunami"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "ca49301c-5219-4527-9738-ca038580e89f", 
-                                "id": "4e849891-d667-4163-a594-04226e443a04", 
-                                "sortorder": "4", 
-                                "text": "hydrological"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e4825a3d-390c-4e8a-a904-9784f5f686c6", 
-                                        "id": "cdc758df-37dd-49f1-adc6-fdb460af04fa", 
-                                        "sortorder": "10", 
-                                        "text": "mass movement"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7579b1f0-2891-462f-804e-150efca73f50", 
-                                        "id": "0096f678-6ed7-4096-b36c-5a201da98a97", 
-                                        "sortorder": "11", 
-                                        "text": "erosion"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "10a4cdf6-140c-4e32-8c16-6381e0480bc1", 
-                                        "id": "f1ea98c1-c7d8-4ed5-93ee-04508a5b3e1a", 
-                                        "sortorder": "8", 
-                                        "text": "volcanic"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "12c5bc16-04e1-4773-9e1d-27219a77eb8b", 
-                                        "id": "2b7da5c3-6815-42a1-907d-462c23347bbc", 
-                                        "sortorder": "9", 
-                                        "text": "seismic"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "24b7e168-28a5-4b7d-bead-e00b105b85f0", 
-                                "id": "a266ea1b-55d2-473b-b745-79f3cf7067da", 
-                                "sortorder": "7", 
-                                "text": "geological"
-                            }
-                        ], 
-                        "placeholder": "Choose as many or as few disturbances as are relevant to this assessment."
-                    }, 
-                    "id": "40609f02-943d-11e8-afae-94659cf754d0", 
-                    "label": "Disturbances", 
-                    "node_id": "40609ef9-943d-11e8-8205-94659cf754d0", 
-                    "sortorder": 5, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "label": "Condition Description", 
-                        "maxLength": null, 
-                        "placeholder": "Enter text", 
-                        "width": "100%"
-                    }, 
-                    "id": "40609efc-943d-11e8-b6ce-94659cf754d0", 
-                    "label": "Condition Description", 
-                    "node_id": "40609efa-943d-11e8-aa97-94659cf754d0", 
-                    "sortorder": 3, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000005"
-                }, 
-                {
-                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Condition", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "16a462cb-cf4c-4959-8991-8d46c041dd6c", 
-                                "id": "5c459cec-0e3f-4f5f-99e5-e4608530508b", 
-                                "sortorder": "1", 
-                                "text": "good"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "863baf30-f9c1-4762-a1fc-57d400294bb4", 
-                                "id": "44dbe54e-0bf2-4ee9-9ae1-ad7ddd0a53a6", 
-                                "sortorder": "2", 
-                                "text": "fair"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3bcf52dc-f8c8-4cb3-9240-44abb7d11c94", 
-                                "id": "4e4e7fbf-d0f6-4f86-8005-b1b52de0aa14", 
-                                "sortorder": "3", 
-                                "text": "poor"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "b33f47c0-f0db-4c79-bc71-deae8813e2ce", 
-                                "id": "6df218a4-1056-4c7d-8519-b013a80384c4", 
-                                "sortorder": "4", 
-                                "text": "very bad"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "40609efe-943d-11e8-8b6a-94659cf754d0", 
-                    "label": "Condition", 
-                    "node_id": "40609efb-943d-11e8-bffe-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000009"
                 }, 
                 {
                     "card_id": "440786e4-943d-11e8-bda7-94659cf754d0", 
@@ -5023,6 +3135,1533 @@
                     "widget_id": "10000000-0000-0000-0000-000000000012"
                 }, 
                 {
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Condition", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "16a462cb-cf4c-4959-8991-8d46c041dd6c", 
+                                "id": "5c459cec-0e3f-4f5f-99e5-e4608530508b", 
+                                "sortorder": "1", 
+                                "text": "good"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "863baf30-f9c1-4762-a1fc-57d400294bb4", 
+                                "id": "44dbe54e-0bf2-4ee9-9ae1-ad7ddd0a53a6", 
+                                "sortorder": "2", 
+                                "text": "fair"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3bcf52dc-f8c8-4cb3-9240-44abb7d11c94", 
+                                "id": "4e4e7fbf-d0f6-4f86-8005-b1b52de0aa14", 
+                                "sortorder": "3", 
+                                "text": "poor"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b33f47c0-f0db-4c79-bc71-deae8813e2ce", 
+                                "id": "6df218a4-1056-4c7d-8519-b013a80384c4", 
+                                "sortorder": "4", 
+                                "text": "very bad"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "40609efe-943d-11e8-8b6a-94659cf754d0", 
+                    "label": "Condition", 
+                    "node_id": "40609efb-943d-11e8-bffe-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000009"
+                }, 
+                {
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
+                    "config": {
+                        "acceptedFiles": "", 
+                        "label": "Images or Documents", 
+                        "maxFilesize": "200", 
+                        "rerender": true
+                    }, 
+                    "id": "40609eff-943d-11e8-8c7a-94659cf754d0", 
+                    "label": "Images or Documents", 
+                    "node_id": "40609ef6-943d-11e8-9259-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000019"
+                }, 
+                {
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Disturbances", 
+                        "options": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "544ec937-13e3-4994-bdc5-fdcd6bf06279", 
+                                        "id": "8eec3bc8-958f-4ed4-9855-d07af708b263", 
+                                        "sortorder": "2", 
+                                        "text": "storm"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cc68a4b0-636e-48e0-be8c-140eb1f54bf7", 
+                                        "id": "d370f3ab-0797-429c-9858-66d60bc66075", 
+                                        "sortorder": "3", 
+                                        "text": "fire induced by lightning"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "46aff001-3c08-4594-aa83-83ffdac5a655", 
+                                "id": "1fed9701-826b-4307-bd10-4ec63d6e5cda", 
+                                "sortorder": "1", 
+                                "text": "meteorological"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "330f950f-72d6-4659-b661-7c87f52b7de1", 
+                                        "id": "5b282deb-5f56-4745-894c-5cdaad712628", 
+                                        "sortorder": "13", 
+                                        "text": "pest infestation"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ffe3693c-a037-4778-9410-a8b05e185778", 
+                                        "id": "9b07b311-d62f-4a50-81a5-19479d61fe5f", 
+                                        "sortorder": "14", 
+                                        "text": "plant growth"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "9c82a674-ecfb-43a1-bf75-aa03b76e583f", 
+                                "id": "3faa99ac-4d1d-4e97-abff-b561dbc863d2", 
+                                "sortorder": "12", 
+                                "text": "biological"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "963c1c77-2cbc-4b8d-9f58-6da04c45e9c5", 
+                                        "id": "5d66180e-91a3-4440-8864-7a863ebdcf4c", 
+                                        "sortorder": "16", 
+                                        "text": "fire"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cfcde299-e99b-49fe-8766-653cf2343338", 
+                                        "id": "ea8b9180-67f7-4fe7-956c-aca0560e7d7e", 
+                                        "sortorder": "17", 
+                                        "text": "explosion"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1b671d35-1742-4213-a012-51c511f395d9", 
+                                        "id": "383af24d-ab74-45e5-a78b-efa60849c5a4", 
+                                        "sortorder": "18", 
+                                        "text": "pollution"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d80c0f5b-40d4-40d2-8825-9b71a3ccbbab", 
+                                        "id": "760b4781-d1a6-42c6-8d32-568e0a8aff74", 
+                                        "sortorder": "19", 
+                                        "text": "violence and conflict"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5d30fb29-00cc-4e5d-a08b-cf7fc6fe1480", 
+                                        "id": "af817166-615a-440c-9447-50e94502b410", 
+                                        "sortorder": "20", 
+                                        "text": "looting/theft"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bbd387fa-f649-44c9-80d4-3441bf262b0b", 
+                                        "id": "680ff8aa-9bec-4b33-bb6e-59137948af72", 
+                                        "sortorder": "21", 
+                                        "text": "vandalism"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d070d967-c62c-4da7-9de7-a5052b24b575", 
+                                        "id": "f1cc4602-894b-474d-89b6-8b67966cc3a5", 
+                                        "sortorder": "22", 
+                                        "text": "infrastructure failure"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "eb267f56-abe1-4693-af3d-a1c031db0a78", 
+                                        "id": "9d1b6e8b-4f7e-449e-8815-d9cdd5639e26", 
+                                        "sortorder": "23", 
+                                        "text": "agriculture"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "17c5dc2b-f47f-44a9-9725-28bb33252daa", 
+                                        "id": "e51c13b8-767c-44d0-b458-86f85fcc61a0", 
+                                        "sortorder": "24", 
+                                        "text": "mining"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9e705c53-b6d5-4e0d-9f2a-f27ca121efde", 
+                                        "id": "e1b51147-4de0-44ed-9dc7-bc9c63c902ed", 
+                                        "sortorder": "25", 
+                                        "text": "construction"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ad073c4a-2bc0-4d40-bb5e-002c945c08f6", 
+                                        "id": "ee4f40ac-a7f0-420a-9800-e2c0777b5ee3", 
+                                        "sortorder": "26", 
+                                        "text": "inappropriate use"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "fab93209-6488-4e54-9cdc-250d6933d2c6", 
+                                        "id": "331cfd47-782d-4aea-b0bc-97eaba1aa875", 
+                                        "sortorder": "27", 
+                                        "text": "lack of maintenance"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "0ff63bf4-3130-4a2c-be8e-c1d5948576d7", 
+                                "id": "149b6f47-ed55-4862-8264-4915106b24f3", 
+                                "sortorder": "15", 
+                                "text": "human-induced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "8440dd1e-cdbf-4197-a1f3-bd69c3a0df34", 
+                                "id": "b2eaf961-ccb4-40a9-997d-792f6ccc5aca", 
+                                "sortorder": "28", 
+                                "text": "climate change"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "98d5654e-3acf-4b0e-abba-5dbe9efeb40e", 
+                                        "id": "5f34df21-b0e4-4b3f-92b9-d5dddf0256a2", 
+                                        "sortorder": "5", 
+                                        "text": "flood"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5440dd24-d7b3-4789-aa19-581547435cd3", 
+                                        "id": "17199483-e13b-495b-a436-adde83e420dc", 
+                                        "sortorder": "6", 
+                                        "text": "tsunami"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "ca49301c-5219-4527-9738-ca038580e89f", 
+                                "id": "4e849891-d667-4163-a594-04226e443a04", 
+                                "sortorder": "4", 
+                                "text": "hydrological"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e4825a3d-390c-4e8a-a904-9784f5f686c6", 
+                                        "id": "cdc758df-37dd-49f1-adc6-fdb460af04fa", 
+                                        "sortorder": "10", 
+                                        "text": "mass movement"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7579b1f0-2891-462f-804e-150efca73f50", 
+                                        "id": "0096f678-6ed7-4096-b36c-5a201da98a97", 
+                                        "sortorder": "11", 
+                                        "text": "erosion"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "10a4cdf6-140c-4e32-8c16-6381e0480bc1", 
+                                        "id": "f1ea98c1-c7d8-4ed5-93ee-04508a5b3e1a", 
+                                        "sortorder": "8", 
+                                        "text": "volcanic"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "12c5bc16-04e1-4773-9e1d-27219a77eb8b", 
+                                        "id": "2b7da5c3-6815-42a1-907d-462c23347bbc", 
+                                        "sortorder": "9", 
+                                        "text": "seismic"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "24b7e168-28a5-4b7d-bead-e00b105b85f0", 
+                                "id": "a266ea1b-55d2-473b-b745-79f3cf7067da", 
+                                "sortorder": "7", 
+                                "text": "geological"
+                            }
+                        ], 
+                        "placeholder": "Choose as many or as few disturbances as are relevant to this assessment."
+                    }, 
+                    "id": "40609f02-943d-11e8-afae-94659cf754d0", 
+                    "label": "Disturbances", 
+                    "node_id": "40609ef9-943d-11e8-8205-94659cf754d0", 
+                    "sortorder": 5, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
+                    "config": {
+                        "label": "Condition Description", 
+                        "maxLength": null, 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "40609efc-943d-11e8-b6ce-94659cf754d0", 
+                    "label": "Condition Description", 
+                    "node_id": "40609efa-943d-11e8-aa97-94659cf754d0", 
+                    "sortorder": 3, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                }, 
+                {
+                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Start Date Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "226bb292-4def-484f-8c6b-6eab8dd48c03", 
+                                "id": "73e5204c-0635-478b-a369-91d5cde5c68f", 
+                                "sortorder": "", 
+                                "text": "Birth Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "cf3683e1-6969-47b4-8cda-c61753819ec7", 
+                                "id": "29adbea8-891a-44bf-b0c5-8912d118f629", 
+                                "sortorder": "", 
+                                "text": "Built Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "11303e6e-9ea1-4b4c-8e2d-c0fa7c9db390", 
+                                "id": "cf4d3fee-1c66-499c-a087-13eb3a069807", 
+                                "sortorder": "", 
+                                "text": "Creation Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0560b41b-123e-413b-ac75-eeb09d7b9de7", 
+                                "id": "af52d238-b9ce-47bd-ba71-585d007d090b", 
+                                "sortorder": "", 
+                                "text": "Formation Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9963003a-f6ae-4792-ad5d-44e4b04da1ea", 
+                                "id": "af8e248f-28c9-4c97-b57b-add942b8e009", 
+                                "sortorder": "", 
+                                "text": "Start Date"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "3c5799d4-943d-11e8-8896-94659cf754d0", 
+                    "label": "Start Date Type", 
+                    "node_id": "3c5799cf-943d-11e8-a34b-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "185b9090-943d-11e8-aeb7-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Name Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "86708338-1305-459e-9cff-7ee0db2a40e4", 
+                                "id": "ecb20ae9-a457-4011-83bf-1c936e2d6b6a", 
+                                "sortorder": "", 
+                                "text": "Alternative"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "884b086e-50a0-4524-a927-4897f0c7452b", 
+                                        "id": "11e60ad2-7dca-47ef-81ff-24561bc45cd6", 
+                                        "sortorder": "", 
+                                        "text": "California Historic Landmark"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "de9d5536-4860-4821-9419-4f66b0897c8f", 
+                                        "id": "0ad1919d-48ed-4957-9c51-6e3ec439323d", 
+                                        "sortorder": "", 
+                                        "text": "California Point of Historical Interest"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cd4c796f-73f8-4cba-8cdc-8cc069c7bcfb", 
+                                        "id": "3d2ef9d9-e2f1-4286-8922-1b153504e6f5", 
+                                        "sortorder": "", 
+                                        "text": "California Register of Historic Resources"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3a6db05d-6897-4021-a087-0d4989faaa06", 
+                                        "id": "726d46f0-5780-422d-8116-fd25e5dd5aee", 
+                                        "sortorder": "", 
+                                        "text": "Los Angeles Historic Cultural Monument"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a7bc4fa3-73d2-498b-a604-ecbc0e18bf55", 
+                                        "id": "26f8294c-98ff-452c-ac3f-a78eb430df93", 
+                                        "sortorder": "", 
+                                        "text": "Los Angeles Historic Preservation Overlay Zone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6821ec06-03a5-4773-8190-496d41564e70", 
+                                        "id": "14dfac42-ed63-4a51-aa99-d846a0e2f9cf", 
+                                        "sortorder": "", 
+                                        "text": "National Historic Landmark"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f1cece23-e8bc-4a54-93b8-2c609d915287", 
+                                        "id": "53af5a29-e5e5-4893-b5a3-432b19c10440", 
+                                        "sortorder": "", 
+                                        "text": "National Monument"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b800a93f-1429-4fee-a3b6-e1fa55e12c9b", 
+                                        "id": "f7aecc0c-9022-440f-a934-7c9456281fd1", 
+                                        "sortorder": "", 
+                                        "text": "National Register of Historic Places"
+                                    }
+                                ], 
+                                "collector": "collector", 
+                                "conceptid": "163cd597-6848-4109-a7b0-56ca98003f85", 
+                                "sortorder": "", 
+                                "text": "Designation Names"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b193cf22-36fc-4024-ae66-fb1a387c6db0", 
+                                "id": "7ad76f8c-ffae-4773-b415-899fbf2a6ffd", 
+                                "sortorder": "", 
+                                "text": "Historic"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "866e8d3b-e00a-4559-bf23-dc1812c27e1f", 
+                                "id": "81dd62d2-6701-4195-b74b-8057456bba4b", 
+                                "sortorder": "", 
+                                "text": "Primary"
+                            }
+                        ], 
+                        "placeholder": "Select a name type "
+                    }, 
+                    "id": "185b9092-943d-11e8-ad30-94659cf754d0", 
+                    "label": "Name Type", 
+                    "node_id": "185b9091-943d-11e8-8c9e-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "48318180-943d-11e8-a635-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Resource Type Classification", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5db4ab60-0936-4841-b164-d4b55be9ddb5", 
+                                "id": "e675887c-23e3-4c60-9036-c7c864b4272f", 
+                                "sortorder": "1", 
+                                "text": "Building"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "033220d0-79fe-4742-8c0e-e83266d843b1", 
+                                "id": "3cf28c22-7271-4bd8-a7da-6e6c45ca4c13", 
+                                "sortorder": "2", 
+                                "text": "Structure"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3f700bb6-a858-41e0-bb48-67a0308d2997", 
+                                "id": "5d3a1585-0a65-4a4c-85dc-f894fa17ec0d", 
+                                "sortorder": "3", 
+                                "text": "Object"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "68a6772d-c431-42fa-8772-e76a14992139", 
+                                "id": "e4699732-efee-46c0-87e1-3f0a930a43db", 
+                                "sortorder": "4", 
+                                "text": "Site"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "258e6aeb-ff2b-4f18-8c82-0b593b3112ed", 
+                                "id": "acfee644-090f-4ed6-8424-df82f3560807", 
+                                "sortorder": "5", 
+                                "text": "District"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4abd862f-43be-4783-9dd0-92e0d6ee516b", 
+                                        "id": "7cd6cd34-b423-40d2-bb40-d68879b116dc", 
+                                        "sortorder": "10", 
+                                        "text": "District Potential Contributor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e52e931a-797e-4833-8f07-bf24c546271e", 
+                                        "id": "eb7a8bec-2a12-4f5b-a11f-9c200954fb10", 
+                                        "sortorder": "11", 
+                                        "text": "Planning District"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "789ab887-b19e-4252-8e74-60e85c284b5c", 
+                                        "id": "c3d9af83-4af1-4554-b9e9-09fb59ca03a6", 
+                                        "sortorder": "7", 
+                                        "text": "District Contributor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a5486051-7c1d-446c-923f-270937443b2c", 
+                                        "id": "8dfdaa13-5073-4ee8-894c-01a68c08dff0", 
+                                        "sortorder": "8", 
+                                        "text": "District Non-Contributor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6db901b2-2e82-4c5b-8aae-05231b938c20", 
+                                        "id": "e0229b20-46f2-44a8-9a89-85015e953d89", 
+                                        "sortorder": "9", 
+                                        "text": "District Altered Contributor"
+                                    }
+                                ], 
+                                "collector": "collector", 
+                                "conceptid": "5d787426-4110-4b4f-8c9e-60be8d701013", 
+                                "sortorder": "6", 
+                                "text": "District Element"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "48318181-943d-11e8-9437-94659cf754d0", 
+                    "label": "Resource Type Classification", 
+                    "node_id": "48315a71-943d-11e8-90d3-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "185b9090-943d-11e8-aeb7-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Name", 
+                        "maxLength": null, 
+                        "placeholder": "Enter name here", 
+                        "width": "100%"
+                    }, 
+                    "id": "185b9093-943d-11e8-b3f7-94659cf754d0", 
+                    "label": "Name", 
+                    "node_id": "185b6981-943d-11e8-8310-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }, 
+                {
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Date Condition Assessed", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "40609f00-943d-11e8-978d-94659cf754d0", 
+                    "label": "Date Condition Assessed", 
+                    "node_id": "40609ef4-943d-11e8-821f-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Heritage Resource Type Cultural Period", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "bcd74d1f-dc6e-11e8-9d5d-94659cf754d0", 
+                    "label": "Heritage Resource Type Cultural Period", 
+                    "node_id": "086df567-943d-11e8-a111-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "54188892-943d-11e8-8554-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Measurement Value", 
+                        "max": "", 
+                        "min": "", 
+                        "placeholder": "Enter value", 
+                        "precision": "", 
+                        "prefix": "", 
+                        "step": "", 
+                        "suffix": "", 
+                        "width": "100%"
+                    }, 
+                    "id": "5418afa0-943d-11e8-ba29-94659cf754d0", 
+                    "label": "Measurement Value", 
+                    "node_id": "54188893-943d-11e8-9011-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000008"
+                }, 
+                {
+                    "card_id": "54188892-943d-11e8-8554-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Measurement Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "2d152d1d-17e5-4fed-ac36-919f823be256", 
+                                "id": "857d8806-0e0f-4f7d-aed6-fad250ef97ea", 
+                                "sortorder": "", 
+                                "text": "breadth"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "99e96cb3-21ec-499b-9536-2ed69754d2c5", 
+                                "id": "8a3fe0fe-3c5f-4a8e-a08d-b2fe4ad95653", 
+                                "sortorder": "", 
+                                "text": "depth"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "5e0124cc-c308-4fec-ab60-08a39ba1f643", 
+                                "id": "db42d2f8-d2d7-465f-b1b2-189f433a6b7c", 
+                                "sortorder": "", 
+                                "text": "height"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "8a0cf26a-2184-4af4-9df4-5ee5dc4879b0", 
+                                "id": "88f2a040-48c0-4240-a9e2-75312a6dd04d", 
+                                "sortorder": "", 
+                                "text": "length"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "26980537-8582-4bdb-8aea-38d60202face", 
+                                        "id": "5d6a0c6c-40b0-409c-a88f-3378761c5562", 
+                                        "sortorder": "", 
+                                        "text": "tonnage"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "32a94c6d-d55f-4019-9f56-3ac7934b59a3", 
+                                "id": "a9bfce58-2a2f-4c48-a8fe-88f1b24463d6", 
+                                "sortorder": "", 
+                                "text": "weight"
+                            }
+                        ], 
+                        "placeholder": "Select type"
+                    }, 
+                    "id": "5418afa1-943d-11e8-b920-94659cf754d0", 
+                    "label": "Measurement Type", 
+                    "node_id": "54188894-943d-11e8-bb0e-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Style Use Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "c97680a2-dc6e-11e8-801e-94659cf754d0", 
+                    "label": "Style Use Type", 
+                    "node_id": "086e1c70-943d-11e8-9026-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "5008a5a1-943d-11e8-90a4-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "External Identifier", 
+                        "maxLength": null, 
+                        "placeholder": "Enter indentifier", 
+                        "width": "100%"
+                    }, 
+                    "id": "5008a5a4-943d-11e8-a098-94659cf754d0", 
+                    "label": "External Identifier", 
+                    "node_id": "5008a59f-943d-11e8-985e-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }, 
+                {
+                    "card_id": "5008a5a1-943d-11e8-90a4-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Source of Identifier", 
+                        "options": [], 
+                        "placeholder": "Select the source of the indentifier"
+                    }, 
+                    "id": "5008a5a5-943d-11e8-bbe7-94659cf754d0", 
+                    "label": "Source of Identifier", 
+                    "node_id": "5008a5a2-943d-11e8-8ee7-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000015"
+                }, 
+                {
+                    "card_id": "5008a5a1-943d-11e8-90a4-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Type of Identifier", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "21ab0b62-809b-47da-a48c-ab1cd13f0db2", 
+                                "id": "d796303e-5075-4a57-ad9c-226775cf1f4f", 
+                                "sortorder": "", 
+                                "text": "ARK"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "72d3b085-2d10-4f9e-8697-20744299bacf", 
+                                "id": "61bc441a-dad2-4cdb-9c9b-f0112c352731", 
+                                "sortorder": "", 
+                                "text": "DOI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "818b9221-78f2-4c25-84cf-686c21eff8e3", 
+                                "id": "24bcc5d3-ba51-42bd-a9c6-44d5bd6ed681", 
+                                "sortorder": "", 
+                                "text": "HANDLE"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "7ca60d3f-6f3c-4d19-8914-e5800fb805ca", 
+                                "id": "5c340034-fa93-4131-ade8-f670da714bad", 
+                                "sortorder": "", 
+                                "text": "ISBN"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "01251c2a-8e5a-49e5-a389-20b4637c4c76", 
+                                "id": "c8d1e199-ccfc-4882-b551-8d85c37c04e6", 
+                                "sortorder": "", 
+                                "text": "ISSN"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "67b17fc8-d205-471b-bdf5-a361f032e545", 
+                                "id": "77569746-6bf0-4c73-949d-496115fc9cea", 
+                                "sortorder": "", 
+                                "text": "POI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "02c09240-a9a3-4cd5-98cd-c2fbafc9173b", 
+                                "id": "fb795aad-a09c-4fd0-87ce-3012c2f3d631", 
+                                "sortorder": "", 
+                                "text": "PURL"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0a4ce957-d837-4595-8320-8d142af864ab", 
+                                "id": "acab77ad-dbee-4448-8ce9-8e7dd2ec1651", 
+                                "sortorder": "", 
+                                "text": "SICI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "eaa19556-fcfa-40c8-9696-0d89804ad895", 
+                                "id": "f39679be-899b-4472-9484-df377e43d776", 
+                                "sortorder": "", 
+                                "text": "URI"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d8f00076-3b8e-4984-8ab9-152cc21ebc40", 
+                                "id": "763105f1-757f-431b-90ff-a0511d2ba900", 
+                                "sortorder": "", 
+                                "text": "URL"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ec9e80e3-ae93-4aed-97a6-f61b0f93da43", 
+                                "id": "b411a4a6-1db0-4745-a67a-e74cf586193e", 
+                                "sortorder": "", 
+                                "text": "URN"
+                            }
+                        ], 
+                        "placeholder": "Select the type of identifier"
+                    }, 
+                    "id": "5008a5a6-943d-11e8-b736-94659cf754d0", 
+                    "label": "Type of Identifier", 
+                    "node_id": "5008a5a3-943d-11e8-b0ea-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000009"
+                }, 
+                {
+                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Heritage Resource Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "bcdb1db0-dc6e-11e8-9c12-94659cf754d0", 
+                    "label": "Heritage Resource Type", 
+                    "node_id": "086df56b-943d-11e8-9f46-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Ancillary Feature From Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "ccb6b781-dc6e-11e8-91bd-94659cf754d0", 
+                    "label": "Ancillary Feature From Date", 
+                    "node_id": "086df561-943d-11e8-a0e0-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Heritage Resource Use Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "bcda0c41-dc6e-11e8-8c57-94659cf754d0", 
+                    "label": "Heritage Resource Use Type", 
+                    "node_id": "086df56a-943d-11e8-bb62-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "1c41f292-943d-11e8-8d18-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Reasons", 
+                        "maxLength": null, 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "1fa07090-a9af-11e9-afa0-94659cf754d0", 
+                    "label": "Reasons", 
+                    "node_id": "1c41f290-943d-11e8-a80a-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }, 
+                {
+                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Style Cultural Period", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "c975bd4f-dc6e-11e8-be86-94659cf754d0", 
+                    "label": "Style Cultural Period", 
+                    "node_id": "086df570-943d-11e8-8ebb-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "End Date Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "393e8c52-11c9-4163-8670-8680c895e8f3", 
+                                "id": "9697e0bd-15ea-476f-94fb-092a351418d9", 
+                                "sortorder": "", 
+                                "text": "Death Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "edf1336f-df77-48ad-a992-a27111031404", 
+                                "id": "6449c50e-289c-425d-aac1-50e2ce070100", 
+                                "sortorder": "", 
+                                "text": "Demolition Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0af60c1e-947c-4e9b-80ce-96a8d76ebf5b", 
+                                "id": "f21fd154-a96d-4b50-9fa9-dbab3c54d441", 
+                                "sortorder": "", 
+                                "text": "Destruction Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0f24c72b-c065-42b6-869f-ba107440376f", 
+                                "id": "24807451-df89-4cf1-99a2-18967b43fe40", 
+                                "sortorder": "", 
+                                "text": "Dissolution Date"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0f0126f2-1f26-431f-b0f3-06fcbd172162", 
+                                "id": "2195c931-95b0-4c91-9a1d-7607d56d1377", 
+                                "sortorder": "", 
+                                "text": "End Date"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "3c5799d5-943d-11e8-9f5d-94659cf754d0", 
+                    "label": "End Date Type", 
+                    "node_id": "3c5772c4-943d-11e8-aad6-94659cf754d0", 
+                    "sortorder": 3, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "0cebb552-943d-11e8-8a58-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Modification/Alteration Type", 
+                        "options": [
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "722d9ff4-c470-466c-8e96-d8037979d5ba", 
+                                "id": "496d7001-5912-48c4-b9b1-5a60d8afec27", 
+                                "sortorder": "", 
+                                "text": "Addition to primary elevation"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "2e234b26-d24a-4cf3-99f4-f8c355f8b9be", 
+                                "id": "9e416521-dc78-4690-b658-1e128ce81ec2", 
+                                "sortorder": "", 
+                                "text": "Addition to rear/side elevation"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3674c32c-d89f-45a6-bff8-eef76bee4d50", 
+                                "id": "07adc1d8-2f7a-4799-ac2b-371b593d6be6", 
+                                "sortorder": "", 
+                                "text": "Addition to upper story"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ab586613-9ec2-4a7f-931f-e4cc4633081f", 
+                                "id": "711fc7aa-7e53-4b3d-9c76-951a6bf0d020", 
+                                "sortorder": "", 
+                                "text": "Appears to be unaltered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b103fec3-bbcf-4b76-b817-42c3a769d11d", 
+                                "id": "28c9f8c7-9c5d-4d8d-8781-dc51d12a0614", 
+                                "sortorder": "", 
+                                "text": "Awnings added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "76dea51c-0f17-474c-a1d5-c5bfebecf53f", 
+                                "id": "068f4791-4845-41bd-8d09-f49769c8344e", 
+                                "sortorder": "", 
+                                "text": "Balcony added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "19fea997-ca00-4c00-a25d-25d1590b7b66", 
+                                "id": "eeea1e2e-ba3b-4007-9a40-35a78ab40115", 
+                                "sortorder": "", 
+                                "text": "Balcony altered or enclosed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9c9c5138-f4a4-459a-97fb-1e59980c2f2b", 
+                                "id": "a7fcd074-00fc-49bd-b213-e128d95ec53a", 
+                                "sortorder": "", 
+                                "text": "Brickwork/stone painted"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "4c9cb8ef-7afe-4f4b-adcc-948f6f02a6ee", 
+                                "id": "ff6dba95-bae6-4289-927d-20bfc9683a0b", 
+                                "sortorder": "", 
+                                "text": "Carport added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "8a6bd560-b494-4dab-ab91-9566dbc52d08", 
+                                "id": "7da367ed-379c-4b17-a1bb-b9b47895a215", 
+                                "sortorder": "", 
+                                "text": "Carport altered or enclosed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9c6235e2-f5f1-456c-b136-7ebb5be4dd9e", 
+                                "id": "b1ca9c93-c368-41c0-b5a8-4ef4a5eb07a0", 
+                                "sortorder": "", 
+                                "text": "Carport removed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "a3c50729-179a-4bf5-94b7-137df07b6eb5", 
+                                "id": "e84b812c-4e6d-4d97-8b18-64394c5344cb", 
+                                "sortorder": "", 
+                                "text": "Chimney altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "e7571328-ab5b-4083-8c30-66cf41ac4316", 
+                                "id": "d84e1720-027d-48a4-b947-36a6b22d9eee", 
+                                "sortorder": "", 
+                                "text": "Completely altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "ece925a3-8bf6-475e-a63f-8cc30eefbe32", 
+                                "id": "df0ad63d-c926-4d32-bf7d-c600fca1d950", 
+                                "sortorder": "", 
+                                "text": "Decorative elements added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d8c9c16d-21ad-4213-9c9f-b05c9cc0eb2b", 
+                                "id": "93b76072-816e-47cd-9371-7c5d5668fe2f", 
+                                "sortorder": "", 
+                                "text": "Decorative elements removed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "66e0a7ba-bf49-4f48-b40e-1d78f45a2bd7", 
+                                "id": "97a82c25-8acc-4546-8adb-ac2b8152f0ef", 
+                                "sortorder": "", 
+                                "text": "Door (primary) opening or entrance altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "afdd437d-b7d3-430c-b71a-3173a12f9818", 
+                                "id": "76e75d2e-b9db-43b9-a114-9430f8da9b80", 
+                                "sortorder": "", 
+                                "text": "Door (primary) replaced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "1a60452a-4a58-4027-b872-f1c407ae08d8", 
+                                "id": "e06c79e4-629a-4a00-b1f9-3bd2d7f256ee", 
+                                "sortorder": "", 
+                                "text": "Door/entrance added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "7c5db7f1-e3a4-4b41-9631-39580343136d", 
+                                "id": "6e8e64cd-480a-436e-acbf-b303865a1b32", 
+                                "sortorder": "", 
+                                "text": "Exterior staircases added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "f2b24e50-4df0-452f-a1cf-9802a80829f6", 
+                                "id": "f3850419-758e-45f0-8264-d1c8f53b6fd1", 
+                                "sortorder": "", 
+                                "text": "Garage altered or replaced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "4ad2324d-20c2-40d7-b790-d768045f20e4", 
+                                "id": "eb87fd5d-3bf4-4aba-9465-1766b920280f", 
+                                "sortorder": "", 
+                                "text": "Garage door replaced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "64138cf0-9c32-4a72-834b-7b56c01b32d8", 
+                                "id": "6ca711c4-5f1f-4153-b0e9-c4ea177d055d", 
+                                "sortorder": "", 
+                                "text": "Garage postdates residence"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "0f916134-f57f-46c1-93b3-e1c9ebcf1ac6", 
+                                "id": "d64c28ba-b418-4aca-ae99-1b346e74788b", 
+                                "sortorder": "", 
+                                "text": "Landscape/hardscape altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "bdbf4fd0-2233-487c-b0d4-ac65a31aae47", 
+                                "id": "18310916-7403-4f31-a8ef-600363ff4b5f", 
+                                "sortorder": "", 
+                                "text": "No major alterations"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "fb01e551-3d33-4d20-849a-7587e060f527", 
+                                "id": "7786d45a-ae12-421b-b267-994c1f82d373", 
+                                "sortorder": "", 
+                                "text": "Parapet altered or removed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "78a5445b-3086-4cbe-9a1a-c8f127f4b7aa", 
+                                "id": "42db092d-b3dd-4813-9869-99ba3db8cc46", 
+                                "sortorder": "", 
+                                "text": "Perimeter fence or wall added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "a9d3ccb1-0db7-48d2-a3c7-3d90f1d1146e", 
+                                "id": "9d114895-8a59-4cf1-bd39-34dbabfe0497", 
+                                "sortorder": "", 
+                                "text": "Porch added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "e9e11871-1b1f-489e-a38b-0ed2c1b90363", 
+                                "id": "e702213d-08ce-4078-ac3b-685112a09d94", 
+                                "sortorder": "", 
+                                "text": "Porch altered or enclosed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "30b7a498-9959-4269-96eb-800d77d9b3a1", 
+                                "id": "8f3e61e4-80f0-41ba-9318-4c8333402ea5", 
+                                "sortorder": "", 
+                                "text": "Porch rails altered or replaced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "4a6219ac-dba5-430c-9926-ed6dbfbf50c7", 
+                                "id": "37a83a92-a962-495f-9d54-28672a54a92c", 
+                                "sortorder": "", 
+                                "text": "Porch removed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "476aee69-8ca9-4960-971d-9bb0b2a6f299", 
+                                "id": "8e13bbe2-2b90-43ba-bc60-4cbe1ee3bde5", 
+                                "sortorder": "", 
+                                "text": "Porte cochere added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "e67906a5-24a4-4914-8d2f-2ba109d32a6d", 
+                                "id": "dcd817dc-64ee-48d0-be7f-44149e709876", 
+                                "sortorder": "", 
+                                "text": "Porte cochere altered or removed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "dfed084f-fe7f-45c3-84ac-80f52bd7335b", 
+                                "id": "673f762d-4444-485a-9660-bc6237518f06", 
+                                "sortorder": "", 
+                                "text": "Roof dormer added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "38653962-7965-41c7-ad45-d5e5c50c0918", 
+                                "id": "3803442d-4c31-4bd0-9f69-62f5ff512d2a", 
+                                "sortorder": "", 
+                                "text": "Roof dormer altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "153cfd84-7208-499e-9575-c131a96984fe", 
+                                "id": "38e69e10-b953-4200-8c09-7e9c0ce8736f", 
+                                "sortorder": "", 
+                                "text": "Roof replaced with incompatible materials"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9fc0b4c5-5df7-450b-93d1-3768be234f0a", 
+                                "id": "9bc61bd7-d09b-4c13-97a0-ceee3e02be46", 
+                                "sortorder": "", 
+                                "text": "Roofline altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "d6cf0af7-d58e-4a24-8684-88dec3b1961a", 
+                                "id": "77b7ce4c-a645-4687-acdb-e6aec563cb40", 
+                                "sortorder": "", 
+                                "text": "Security door(s) added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "91d7c00f-4ca3-444a-9e32-8d16ffea4697", 
+                                "id": "b8ebcd34-5d07-4e93-87d9-e95ce9fda9a6", 
+                                "sortorder": "", 
+                                "text": "Security window bars added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "78f80db2-2f21-4089-9473-bb35df779c3f", 
+                                "id": "5bfa94f0-fd1b-4fe4-8217-086598188890", 
+                                "sortorder": "", 
+                                "text": "Seismic anchor plates added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "e0f8be08-2153-4574-a6b9-483a0e0c4c0f", 
+                                "id": "947a9561-b189-4fb5-9758-23d0e05f594e", 
+                                "sortorder": "", 
+                                "text": "Signage added"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "b0101c83-6c3d-4627-9f64-e6e87ee7052a", 
+                                "id": "c817866f-ed07-4347-b26e-ddfa2250c317", 
+                                "sortorder": "", 
+                                "text": "Signage altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "9d7434a7-598a-4d9c-b479-ad23f008d924", 
+                                "id": "d2c71e8a-4b5a-437b-b3ed-a24aba8d4b5b", 
+                                "sortorder": "", 
+                                "text": "Signage removed"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "1583eae9-7145-4148-bf64-35b744e5b13c", 
+                                "id": "43e85383-11e4-4f76-9ad4-8f00d454e298", 
+                                "sortorder": "", 
+                                "text": "Single-family converted to multi-family"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "a0f1b60a-8022-4bca-920e-3efe18901acc", 
+                                "id": "01423229-dd8b-4506-ad4d-dd914ef3c697", 
+                                "sortorder": "", 
+                                "text": "Stonework painted"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "12358bc8-0ef0-474e-a34a-93fc96eaf3ae", 
+                                "id": "3cb10e8d-15a2-4574-9f44-b62b11d2d364", 
+                                "sortorder": "", 
+                                "text": "Storefront altered or replaced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "c684bb1d-45a8-4971-8f4f-c0910216ab08", 
+                                "id": "bccaa536-01eb-452f-ada3-65b196718646", 
+                                "sortorder": "", 
+                                "text": "Unknown/not visible"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "01e9e313-04aa-4e19-bd4f-d349ec8f6afe", 
+                                "id": "063ddb6f-953f-4a3e-bf72-652d60ba050f", 
+                                "sortorder": "", 
+                                "text": "Wall cladding replaced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "3b955768-3358-4f1d-96dd-7095a737778d", 
+                                "id": "8f5203c5-8ef9-4be8-941a-2362b36dc8e5", 
+                                "sortorder": "", 
+                                "text": "Window openings altered"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "6be61848-32c4-4039-b9bf-ce621c679fa7", 
+                                "id": "80e412a8-d0f2-423a-a755-05563a300450", 
+                                "sortorder": "", 
+                                "text": "Window openings infilled"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "31323cf4-4bb7-4559-a6bf-f267f086d7fd", 
+                                "id": "97a5ee2b-e899-4194-9817-d8004df3ca16", 
+                                "sortorder": "", 
+                                "text": "Windows boarded up"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "bf8c90b3-5536-422a-93fe-6873b7a437cb", 
+                                "id": "9f1f3e67-dca3-4f5e-b020-da5ac4c25c46", 
+                                "sortorder": "", 
+                                "text": "Windows replaced - all"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "458cd156-e2fa-4f1c-bbef-aa6c7c27358d", 
+                                "id": "639a237c-f79e-4831-a17d-af8773873ed2", 
+                                "sortorder": "", 
+                                "text": "Windows replaced - some"
+                            }
+                        ], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "0cebdc65-943d-11e8-92da-94659cf754d0", 
+                    "label": "Modification/Alteration Type", 
+                    "node_id": "0cebdc62-943d-11e8-b47c-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "1f816613-943d-11e8-bd5d-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Designation or Protection From Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "de26160f-dc81-11e8-a06e-94659cf754d0", 
+                    "label": "Designation or Protection From Date", 
+                    "node_id": "1f818d25-943d-11e8-bfa9-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "26733342-943d-11e8-8e7c-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Geometry Qualifier", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "19422fe9-cbfb-11e8-9b34-027f111c8e34", 
+                    "label": "Geometry Qualifier", 
+                    "node_id": "26733349-943d-11e8-be82-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "13e63510-943d-11e8-8bc5-94659cf754d0", 
+                    "config": {
+                        "label": "Description", 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "13e63513-943d-11e8-a7b4-94659cf754d0", 
+                    "label": "Description", 
+                    "node_id": "13e63512-943d-11e8-ab12-94659cf754d0", 
+                    "sortorder": 0, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                }, 
+                {
+                    "card_id": "13e63510-943d-11e8-8bc5-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Description Type", 
+                        "options": [], 
+                        "placeholder": "Select a description type"
+                    }, 
+                    "id": "13e63514-943d-11e8-98a0-94659cf754d0", 
+                    "label": "Description Type", 
+                    "node_id": "13e63511-943d-11e8-984c-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Style To Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "c9771ce2-dc6e-11e8-94e1-94659cf754d0", 
+                    "label": "Style To Date", 
+                    "node_id": "086e1c71-943d-11e8-9185-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
                     "card_id": "440786e4-943d-11e8-bda7-94659cf754d0", 
                     "config": {
                         "defaultValue": "", 
@@ -5130,2636 +4769,6 @@
                     "id": "440786e9-943d-11e8-993d-94659cf754d0", 
                     "label": "Component", 
                     "node_id": "440786e6-943d-11e8-b6dc-94659cf754d0", 
-                    "sortorder": 0, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                }, 
-                {
-                    "card_id": "440786e4-943d-11e8-bda7-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Material", 
-                        "options": [
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d83d089b-a4c9-4b7f-b0c3-81e3dbf0cea4", 
-                                        "id": "5fc92031-09ed-4fd5-9e61-c4c24a814cdc", 
-                                        "sortorder": "", 
-                                        "text": "Brick"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "dd63d5e8-dc43-4a5a-82d3-2e52b9032c38", 
-                                        "id": "f367147d-8813-491a-a9d8-83db58875b29", 
-                                        "sortorder": "", 
-                                        "text": "Concrete"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "06041405-d5d8-4899-b266-75b0a438bfd8", 
-                                        "id": "547b918d-be60-4b32-8f31-cad2f783b8ba", 
-                                        "sortorder": "", 
-                                        "text": "Concrete block"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "dcc73c41-5d27-47e6-9f55-c4148fc91ea9", 
-                                        "id": "1b97739f-c90a-4252-8c87-5c36468119ac", 
-                                        "sortorder": "", 
-                                        "text": "Exterior"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "098a1079-83d3-46cb-8a0b-fad10188ac1a", 
-                                        "id": "ad89e730-5087-405a-bb9f-418f8e8e68a7", 
-                                        "sortorder": "", 
-                                        "text": "Interior"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a48ce2ac-2208-4fd1-bfe2-ded228a2bc6f", 
-                                        "id": "50caac9f-2052-4ac7-9a54-eb50fc40e8dc", 
-                                        "sortorder": "", 
-                                        "text": "Pipe"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f157f18b-d615-4dec-9e3f-a71a5d1dfe4e", 
-                                        "id": "7b8d467f-f37c-4cd5-8ec1-4cdc782135da", 
-                                        "sortorder": "", 
-                                        "text": "Stone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "fb3a85a7-7aac-4d76-88ab-a231ef86ab28", 
-                                        "id": "6dbc1e84-bc15-4910-93c1-aaadbfc99905", 
-                                        "sortorder": "", 
-                                        "text": "Stucco"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2bde75aa-c629-4fd5-8387-f2b3013569e6", 
-                                        "id": "72fb1350-b85f-46b7-a3e0-18a10de4a5b0", 
-                                        "sortorder": "", 
-                                        "text": "Unknown"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "af3a391a-f831-44b3-9519-51ffff7234e5", 
-                                        "id": "f97558d2-0b0c-4d03-9e42-0a4a8cb9d09d", 
-                                        "sortorder": "", 
-                                        "text": "Wood"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "b803a540-be9c-40af-a670-d6a302bd35b7", 
-                                "id": "fb84842c-df39-426e-92c2-b3140664066d", 
-                                "sortorder": "", 
-                                "text": "Chimney"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d6d5f448-c6d2-4fe8-a012-7c679fceecdc", 
-                                        "id": "0009781f-cf53-47a7-8331-cdc6894154d0", 
-                                        "sortorder": "", 
-                                        "text": "Aluminum"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d3a190e9-38c6-493f-af7d-53a2daeecc00", 
-                                        "id": "f5abe63a-5137-44ba-bbd6-774add95e359", 
-                                        "sortorder": "", 
-                                        "text": "Asbestos"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1113ad05-bea4-42e6-9157-52411f52e4ff", 
-                                        "id": "c5bf4176-2dc1-4d0e-99ca-28747301046d", 
-                                        "sortorder": "", 
-                                        "text": "Board and batten"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "caef2f8f-c599-4ec6-8e3c-0aa9aa87efae", 
-                                        "id": "8f84a3f0-f450-4771-a654-e8d71e619a44", 
-                                        "sortorder": "", 
-                                        "text": "Brick"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cc97eb82-3724-488c-9733-e0af8608c850", 
-                                        "id": "a6d74418-233a-48d9-bf80-20292f03b770", 
-                                        "sortorder": "", 
-                                        "text": "Concrete"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1fa6c870-5a25-433c-b3e8-117f52095b24", 
-                                        "id": "18c61e14-92a2-43ed-9f4d-3856fe8c4edf", 
-                                        "sortorder": "", 
-                                        "text": "Concrete block"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c9ad9cfd-6e6c-4288-93e2-85de694c159d", 
-                                        "id": "5d3f76f9-d345-45e9-9750-e02a85dc16e2", 
-                                        "sortorder": "", 
-                                        "text": "Corrugated metal"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8cb577ef-b73e-4ac7-b5f7-762be1d5b255", 
-                                        "id": "9132e30d-14af-4ca7-86b0-7da3f1cfbec2", 
-                                        "sortorder": "", 
-                                        "text": "Fieldstone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5e552d33-b3da-4338-aa3d-50496a739d85", 
-                                        "id": "b548aa46-460b-41d1-91d4-5851a125dc5a", 
-                                        "sortorder": "", 
-                                        "text": "Glass skin"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b6a20dfe-0c45-49d0-bf49-3d6fd8a9b711", 
-                                        "id": "2dab5cf7-0c21-47c8-a7d6-4db24d3a6c49", 
-                                        "sortorder": "", 
-                                        "text": "Half timbering"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8b6b088f-a330-4a36-aca9-05b6810aaba3", 
-                                        "id": "ce07b222-5a1f-4567-af7a-7e9d1aded8c5", 
-                                        "sortorder": "", 
-                                        "text": "Marble"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "38de006a-c0b3-4c8a-ac41-8f76ed6f09b8", 
-                                        "id": "c9015605-4469-4516-96fa-deedfb4f96a9", 
-                                        "sortorder": "", 
-                                        "text": "Other"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "73997e60-2d44-4fc4-b844-6accf5138ec2", 
-                                        "id": "f80ca62c-a945-4687-8cf6-8ef07b525282", 
-                                        "sortorder": "", 
-                                        "text": "Permastone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ceb41faf-5a79-4381-b58f-1574d1cde5db", 
-                                        "id": "9afe7db4-3f9f-437b-adc5-129cdf768fb9", 
-                                        "sortorder": "", 
-                                        "text": "Stone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3629107e-0f0c-4eb0-bd44-d8bb702a3bc5", 
-                                        "id": "c024f820-e8a9-46d9-88bb-00400bda1de1", 
-                                        "sortorder": "", 
-                                        "text": "Stone, arroyo"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d12ba87a-04b0-4924-a12e-d4d83910dbe3", 
-                                        "id": "9a3a0763-36f0-4453-815f-074c32c61518", 
-                                        "sortorder": "", 
-                                        "text": "Stone, art"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f240a39b-6f0d-4ccd-b511-025f7969c72d", 
-                                        "id": "f3f433e8-db70-4c70-ac90-54e002fb5721", 
-                                        "sortorder": "", 
-                                        "text": "Stone, cast"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9d305fa2-cc75-4990-9dcf-7f507a2608a2", 
-                                        "id": "e9b21a41-400b-4ecc-a32c-eb9377eae0cd", 
-                                        "sortorder": "", 
-                                        "text": "Stone, cut"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "331afb63-1860-46ab-8d53-24076d541b9a", 
-                                        "id": "7966610d-5307-47a4-a389-f2dc8e5a902e", 
-                                        "sortorder": "", 
-                                        "text": "Stone, natural"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cb23d491-9099-48c1-8899-bad44bad1a30", 
-                                        "id": "125f1c25-56d2-4a77-8827-a82c57652e20", 
-                                        "sortorder": "", 
-                                        "text": "Stone, simulated"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "0ff18aa2-18b6-41f3-8354-45de8283af5d", 
-                                        "id": "2aa732e2-f967-4933-977a-53a210da486e", 
-                                        "sortorder": "", 
-                                        "text": "Stucco, smooth"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "fd71076e-0be3-4c6b-94ec-0c31bc46ebaf", 
-                                        "id": "1451f3e0-9191-4235-baa2-3b5a5ee7f406", 
-                                        "sortorder": "", 
-                                        "text": "Stucco, textured"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b9df914a-3f4f-41c9-8ee1-d8e74feb9e27", 
-                                        "id": "a44623a8-2cf6-4b01-a3d3-cae9e85b0f45", 
-                                        "sortorder": "", 
-                                        "text": "Terra cotta"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a519a887-66a9-42a8-afdf-ecae66551dae", 
-                                        "id": "e6cb7d8b-548d-40c7-9e69-25c31f3f6f6e", 
-                                        "sortorder": "", 
-                                        "text": "Travertine"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4154e783-25c4-4504-bfe9-8f266994fcbc", 
-                                        "id": "e11b4652-038a-4a9b-88e6-b225e218728e", 
-                                        "sortorder": "", 
-                                        "text": "Unknown"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f2e86216-6a57-4362-95de-f0b7584bfe1f", 
-                                        "id": "5948bc12-a363-4682-9bd7-c2530a928732", 
-                                        "sortorder": "", 
-                                        "text": "Vinyl"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "af81e762-1157-4a9e-a0b9-5d3f5387514f", 
-                                        "id": "891528a7-f3b4-4db2-8735-fc6a5010811b", 
-                                        "sortorder": "", 
-                                        "text": "Wood channel drop"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "87f7a123-c3c8-4d75-a444-b1f2413a9962", 
-                                        "id": "a1045051-076b-47ed-b1b5-721720dfdc23", 
-                                        "sortorder": "", 
-                                        "text": "Wood clapboards"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "841c7780-9daa-42bd-91cd-6b05f6ce6f3e", 
-                                        "id": "3c74077d-bbb8-44d4-88e3-59e29769f53c", 
-                                        "sortorder": "", 
-                                        "text": "Wood horizontal boards"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9d5dfa0f-b469-478c-a807-307c4d351672", 
-                                        "id": "96e5ce15-3686-4481-99a9-a0d58825de21", 
-                                        "sortorder": "", 
-                                        "text": "Wood panels"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d28a48bf-4e50-4373-bc18-7dd92505e432", 
-                                        "id": "f1061945-c507-4909-946f-34d0e676e71d", 
-                                        "sortorder": "", 
-                                        "text": "Wood rustic"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1cee5e8c-b889-430f-b91e-dc466f7dfb5a", 
-                                        "id": "e5300e6d-423b-490e-b1f7-7836a3cb08c8", 
-                                        "sortorder": "", 
-                                        "text": "Wood shingles"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8bfa0e72-b54e-4d8d-9b61-6ebcbdc41ea7", 
-                                        "id": "2b88f723-d8c7-4072-b2e6-fb93ad9fbcc8", 
-                                        "sortorder": "", 
-                                        "text": "Wood shingles, fish scale"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "03386f42-14ac-431d-b838-a24e9c808e6b", 
-                                        "id": "9bb25367-1b59-4d2a-b77a-a792cf71707f", 
-                                        "sortorder": "", 
-                                        "text": "Wood tongue-and-groove"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d4a12b5f-fea2-4e94-8795-04f42ec09114", 
-                                        "id": "78a133fe-ce0d-4018-bc29-7cdad6ef86d7", 
-                                        "sortorder": "", 
-                                        "text": "Wood vertical boards"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "fe7866a1-13a1-4d1b-825f-48ab730c6242", 
-                                        "id": "ecdd773d-78cf-4b92-8f2a-768947c63099", 
-                                        "sortorder": "", 
-                                        "text": "Wood, Board and Batten"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "0e82ac27-63db-46c1-ad8f-7933f7d6523b", 
-                                "id": "63bc49bb-84b6-4418-97ed-46f14cf3e48b", 
-                                "sortorder": "", 
-                                "text": "Cladding"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "33e14719-7250-46d6-b559-f61db61cf78e", 
-                                        "id": "2917fe20-4102-4228-aeed-1211158fb87d", 
-                                        "sortorder": "", 
-                                        "text": "Adobe"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7b23c150-b93b-45ff-8495-a896980ef742", 
-                                        "id": "d7952439-79ca-44ad-bea1-2b855c6df59b", 
-                                        "sortorder": "", 
-                                        "text": "Brick"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d5ae0607-7813-4182-819a-b087f5238d2c", 
-                                        "id": "9b5b0e2d-a603-4ea8-b0eb-f59aae42bb8e", 
-                                        "sortorder": "", 
-                                        "text": "Concrete masonry unit"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e5210afd-6134-410a-99d5-ea0807cfbfa6", 
-                                        "id": "0a2b13db-1141-4e47-9ea8-2ce60fde706d", 
-                                        "sortorder": "", 
-                                        "text": "Concrete poured/precast"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "de6bdf3d-f6fe-4a77-82e8-d38621708c8f", 
-                                        "id": "4b80592d-2e8d-4e9e-81fd-ed8b0a869839", 
-                                        "sortorder": "", 
-                                        "text": "Concrete, masonry unit"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b00169f9-7169-4ef5-8024-d78432767117", 
-                                        "id": "ed273fe0-6f4a-4519-9b41-09592b48344a", 
-                                        "sortorder": "", 
-                                        "text": "Concrete, poured/precast"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "55d5486f-fe37-41cb-9577-db04b729ca6f", 
-                                        "id": "2b2675db-610e-4297-9b94-f286e416bab4", 
-                                        "sortorder": "", 
-                                        "text": "Corrogated metal"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1b330be1-8260-4715-b95b-3313e0561f38", 
-                                        "id": "2a3e2771-46da-439a-a701-f5e8fac5bcd8", 
-                                        "sortorder": "", 
-                                        "text": "Hollow clay tile"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e0898bb2-d048-4b0f-a5ef-56954899be21", 
-                                        "id": "1b7dd884-a6e3-4cd5-b1de-0b96d7b36a41", 
-                                        "sortorder": "", 
-                                        "text": "Post-and-beam"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "699757d8-1194-4507-9612-e39b1cdf6989", 
-                                        "id": "b4805ef3-bbc1-45b6-8339-b780be497547", 
-                                        "sortorder": "", 
-                                        "text": "Steel"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "da321753-5265-4dff-95fd-cb3d33651e54", 
-                                        "id": "4bba90f5-d998-4a53-9bc2-99027cd4e3e7", 
-                                        "sortorder": "", 
-                                        "text": "Stone"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "42ca5a0e-f439-4e5c-b7d5-5b752c44a48f", 
-                                        "id": "b82aaa50-722a-4f2c-87d4-7d2df5e2f129", 
-                                        "sortorder": "", 
-                                        "text": "Unknown"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5e9299fc-7629-4239-9719-17e1ac6a8d95", 
-                                        "id": "e8b36e0b-993e-4e1e-a613-8bbb27d09b4f", 
-                                        "sortorder": "", 
-                                        "text": "Wood"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "90fc0f69-9b3e-41c3-80f7-b40b5f3afe29", 
-                                "id": "f178fb92-9514-4ca4-9c2a-29efaa99c00a", 
-                                "sortorder": "", 
-                                "text": "Construction"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e6c46b2e-408e-4dcb-be0a-dd3ca4c55f44", 
-                                        "id": "933d0c1b-1fb6-43d9-949c-3474ced8139c", 
-                                        "sortorder": "", 
-                                        "text": "Applied decoration"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d93eb68f-e7b5-4a26-a94b-093ebbd20240", 
-                                        "id": "8bb47086-9b43-4be6-b7de-555dc69dfb52", 
-                                        "sortorder": "", 
-                                        "text": "Balconette"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ba44c544-a078-43b7-a913-59ec24828e20", 
-                                        "id": "1cb3ad6d-6d35-4339-8e52-8f1a9616bc77", 
-                                        "sortorder": "", 
-                                        "text": "Belt course"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "53a38db4-82e8-424e-9b78-02a35234b7df", 
-                                        "id": "78af07f8-5f24-4f92-a42a-0e0168eafdcd", 
-                                        "sortorder": "", 
-                                        "text": "Bris soleil"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c672c96b-f443-498d-914f-b756895751b3", 
-                                        "id": "f00730f2-a512-4431-9fb9-6d612bb48ce8", 
-                                        "sortorder": "", 
-                                        "text": "Buttresses"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "190f06c4-b43f-46cf-a295-a2a3ba9d852c", 
-                                        "id": "c72d09bd-c3e7-49b2-a383-b6d306eb3cd0", 
-                                        "sortorder": "", 
-                                        "text": "Dingbats"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e7b3c3b3-e94f-48a7-aef0-a23c904e5a99", 
-                                        "id": "c5067420-1981-4990-9e24-a649019ead76", 
-                                        "sortorder": "", 
-                                        "text": "Grilles"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6751efb7-c690-461b-9f96-d57ba757a345", 
-                                        "id": "7c37b10a-12ba-46ac-827e-891340e25694", 
-                                        "sortorder": "", 
-                                        "text": "Light Fixtures"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3445a317-878c-4238-9c85-24a7577eb586", 
-                                        "id": "34b082df-87b4-4577-911e-95ccda691909", 
-                                        "sortorder": "", 
-                                        "text": "Loading Dock"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8f6ab6c3-ec16-4828-9fee-3a858d257b1a", 
-                                        "id": "cf7dfbb0-603b-49b1-b40f-4ae8534fc7d8", 
-                                        "sortorder": "", 
-                                        "text": "Pierced screens"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6697cb01-8994-454b-8a80-dc0a52e954f5", 
-                                        "id": "d82a1370-90fc-49d1-b8b4-8c4ff42f19e5", 
-                                        "sortorder": "", 
-                                        "text": "Pilasters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "39bcd5b1-0118-4e63-b0a1-ecf9d1e44421", 
-                                        "id": "cf61bc5e-c303-4cd6-8591-4642e77bb0b9", 
-                                        "sortorder": "", 
-                                        "text": "Planters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "333bdf3b-7598-42de-b322-844de2dff251", 
-                                        "id": "61fa58fe-8645-4386-a18d-c82cffdfaeed", 
-                                        "sortorder": "", 
-                                        "text": "Quoins"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "10b63b6c-ea54-485e-9dcb-6c98a149b1d2", 
-                                        "id": "fc12d816-d48b-4de8-9d30-951f9dc24401", 
-                                        "sortorder": "", 
-                                        "text": "Sign"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "020754ba-c6ec-4b0b-b1ed-c6777c13ece8", 
-                                        "id": "3f911014-7af5-4e06-8bf4-dab91d818b10", 
-                                        "sortorder": "", 
-                                        "text": "String course"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2ecbbe3d-1ae1-4f96-8d12-d3bba7c29148", 
-                                        "id": "04416b6a-c7ef-4a89-a9fc-964a5ddb10bd", 
-                                        "sortorder": "", 
-                                        "text": "Tile"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "382e51df-5c89-49b8-9f54-29093ec6aca4", 
-                                "id": "8866fb45-dcfd-422b-b95e-e2a7f5862199", 
-                                "sortorder": "", 
-                                "text": "Details"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "20c54fe3-06b2-44cf-9845-d2d590110798", 
-                                        "id": "07e9cf15-7cec-4b7a-b5d1-157abf14e97e", 
-                                        "sortorder": "", 
-                                        "text": "Arched"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7e434625-5ab6-474f-8fa3-39eb0d25a5b5", 
-                                        "id": "3f1d38bd-bb8f-4c5a-80ce-f5a2464eba51", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening, pointed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5c2cddba-fd0e-459f-80ac-055f9b986d16", 
-                                        "id": "e880c63d-b16b-44b5-abc2-3dc7947dbedb", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening, round"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c29db6a0-d4f4-40e8-846e-176e3e473763", 
-                                        "id": "031ec715-d2f4-4baf-83cc-f7165896bd1d", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening, segmental"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "07450ab1-5996-4c04-901c-3240627d2139", 
-                                        "id": "5a5c03f5-6c88-4a41-bfea-3f201e81cf9d", 
-                                        "sortorder": "", 
-                                        "text": "Awning"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8452db7c-56a0-42c2-894e-69c6c3c83b0e", 
-                                        "id": "f5b64f26-b68b-425f-94d4-5aeacdc5f610", 
-                                        "sortorder": "", 
-                                        "text": "Canopy"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a07d2c76-0a4a-41c5-9071-f23969ca022a", 
-                                        "id": "cdcae785-14d8-4fe1-9d7f-6dbfbab4b08f", 
-                                        "sortorder": "", 
-                                        "text": "Decorative hardware"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b294fa28-c66c-492c-b163-d953f6491569", 
-                                        "id": "ec1217cd-5246-4a38-9c72-184621cb95a7", 
-                                        "sortorder": "", 
-                                        "text": "Decorative surround"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9250e425-4340-41cb-a588-da04a072594b", 
-                                        "id": "f2eb521e-c2aa-4241-92e4-63d6fb070746", 
-                                        "sortorder": "", 
-                                        "text": "Divided lights"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1e93344a-3a74-4d6e-8159-9d5d19120f7e", 
-                                        "id": "73ccb465-6b8f-4e5d-ac26-e35dc40bfcb8", 
-                                        "sortorder": "", 
-                                        "text": "Double"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c59713cd-7c2b-4104-8f11-3b6c80382c06", 
-                                        "id": "2c5bab37-0001-484c-841b-16ef793a4fa3", 
-                                        "sortorder": "", 
-                                        "text": "Fanlight"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d4b036f1-6e4a-4357-a3a3-36f433edfb8d", 
-                                        "id": "50579aec-f633-4e88-bb23-b615642fb8ae", 
-                                        "sortorder": "", 
-                                        "text": "French doors"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6fc50e04-bd62-458d-b9ae-e6eafce270cb", 
-                                        "id": "359a5e23-3f4f-4a32-8be2-94b2e336ed03", 
-                                        "sortorder": "", 
-                                        "text": "Fully glazed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "01cc780e-3ec0-4a9f-b28d-cd531b4e374a", 
-                                        "id": "d635fd64-dcb5-4b40-a90d-8037bd0bf748", 
-                                        "sortorder": "", 
-                                        "text": "Glazed, fully"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c0606ee0-1326-4328-a1e5-2714702ee243", 
-                                        "id": "ef7eed00-6173-4a7d-a6ce-25965b3929f3", 
-                                        "sortorder": "", 
-                                        "text": "Glazed, partially"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9d3f1e38-3396-40a5-9cae-5e0bed40dfb9", 
-                                        "id": "ff6d63ea-f7bb-41de-b293-12ca6ed30d38", 
-                                        "sortorder": "", 
-                                        "text": "Historic Surround"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "acdc82ac-91a2-488d-9e5c-2d3c57e6f7c7", 
-                                        "id": "6494b61e-ec73-4967-a065-0aadff397e89", 
-                                        "sortorder": "", 
-                                        "text": "Historic hardware"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ff3d6e44-750d-432a-bf57-e530dd3d5f01", 
-                                        "id": "ef20ecb7-f80d-4a5c-96ce-6ebd9b1b0055", 
-                                        "sortorder": "", 
-                                        "text": "Metal screen"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ea6d10a1-5bd5-42d2-97b4-a7a1fa64a421", 
-                                        "id": "c44cf506-8722-4cb9-abbb-2ae069ca8ad0", 
-                                        "sortorder": "", 
-                                        "text": "Paneled"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5c05dc48-79fe-4936-9809-331154426b44", 
-                                        "id": "fc468ce8-7b90-4e55-94a4-2e9b88b4d1bb", 
-                                        "sortorder": "", 
-                                        "text": "Partially glazed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bb049f11-4cac-4dbb-9e13-7d4e56d4051c", 
-                                        "id": "582cc454-9bf3-496a-8479-1191e9db7907", 
-                                        "sortorder": "", 
-                                        "text": "Pediment"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "75102bfd-289b-4882-a40b-fbbc06f99031", 
-                                        "id": "3cc5f144-9874-47f8-80b6-80a7809d7f6e", 
-                                        "sortorder": "", 
-                                        "text": "Pilasters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4564892f-6d67-4058-ae4d-52a9ab6c7c2c", 
-                                        "id": "8a5e4d50-9937-4a1c-9584-9e0427d17eb1", 
-                                        "sortorder": "", 
-                                        "text": "Roll-up"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "27ab4fbe-57d6-44f8-bc6f-68e17239d45f", 
-                                        "id": "48947ba1-160c-4851-926b-8e938f1f14df", 
-                                        "sortorder": "", 
-                                        "text": "Security door"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "86e8fc76-b87d-4f8d-837a-8b708ca802f5", 
-                                        "id": "0bdbb0b2-7be7-48ce-ae6a-0832f7eb2860", 
-                                        "sortorder": "", 
-                                        "text": "Sidelights"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d25e5e65-8aee-42f2-85b2-de92e03651be", 
-                                        "id": "6a34225c-3917-459e-bf63-0bedb59e14dc", 
-                                        "sortorder": "", 
-                                        "text": "Single"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "0eacfc92-78b9-4cab-814f-30fe2dce467f", 
-                                        "id": "1a477484-dce4-47c4-b8dc-c12373dc42c5", 
-                                        "sortorder": "", 
-                                        "text": "Sliding"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b8830b8c-9463-4ac3-9495-804f9f6759c7", 
-                                        "id": "d17c4563-2743-4426-9a49-a4a5566575c5", 
-                                        "sortorder": "", 
-                                        "text": "Transom"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "541f7f2e-30b2-4516-abb1-ece53a050196", 
-                                        "id": "74868e3d-ca47-4026-8876-39febc34ab8b", 
-                                        "sortorder": "", 
-                                        "text": "Unknown"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "38435fbd-3ee2-4159-84e6-fad2ebacfad9", 
-                                        "id": "d6cb9285-609a-4565-a3c7-2fce84ff966e", 
-                                        "sortorder": "", 
-                                        "text": "Wood screen"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "d1ffee68-31f7-4b69-869f-cc5fe8d01da5", 
-                                "id": "d9c73268-97cf-418d-80fb-92d0f0f16a75", 
-                                "sortorder": "", 
-                                "text": "Door Types"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2ee9ecfe-f8bf-4681-8919-2a83a81a629c", 
-                                        "id": "0b1c1b6a-0ef9-4707-b30e-d113285a66e1", 
-                                        "sortorder": "", 
-                                        "text": "Arches"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "11885ebc-e3ce-4a9c-b6f5-11d67d571a78", 
-                                        "id": "51337cf2-e416-4c6d-a0ac-8b90b5233923", 
-                                        "sortorder": "", 
-                                        "text": "Atrium"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5fa8c46a-fb89-4828-b3bf-ae631a76a934", 
-                                        "id": "8566f513-6fe8-450b-b52b-5b560b0b6a69", 
-                                        "sortorder": "", 
-                                        "text": "Awning(s)"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b259c1e2-c54a-4345-a8e6-85bf0cddd896", 
-                                        "id": "9f9fd6b3-0a76-46ab-b054-a4b4b79d4d2d", 
-                                        "sortorder": "", 
-                                        "text": "Balcony"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6ff76bb7-a5fb-44aa-aed3-2b659c2bc6c1", 
-                                        "id": "dd177ccf-fd7f-4a19-9863-bc3083946464", 
-                                        "sortorder": "", 
-                                        "text": "Balustrade"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1cbc707e-d184-407d-ab70-3af14287f5ed", 
-                                        "id": "fc75aa20-4f6f-4851-82bb-ae134b4fa06c", 
-                                        "sortorder": "", 
-                                        "text": "Canopy"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "acd09b87-bb5c-4fd2-857a-4e568adb8f89", 
-                                        "id": "29d3b2a7-a90a-4496-9af0-ee200e8ce0f9", 
-                                        "sortorder": "", 
-                                        "text": "Colonnade/arcade"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "de3d0b45-348f-4133-8d3b-f546f2d67fa7", 
-                                        "id": "ef45639f-5dc7-4540-9484-23df054ad034", 
-                                        "sortorder": "", 
-                                        "text": "Columns"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c501b7c9-8919-42e4-a872-8478b974a68c", 
-                                        "id": "1356d379-34b3-42f0-a37f-ca8176b18f22", 
-                                        "sortorder": "", 
-                                        "text": "Courtyard"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "283b94e9-42f6-48a0-9de7-829d6be82571", 
-                                        "id": "531011a1-7285-41ba-a9a1-43546dca6f07", 
-                                        "sortorder": "", 
-                                        "text": "Marquee"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "57dca478-fc6d-4bf1-bfc9-1985bb7ca052", 
-                                        "id": "19dfeb13-0ed9-4b0b-84f1-53c344b7de7f", 
-                                        "sortorder": "", 
-                                        "text": "Patio"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a08f0203-5ab8-4293-bbf6-93027c4fc76e", 
-                                        "id": "d408b762-2027-45b6-84fb-53303c3e28af", 
-                                        "sortorder": "", 
-                                        "text": "Pilasters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "86162a52-f1cd-4527-b12f-65e80a7c28fe", 
-                                        "id": "2b041cb4-cc36-4506-95b8-b6c62144b433", 
-                                        "sortorder": "", 
-                                        "text": "Portico"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bf2fbf74-1d07-4d0a-9933-33f77089bb09", 
-                                        "id": "b34c736c-90a3-4b08-87b8-3b19dfa0b5d6", 
-                                        "sortorder": "", 
-                                        "text": "Projecting"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9eb17204-3313-438c-bf9c-40b0e3bb86ea", 
-                                        "id": "4eb2fc54-5242-4ba8-9519-33129941449f", 
-                                        "sortorder": "", 
-                                        "text": "Recessed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ebf8a33d-ff3c-4ed3-abe2-c1c06a7a9622", 
-                                        "id": "17eda140-4d61-4da8-9146-d1ef7c74bf34", 
-                                        "sortorder": "", 
-                                        "text": "Stoop"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f48a7c77-a1e6-4265-b1e7-73e363e0067c", 
-                                        "id": "b7d06469-ae74-4e39-8ea9-3282b4db67d2", 
-                                        "sortorder": "", 
-                                        "text": "Subterranean"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8dd192bb-8e07-4aa6-bf75-0c4fa5ac5442", 
-                                        "id": "659a0761-05e2-4bc6-939b-ae287a065b09", 
-                                        "sortorder": "", 
-                                        "text": "Vehicular entry"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e7ccddcf-1619-41f7-b7eb-06b7756dff3d", 
-                                        "id": "5a34fc16-7d61-427f-9066-53248c380255", 
-                                        "sortorder": "", 
-                                        "text": "Wall"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "26c50759-f7ed-4813-b56b-029db5fd2f93", 
-                                "id": "e9b15d8e-c33b-41ab-bb86-dbf42b63cddc", 
-                                "sortorder": "", 
-                                "text": "Entryway"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e232ba64-d69f-4976-b426-3c844d23cc2c", 
-                                        "id": "1ccace88-b1a1-4800-942a-6b1237b5134a", 
-                                        "sortorder": "", 
-                                        "text": "Asymmetrical"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5e9938c3-b1a3-48af-8120-67475d6daba4", 
-                                        "id": "fb2a07a9-457b-4784-af2e-5fe125dd1fe9", 
-                                        "sortorder": "", 
-                                        "text": "Symmetrical"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "6f50a4f9-0e31-4984-8a5e-ae157847c7fb", 
-                                "id": "1f0aa116-587b-4f4b-b474-c48e5d1791f3", 
-                                "sortorder": "", 
-                                "text": "Fa\u00e7ade"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "291eb4ff-4540-4915-8fb0-dff3a64445fe", 
-                                        "id": "b4e2a277-6c63-428b-b4e0-8a21fb539c25", 
-                                        "sortorder": "", 
-                                        "text": "Circular"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "04901917-51ac-4df4-b112-983e0fed8a2d", 
-                                        "id": "324a0b3b-a14f-4ae5-8aa3-61fdface0181", 
-                                        "sortorder": "", 
-                                        "text": "H-shaped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5495e6c5-0687-4014-9c92-7ac682f3c60b", 
-                                        "id": "62632597-a927-49a7-912e-bc7a75790423", 
-                                        "sortorder": "", 
-                                        "text": "Irregular"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "91d9bcde-1c80-4f70-bd7e-8238fc7ac8e9", 
-                                        "id": "251d058e-e302-4f9f-a28f-311b37c747a6", 
-                                        "sortorder": "", 
-                                        "text": "L-shaped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "81611727-82ee-4a48-9c97-bba951e48195", 
-                                        "id": "3166f5e0-af43-40ef-ab1a-6b55694f8826", 
-                                        "sortorder": "", 
-                                        "text": "Octagonal"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9098d9ed-5a94-43de-b394-409b905b7c36", 
-                                        "id": "c54d0573-af04-4312-9b6f-fd2840713760", 
-                                        "sortorder": "", 
-                                        "text": "Rectangular"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "39de0979-8dac-4bff-b90d-f942d5429518", 
-                                        "id": "c8cfb079-5318-4adb-bf81-825b9569b755", 
-                                        "sortorder": "", 
-                                        "text": "Square"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "fa5d41b2-27c1-493e-9c0c-cd66c45958ae", 
-                                        "id": "51015c31-8735-44a3-af99-ce9f10426bfa", 
-                                        "sortorder": "", 
-                                        "text": "T-shaped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b5300111-7b9f-4890-b640-965a95bdfb34", 
-                                        "id": "7b72f8e0-9732-42d1-9415-22b1258b2a50", 
-                                        "sortorder": "", 
-                                        "text": "Triangular"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9170468e-04e3-4d6a-a7e3-21de23caf144", 
-                                        "id": "e63f4a97-9503-4446-8f3d-3896f1d68430", 
-                                        "sortorder": "", 
-                                        "text": "U-shaped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1ab3342d-a22b-49a6-a940-d150a670b5b8", 
-                                        "id": "57f1d880-3a19-4829-95eb-6e4fc348f0e5", 
-                                        "sortorder": "", 
-                                        "text": "Unknown"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "43ecf05a-b100-452c-b8db-41e733faaac2", 
-                                "id": "2f75b7e4-b3d8-4fd9-af88-d59189f2df8c", 
-                                "sortorder": "", 
-                                "text": "Plan"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2ab656d8-44d4-433e-a935-ea33a67a6f9d", 
-                                        "id": "6aa17b31-cc09-40b3-b514-e387a4dece84", 
-                                        "sortorder": "", 
-                                        "text": "Entrance porch/stoop"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7aaa0415-9410-44fc-8111-a465604d7122", 
-                                        "id": "dd370a00-1717-4121-b2b4-85b93de2ea69", 
-                                        "sortorder": "", 
-                                        "text": "Full width"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5d45b12d-80b5-4f95-8367-861eb9fc4072", 
-                                        "id": "89ff4b90-ec2c-4821-97d8-60dc153be92d", 
-                                        "sortorder": "", 
-                                        "text": "Partial width"
-                                    }, 
-                                    {
-                                        "children": [
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "d1e589e8-f3f6-4e51-9032-7870a7404591", 
-                                                "id": "c64b0bee-2808-44d1-a1cb-b1887851993c", 
-                                                "sortorder": "", 
-                                                "text": "Balustrade (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "3362f620-35ac-41be-bf6d-63b22f309304", 
-                                                "id": "44a83fe0-62d6-41e2-a59f-b47aefd52076", 
-                                                "sortorder": "", 
-                                                "text": "Brick (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "f9ee42f3-dcc2-42ed-9025-3264a453b742", 
-                                                "id": "ad971d05-9bf6-45ed-a5cc-e041924cbf69", 
-                                                "sortorder": "", 
-                                                "text": "Concrete (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "8ad1d739-f80d-4ee5-a3ac-11caafb0c890", 
-                                                "id": "e21b03e9-635c-4abe-a81f-7002a9b301e7", 
-                                                "sortorder": "", 
-                                                "text": "Handrail (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "679a2447-ab7a-4b03-a097-a0139634b077", 
-                                                "id": "1b3e35be-1c24-4380-ac28-838f3abc659f", 
-                                                "sortorder": "", 
-                                                "text": "Iron (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "cb89845a-4c73-40ce-89bc-731705c2b1de", 
-                                                "id": "9c1358d9-8c14-4991-a1ea-09c8464ed6a8", 
-                                                "sortorder": "", 
-                                                "text": "Metal (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "4eec3c66-bbb2-400f-8c57-2e58ec714123", 
-                                                "id": "2eb88881-3800-4460-801a-559a7a5620bd", 
-                                                "sortorder": "", 
-                                                "text": "Other (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "8d268c08-7ccd-4f58-b0c9-9498422598ff", 
-                                                "id": "a9d02bb1-875e-4906-a65c-7e28c8f5f695", 
-                                                "sortorder": "", 
-                                                "text": "Stair rail (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "84c20f2d-ba21-4379-845d-1e934f15535e", 
-                                                "id": "8e79c43b-87a9-4a40-890c-018b33baaf6e", 
-                                                "sortorder": "", 
-                                                "text": "Stone (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "9cb95f90-6a0e-4a74-9545-7a345eee4d6b", 
-                                                "id": "096d725c-3515-4ba6-be0b-f62a74dac09f", 
-                                                "sortorder": "", 
-                                                "text": "Stone, arroyo (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "d2b8e5a0-496a-49ce-8bc4-67040e1e4128", 
-                                                "id": "18027796-af7e-48fc-a49a-9ae59d006adf", 
-                                                "sortorder": "", 
-                                                "text": "Stone, cast (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "92567806-0817-4a44-965f-918e6ddc060c", 
-                                                "id": "750d8f1e-ea4e-4c10-8c81-3ffd2f943309", 
-                                                "sortorder": "", 
-                                                "text": "Stone, cut (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "3d77ece9-3f1e-4384-9a35-111f42e7c21d", 
-                                                "id": "2f087443-1f20-4274-ab20-ac649e293343", 
-                                                "sortorder": "", 
-                                                "text": "Stone, natural (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "a1054bf5-9af0-4178-85f4-097757fecb65", 
-                                                "id": "7712cd7c-7e98-42f8-8dc3-f7835c503d86", 
-                                                "sortorder": "", 
-                                                "text": "Stone, simulated (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "893b458f-b4a5-4bb5-92cd-472e56f5a8ea", 
-                                                "id": "2814dde6-d8f0-4835-81ff-9751dc3fe1b7", 
-                                                "sortorder": "", 
-                                                "text": "Stucco (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "6107e049-34ae-42d2-aaba-de5be0a32b27", 
-                                                "id": "d45262ea-5d01-41cf-9797-483329b1c6d7", 
-                                                "sortorder": "", 
-                                                "text": "Terra cotta (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "6b9b0e97-63d4-4383-8f1c-5f2f6f36baa1", 
-                                                "id": "3c35e01d-7e10-4227-8278-04cbf3cffc30", 
-                                                "sortorder": "", 
-                                                "text": "Wall (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "0500d7fd-bddf-46ae-8998-23247145aa92", 
-                                                "id": "8760227d-738e-410d-a03a-c19b6cee1a12", 
-                                                "sortorder": "", 
-                                                "text": "Wall, low (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "691c10e1-3e09-43ad-baac-0b4b202a1bca", 
-                                                "id": "f58756b9-553c-4560-95b1-c154e3de7bf0", 
-                                                "sortorder": "", 
-                                                "text": "Wood (Porch Rail)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "50cc6e44-5fe2-47cb-944b-3618ab2e7989", 
-                                                "id": "5b2fc096-eb6c-4942-b4a4-e440a2280cfd", 
-                                                "sortorder": "", 
-                                                "text": "Wrought iron (Porch Rail)"
-                                            }
-                                        ], 
-                                        "collector": "", 
-                                        "conceptid": "88255896-b525-4cae-a12d-d488e5505366", 
-                                        "id": "8f85a2a7-9e02-4fbc-9d1d-64c7d0b1b09e", 
-                                        "sortorder": "", 
-                                        "text": "Porch Rail (Porch Rail)"
-                                    }, 
-                                    {
-                                        "children": [
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "c6e6691d-fd47-4412-ab21-ab60ecab8b95", 
-                                                "id": "288a4f2d-3658-4edd-ab60-9e40b2bbc795", 
-                                                "sortorder": "", 
-                                                "text": "Arches (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "a4e01a02-d311-4efc-ba2c-0aaf1e78789c", 
-                                                "id": "f4ca5517-8a47-4da3-8e9a-887dcb6c60dd", 
-                                                "sortorder": "", 
-                                                "text": "Brackets (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "f4b59fca-c26d-4db5-a966-647863292a25", 
-                                                "id": "4fd21078-1a7a-4f9a-ab17-70b7117f3c9e", 
-                                                "sortorder": "", 
-                                                "text": "Columns (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "54890950-eb0d-4a07-a7ff-166a8f3a9b47", 
-                                                "id": "117a35c2-3bf7-4ff8-8654-e15abb8dea80", 
-                                                "sortorder": "", 
-                                                "text": "Piers (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "20eee33e-b572-4c49-904b-78598007ba03", 
-                                                "id": "c8d8ce8c-6fcb-4e8d-86fd-a12d7e69e1d6", 
-                                                "sortorder": "", 
-                                                "text": "Posts (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "8a5c4c44-3fec-4c1a-ab1c-da4e719cdec3", 
-                                                "id": "89fc8e48-db38-4603-9376-5ad53737b806", 
-                                                "sortorder": "", 
-                                                "text": "Spindles/turned posts (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "d46d9cd6-f7d1-41a0-bb2b-b5a9d18c5f4b", 
-                                                "id": "d12126a5-8359-45a8-98ba-8b39ddd22779", 
-                                                "sortorder": "", 
-                                                "text": "With Pedestals (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "6f0c6817-71bd-4af9-a22a-42a58bffe555", 
-                                                "id": "1b1b189f-ac35-48e3-acd0-98c3f1b6911e", 
-                                                "sortorder": "", 
-                                                "text": "With brick pedestals (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "c39835e7-b123-4382-98be-4511abe44f1e", 
-                                                "id": "a7abe780-9111-41f1-a710-b0e03292f19d", 
-                                                "sortorder": "", 
-                                                "text": "With concrete pedestals (Porch Supports)"
-                                            }, 
-                                            {
-                                                "children": [], 
-                                                "collector": "", 
-                                                "conceptid": "837d36b4-1a33-4f0a-ae6c-26782dbd91ea", 
-                                                "id": "d7fc8ac9-c517-4d1d-9ce0-17f12cbae48a", 
-                                                "sortorder": "", 
-                                                "text": "With stone pedestals (Porch Supports)"
-                                            }
-                                        ], 
-                                        "collector": "", 
-                                        "conceptid": "68602892-c480-4c55-994e-8dcb8bddedc2", 
-                                        "id": "b4a375e1-81c5-4a6a-9313-8189a423541c", 
-                                        "sortorder": "", 
-                                        "text": "Porch Supports (Porch Supports)"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "fb5e0507-031c-41a6-884e-38cd65b2e4cb", 
-                                        "id": "e0d989cc-3832-49c6-9216-9a93e654872b", 
-                                        "sortorder": "", 
-                                        "text": "Projecting"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7dfbb4b2-89af-4104-98e4-72971c667969", 
-                                        "id": "fe638838-07ff-458e-a44e-2765b40415eb", 
-                                        "sortorder": "", 
-                                        "text": "Recessed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "27ba2ce4-e206-4c43-b7f7-12a4ace018a5", 
-                                        "id": "607b49c0-e829-4fe2-ba71-4e6822415180", 
-                                        "sortorder": "", 
-                                        "text": "Roof, flat"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "82233be5-a1f7-44bd-b595-d8ef80d431f1", 
-                                        "id": "80f14cca-ba72-4d17-98b4-4bad04c3803a", 
-                                        "sortorder": "", 
-                                        "text": "Roof, gable"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c5f58eb2-42ec-4143-9d66-97ce9b28c9ab", 
-                                        "id": "a277968d-1f64-43e7-bb03-f29bf402cd60", 
-                                        "sortorder": "", 
-                                        "text": "Roof, hipped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7bc3735e-d671-4fb9-b09e-b3f71ee5c403", 
-                                        "id": "1ec8c8be-8f26-43e0-bbd5-91b76dabb8ca", 
-                                        "sortorder": "", 
-                                        "text": "Roof, mansard"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5a8a325b-47b5-40d4-b44f-9ecbd85b0cf0", 
-                                        "id": "eef4ad62-b9f0-44ba-a207-e847bda79060", 
-                                        "sortorder": "", 
-                                        "text": "Roof, parapet"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a1113b06-efcd-41f9-8da0-93b275744994", 
-                                        "id": "1d5f258a-bf9a-4e3c-9b3b-31a00e4825c6", 
-                                        "sortorder": "", 
-                                        "text": "Roof, shed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4a3f36d4-e0ae-4931-8b8e-9fb6dbefae2d", 
-                                        "id": "c8d92b65-d70b-4009-b6e3-7d5d301f992a", 
-                                        "sortorder": "", 
-                                        "text": "Wraparound"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "f09b843a-60ed-4fd9-8a37-d26aef2b2f6b", 
-                                "id": "d51e0d1a-276d-4b23-ba1c-5fb2143b44c5", 
-                                "sortorder": "", 
-                                "text": "Porch"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1a2234fd-a1dd-4372-a2a2-530ec15bcf2a", 
-                                        "id": "6b1d8187-ec69-4ccc-860a-2a34eba4e613", 
-                                        "sortorder": "", 
-                                        "text": "A-frame"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "efc0e5f2-89ae-4007-a298-d2d20699f7c1", 
-                                        "id": "22b90a49-4a69-4f26-9d6f-9b63adf545b1", 
-                                        "sortorder": "", 
-                                        "text": "Bargeboards"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1dd7cb47-d620-4b9d-a444-b7cc655fda11", 
-                                        "id": "4a01d500-10c8-4953-80ae-2ef3adcfe0b0", 
-                                        "sortorder": "", 
-                                        "text": "Barrel vaulted"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "eb95464b-c2a4-4a88-8ba2-4aaeef01273b", 
-                                        "id": "fea679ba-6a7e-4887-b07a-1a17c1bb7eab", 
-                                        "sortorder": "", 
-                                        "text": "Brackets"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "15a71535-3d81-4e4d-8107-98f9ce489453", 
-                                        "id": "748ad9d2-3fb6-4d23-9f86-e48fc6772c8e", 
-                                        "sortorder": "", 
-                                        "text": "Butterfly"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "769fd4c0-52a8-4f31-8f18-5fa41d81ce62", 
-                                        "id": "14f358f9-fc1e-4fc4-9fb9-b5bb8be3d0e6", 
-                                        "sortorder": "", 
-                                        "text": "Clay tile coping"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a5bf564d-9174-4ea5-9f5c-48300f84c97b", 
-                                        "id": "2a3e907e-1e91-4c67-a21d-fca3a0ff7f13", 
-                                        "sortorder": "", 
-                                        "text": "Clipped Gable, side"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a87deca4-45a7-4cd9-971c-e6d1013f49a4", 
-                                        "id": "51bdb617-012f-43e0-954d-68d5ad056c95", 
-                                        "sortorder": "", 
-                                        "text": "Combination"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e91eb3de-cb82-4f6e-a250-44c4330ada4f", 
-                                        "id": "7ccfcf3d-3c84-4640-87e4-c66973ce9d5a", 
-                                        "sortorder": "", 
-                                        "text": "Cornice"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8c16092b-0599-4cb1-ab85-32d0d52b0fe7", 
-                                        "id": "2eb19cdd-2bb9-419b-aeca-b51cab1c1ae5", 
-                                        "sortorder": "", 
-                                        "text": "Cupola"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "018965f3-4dee-4801-ab3b-610ca22aa93a", 
-                                        "id": "54b6afc7-5154-435b-a53d-9d035e5e93cc", 
-                                        "sortorder": "", 
-                                        "text": "Dentils"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4feba010-ca64-4828-974c-7ecdf9b7c083", 
-                                        "id": "2bbc59ae-fdf5-47d4-aa31-fa02c84d2a73", 
-                                        "sortorder": "", 
-                                        "text": "Dormer"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "aca4f76f-932a-454f-abde-0f50233658ac", 
-                                        "id": "5d64573f-8118-42c2-b8eb-479268177cdd", 
-                                        "sortorder": "", 
-                                        "text": "Dovecote"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "951f85c1-8af8-4d1b-be5c-f3895b47db8c", 
-                                        "id": "96e5f0cc-1c3f-4380-a13d-44c6094b9c8a", 
-                                        "sortorder": "", 
-                                        "text": "Eaves, boxed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9bd3adc6-866e-476b-830c-ab61eca703cc", 
-                                        "id": "93c9b310-773b-4e7e-8948-c4aafce101a9", 
-                                        "sortorder": "", 
-                                        "text": "Eaves, flared"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "23beef4a-26a1-4c71-a506-566386485753", 
-                                        "id": "59346275-d7c3-4409-971e-3617e0b351ff", 
-                                        "sortorder": "", 
-                                        "text": "Eaves, open"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "aac67183-d569-41d8-a645-4515cae65d37", 
-                                        "id": "eb97234e-4321-4f44-b267-06321b721850", 
-                                        "sortorder": "", 
-                                        "text": "Eaves, rolled"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ba260910-a367-4296-8c77-39951af24347", 
-                                        "id": "19977266-ee1e-41e7-9369-aed489a73d94", 
-                                        "sortorder": "", 
-                                        "text": "Eaves, wide"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9bcb9876-ec08-4b09-895d-9ac0e01cc56c", 
-                                        "id": "c3f4f6d2-21bb-4b30-a7bf-bc2bf26d1587", 
-                                        "sortorder": "", 
-                                        "text": "Exposed purlins"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c60cd269-8c48-4960-8963-9d21152bf255", 
-                                        "id": "2d044f52-2741-4b37-bb78-e47e1999c684", 
-                                        "sortorder": "", 
-                                        "text": "Exposed rafter tails"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c1f05b66-24f3-4afa-b131-e34a5019124c", 
-                                        "id": "612a1546-d95f-4c7f-a405-d81846e67b77", 
-                                        "sortorder": "", 
-                                        "text": "Exposed rafters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "5cbe1b77-f123-4796-abaf-5f3cef5263dc", 
-                                        "id": "908a4ec4-320a-4587-bf3a-fb7fca968199", 
-                                        "sortorder": "", 
-                                        "text": "Exposed roof beams"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3c5e5baf-322f-4be2-9cbf-7d50011a8d56", 
-                                        "id": "7911d745-7e11-404c-aec7-7616f318617b", 
-                                        "sortorder": "", 
-                                        "text": "Finial"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "37b86b57-94b5-459c-a0bb-e3806fbf673d", 
-                                        "id": "b424d4ed-53f8-4df0-be75-ffd5e6bf7727", 
-                                        "sortorder": "", 
-                                        "text": "Flat"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "21abcbf1-92b6-4866-86e7-98d064bc5e95", 
-                                        "id": "81691b66-983f-41b6-a423-5ffe10f8afe9", 
-                                        "sortorder": "", 
-                                        "text": "Folded Plate"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "234ef6ae-8823-4069-a5bf-c4a2d31c0f60", 
-                                        "id": "e7202616-0c2e-455b-9974-5492136b8be6", 
-                                        "sortorder": "", 
-                                        "text": "Gable, crossed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "56e1ce53-b63d-49b7-a011-f958d0a6dc1c", 
-                                        "id": "6d70b279-9e20-4773-8eab-8f6ec67c921e", 
-                                        "sortorder": "", 
-                                        "text": "Gable, front"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f9014d33-b08e-4f09-9b39-152c56761208", 
-                                        "id": "886101e6-6ac5-4e6a-b6f2-39c57c35a9c6", 
-                                        "sortorder": "", 
-                                        "text": "Gable, side"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "42dc99e0-1f35-4186-bc78-9809f6aa584f", 
-                                        "id": "9859ee53-ebc0-4118-a0dd-c0b6e0b30534", 
-                                        "sortorder": "", 
-                                        "text": "Gambrel"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b3597a06-7d46-415b-a543-c91844958cc8", 
-                                        "id": "8b13de9e-6a5b-46a0-8f90-03dc3275b1b9", 
-                                        "sortorder": "", 
-                                        "text": "Hipped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a60d5b08-a24b-4a20-970f-182b7a0c8676", 
-                                        "id": "cc4551fa-8e31-4eba-a2f6-f09ec9ef90dc", 
-                                        "sortorder": "", 
-                                        "text": "Hipped, pyramidal"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a623caff-69c0-49e8-b662-deff4630b7fa", 
-                                        "id": "64dc0831-82a0-412f-9610-9e6f704b9daa", 
-                                        "sortorder": "", 
-                                        "text": "Jerkinhead"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c51c267c-acc8-4a2a-b598-34ab6f167a93", 
-                                        "id": "4ed8d1ef-e517-4864-97ee-fd686b4521f9", 
-                                        "sortorder": "", 
-                                        "text": "Mansard"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3dec3ec1-c927-4215-856d-901d646aca1f", 
-                                        "id": "5a97d5b1-9d18-4f14-93dd-b8ced3c952b2", 
-                                        "sortorder": "", 
-                                        "text": "Monitor"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7cea560c-5b67-437e-a3a1-3dc1c8f36145", 
-                                        "id": "71a57290-e93d-44e4-95b6-72f86b67169e", 
-                                        "sortorder": "", 
-                                        "text": "Other"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4e465215-ea00-473e-9bcb-9f825ee1b67b", 
-                                        "id": "733e0e0d-1bba-44b2-abfd-231cdae7cf11", 
-                                        "sortorder": "", 
-                                        "text": "Parapet"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d9fb1f84-ed24-4a8c-83fc-f17e0c1c3252", 
-                                        "id": "41c284d5-d784-4b96-8510-1650d0217478", 
-                                        "sortorder": "", 
-                                        "text": "Parapet, curved"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "db06c151-4b17-4c9b-af40-e5fd34abef31", 
-                                        "id": "fcebc790-f884-41b6-a8b8-c7ea719c1b7c", 
-                                        "sortorder": "", 
-                                        "text": "Parapet, flat"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ecedc623-55cd-4bbb-9590-38fef9d9e80b", 
-                                        "id": "9a048065-87ca-4a26-8995-fdb922edc45b", 
-                                        "sortorder": "", 
-                                        "text": "Parapet, stepped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9d954167-4262-41bb-93fd-795b4fd4b11b", 
-                                        "id": "23ba428f-1a9e-4460-bee9-a8cace75eb3c", 
-                                        "sortorder": "", 
-                                        "text": "Pent"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "30248961-41cc-40dc-b005-ca5f7a31b960", 
-                                        "id": "284196a4-d16c-42ef-a12e-6c3f78df6ec0", 
-                                        "sortorder": "", 
-                                        "text": "Saddle"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "96d862a6-7a3b-4c4d-a0fe-d9ae01743ec0", 
-                                        "id": "18ef9505-2d54-412e-89f3-db796f52cc7e", 
-                                        "sortorder": "", 
-                                        "text": "Sawtooth"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6ce988d4-87d0-4a23-84cd-298a0cd5eab0", 
-                                        "id": "6d29ded0-6261-45f0-aaf7-de3da2dcd3a2", 
-                                        "sortorder": "", 
-                                        "text": "Scalloped bargeboards"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "13f74f4f-35c3-4f62-956f-294db4291b05", 
-                                        "id": "e1ef6727-ce2b-4062-8919-f572e23502dc", 
-                                        "sortorder": "", 
-                                        "text": "Shed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "70292c97-d9f6-44bf-a9e9-9cd46d4d2981", 
-                                        "id": "654ecaba-0b73-4e62-8040-dcf707bed757", 
-                                        "sortorder": "", 
-                                        "text": "Skirt"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "260a22ea-111f-453a-9420-e1ac4fd9afc1", 
-                                        "id": "974a97f1-935b-476c-8adf-0485683c1933", 
-                                        "sortorder": "", 
-                                        "text": "Skylight"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "115b177d-e9c3-432b-879e-a99b784ae72c", 
-                                        "id": "0666e409-656f-43c5-8e71-48118a45f889", 
-                                        "sortorder": "", 
-                                        "text": "Tower"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "075726b6-d283-495f-81eb-d4952b7d24d6", 
-                                        "id": "1823d2b4-1263-475f-99bf-a7ed0761e240", 
-                                        "sortorder": "", 
-                                        "text": "Turret"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "993d5b01-7b2e-4e4c-b792-7f2b0d349e8f", 
-                                        "id": "bb8eabb4-5055-4354-b50e-1242bfd3eab6", 
-                                        "sortorder": "", 
-                                        "text": "Weathervane"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "12e88c9c-2124-4831-8d6e-197f02d5f26f", 
-                                "id": "1815cdb4-f253-4456-a0fb-3febec9812ef", 
-                                "sortorder": "", 
-                                "text": "Roof"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4f2b6dbd-049c-49e5-95d1-5623ece47dda", 
-                                        "id": "158cffa9-2382-4cc5-a904-37be8577ac52", 
-                                        "sortorder": "", 
-                                        "text": "Angled"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1c447fdf-1c9d-41e0-8c6a-2cee686187d9", 
-                                        "id": "4c3cbd78-7be2-4b79-87c2-900054f6a0ad", 
-                                        "sortorder": "", 
-                                        "text": "Awning(s)"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "887562c4-6596-4248-b148-c135f523912e", 
-                                        "id": "e0ec5b73-624b-4049-90e9-573113ef39d8", 
-                                        "sortorder": "", 
-                                        "text": "Bulkhead"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8edf8c0b-21f0-49fa-b90e-6e9b23004e50", 
-                                        "id": "3949002a-54cf-444a-b9d2-c9f67ec6cfcd", 
-                                        "sortorder": "", 
-                                        "text": "Canopy"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "c09fd0f0-e09d-450f-aa96-ab70b0d7829f", 
-                                        "id": "1907b1ef-4a55-4b17-847a-4db9be0cbfdf", 
-                                        "sortorder": "", 
-                                        "text": "Canted"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "01653bc6-e2d0-4fef-8e3b-905402c8fee2", 
-                                        "id": "653174b9-6af8-4261-8903-cabfc6acc75f", 
-                                        "sortorder": "", 
-                                        "text": "Capitals"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "17f0fa8c-a5b0-4b9a-bf9e-b75c4c2b7caf", 
-                                        "id": "18ddbc1b-c2c2-4114-bb31-0bcb7b374728", 
-                                        "sortorder": "", 
-                                        "text": "Corner"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2f52ac94-8975-4c7b-9ba0-b099801908ad", 
-                                        "id": "fbe47088-89b0-454e-9fb6-b59e3871bc67", 
-                                        "sortorder": "", 
-                                        "text": "Entry paving, brick"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "693ce434-5e90-4384-b1ea-6a8d2a414e64", 
-                                        "id": "a7dac324-ca3b-4409-b2d0-15ea771db4ad", 
-                                        "sortorder": "", 
-                                        "text": "Entry paving, terazzo"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2df83d77-322c-4744-ae3d-8bc0c94eb2ff", 
-                                        "id": "539c6273-95b8-4ade-bb4f-8f0554d310ec", 
-                                        "sortorder": "", 
-                                        "text": "Entry paving, tile"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "644ebc0b-a854-4e64-9d14-8a023eb5a288", 
-                                        "id": "8c8de65f-fcfe-4d5b-905e-a62ed0359cff", 
-                                        "sortorder": "", 
-                                        "text": "Entry paving, tile"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a9cb9481-56d7-46ce-be7a-f5e89f31fe97", 
-                                        "id": "c206fc4d-5246-4f6e-ae05-80d4a5808a0a", 
-                                        "sortorder": "", 
-                                        "text": "Flush"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "3eb8e750-6806-4bb4-8862-60ce814b2826", 
-                                        "id": "0f7adf61-7fb7-4ccd-8607-4a1ff72e2968", 
-                                        "sortorder": "", 
-                                        "text": "Frieze"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "82b735af-c855-4d25-82c2-4cc903d37818", 
-                                        "id": "2abbe924-64d0-4b76-bcd0-3743a886a74c", 
-                                        "sortorder": "", 
-                                        "text": "Ghost sign"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d97cfda0-67ed-4204-9c69-e66e83e9c719", 
-                                        "id": "26e96d7f-f520-4144-9966-24eb1cca17fb", 
-                                        "sortorder": "", 
-                                        "text": "Lighting"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ddbbf257-dc36-41e7-a219-168467de8238", 
-                                        "id": "46394b7d-8658-4415-8b0c-31a66d194ad3", 
-                                        "sortorder": "", 
-                                        "text": "Multiple"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7968df4a-4b8b-4262-882d-29776fb6dcf0", 
-                                        "id": "f7f930c0-4f75-443e-a610-a4cae8b553fd", 
-                                        "sortorder": "", 
-                                        "text": "Piers"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bafaab35-6ebf-4c7d-a6e2-3899a0c18ee7", 
-                                        "id": "d4f16600-4b8c-497c-bb52-c0c44f6c64b9", 
-                                        "sortorder": "", 
-                                        "text": "Pilasters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b077f187-7079-470a-921f-2ef44e6439e5", 
-                                        "id": "f1be7d53-3229-4397-8d99-b4dc2303e93b", 
-                                        "sortorder": "", 
-                                        "text": "Planters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8d22de17-2bd3-479a-b9ad-ebab90315406", 
-                                        "id": "61e39eca-85f6-4498-8110-b1c570b86993", 
-                                        "sortorder": "", 
-                                        "text": "Recessed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "11d97e2a-88cd-4de6-83ae-06aa5084d4fb", 
-                                        "id": "bf43869f-0dae-435b-96e7-8a66a12edf9a", 
-                                        "sortorder": "", 
-                                        "text": "Security gate/screen"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "eb2f97c5-fc90-4081-a41c-949e42ed7563", 
-                                        "id": "88e20e09-0082-4b44-9632-c71ccb402f24", 
-                                        "sortorder": "", 
-                                        "text": "Sign"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "850d67ed-2a9c-470f-b251-e4801090ce24", 
-                                "id": "90f5586f-6df6-4938-9877-270821120298", 
-                                "sortorder": "", 
-                                "text": "Storefront"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f81bce66-3e84-46a8-8642-f680a5499184", 
-                                        "id": "c06e2527-a2c2-49d6-b3c1-618711ee0c51", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "288f5950-6e0c-419c-95fd-b2402545b170", 
-                                        "id": "7e1385ff-a92a-4b09-ba50-3abdefb62b26", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening, pointed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7bc4608e-0fc4-4640-acdc-9e684fdbfe17", 
-                                        "id": "45e1d6fe-39fe-4751-821e-34134bf0f3ba", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening, round"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "36eeec32-4614-4f24-a607-39e8d0251e08", 
-                                        "id": "37862b31-1981-4d1d-93f0-5243d9513d77", 
-                                        "sortorder": "", 
-                                        "text": "Arched opening, segmental"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "aab9190a-4c5d-40ac-a15f-b6be0233c7a9", 
-                                        "id": "a0fd4463-fb78-4468-ad07-a4505f6ecc1c", 
-                                        "sortorder": "", 
-                                        "text": "Awning"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "7ac21d61-352d-4e8e-91b1-8c5db3e02708", 
-                                        "id": "d3402272-8248-4692-acab-c9bf6c73359e", 
-                                        "sortorder": "", 
-                                        "text": "Bay, bowed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "412b5fdd-03bc-4382-96a5-c1d206153d35", 
-                                        "id": "6ceaec61-35f9-4bce-926e-1c746766bf8d", 
-                                        "sortorder": "", 
-                                        "text": "Bay, canted"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bc7688cf-fe6d-43c2-a39b-13fbaf746fb7", 
-                                        "id": "3bcf9af4-dc40-418a-b467-07ce779dcd11", 
-                                        "sortorder": "", 
-                                        "text": "Bay, rounded"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "568aee4a-da4e-4c7b-bc2e-1099cc648984", 
-                                        "id": "e05a8e29-9b81-4773-b028-5d7ca2d5e8d3", 
-                                        "sortorder": "", 
-                                        "text": "Bay, squared"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8bfe1e69-15ab-4388-824c-b8e7f936405a", 
-                                        "id": "54893741-1988-4292-8a91-351a0a1e648c", 
-                                        "sortorder": "", 
-                                        "text": "Butted glass"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "967bb1fc-0e87-4f82-96e2-b0d9439464f0", 
-                                        "id": "97d002f0-4cf6-4f51-903a-bdffa01cc075", 
-                                        "sortorder": "", 
-                                        "text": "Casement"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d9f8fbf7-cc52-4426-ae3c-8859663e0271", 
-                                        "id": "49895419-405d-4f29-95e3-d38742d95f43", 
-                                        "sortorder": "", 
-                                        "text": "Clerestory"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "17f5d453-bbda-4f09-82f6-edd25867ba8c", 
-                                        "id": "6e17e66f-e77b-4767-a9d9-1819988f2fdb", 
-                                        "sortorder": "", 
-                                        "text": "Corner"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "46ad341c-5b5d-41e0-8344-b8b7ec94137e", 
-                                        "id": "bf6d8517-14bb-48d6-a24e-63401843d0f5", 
-                                        "sortorder": "", 
-                                        "text": "Decorative surround"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "2a46fb2b-54f4-436f-ba4a-43f03ccf36f4", 
-                                        "id": "9f9f1743-b097-4036-bb8b-9e73eee8aa7a", 
-                                        "sortorder": "", 
-                                        "text": "Diamond pane"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4e923866-e998-4597-a85c-f889696b7cba", 
-                                        "id": "802b8d82-2476-4cf0-9f7c-c05946819d6d", 
-                                        "sortorder": "", 
-                                        "text": "Display"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "742d9b9c-036c-4707-a223-051ad64ae6f4", 
-                                        "id": "88f2896f-4d1b-4c0a-9224-4374795a5804", 
-                                        "sortorder": "", 
-                                        "text": "Divided lights"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bfd78f7b-21e5-42ba-baa9-559afca5984f", 
-                                        "id": "f085c885-149c-4636-b930-a90d3ce02bc1", 
-                                        "sortorder": "", 
-                                        "text": "Divided lights, top sash"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "55d924c4-50f7-40d5-ba14-e4c4c9f87a24", 
-                                        "id": "63a6855b-8e33-40ce-8a6b-712513a6a35e", 
-                                        "sortorder": "", 
-                                        "text": "Double-hung"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ed47abd5-62bc-4621-b4e8-f70416e6a462", 
-                                        "id": "4c04f7f9-aed9-4f2e-862e-b18a71870f44", 
-                                        "sortorder": "", 
-                                        "text": "Fixed"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8d28c8cb-13f1-4c23-b918-43162a45bba0", 
-                                        "id": "26ab681f-4685-4fee-a91c-19f2e6bb7feb", 
-                                        "sortorder": "", 
-                                        "text": "Floor-to-ceiling"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1d166234-8e6c-42c1-8c1e-a969c620150c", 
-                                        "id": "c338b8a0-767d-458d-940b-04dc8d4fae69", 
-                                        "sortorder": "", 
-                                        "text": "Grouped"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "1ece5487-d3ef-4dc8-b3dc-d3a9e3832abe", 
-                                        "id": "023443b0-1aba-416b-8cd7-1d2a58c04b98", 
-                                        "sortorder": "", 
-                                        "text": "Historic Surround"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "d4e810c0-9498-40c5-9fe9-5b6a5c2b1b50", 
-                                        "id": "0fc4ba36-46b8-4aad-a8f8-0d07abf9cc47", 
-                                        "sortorder": "", 
-                                        "text": "Hopper"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "456b969e-4dbe-49b8-b316-8add2445a92a", 
-                                        "id": "09c6801c-45ca-4550-8961-20f4ff504de8", 
-                                        "sortorder": "", 
-                                        "text": "Jalousie/louver"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "b10ce779-b99d-468c-b490-7852a33f8e71", 
-                                        "id": "4ccccd14-88ee-4aec-a662-15f30199820d", 
-                                        "sortorder": "", 
-                                        "text": "Leaded glass"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9e7352fe-e046-4f83-a57d-58d195baf2ca", 
-                                        "id": "4a425c66-48ed-4376-819c-eaa02295242e", 
-                                        "sortorder": "", 
-                                        "text": "Multi-light"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "97ea2b2f-fced-4db7-9ed3-59df57d26296", 
-                                        "id": "331f4bf6-d62a-40b9-9cd3-bed5b826707c", 
-                                        "sortorder": "", 
-                                        "text": "Multi-light top sash"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "766d15aa-9c17-4e0a-9216-e3a3ed288c4b", 
-                                        "id": "515e3ca5-6e56-431d-bf15-4c318a2b0b8f", 
-                                        "sortorder": "", 
-                                        "text": "Obscure glass"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f07a41e8-6f8e-4a6b-b5ed-1c25284eb7a3", 
-                                        "id": "e92e116e-215f-4183-a185-030e61ff01da", 
-                                        "sortorder": "", 
-                                        "text": "Oriel"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "cf0f3360-be2e-46b5-82f8-4be4781219b9", 
-                                        "id": "227e525d-9639-4279-bfc4-e9fc4fe6fde8", 
-                                        "sortorder": "", 
-                                        "text": "Other"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ef96a02f-01be-4c50-8bb7-d1a653bd644a", 
-                                        "id": "1627ab6e-1a4a-4d05-a203-d2fa23f761f8", 
-                                        "sortorder": "", 
-                                        "text": "Paired"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "00708d06-ab1d-40ce-8b02-c3ad874ac18f", 
-                                        "id": "6198a885-cc7b-4722-99e2-75ddb9f954f4", 
-                                        "sortorder": "", 
-                                        "text": "Palladian"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "8db4aca3-a5e0-4d56-8676-3be311eb2483", 
-                                        "id": "73c88c14-6ce5-4be0-9a60-f21a7910ad97", 
-                                        "sortorder": "", 
-                                        "text": "Pivot"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "89392663-7e1b-4ecf-8a26-d4d15585b61f", 
-                                        "id": "5fa196d6-d78b-4afa-ab5a-df65e5ee3e17", 
-                                        "sortorder": "", 
-                                        "text": "Porthole"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "04d29f6d-7fa8-4ab3-855a-2f95aa619b9a", 
-                                        "id": "45745c79-caaa-461f-b2b7-cced3fc1d667", 
-                                        "sortorder": "", 
-                                        "text": "Ribbon"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "85d59130-b1a4-49da-bcd4-6f0c3ae22554", 
-                                        "id": "6a90f88a-1a06-45ef-942e-d2f61ad88a6e", 
-                                        "sortorder": "", 
-                                        "text": "Sawtooth"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "0c983718-1d93-4139-9bf3-b1127d7bfc95", 
-                                        "id": "3f769b66-fe82-4af2-9ab3-54adddcefb46", 
-                                        "sortorder": "", 
-                                        "text": "Security bars"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "77a79a10-c592-4d20-b913-47438aeadd24", 
-                                        "id": "4ee33276-f127-42d8-9b84-dc596a57af9d", 
-                                        "sortorder": "", 
-                                        "text": "Shutters"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "102169c8-eb47-495e-bb38-778807727025", 
-                                        "id": "f791a17e-aa45-4eb6-b78b-5c579803a9f1", 
-                                        "sortorder": "", 
-                                        "text": "Single"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "9f046d11-dced-4310-8420-a11e4d67eaef", 
-                                        "id": "21ac1caf-439e-41b8-987f-b41a91817560", 
-                                        "sortorder": "", 
-                                        "text": "Single-hung"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f65422d8-400d-43a1-bf7f-14e65a5858e8", 
-                                        "id": "50cb28b1-39b9-4762-a607-6d27fbfc062b", 
-                                        "sortorder": "", 
-                                        "text": "Sliding"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "f2f18e21-17c3-489f-8456-0ac3931ffe8a", 
-                                        "id": "f4799706-48b7-4aef-a732-d25997c16d08", 
-                                        "sortorder": "", 
-                                        "text": "Stained glass"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "22a3652f-0a5a-4a32-a310-24fb2321af2e", 
-                                        "id": "8cce4498-ea0b-4a5c-95a3-e1af3d20a8d2", 
-                                        "sortorder": "", 
-                                        "text": "Storefront"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "98698526-94a8-4797-8367-ebf005347bba", 
-                                        "id": "88c801c0-c40b-4251-a75b-f012c80f1f96", 
-                                        "sortorder": "", 
-                                        "text": "Transom"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "bb1f95fb-0b4a-4f08-9564-e851b540e952", 
-                                        "id": "b07724bc-41b8-43d6-acfb-77d96b15ca38", 
-                                        "sortorder": "", 
-                                        "text": "Tripartite"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e12e39bb-9df8-477c-85c7-cc802c76b5ef", 
-                                        "id": "e3db3ec5-06f8-424b-8405-f815d2e9657e", 
-                                        "sortorder": "", 
-                                        "text": "Unknown"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "ee5cc394-0cca-426a-b4d2-0c3f44aef37a", 
-                                        "id": "5081ea23-2a7b-4fb0-99cf-4a3ba1b9aba2", 
-                                        "sortorder": "", 
-                                        "text": "Vent"
-                                    }
-                                ], 
-                                "collector": "", 
-                                "conceptid": "0879fd52-2678-41aa-be66-d911ad8d314f", 
-                                "id": "e2401fd5-04a8-416a-b3e5-900049c51dec", 
-                                "sortorder": "", 
-                                "text": "Window"
-                            }
-                        ], 
-                        "placeholder": "Select the component's material"
-                    }, 
-                    "id": "440786e8-943d-11e8-b5a0-94659cf754d0", 
-                    "label": "Material", 
-                    "node_id": "440786e7-943d-11e8-a7e4-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000012"
-                }, 
-                {
-                    "card_id": "48318180-943d-11e8-a635-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Resource Type Classification", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5db4ab60-0936-4841-b164-d4b55be9ddb5", 
-                                "id": "e675887c-23e3-4c60-9036-c7c864b4272f", 
-                                "sortorder": "1", 
-                                "text": "Building"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "033220d0-79fe-4742-8c0e-e83266d843b1", 
-                                "id": "3cf28c22-7271-4bd8-a7da-6e6c45ca4c13", 
-                                "sortorder": "2", 
-                                "text": "Structure"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "3f700bb6-a858-41e0-bb48-67a0308d2997", 
-                                "id": "5d3a1585-0a65-4a4c-85dc-f894fa17ec0d", 
-                                "sortorder": "3", 
-                                "text": "Object"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "68a6772d-c431-42fa-8772-e76a14992139", 
-                                "id": "e4699732-efee-46c0-87e1-3f0a930a43db", 
-                                "sortorder": "4", 
-                                "text": "Site"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "258e6aeb-ff2b-4f18-8c82-0b593b3112ed", 
-                                "id": "acfee644-090f-4ed6-8424-df82f3560807", 
-                                "sortorder": "5", 
-                                "text": "District"
-                            }, 
-                            {
-                                "children": [
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "4abd862f-43be-4783-9dd0-92e0d6ee516b", 
-                                        "id": "7cd6cd34-b423-40d2-bb40-d68879b116dc", 
-                                        "sortorder": "10", 
-                                        "text": "District Potential Contributor"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "e52e931a-797e-4833-8f07-bf24c546271e", 
-                                        "id": "eb7a8bec-2a12-4f5b-a11f-9c200954fb10", 
-                                        "sortorder": "11", 
-                                        "text": "Planning District"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "789ab887-b19e-4252-8e74-60e85c284b5c", 
-                                        "id": "c3d9af83-4af1-4554-b9e9-09fb59ca03a6", 
-                                        "sortorder": "7", 
-                                        "text": "District Contributor"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "a5486051-7c1d-446c-923f-270937443b2c", 
-                                        "id": "8dfdaa13-5073-4ee8-894c-01a68c08dff0", 
-                                        "sortorder": "8", 
-                                        "text": "District Non-Contributor"
-                                    }, 
-                                    {
-                                        "children": [], 
-                                        "collector": "", 
-                                        "conceptid": "6db901b2-2e82-4c5b-8aae-05231b938c20", 
-                                        "id": "e0229b20-46f2-44a8-9a89-85015e953d89", 
-                                        "sortorder": "9", 
-                                        "text": "District Altered Contributor"
-                                    }
-                                ], 
-                                "collector": "collector", 
-                                "conceptid": "5d787426-4110-4b4f-8c9e-60be8d701013", 
-                                "sortorder": "6", 
-                                "text": "District Element"
-                            }
-                        ], 
-                        "placeholder": "Select an option"
-                    }, 
-                    "id": "48318181-943d-11e8-9437-94659cf754d0", 
-                    "label": "Resource Type Classification", 
-                    "node_id": "48315a71-943d-11e8-90d3-94659cf754d0", 
                     "sortorder": 0, 
                     "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000002"
@@ -15245,225 +12254,3280 @@
                     "widget_id": "10000000-0000-0000-0000-000000000012"
                 }, 
                 {
-                    "card_id": "5008a5a1-943d-11e8-90a4-94659cf754d0", 
+                    "card_id": "1f816613-943d-11e8-bd5d-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Designation or Protection To Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "de1f5f4f-dc81-11e8-bd64-94659cf754d0", 
+                    "label": "Designation or Protection To Date", 
+                    "node_id": "1f818d24-943d-11e8-b16e-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "1c41f286-943d-11e8-9056-94659cf754d0", 
                     "config": {
                         "defaultValue": "", 
-                        "label": "External Identifier", 
-                        "maxLength": null, 
-                        "placeholder": "Enter indentifier", 
-                        "width": "100%"
+                        "label": "Evaluation Criteria Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
                     }, 
-                    "id": "5008a5a4-943d-11e8-a098-94659cf754d0", 
-                    "label": "External Identifier", 
-                    "node_id": "5008a59f-943d-11e8-985e-94659cf754d0", 
+                    "id": "9122dc50-a8c7-11e9-9d63-94659cf754d0", 
+                    "label": "Evaluation Criteria Type", 
+                    "node_id": "1c41f284-943d-11e8-8ef9-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "End Date of Existence", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "3c5799d6-943d-11e8-b18c-94659cf754d0", 
+                    "label": "End Date of Existence", 
+                    "node_id": "3c5772c6-943d-11e8-8ca6-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Ancilary Feature To Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "ccb9c4c1-dc6e-11e8-b987-94659cf754d0", 
+                    "label": "Ancilary Feature To Date", 
+                    "node_id": "086df565-943d-11e8-86d5-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "1c421994-943d-11e8-862a-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Eligibility Requirement Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "b396bddf-dc82-11e8-8e2c-94659cf754d0", 
+                    "label": "Eligibility Requirement Type", 
+                    "node_id": "1c421992-943d-11e8-ae0a-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "3c5772c3-943d-11e8-aba1-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Start Date of Existence", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "3c5799d3-943d-11e8-b3ac-94659cf754d0", 
+                    "label": "Start Date of Existence", 
+                    "node_id": "3c5799d2-943d-11e8-874e-94659cf754d0", 
                     "sortorder": 0, 
                     "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
                 }, 
                 {
-                    "card_id": "5008a5a1-943d-11e8-90a4-94659cf754d0", 
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
                     "config": {
                         "defaultValue": "", 
-                        "label": "Source of Identifier", 
-                        "options": [], 
-                        "placeholder": "Select the source of the indentifier"
-                    }, 
-                    "id": "5008a5a5-943d-11e8-bbe7-94659cf754d0", 
-                    "label": "Source of Identifier", 
-                    "node_id": "5008a5a2-943d-11e8-8ee7-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000015"
-                }, 
-                {
-                    "card_id": "5008a5a1-943d-11e8-90a4-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Type of Identifier", 
+                        "label": "Recommendations", 
                         "options": [
                             {
-                                "children": [], 
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a3157c46-7c4f-4de3-a355-11d68d6788e6", 
+                                        "id": "6d52b780-1091-4b14-b5b2-796f1068bb2a", 
+                                        "sortorder": "2", 
+                                        "text": "archaeological survey"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6d912f16-890e-4176-98db-95b99284e639", 
+                                        "id": "b44cf8f0-0558-4f90-83fa-1e216320df26", 
+                                        "sortorder": "3", 
+                                        "text": "excavation"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e0fa5826-6ddd-404b-b409-32a22475ea54", 
+                                        "id": "1ac24a75-7ea5-4dbf-9a95-dc4e2d612cf9", 
+                                        "sortorder": "4", 
+                                        "text": "salvage recording"
+                                    }
+                                ], 
                                 "collector": "", 
-                                "conceptid": "21ab0b62-809b-47da-a48c-ab1cd13f0db2", 
-                                "id": "d796303e-5075-4a57-ad9c-226775cf1f4f", 
-                                "sortorder": "", 
-                                "text": "ARK"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "72d3b085-2d10-4f9e-8697-20744299bacf", 
-                                "id": "61bc441a-dad2-4cdb-9c9b-f0112c352731", 
-                                "sortorder": "", 
-                                "text": "DOI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "818b9221-78f2-4c25-84cf-686c21eff8e3", 
-                                "id": "24bcc5d3-ba51-42bd-a9c6-44d5bd6ed681", 
-                                "sortorder": "", 
-                                "text": "HANDLE"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "7ca60d3f-6f3c-4d19-8914-e5800fb805ca", 
-                                "id": "5c340034-fa93-4131-ade8-f670da714bad", 
-                                "sortorder": "", 
-                                "text": "ISBN"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "01251c2a-8e5a-49e5-a389-20b4637c4c76", 
-                                "id": "c8d1e199-ccfc-4882-b551-8d85c37c04e6", 
-                                "sortorder": "", 
-                                "text": "ISSN"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "67b17fc8-d205-471b-bdf5-a361f032e545", 
-                                "id": "77569746-6bf0-4c73-949d-496115fc9cea", 
-                                "sortorder": "", 
-                                "text": "POI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "02c09240-a9a3-4cd5-98cd-c2fbafc9173b", 
-                                "id": "fb795aad-a09c-4fd0-87ce-3012c2f3d631", 
-                                "sortorder": "", 
-                                "text": "PURL"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "0a4ce957-d837-4595-8320-8d142af864ab", 
-                                "id": "acab77ad-dbee-4448-8ce9-8e7dd2ec1651", 
-                                "sortorder": "", 
-                                "text": "SICI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "eaa19556-fcfa-40c8-9696-0d89804ad895", 
-                                "id": "f39679be-899b-4472-9484-df377e43d776", 
-                                "sortorder": "", 
-                                "text": "URI"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "d8f00076-3b8e-4984-8ab9-152cc21ebc40", 
-                                "id": "763105f1-757f-431b-90ff-a0511d2ba900", 
-                                "sortorder": "", 
-                                "text": "URL"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "ec9e80e3-ae93-4aed-97a6-f61b0f93da43", 
-                                "id": "b411a4a6-1db0-4745-a67a-e74cf586193e", 
-                                "sortorder": "", 
-                                "text": "URN"
-                            }
-                        ], 
-                        "placeholder": "Select the type of identifier"
-                    }, 
-                    "id": "5008a5a6-943d-11e8-b736-94659cf754d0", 
-                    "label": "Type of Identifier", 
-                    "node_id": "5008a5a3-943d-11e8-b0ea-94659cf754d0", 
-                    "sortorder": 1, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000009"
-                }, 
-                {
-                    "card_id": "54188892-943d-11e8-8554-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Measurement Value", 
-                        "max": "", 
-                        "min": "", 
-                        "placeholder": "Enter value", 
-                        "precision": "", 
-                        "prefix": "", 
-                        "step": "", 
-                        "suffix": "", 
-                        "width": "100%"
-                    }, 
-                    "id": "5418afa0-943d-11e8-ba29-94659cf754d0", 
-                    "label": "Measurement Value", 
-                    "node_id": "54188893-943d-11e8-9011-94659cf754d0", 
-                    "sortorder": 2, 
-                    "visible": true, 
-                    "widget_id": "10000000-0000-0000-0000-000000000008"
-                }, 
-                {
-                    "card_id": "54188892-943d-11e8-8554-94659cf754d0", 
-                    "config": {
-                        "defaultValue": "", 
-                        "label": "Measurement Type", 
-                        "options": [
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "2d152d1d-17e5-4fed-ac36-919f823be256", 
-                                "id": "857d8806-0e0f-4f7d-aed6-fad250ef97ea", 
-                                "sortorder": "", 
-                                "text": "breadth"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "99e96cb3-21ec-499b-9536-2ed69754d2c5", 
-                                "id": "8a3fe0fe-3c5f-4a8e-a08d-b2fe4ad95653", 
-                                "sortorder": "", 
-                                "text": "depth"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "5e0124cc-c308-4fec-ab60-08a39ba1f643", 
-                                "id": "db42d2f8-d2d7-465f-b1b2-189f433a6b7c", 
-                                "sortorder": "", 
-                                "text": "height"
-                            }, 
-                            {
-                                "children": [], 
-                                "collector": "", 
-                                "conceptid": "8a0cf26a-2184-4af4-9df4-5ee5dc4879b0", 
-                                "id": "88f2a040-48c0-4240-a9e2-75312a6dd04d", 
-                                "sortorder": "", 
-                                "text": "length"
+                                "conceptid": "88975b48-71d5-4c78-9c64-3687123dbc28", 
+                                "id": "305040c0-a87b-42bd-875f-ee13a95f7890", 
+                                "sortorder": "1", 
+                                "text": "archaeological intervention"
                             }, 
                             {
                                 "children": [
                                     {
                                         "children": [], 
                                         "collector": "", 
-                                        "conceptid": "26980537-8582-4bdb-8aea-38d60202face", 
-                                        "id": "5d6a0c6c-40b0-409c-a88f-3378761c5562", 
-                                        "sortorder": "", 
-                                        "text": "tonnage"
+                                        "conceptid": "7a742a3f-fe28-4b33-8adf-5630e09358b9", 
+                                        "id": "50faa45c-d5f2-4fad-ba3f-b2d9005004ed", 
+                                        "sortorder": "11", 
+                                        "text": "aerial photograph interpretation"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "63404be1-f395-4cd8-b448-e2c8a796331a", 
+                                        "id": "68b09c5c-59ac-460b-8a0a-8467bf92dc36", 
+                                        "sortorder": "12", 
+                                        "text": "desk based assessment"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "96d1444f-2203-43b0-b7ec-40ce0f004574", 
+                                        "id": "d4b35ecb-16cd-4d42-9bed-fe2c94e75c3e", 
+                                        "sortorder": "13", 
+                                        "text": "environmental impact assessment"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7bce9ef8-5801-4291-a407-a7823326b2ee", 
+                                        "id": "d5edc2b2-4736-4cd3-9568-08beeb8420ab", 
+                                        "sortorder": "14", 
+                                        "text": "historic landscape characterisation"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "0fbc093b-e558-465e-9bfe-9aaee4a879ee", 
+                                        "id": "a5696559-4ca3-444a-9233-8d9a5edc7c23", 
+                                        "sortorder": "15", 
+                                        "text": "in-depth condition assessment"
                                     }
                                 ], 
                                 "collector": "", 
-                                "conceptid": "32a94c6d-d55f-4019-9f56-3ac7934b59a3", 
-                                "id": "a9bfce58-2a2f-4c48-a8fe-88f1b24463d6", 
-                                "sortorder": "", 
-                                "text": "weight"
+                                "conceptid": "22d7b0cc-fc6e-47da-82a9-664b2875f94b", 
+                                "id": "fb224913-b29e-4aee-9a29-5e5e5e6d4fe7", 
+                                "sortorder": "10", 
+                                "text": "heritage assessment"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "e87f8cf5-b3ec-43bf-b296-960959a6edaa", 
+                                "id": "f9bdbc6a-e219-46cb-9eb9-9d7ac6e7855d", 
+                                "sortorder": "16", 
+                                "text": "remote sensing"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "0bdcd50f-a701-439f-a455-9fe8c1c596e4", 
+                                        "id": "a9f9afe9-5333-45b3-85fc-53205266223e", 
+                                        "sortorder": "18", 
+                                        "text": "conservation intervention"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "eab3dba2-19ab-4d20-81cc-cd9bfca00cc0", 
+                                        "id": "df81de3c-4cd5-45a9-a083-f8f2c7ec1c3e", 
+                                        "sortorder": "19", 
+                                        "text": "reburial"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "63234c3f-4674-4518-85de-73b84694c6d9", 
+                                        "id": "792b7faa-8cc0-446e-9b9c-3dad85822013", 
+                                        "sortorder": "20", 
+                                        "text": "fencing"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1e0afd30-d5a1-42e0-a02f-3754df3418d6", 
+                                        "id": "3889503a-2524-4edd-920c-f1ac7d4675cd", 
+                                        "sortorder": "21", 
+                                        "text": "fire mitigation"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7022ec05-d669-49be-a000-27a717923023", 
+                                        "id": "e4649da0-95d0-4638-8f14-53f781900943", 
+                                        "sortorder": "22", 
+                                        "text": "designation"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "64d21cb1-444b-4b3b-990d-cbf7c5a03e50", 
+                                "id": "2c29727d-b17c-4311-9d8c-ffa125a90ab2", 
+                                "sortorder": "17", 
+                                "text": "management intervention"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "dc1873f7-49c5-42a2-9863-6a950cd6f3d4", 
+                                        "id": "e6db97a7-a719-4dc6-82dc-fd4aa42e2881", 
+                                        "sortorder": "6", 
+                                        "text": "architectural survey"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9b46acbe-50d1-4870-bb46-55981d2178cd", 
+                                        "id": "57396bb2-b47b-4f53-a2e7-e7d936b55696", 
+                                        "sortorder": "7", 
+                                        "text": "measured survey"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4764910d-3d9e-45bc-a390-147d58b400c7", 
+                                        "id": "93de3278-3a37-455c-8216-ff939f87cf27", 
+                                        "sortorder": "8", 
+                                        "text": "photographic recording"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2b1660dd-b47e-479a-95ae-9e656418acb2", 
+                                        "id": "98aa7952-8775-49c1-b5ce-8ad53d99f3a9", 
+                                        "sortorder": "9", 
+                                        "text": "topographic survey"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "6c1ea4a0-fa6c-4bd3-815a-f57239680abb", 
+                                "id": "de6d7318-929b-4a7a-9e17-69035e16b48a", 
+                                "sortorder": "5", 
+                                "text": "field survey"
                             }
                         ], 
-                        "placeholder": "Select type"
+                        "placeholder": "Choose as many or as few recommendations as are relevant to this assessment."
                     }, 
-                    "id": "5418afa1-943d-11e8-b920-94659cf754d0", 
-                    "label": "Measurement Type", 
-                    "node_id": "54188894-943d-11e8-bb0e-94659cf754d0", 
+                    "id": "40609efd-943d-11e8-8154-94659cf754d0", 
+                    "label": "Recommendations", 
+                    "node_id": "40609ef1-943d-11e8-a59f-94659cf754d0", 
+                    "sortorder": 6, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "0cebb552-943d-11e8-8a58-94659cf754d0", 
+                    "config": {
+                        "label": "Modification/Alteration Description", 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "0cebdc63-943d-11e8-aa10-94659cf754d0", 
+                    "label": "Modification/Alteration Description", 
+                    "node_id": "0cebdc5e-943d-11e8-bccc-94659cf754d0", 
+                    "sortorder": 2, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                }, 
+                {
+                    "card_id": "0cebb552-943d-11e8-8a58-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Modification/Alteration Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "0cebdc64-943d-11e8-bcc1-94659cf754d0", 
+                    "label": "Modification/Alteration Date", 
+                    "node_id": "0cebdc61-943d-11e8-8e54-94659cf754d0", 
                     "sortorder": 0, 
                     "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Ancillary Feature Use Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "ccb9016f-dc6e-11e8-9aa8-94659cf754d0", 
+                    "label": "Ancillary Feature Use Type", 
+                    "node_id": "086df564-943d-11e8-9803-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "1c41f28f-943d-11e8-ac56-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Integrity Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "fbbe84f1-aa30-11e9-ba00-94659cf754d0", 
+                    "label": "Integrity Type", 
+                    "node_id": "1c41f28d-943d-11e8-a0a5-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
                     "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "40609ef0-943d-11e8-86f7-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Threats", 
+                        "options": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9935c53c-dac4-4e1a-b4a7-a425b777a48b", 
+                                        "id": "51684806-5519-46ef-92e1-b04c8167c975", 
+                                        "sortorder": "2", 
+                                        "text": "storm"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f906108c-b848-4eea-8f7f-0294b4aeb174", 
+                                        "id": "c58a80fe-49b7-45ee-81b6-9cb574c10c7b", 
+                                        "sortorder": "3", 
+                                        "text": "fire induced by lightning"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "6fcc5949-bffc-46f8-93eb-c1f93fc2ef89", 
+                                "id": "3ef4850d-292d-41c7-9c44-bc2376d979ee", 
+                                "sortorder": "1", 
+                                "text": "meteorological"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "76b1670c-2eff-40bb-a0c5-a83f4c7331a1", 
+                                        "id": "73c3928a-c12b-4552-833c-3ae40b70fe25", 
+                                        "sortorder": "13", 
+                                        "text": "pest infestation"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "728e6ada-189a-466c-b5f6-725366036b5d", 
+                                        "id": "4fe7b71e-068d-4a7b-bb98-8bcac148da66", 
+                                        "sortorder": "14", 
+                                        "text": "plant growth"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "0e132db9-a8e9-4998-bbfd-ee696d6c2c97", 
+                                "id": "e33709ec-bc10-45d4-9080-515a337d826d", 
+                                "sortorder": "12", 
+                                "text": "biological"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8e662c34-bf7f-4471-9693-63d4bc7715b3", 
+                                        "id": "061adf90-03f6-4a49-b647-100c4f590898", 
+                                        "sortorder": "16", 
+                                        "text": "fire"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ec543f7c-1470-4f73-b702-35dbc78a55cc", 
+                                        "id": "74a1e963-60fe-4b7d-8d99-42a51fffb4c1", 
+                                        "sortorder": "17", 
+                                        "text": "explosion"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c8303ac1-508c-4cc1-adf6-dba6dc621842", 
+                                        "id": "4efb3606-bf24-40c4-8761-0f7b14ed0fa9", 
+                                        "sortorder": "18", 
+                                        "text": "pollution"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "05bf6c79-b08e-4b4b-82df-f40c3436cd6d", 
+                                        "id": "8153e584-886c-4e57-a79b-b1ff13a2f369", 
+                                        "sortorder": "19", 
+                                        "text": "violence and conflict"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f064f439-5b81-4db4-879a-62a3dac35c0c", 
+                                        "id": "5f8357e8-a0e2-4e9f-bd3e-8931218a3ba2", 
+                                        "sortorder": "20", 
+                                        "text": "looting/theft"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5acbf219-dec2-42ce-a6fa-4da7c4590f4a", 
+                                        "id": "69d53378-1179-49c5-9188-c318850808ae", 
+                                        "sortorder": "21", 
+                                        "text": "vandalism"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "41bc559e-8c0e-4036-aec0-c57d6380d7fb", 
+                                        "id": "cf9635be-b655-47f2-b74c-31f806d9062d", 
+                                        "sortorder": "22", 
+                                        "text": "infrastructure failure"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bb6939ab-57a9-4c4e-94b2-a0d24895890e", 
+                                        "id": "ee67684f-f413-44b5-af99-a746ec93658e", 
+                                        "sortorder": "23", 
+                                        "text": "agriculture"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "61541316-b2e2-4c1e-be6c-9ae2501c71fb", 
+                                        "id": "1176e6a0-1d9b-4653-b733-cd5eb7759c0d", 
+                                        "sortorder": "24", 
+                                        "text": "mining"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "56dcb2d4-0be1-475e-ad09-2fbe4496ea68", 
+                                        "id": "7b474f48-036e-491a-b322-ba52bb33b77a", 
+                                        "sortorder": "25", 
+                                        "text": "construction"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6f046e96-5995-4015-acb9-ebabeac6e4e8", 
+                                        "id": "09d58c58-7a27-4ff1-b6d1-0c9f3723e298", 
+                                        "sortorder": "26", 
+                                        "text": "inappropriate use"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ed6bfcc4-1f2c-4cce-94ba-b304225c279b", 
+                                        "id": "23de2ea6-2e66-4f07-9cbb-7a5492da05e2", 
+                                        "sortorder": "27", 
+                                        "text": "lack of maintenance"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "f2440185-a80e-4ced-8b34-53789882ae3f", 
+                                "id": "26f0ead7-3243-40d0-af5e-c7c8c4c5e4cd", 
+                                "sortorder": "15", 
+                                "text": "human-induced"
+                            }, 
+                            {
+                                "children": [], 
+                                "collector": "", 
+                                "conceptid": "380ec64b-2e69-41da-afb9-48ab90caa2d9", 
+                                "id": "b7d1f3fc-3ccf-43a5-98e2-f81e6c5ec528", 
+                                "sortorder": "28", 
+                                "text": "climate change"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "0a0156cc-98fe-4f16-867b-55dfb2dacf9f", 
+                                        "id": "ef34616d-c9d1-4fdc-b787-827d31784025", 
+                                        "sortorder": "5", 
+                                        "text": "flood"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1bdcc469-7f36-4de9-8a6f-802451119dc9", 
+                                        "id": "c3a47bbe-d2e7-4030-a6a7-62dad44e4dc7", 
+                                        "sortorder": "6", 
+                                        "text": "tsunami"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "9167de08-93e7-4080-ac71-2fbe7e6841de", 
+                                "id": "4e44ac6e-98ae-4bc5-96de-fe03ef87a7a9", 
+                                "sortorder": "4", 
+                                "text": "hydrological"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "247a6447-9235-4265-8a5e-a6a77a11bcd2", 
+                                        "id": "809b66b1-014a-42d4-9a38-e2f1f58738de", 
+                                        "sortorder": "10", 
+                                        "text": "mass movement"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "aaae19f4-7164-442e-a3ec-b1562614214a", 
+                                        "id": "4b7d04ef-be4c-4c59-8d98-e5470a8cfa8b", 
+                                        "sortorder": "11", 
+                                        "text": "erosion"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a1370bda-8706-4a80-abc5-412db82a8dd3", 
+                                        "id": "c7e98c6a-22ef-4024-9021-913c80746e26", 
+                                        "sortorder": "8", 
+                                        "text": "volcanic"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "55bc684d-1888-4e78-952a-c417e6418921", 
+                                        "id": "9c35a534-8245-4c87-a511-90b13cbda8f6", 
+                                        "sortorder": "9", 
+                                        "text": "seismic"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "fa6d7f18-f3bf-4bef-86d3-90a1cd13a7df", 
+                                "id": "429d8ca0-7b98-41ea-8452-d9cde03969e5", 
+                                "sortorder": "7", 
+                                "text": "geological"
+                            }
+                        ], 
+                        "placeholder": "Threats are potential future disturbances.  Choose as many or as few threats are you can identify in this assessment."
+                    }, 
+                    "id": "40609f01-943d-11e8-b33e-94659cf754d0", 
+                    "label": "Threats", 
+                    "node_id": "40609ef5-943d-11e8-9cce-94659cf754d0", 
+                    "sortorder": 4, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Style From Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "c9737362-dc6e-11e8-a8cf-94659cf754d0", 
+                    "label": "Style From Date", 
+                    "node_id": "086df56e-943d-11e8-b150-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Ancillary Feature Type", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "ccba8810-dc6e-11e8-b1e7-94659cf754d0", 
+                    "label": "Ancillary Feature Type", 
+                    "node_id": "086df566-943d-11e8-ba38-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "086dce52-943d-11e8-b3f1-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Ancillary Feature Cultural Period", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "ccb86531-dc6e-11e8-9087-94659cf754d0", 
+                    "label": "Ancillary Feature Cultural Period", 
+                    "node_id": "086df562-943d-11e8-a4c9-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "1f816613-943d-11e8-bd5d-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Type of Designation or Protection", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "de2838ef-dc81-11e8-b4ae-94659cf754d0", 
+                    "label": "Type of Designation or Protection", 
+                    "node_id": "1f818d22-943d-11e8-9a3c-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Heritage Resource Type To Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "bcd97001-dc6e-11e8-8bac-94659cf754d0", 
+                    "label": "Heritage Resource Type To Date", 
+                    "node_id": "086df569-943d-11e8-ad82-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "440786e4-943d-11e8-bda7-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Material", 
+                        "options": [
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d83d089b-a4c9-4b7f-b0c3-81e3dbf0cea4", 
+                                        "id": "5fc92031-09ed-4fd5-9e61-c4c24a814cdc", 
+                                        "sortorder": "", 
+                                        "text": "Brick"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "dd63d5e8-dc43-4a5a-82d3-2e52b9032c38", 
+                                        "id": "f367147d-8813-491a-a9d8-83db58875b29", 
+                                        "sortorder": "", 
+                                        "text": "Concrete"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "06041405-d5d8-4899-b266-75b0a438bfd8", 
+                                        "id": "547b918d-be60-4b32-8f31-cad2f783b8ba", 
+                                        "sortorder": "", 
+                                        "text": "Concrete block"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "dcc73c41-5d27-47e6-9f55-c4148fc91ea9", 
+                                        "id": "1b97739f-c90a-4252-8c87-5c36468119ac", 
+                                        "sortorder": "", 
+                                        "text": "Exterior"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "098a1079-83d3-46cb-8a0b-fad10188ac1a", 
+                                        "id": "ad89e730-5087-405a-bb9f-418f8e8e68a7", 
+                                        "sortorder": "", 
+                                        "text": "Interior"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a48ce2ac-2208-4fd1-bfe2-ded228a2bc6f", 
+                                        "id": "50caac9f-2052-4ac7-9a54-eb50fc40e8dc", 
+                                        "sortorder": "", 
+                                        "text": "Pipe"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f157f18b-d615-4dec-9e3f-a71a5d1dfe4e", 
+                                        "id": "7b8d467f-f37c-4cd5-8ec1-4cdc782135da", 
+                                        "sortorder": "", 
+                                        "text": "Stone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "fb3a85a7-7aac-4d76-88ab-a231ef86ab28", 
+                                        "id": "6dbc1e84-bc15-4910-93c1-aaadbfc99905", 
+                                        "sortorder": "", 
+                                        "text": "Stucco"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2bde75aa-c629-4fd5-8387-f2b3013569e6", 
+                                        "id": "72fb1350-b85f-46b7-a3e0-18a10de4a5b0", 
+                                        "sortorder": "", 
+                                        "text": "Unknown"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "af3a391a-f831-44b3-9519-51ffff7234e5", 
+                                        "id": "f97558d2-0b0c-4d03-9e42-0a4a8cb9d09d", 
+                                        "sortorder": "", 
+                                        "text": "Wood"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "b803a540-be9c-40af-a670-d6a302bd35b7", 
+                                "id": "fb84842c-df39-426e-92c2-b3140664066d", 
+                                "sortorder": "", 
+                                "text": "Chimney"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d6d5f448-c6d2-4fe8-a012-7c679fceecdc", 
+                                        "id": "0009781f-cf53-47a7-8331-cdc6894154d0", 
+                                        "sortorder": "", 
+                                        "text": "Aluminum"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d3a190e9-38c6-493f-af7d-53a2daeecc00", 
+                                        "id": "f5abe63a-5137-44ba-bbd6-774add95e359", 
+                                        "sortorder": "", 
+                                        "text": "Asbestos"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1113ad05-bea4-42e6-9157-52411f52e4ff", 
+                                        "id": "c5bf4176-2dc1-4d0e-99ca-28747301046d", 
+                                        "sortorder": "", 
+                                        "text": "Board and batten"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "caef2f8f-c599-4ec6-8e3c-0aa9aa87efae", 
+                                        "id": "8f84a3f0-f450-4771-a654-e8d71e619a44", 
+                                        "sortorder": "", 
+                                        "text": "Brick"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cc97eb82-3724-488c-9733-e0af8608c850", 
+                                        "id": "a6d74418-233a-48d9-bf80-20292f03b770", 
+                                        "sortorder": "", 
+                                        "text": "Concrete"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1fa6c870-5a25-433c-b3e8-117f52095b24", 
+                                        "id": "18c61e14-92a2-43ed-9f4d-3856fe8c4edf", 
+                                        "sortorder": "", 
+                                        "text": "Concrete block"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c9ad9cfd-6e6c-4288-93e2-85de694c159d", 
+                                        "id": "5d3f76f9-d345-45e9-9750-e02a85dc16e2", 
+                                        "sortorder": "", 
+                                        "text": "Corrugated metal"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8cb577ef-b73e-4ac7-b5f7-762be1d5b255", 
+                                        "id": "9132e30d-14af-4ca7-86b0-7da3f1cfbec2", 
+                                        "sortorder": "", 
+                                        "text": "Fieldstone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5e552d33-b3da-4338-aa3d-50496a739d85", 
+                                        "id": "b548aa46-460b-41d1-91d4-5851a125dc5a", 
+                                        "sortorder": "", 
+                                        "text": "Glass skin"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b6a20dfe-0c45-49d0-bf49-3d6fd8a9b711", 
+                                        "id": "2dab5cf7-0c21-47c8-a7d6-4db24d3a6c49", 
+                                        "sortorder": "", 
+                                        "text": "Half timbering"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8b6b088f-a330-4a36-aca9-05b6810aaba3", 
+                                        "id": "ce07b222-5a1f-4567-af7a-7e9d1aded8c5", 
+                                        "sortorder": "", 
+                                        "text": "Marble"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "38de006a-c0b3-4c8a-ac41-8f76ed6f09b8", 
+                                        "id": "c9015605-4469-4516-96fa-deedfb4f96a9", 
+                                        "sortorder": "", 
+                                        "text": "Other"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "73997e60-2d44-4fc4-b844-6accf5138ec2", 
+                                        "id": "f80ca62c-a945-4687-8cf6-8ef07b525282", 
+                                        "sortorder": "", 
+                                        "text": "Permastone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ceb41faf-5a79-4381-b58f-1574d1cde5db", 
+                                        "id": "9afe7db4-3f9f-437b-adc5-129cdf768fb9", 
+                                        "sortorder": "", 
+                                        "text": "Stone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3629107e-0f0c-4eb0-bd44-d8bb702a3bc5", 
+                                        "id": "c024f820-e8a9-46d9-88bb-00400bda1de1", 
+                                        "sortorder": "", 
+                                        "text": "Stone, arroyo"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d12ba87a-04b0-4924-a12e-d4d83910dbe3", 
+                                        "id": "9a3a0763-36f0-4453-815f-074c32c61518", 
+                                        "sortorder": "", 
+                                        "text": "Stone, art"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f240a39b-6f0d-4ccd-b511-025f7969c72d", 
+                                        "id": "f3f433e8-db70-4c70-ac90-54e002fb5721", 
+                                        "sortorder": "", 
+                                        "text": "Stone, cast"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9d305fa2-cc75-4990-9dcf-7f507a2608a2", 
+                                        "id": "e9b21a41-400b-4ecc-a32c-eb9377eae0cd", 
+                                        "sortorder": "", 
+                                        "text": "Stone, cut"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "331afb63-1860-46ab-8d53-24076d541b9a", 
+                                        "id": "7966610d-5307-47a4-a389-f2dc8e5a902e", 
+                                        "sortorder": "", 
+                                        "text": "Stone, natural"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cb23d491-9099-48c1-8899-bad44bad1a30", 
+                                        "id": "125f1c25-56d2-4a77-8827-a82c57652e20", 
+                                        "sortorder": "", 
+                                        "text": "Stone, simulated"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "0ff18aa2-18b6-41f3-8354-45de8283af5d", 
+                                        "id": "2aa732e2-f967-4933-977a-53a210da486e", 
+                                        "sortorder": "", 
+                                        "text": "Stucco, smooth"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "fd71076e-0be3-4c6b-94ec-0c31bc46ebaf", 
+                                        "id": "1451f3e0-9191-4235-baa2-3b5a5ee7f406", 
+                                        "sortorder": "", 
+                                        "text": "Stucco, textured"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b9df914a-3f4f-41c9-8ee1-d8e74feb9e27", 
+                                        "id": "a44623a8-2cf6-4b01-a3d3-cae9e85b0f45", 
+                                        "sortorder": "", 
+                                        "text": "Terra cotta"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a519a887-66a9-42a8-afdf-ecae66551dae", 
+                                        "id": "e6cb7d8b-548d-40c7-9e69-25c31f3f6f6e", 
+                                        "sortorder": "", 
+                                        "text": "Travertine"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4154e783-25c4-4504-bfe9-8f266994fcbc", 
+                                        "id": "e11b4652-038a-4a9b-88e6-b225e218728e", 
+                                        "sortorder": "", 
+                                        "text": "Unknown"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f2e86216-6a57-4362-95de-f0b7584bfe1f", 
+                                        "id": "5948bc12-a363-4682-9bd7-c2530a928732", 
+                                        "sortorder": "", 
+                                        "text": "Vinyl"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "af81e762-1157-4a9e-a0b9-5d3f5387514f", 
+                                        "id": "891528a7-f3b4-4db2-8735-fc6a5010811b", 
+                                        "sortorder": "", 
+                                        "text": "Wood channel drop"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "87f7a123-c3c8-4d75-a444-b1f2413a9962", 
+                                        "id": "a1045051-076b-47ed-b1b5-721720dfdc23", 
+                                        "sortorder": "", 
+                                        "text": "Wood clapboards"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "841c7780-9daa-42bd-91cd-6b05f6ce6f3e", 
+                                        "id": "3c74077d-bbb8-44d4-88e3-59e29769f53c", 
+                                        "sortorder": "", 
+                                        "text": "Wood horizontal boards"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9d5dfa0f-b469-478c-a807-307c4d351672", 
+                                        "id": "96e5ce15-3686-4481-99a9-a0d58825de21", 
+                                        "sortorder": "", 
+                                        "text": "Wood panels"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d28a48bf-4e50-4373-bc18-7dd92505e432", 
+                                        "id": "f1061945-c507-4909-946f-34d0e676e71d", 
+                                        "sortorder": "", 
+                                        "text": "Wood rustic"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1cee5e8c-b889-430f-b91e-dc466f7dfb5a", 
+                                        "id": "e5300e6d-423b-490e-b1f7-7836a3cb08c8", 
+                                        "sortorder": "", 
+                                        "text": "Wood shingles"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8bfa0e72-b54e-4d8d-9b61-6ebcbdc41ea7", 
+                                        "id": "2b88f723-d8c7-4072-b2e6-fb93ad9fbcc8", 
+                                        "sortorder": "", 
+                                        "text": "Wood shingles, fish scale"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "03386f42-14ac-431d-b838-a24e9c808e6b", 
+                                        "id": "9bb25367-1b59-4d2a-b77a-a792cf71707f", 
+                                        "sortorder": "", 
+                                        "text": "Wood tongue-and-groove"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d4a12b5f-fea2-4e94-8795-04f42ec09114", 
+                                        "id": "78a133fe-ce0d-4018-bc29-7cdad6ef86d7", 
+                                        "sortorder": "", 
+                                        "text": "Wood vertical boards"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "fe7866a1-13a1-4d1b-825f-48ab730c6242", 
+                                        "id": "ecdd773d-78cf-4b92-8f2a-768947c63099", 
+                                        "sortorder": "", 
+                                        "text": "Wood, Board and Batten"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "0e82ac27-63db-46c1-ad8f-7933f7d6523b", 
+                                "id": "63bc49bb-84b6-4418-97ed-46f14cf3e48b", 
+                                "sortorder": "", 
+                                "text": "Cladding"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "33e14719-7250-46d6-b559-f61db61cf78e", 
+                                        "id": "2917fe20-4102-4228-aeed-1211158fb87d", 
+                                        "sortorder": "", 
+                                        "text": "Adobe"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7b23c150-b93b-45ff-8495-a896980ef742", 
+                                        "id": "d7952439-79ca-44ad-bea1-2b855c6df59b", 
+                                        "sortorder": "", 
+                                        "text": "Brick"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d5ae0607-7813-4182-819a-b087f5238d2c", 
+                                        "id": "9b5b0e2d-a603-4ea8-b0eb-f59aae42bb8e", 
+                                        "sortorder": "", 
+                                        "text": "Concrete masonry unit"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e5210afd-6134-410a-99d5-ea0807cfbfa6", 
+                                        "id": "0a2b13db-1141-4e47-9ea8-2ce60fde706d", 
+                                        "sortorder": "", 
+                                        "text": "Concrete poured/precast"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "de6bdf3d-f6fe-4a77-82e8-d38621708c8f", 
+                                        "id": "4b80592d-2e8d-4e9e-81fd-ed8b0a869839", 
+                                        "sortorder": "", 
+                                        "text": "Concrete, masonry unit"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b00169f9-7169-4ef5-8024-d78432767117", 
+                                        "id": "ed273fe0-6f4a-4519-9b41-09592b48344a", 
+                                        "sortorder": "", 
+                                        "text": "Concrete, poured/precast"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "55d5486f-fe37-41cb-9577-db04b729ca6f", 
+                                        "id": "2b2675db-610e-4297-9b94-f286e416bab4", 
+                                        "sortorder": "", 
+                                        "text": "Corrogated metal"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1b330be1-8260-4715-b95b-3313e0561f38", 
+                                        "id": "2a3e2771-46da-439a-a701-f5e8fac5bcd8", 
+                                        "sortorder": "", 
+                                        "text": "Hollow clay tile"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e0898bb2-d048-4b0f-a5ef-56954899be21", 
+                                        "id": "1b7dd884-a6e3-4cd5-b1de-0b96d7b36a41", 
+                                        "sortorder": "", 
+                                        "text": "Post-and-beam"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "699757d8-1194-4507-9612-e39b1cdf6989", 
+                                        "id": "b4805ef3-bbc1-45b6-8339-b780be497547", 
+                                        "sortorder": "", 
+                                        "text": "Steel"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "da321753-5265-4dff-95fd-cb3d33651e54", 
+                                        "id": "4bba90f5-d998-4a53-9bc2-99027cd4e3e7", 
+                                        "sortorder": "", 
+                                        "text": "Stone"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "42ca5a0e-f439-4e5c-b7d5-5b752c44a48f", 
+                                        "id": "b82aaa50-722a-4f2c-87d4-7d2df5e2f129", 
+                                        "sortorder": "", 
+                                        "text": "Unknown"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5e9299fc-7629-4239-9719-17e1ac6a8d95", 
+                                        "id": "e8b36e0b-993e-4e1e-a613-8bbb27d09b4f", 
+                                        "sortorder": "", 
+                                        "text": "Wood"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "90fc0f69-9b3e-41c3-80f7-b40b5f3afe29", 
+                                "id": "f178fb92-9514-4ca4-9c2a-29efaa99c00a", 
+                                "sortorder": "", 
+                                "text": "Construction"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e6c46b2e-408e-4dcb-be0a-dd3ca4c55f44", 
+                                        "id": "933d0c1b-1fb6-43d9-949c-3474ced8139c", 
+                                        "sortorder": "", 
+                                        "text": "Applied decoration"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d93eb68f-e7b5-4a26-a94b-093ebbd20240", 
+                                        "id": "8bb47086-9b43-4be6-b7de-555dc69dfb52", 
+                                        "sortorder": "", 
+                                        "text": "Balconette"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ba44c544-a078-43b7-a913-59ec24828e20", 
+                                        "id": "1cb3ad6d-6d35-4339-8e52-8f1a9616bc77", 
+                                        "sortorder": "", 
+                                        "text": "Belt course"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "53a38db4-82e8-424e-9b78-02a35234b7df", 
+                                        "id": "78af07f8-5f24-4f92-a42a-0e0168eafdcd", 
+                                        "sortorder": "", 
+                                        "text": "Bris soleil"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c672c96b-f443-498d-914f-b756895751b3", 
+                                        "id": "f00730f2-a512-4431-9fb9-6d612bb48ce8", 
+                                        "sortorder": "", 
+                                        "text": "Buttresses"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "190f06c4-b43f-46cf-a295-a2a3ba9d852c", 
+                                        "id": "c72d09bd-c3e7-49b2-a383-b6d306eb3cd0", 
+                                        "sortorder": "", 
+                                        "text": "Dingbats"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e7b3c3b3-e94f-48a7-aef0-a23c904e5a99", 
+                                        "id": "c5067420-1981-4990-9e24-a649019ead76", 
+                                        "sortorder": "", 
+                                        "text": "Grilles"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6751efb7-c690-461b-9f96-d57ba757a345", 
+                                        "id": "7c37b10a-12ba-46ac-827e-891340e25694", 
+                                        "sortorder": "", 
+                                        "text": "Light Fixtures"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3445a317-878c-4238-9c85-24a7577eb586", 
+                                        "id": "34b082df-87b4-4577-911e-95ccda691909", 
+                                        "sortorder": "", 
+                                        "text": "Loading Dock"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8f6ab6c3-ec16-4828-9fee-3a858d257b1a", 
+                                        "id": "cf7dfbb0-603b-49b1-b40f-4ae8534fc7d8", 
+                                        "sortorder": "", 
+                                        "text": "Pierced screens"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6697cb01-8994-454b-8a80-dc0a52e954f5", 
+                                        "id": "d82a1370-90fc-49d1-b8b4-8c4ff42f19e5", 
+                                        "sortorder": "", 
+                                        "text": "Pilasters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "39bcd5b1-0118-4e63-b0a1-ecf9d1e44421", 
+                                        "id": "cf61bc5e-c303-4cd6-8591-4642e77bb0b9", 
+                                        "sortorder": "", 
+                                        "text": "Planters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "333bdf3b-7598-42de-b322-844de2dff251", 
+                                        "id": "61fa58fe-8645-4386-a18d-c82cffdfaeed", 
+                                        "sortorder": "", 
+                                        "text": "Quoins"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "10b63b6c-ea54-485e-9dcb-6c98a149b1d2", 
+                                        "id": "fc12d816-d48b-4de8-9d30-951f9dc24401", 
+                                        "sortorder": "", 
+                                        "text": "Sign"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "020754ba-c6ec-4b0b-b1ed-c6777c13ece8", 
+                                        "id": "3f911014-7af5-4e06-8bf4-dab91d818b10", 
+                                        "sortorder": "", 
+                                        "text": "String course"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2ecbbe3d-1ae1-4f96-8d12-d3bba7c29148", 
+                                        "id": "04416b6a-c7ef-4a89-a9fc-964a5ddb10bd", 
+                                        "sortorder": "", 
+                                        "text": "Tile"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "382e51df-5c89-49b8-9f54-29093ec6aca4", 
+                                "id": "8866fb45-dcfd-422b-b95e-e2a7f5862199", 
+                                "sortorder": "", 
+                                "text": "Details"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "20c54fe3-06b2-44cf-9845-d2d590110798", 
+                                        "id": "07e9cf15-7cec-4b7a-b5d1-157abf14e97e", 
+                                        "sortorder": "", 
+                                        "text": "Arched"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7e434625-5ab6-474f-8fa3-39eb0d25a5b5", 
+                                        "id": "3f1d38bd-bb8f-4c5a-80ce-f5a2464eba51", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening, pointed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5c2cddba-fd0e-459f-80ac-055f9b986d16", 
+                                        "id": "e880c63d-b16b-44b5-abc2-3dc7947dbedb", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening, round"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c29db6a0-d4f4-40e8-846e-176e3e473763", 
+                                        "id": "031ec715-d2f4-4baf-83cc-f7165896bd1d", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening, segmental"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "07450ab1-5996-4c04-901c-3240627d2139", 
+                                        "id": "5a5c03f5-6c88-4a41-bfea-3f201e81cf9d", 
+                                        "sortorder": "", 
+                                        "text": "Awning"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8452db7c-56a0-42c2-894e-69c6c3c83b0e", 
+                                        "id": "f5b64f26-b68b-425f-94d4-5aeacdc5f610", 
+                                        "sortorder": "", 
+                                        "text": "Canopy"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a07d2c76-0a4a-41c5-9071-f23969ca022a", 
+                                        "id": "cdcae785-14d8-4fe1-9d7f-6dbfbab4b08f", 
+                                        "sortorder": "", 
+                                        "text": "Decorative hardware"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b294fa28-c66c-492c-b163-d953f6491569", 
+                                        "id": "ec1217cd-5246-4a38-9c72-184621cb95a7", 
+                                        "sortorder": "", 
+                                        "text": "Decorative surround"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9250e425-4340-41cb-a588-da04a072594b", 
+                                        "id": "f2eb521e-c2aa-4241-92e4-63d6fb070746", 
+                                        "sortorder": "", 
+                                        "text": "Divided lights"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1e93344a-3a74-4d6e-8159-9d5d19120f7e", 
+                                        "id": "73ccb465-6b8f-4e5d-ac26-e35dc40bfcb8", 
+                                        "sortorder": "", 
+                                        "text": "Double"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c59713cd-7c2b-4104-8f11-3b6c80382c06", 
+                                        "id": "2c5bab37-0001-484c-841b-16ef793a4fa3", 
+                                        "sortorder": "", 
+                                        "text": "Fanlight"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d4b036f1-6e4a-4357-a3a3-36f433edfb8d", 
+                                        "id": "50579aec-f633-4e88-bb23-b615642fb8ae", 
+                                        "sortorder": "", 
+                                        "text": "French doors"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6fc50e04-bd62-458d-b9ae-e6eafce270cb", 
+                                        "id": "359a5e23-3f4f-4a32-8be2-94b2e336ed03", 
+                                        "sortorder": "", 
+                                        "text": "Fully glazed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "01cc780e-3ec0-4a9f-b28d-cd531b4e374a", 
+                                        "id": "d635fd64-dcb5-4b40-a90d-8037bd0bf748", 
+                                        "sortorder": "", 
+                                        "text": "Glazed, fully"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c0606ee0-1326-4328-a1e5-2714702ee243", 
+                                        "id": "ef7eed00-6173-4a7d-a6ce-25965b3929f3", 
+                                        "sortorder": "", 
+                                        "text": "Glazed, partially"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9d3f1e38-3396-40a5-9cae-5e0bed40dfb9", 
+                                        "id": "ff6d63ea-f7bb-41de-b293-12ca6ed30d38", 
+                                        "sortorder": "", 
+                                        "text": "Historic Surround"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "acdc82ac-91a2-488d-9e5c-2d3c57e6f7c7", 
+                                        "id": "6494b61e-ec73-4967-a065-0aadff397e89", 
+                                        "sortorder": "", 
+                                        "text": "Historic hardware"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ff3d6e44-750d-432a-bf57-e530dd3d5f01", 
+                                        "id": "ef20ecb7-f80d-4a5c-96ce-6ebd9b1b0055", 
+                                        "sortorder": "", 
+                                        "text": "Metal screen"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ea6d10a1-5bd5-42d2-97b4-a7a1fa64a421", 
+                                        "id": "c44cf506-8722-4cb9-abbb-2ae069ca8ad0", 
+                                        "sortorder": "", 
+                                        "text": "Paneled"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5c05dc48-79fe-4936-9809-331154426b44", 
+                                        "id": "fc468ce8-7b90-4e55-94a4-2e9b88b4d1bb", 
+                                        "sortorder": "", 
+                                        "text": "Partially glazed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bb049f11-4cac-4dbb-9e13-7d4e56d4051c", 
+                                        "id": "582cc454-9bf3-496a-8479-1191e9db7907", 
+                                        "sortorder": "", 
+                                        "text": "Pediment"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "75102bfd-289b-4882-a40b-fbbc06f99031", 
+                                        "id": "3cc5f144-9874-47f8-80b6-80a7809d7f6e", 
+                                        "sortorder": "", 
+                                        "text": "Pilasters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4564892f-6d67-4058-ae4d-52a9ab6c7c2c", 
+                                        "id": "8a5e4d50-9937-4a1c-9584-9e0427d17eb1", 
+                                        "sortorder": "", 
+                                        "text": "Roll-up"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "27ab4fbe-57d6-44f8-bc6f-68e17239d45f", 
+                                        "id": "48947ba1-160c-4851-926b-8e938f1f14df", 
+                                        "sortorder": "", 
+                                        "text": "Security door"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "86e8fc76-b87d-4f8d-837a-8b708ca802f5", 
+                                        "id": "0bdbb0b2-7be7-48ce-ae6a-0832f7eb2860", 
+                                        "sortorder": "", 
+                                        "text": "Sidelights"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d25e5e65-8aee-42f2-85b2-de92e03651be", 
+                                        "id": "6a34225c-3917-459e-bf63-0bedb59e14dc", 
+                                        "sortorder": "", 
+                                        "text": "Single"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "0eacfc92-78b9-4cab-814f-30fe2dce467f", 
+                                        "id": "1a477484-dce4-47c4-b8dc-c12373dc42c5", 
+                                        "sortorder": "", 
+                                        "text": "Sliding"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b8830b8c-9463-4ac3-9495-804f9f6759c7", 
+                                        "id": "d17c4563-2743-4426-9a49-a4a5566575c5", 
+                                        "sortorder": "", 
+                                        "text": "Transom"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "541f7f2e-30b2-4516-abb1-ece53a050196", 
+                                        "id": "74868e3d-ca47-4026-8876-39febc34ab8b", 
+                                        "sortorder": "", 
+                                        "text": "Unknown"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "38435fbd-3ee2-4159-84e6-fad2ebacfad9", 
+                                        "id": "d6cb9285-609a-4565-a3c7-2fce84ff966e", 
+                                        "sortorder": "", 
+                                        "text": "Wood screen"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "d1ffee68-31f7-4b69-869f-cc5fe8d01da5", 
+                                "id": "d9c73268-97cf-418d-80fb-92d0f0f16a75", 
+                                "sortorder": "", 
+                                "text": "Door Types"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2ee9ecfe-f8bf-4681-8919-2a83a81a629c", 
+                                        "id": "0b1c1b6a-0ef9-4707-b30e-d113285a66e1", 
+                                        "sortorder": "", 
+                                        "text": "Arches"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "11885ebc-e3ce-4a9c-b6f5-11d67d571a78", 
+                                        "id": "51337cf2-e416-4c6d-a0ac-8b90b5233923", 
+                                        "sortorder": "", 
+                                        "text": "Atrium"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5fa8c46a-fb89-4828-b3bf-ae631a76a934", 
+                                        "id": "8566f513-6fe8-450b-b52b-5b560b0b6a69", 
+                                        "sortorder": "", 
+                                        "text": "Awning(s)"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b259c1e2-c54a-4345-a8e6-85bf0cddd896", 
+                                        "id": "9f9fd6b3-0a76-46ab-b054-a4b4b79d4d2d", 
+                                        "sortorder": "", 
+                                        "text": "Balcony"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6ff76bb7-a5fb-44aa-aed3-2b659c2bc6c1", 
+                                        "id": "dd177ccf-fd7f-4a19-9863-bc3083946464", 
+                                        "sortorder": "", 
+                                        "text": "Balustrade"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1cbc707e-d184-407d-ab70-3af14287f5ed", 
+                                        "id": "fc75aa20-4f6f-4851-82bb-ae134b4fa06c", 
+                                        "sortorder": "", 
+                                        "text": "Canopy"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "acd09b87-bb5c-4fd2-857a-4e568adb8f89", 
+                                        "id": "29d3b2a7-a90a-4496-9af0-ee200e8ce0f9", 
+                                        "sortorder": "", 
+                                        "text": "Colonnade/arcade"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "de3d0b45-348f-4133-8d3b-f546f2d67fa7", 
+                                        "id": "ef45639f-5dc7-4540-9484-23df054ad034", 
+                                        "sortorder": "", 
+                                        "text": "Columns"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c501b7c9-8919-42e4-a872-8478b974a68c", 
+                                        "id": "1356d379-34b3-42f0-a37f-ca8176b18f22", 
+                                        "sortorder": "", 
+                                        "text": "Courtyard"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "283b94e9-42f6-48a0-9de7-829d6be82571", 
+                                        "id": "531011a1-7285-41ba-a9a1-43546dca6f07", 
+                                        "sortorder": "", 
+                                        "text": "Marquee"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "57dca478-fc6d-4bf1-bfc9-1985bb7ca052", 
+                                        "id": "19dfeb13-0ed9-4b0b-84f1-53c344b7de7f", 
+                                        "sortorder": "", 
+                                        "text": "Patio"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a08f0203-5ab8-4293-bbf6-93027c4fc76e", 
+                                        "id": "d408b762-2027-45b6-84fb-53303c3e28af", 
+                                        "sortorder": "", 
+                                        "text": "Pilasters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "86162a52-f1cd-4527-b12f-65e80a7c28fe", 
+                                        "id": "2b041cb4-cc36-4506-95b8-b6c62144b433", 
+                                        "sortorder": "", 
+                                        "text": "Portico"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bf2fbf74-1d07-4d0a-9933-33f77089bb09", 
+                                        "id": "b34c736c-90a3-4b08-87b8-3b19dfa0b5d6", 
+                                        "sortorder": "", 
+                                        "text": "Projecting"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9eb17204-3313-438c-bf9c-40b0e3bb86ea", 
+                                        "id": "4eb2fc54-5242-4ba8-9519-33129941449f", 
+                                        "sortorder": "", 
+                                        "text": "Recessed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ebf8a33d-ff3c-4ed3-abe2-c1c06a7a9622", 
+                                        "id": "17eda140-4d61-4da8-9146-d1ef7c74bf34", 
+                                        "sortorder": "", 
+                                        "text": "Stoop"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f48a7c77-a1e6-4265-b1e7-73e363e0067c", 
+                                        "id": "b7d06469-ae74-4e39-8ea9-3282b4db67d2", 
+                                        "sortorder": "", 
+                                        "text": "Subterranean"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8dd192bb-8e07-4aa6-bf75-0c4fa5ac5442", 
+                                        "id": "659a0761-05e2-4bc6-939b-ae287a065b09", 
+                                        "sortorder": "", 
+                                        "text": "Vehicular entry"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e7ccddcf-1619-41f7-b7eb-06b7756dff3d", 
+                                        "id": "5a34fc16-7d61-427f-9066-53248c380255", 
+                                        "sortorder": "", 
+                                        "text": "Wall"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "26c50759-f7ed-4813-b56b-029db5fd2f93", 
+                                "id": "e9b15d8e-c33b-41ab-bb86-dbf42b63cddc", 
+                                "sortorder": "", 
+                                "text": "Entryway"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e232ba64-d69f-4976-b426-3c844d23cc2c", 
+                                        "id": "1ccace88-b1a1-4800-942a-6b1237b5134a", 
+                                        "sortorder": "", 
+                                        "text": "Asymmetrical"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5e9938c3-b1a3-48af-8120-67475d6daba4", 
+                                        "id": "fb2a07a9-457b-4784-af2e-5fe125dd1fe9", 
+                                        "sortorder": "", 
+                                        "text": "Symmetrical"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "6f50a4f9-0e31-4984-8a5e-ae157847c7fb", 
+                                "id": "1f0aa116-587b-4f4b-b474-c48e5d1791f3", 
+                                "sortorder": "", 
+                                "text": "Fa\u00e7ade"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "291eb4ff-4540-4915-8fb0-dff3a64445fe", 
+                                        "id": "b4e2a277-6c63-428b-b4e0-8a21fb539c25", 
+                                        "sortorder": "", 
+                                        "text": "Circular"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "04901917-51ac-4df4-b112-983e0fed8a2d", 
+                                        "id": "324a0b3b-a14f-4ae5-8aa3-61fdface0181", 
+                                        "sortorder": "", 
+                                        "text": "H-shaped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5495e6c5-0687-4014-9c92-7ac682f3c60b", 
+                                        "id": "62632597-a927-49a7-912e-bc7a75790423", 
+                                        "sortorder": "", 
+                                        "text": "Irregular"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "91d9bcde-1c80-4f70-bd7e-8238fc7ac8e9", 
+                                        "id": "251d058e-e302-4f9f-a28f-311b37c747a6", 
+                                        "sortorder": "", 
+                                        "text": "L-shaped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "81611727-82ee-4a48-9c97-bba951e48195", 
+                                        "id": "3166f5e0-af43-40ef-ab1a-6b55694f8826", 
+                                        "sortorder": "", 
+                                        "text": "Octagonal"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9098d9ed-5a94-43de-b394-409b905b7c36", 
+                                        "id": "c54d0573-af04-4312-9b6f-fd2840713760", 
+                                        "sortorder": "", 
+                                        "text": "Rectangular"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "39de0979-8dac-4bff-b90d-f942d5429518", 
+                                        "id": "c8cfb079-5318-4adb-bf81-825b9569b755", 
+                                        "sortorder": "", 
+                                        "text": "Square"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "fa5d41b2-27c1-493e-9c0c-cd66c45958ae", 
+                                        "id": "51015c31-8735-44a3-af99-ce9f10426bfa", 
+                                        "sortorder": "", 
+                                        "text": "T-shaped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b5300111-7b9f-4890-b640-965a95bdfb34", 
+                                        "id": "7b72f8e0-9732-42d1-9415-22b1258b2a50", 
+                                        "sortorder": "", 
+                                        "text": "Triangular"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9170468e-04e3-4d6a-a7e3-21de23caf144", 
+                                        "id": "e63f4a97-9503-4446-8f3d-3896f1d68430", 
+                                        "sortorder": "", 
+                                        "text": "U-shaped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1ab3342d-a22b-49a6-a940-d150a670b5b8", 
+                                        "id": "57f1d880-3a19-4829-95eb-6e4fc348f0e5", 
+                                        "sortorder": "", 
+                                        "text": "Unknown"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "43ecf05a-b100-452c-b8db-41e733faaac2", 
+                                "id": "2f75b7e4-b3d8-4fd9-af88-d59189f2df8c", 
+                                "sortorder": "", 
+                                "text": "Plan"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2ab656d8-44d4-433e-a935-ea33a67a6f9d", 
+                                        "id": "6aa17b31-cc09-40b3-b514-e387a4dece84", 
+                                        "sortorder": "", 
+                                        "text": "Entrance porch/stoop"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7aaa0415-9410-44fc-8111-a465604d7122", 
+                                        "id": "dd370a00-1717-4121-b2b4-85b93de2ea69", 
+                                        "sortorder": "", 
+                                        "text": "Full width"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5d45b12d-80b5-4f95-8367-861eb9fc4072", 
+                                        "id": "89ff4b90-ec2c-4821-97d8-60dc153be92d", 
+                                        "sortorder": "", 
+                                        "text": "Partial width"
+                                    }, 
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "d1e589e8-f3f6-4e51-9032-7870a7404591", 
+                                                "id": "c64b0bee-2808-44d1-a1cb-b1887851993c", 
+                                                "sortorder": "", 
+                                                "text": "Balustrade (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "3362f620-35ac-41be-bf6d-63b22f309304", 
+                                                "id": "44a83fe0-62d6-41e2-a59f-b47aefd52076", 
+                                                "sortorder": "", 
+                                                "text": "Brick (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "f9ee42f3-dcc2-42ed-9025-3264a453b742", 
+                                                "id": "ad971d05-9bf6-45ed-a5cc-e041924cbf69", 
+                                                "sortorder": "", 
+                                                "text": "Concrete (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "8ad1d739-f80d-4ee5-a3ac-11caafb0c890", 
+                                                "id": "e21b03e9-635c-4abe-a81f-7002a9b301e7", 
+                                                "sortorder": "", 
+                                                "text": "Handrail (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "679a2447-ab7a-4b03-a097-a0139634b077", 
+                                                "id": "1b3e35be-1c24-4380-ac28-838f3abc659f", 
+                                                "sortorder": "", 
+                                                "text": "Iron (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "cb89845a-4c73-40ce-89bc-731705c2b1de", 
+                                                "id": "9c1358d9-8c14-4991-a1ea-09c8464ed6a8", 
+                                                "sortorder": "", 
+                                                "text": "Metal (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "4eec3c66-bbb2-400f-8c57-2e58ec714123", 
+                                                "id": "2eb88881-3800-4460-801a-559a7a5620bd", 
+                                                "sortorder": "", 
+                                                "text": "Other (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "8d268c08-7ccd-4f58-b0c9-9498422598ff", 
+                                                "id": "a9d02bb1-875e-4906-a65c-7e28c8f5f695", 
+                                                "sortorder": "", 
+                                                "text": "Stair rail (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "84c20f2d-ba21-4379-845d-1e934f15535e", 
+                                                "id": "8e79c43b-87a9-4a40-890c-018b33baaf6e", 
+                                                "sortorder": "", 
+                                                "text": "Stone (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "9cb95f90-6a0e-4a74-9545-7a345eee4d6b", 
+                                                "id": "096d725c-3515-4ba6-be0b-f62a74dac09f", 
+                                                "sortorder": "", 
+                                                "text": "Stone, arroyo (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "d2b8e5a0-496a-49ce-8bc4-67040e1e4128", 
+                                                "id": "18027796-af7e-48fc-a49a-9ae59d006adf", 
+                                                "sortorder": "", 
+                                                "text": "Stone, cast (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "92567806-0817-4a44-965f-918e6ddc060c", 
+                                                "id": "750d8f1e-ea4e-4c10-8c81-3ffd2f943309", 
+                                                "sortorder": "", 
+                                                "text": "Stone, cut (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "3d77ece9-3f1e-4384-9a35-111f42e7c21d", 
+                                                "id": "2f087443-1f20-4274-ab20-ac649e293343", 
+                                                "sortorder": "", 
+                                                "text": "Stone, natural (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "a1054bf5-9af0-4178-85f4-097757fecb65", 
+                                                "id": "7712cd7c-7e98-42f8-8dc3-f7835c503d86", 
+                                                "sortorder": "", 
+                                                "text": "Stone, simulated (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "893b458f-b4a5-4bb5-92cd-472e56f5a8ea", 
+                                                "id": "2814dde6-d8f0-4835-81ff-9751dc3fe1b7", 
+                                                "sortorder": "", 
+                                                "text": "Stucco (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "6107e049-34ae-42d2-aaba-de5be0a32b27", 
+                                                "id": "d45262ea-5d01-41cf-9797-483329b1c6d7", 
+                                                "sortorder": "", 
+                                                "text": "Terra cotta (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "6b9b0e97-63d4-4383-8f1c-5f2f6f36baa1", 
+                                                "id": "3c35e01d-7e10-4227-8278-04cbf3cffc30", 
+                                                "sortorder": "", 
+                                                "text": "Wall (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "0500d7fd-bddf-46ae-8998-23247145aa92", 
+                                                "id": "8760227d-738e-410d-a03a-c19b6cee1a12", 
+                                                "sortorder": "", 
+                                                "text": "Wall, low (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "691c10e1-3e09-43ad-baac-0b4b202a1bca", 
+                                                "id": "f58756b9-553c-4560-95b1-c154e3de7bf0", 
+                                                "sortorder": "", 
+                                                "text": "Wood (Porch Rail)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "50cc6e44-5fe2-47cb-944b-3618ab2e7989", 
+                                                "id": "5b2fc096-eb6c-4942-b4a4-e440a2280cfd", 
+                                                "sortorder": "", 
+                                                "text": "Wrought iron (Porch Rail)"
+                                            }
+                                        ], 
+                                        "collector": "", 
+                                        "conceptid": "88255896-b525-4cae-a12d-d488e5505366", 
+                                        "id": "8f85a2a7-9e02-4fbc-9d1d-64c7d0b1b09e", 
+                                        "sortorder": "", 
+                                        "text": "Porch Rail (Porch Rail)"
+                                    }, 
+                                    {
+                                        "children": [
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "c6e6691d-fd47-4412-ab21-ab60ecab8b95", 
+                                                "id": "288a4f2d-3658-4edd-ab60-9e40b2bbc795", 
+                                                "sortorder": "", 
+                                                "text": "Arches (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "a4e01a02-d311-4efc-ba2c-0aaf1e78789c", 
+                                                "id": "f4ca5517-8a47-4da3-8e9a-887dcb6c60dd", 
+                                                "sortorder": "", 
+                                                "text": "Brackets (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "f4b59fca-c26d-4db5-a966-647863292a25", 
+                                                "id": "4fd21078-1a7a-4f9a-ab17-70b7117f3c9e", 
+                                                "sortorder": "", 
+                                                "text": "Columns (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "54890950-eb0d-4a07-a7ff-166a8f3a9b47", 
+                                                "id": "117a35c2-3bf7-4ff8-8654-e15abb8dea80", 
+                                                "sortorder": "", 
+                                                "text": "Piers (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "20eee33e-b572-4c49-904b-78598007ba03", 
+                                                "id": "c8d8ce8c-6fcb-4e8d-86fd-a12d7e69e1d6", 
+                                                "sortorder": "", 
+                                                "text": "Posts (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "8a5c4c44-3fec-4c1a-ab1c-da4e719cdec3", 
+                                                "id": "89fc8e48-db38-4603-9376-5ad53737b806", 
+                                                "sortorder": "", 
+                                                "text": "Spindles/turned posts (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "d46d9cd6-f7d1-41a0-bb2b-b5a9d18c5f4b", 
+                                                "id": "d12126a5-8359-45a8-98ba-8b39ddd22779", 
+                                                "sortorder": "", 
+                                                "text": "With Pedestals (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "6f0c6817-71bd-4af9-a22a-42a58bffe555", 
+                                                "id": "1b1b189f-ac35-48e3-acd0-98c3f1b6911e", 
+                                                "sortorder": "", 
+                                                "text": "With brick pedestals (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "c39835e7-b123-4382-98be-4511abe44f1e", 
+                                                "id": "a7abe780-9111-41f1-a710-b0e03292f19d", 
+                                                "sortorder": "", 
+                                                "text": "With concrete pedestals (Porch Supports)"
+                                            }, 
+                                            {
+                                                "children": [], 
+                                                "collector": "", 
+                                                "conceptid": "837d36b4-1a33-4f0a-ae6c-26782dbd91ea", 
+                                                "id": "d7fc8ac9-c517-4d1d-9ce0-17f12cbae48a", 
+                                                "sortorder": "", 
+                                                "text": "With stone pedestals (Porch Supports)"
+                                            }
+                                        ], 
+                                        "collector": "", 
+                                        "conceptid": "68602892-c480-4c55-994e-8dcb8bddedc2", 
+                                        "id": "b4a375e1-81c5-4a6a-9313-8189a423541c", 
+                                        "sortorder": "", 
+                                        "text": "Porch Supports (Porch Supports)"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "fb5e0507-031c-41a6-884e-38cd65b2e4cb", 
+                                        "id": "e0d989cc-3832-49c6-9216-9a93e654872b", 
+                                        "sortorder": "", 
+                                        "text": "Projecting"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7dfbb4b2-89af-4104-98e4-72971c667969", 
+                                        "id": "fe638838-07ff-458e-a44e-2765b40415eb", 
+                                        "sortorder": "", 
+                                        "text": "Recessed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "27ba2ce4-e206-4c43-b7f7-12a4ace018a5", 
+                                        "id": "607b49c0-e829-4fe2-ba71-4e6822415180", 
+                                        "sortorder": "", 
+                                        "text": "Roof, flat"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "82233be5-a1f7-44bd-b595-d8ef80d431f1", 
+                                        "id": "80f14cca-ba72-4d17-98b4-4bad04c3803a", 
+                                        "sortorder": "", 
+                                        "text": "Roof, gable"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c5f58eb2-42ec-4143-9d66-97ce9b28c9ab", 
+                                        "id": "a277968d-1f64-43e7-bb03-f29bf402cd60", 
+                                        "sortorder": "", 
+                                        "text": "Roof, hipped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7bc3735e-d671-4fb9-b09e-b3f71ee5c403", 
+                                        "id": "1ec8c8be-8f26-43e0-bbd5-91b76dabb8ca", 
+                                        "sortorder": "", 
+                                        "text": "Roof, mansard"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5a8a325b-47b5-40d4-b44f-9ecbd85b0cf0", 
+                                        "id": "eef4ad62-b9f0-44ba-a207-e847bda79060", 
+                                        "sortorder": "", 
+                                        "text": "Roof, parapet"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a1113b06-efcd-41f9-8da0-93b275744994", 
+                                        "id": "1d5f258a-bf9a-4e3c-9b3b-31a00e4825c6", 
+                                        "sortorder": "", 
+                                        "text": "Roof, shed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4a3f36d4-e0ae-4931-8b8e-9fb6dbefae2d", 
+                                        "id": "c8d92b65-d70b-4009-b6e3-7d5d301f992a", 
+                                        "sortorder": "", 
+                                        "text": "Wraparound"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "f09b843a-60ed-4fd9-8a37-d26aef2b2f6b", 
+                                "id": "d51e0d1a-276d-4b23-ba1c-5fb2143b44c5", 
+                                "sortorder": "", 
+                                "text": "Porch"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1a2234fd-a1dd-4372-a2a2-530ec15bcf2a", 
+                                        "id": "6b1d8187-ec69-4ccc-860a-2a34eba4e613", 
+                                        "sortorder": "", 
+                                        "text": "A-frame"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "efc0e5f2-89ae-4007-a298-d2d20699f7c1", 
+                                        "id": "22b90a49-4a69-4f26-9d6f-9b63adf545b1", 
+                                        "sortorder": "", 
+                                        "text": "Bargeboards"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1dd7cb47-d620-4b9d-a444-b7cc655fda11", 
+                                        "id": "4a01d500-10c8-4953-80ae-2ef3adcfe0b0", 
+                                        "sortorder": "", 
+                                        "text": "Barrel vaulted"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "eb95464b-c2a4-4a88-8ba2-4aaeef01273b", 
+                                        "id": "fea679ba-6a7e-4887-b07a-1a17c1bb7eab", 
+                                        "sortorder": "", 
+                                        "text": "Brackets"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "15a71535-3d81-4e4d-8107-98f9ce489453", 
+                                        "id": "748ad9d2-3fb6-4d23-9f86-e48fc6772c8e", 
+                                        "sortorder": "", 
+                                        "text": "Butterfly"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "769fd4c0-52a8-4f31-8f18-5fa41d81ce62", 
+                                        "id": "14f358f9-fc1e-4fc4-9fb9-b5bb8be3d0e6", 
+                                        "sortorder": "", 
+                                        "text": "Clay tile coping"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a5bf564d-9174-4ea5-9f5c-48300f84c97b", 
+                                        "id": "2a3e907e-1e91-4c67-a21d-fca3a0ff7f13", 
+                                        "sortorder": "", 
+                                        "text": "Clipped Gable, side"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a87deca4-45a7-4cd9-971c-e6d1013f49a4", 
+                                        "id": "51bdb617-012f-43e0-954d-68d5ad056c95", 
+                                        "sortorder": "", 
+                                        "text": "Combination"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e91eb3de-cb82-4f6e-a250-44c4330ada4f", 
+                                        "id": "7ccfcf3d-3c84-4640-87e4-c66973ce9d5a", 
+                                        "sortorder": "", 
+                                        "text": "Cornice"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8c16092b-0599-4cb1-ab85-32d0d52b0fe7", 
+                                        "id": "2eb19cdd-2bb9-419b-aeca-b51cab1c1ae5", 
+                                        "sortorder": "", 
+                                        "text": "Cupola"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "018965f3-4dee-4801-ab3b-610ca22aa93a", 
+                                        "id": "54b6afc7-5154-435b-a53d-9d035e5e93cc", 
+                                        "sortorder": "", 
+                                        "text": "Dentils"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4feba010-ca64-4828-974c-7ecdf9b7c083", 
+                                        "id": "2bbc59ae-fdf5-47d4-aa31-fa02c84d2a73", 
+                                        "sortorder": "", 
+                                        "text": "Dormer"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "aca4f76f-932a-454f-abde-0f50233658ac", 
+                                        "id": "5d64573f-8118-42c2-b8eb-479268177cdd", 
+                                        "sortorder": "", 
+                                        "text": "Dovecote"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "951f85c1-8af8-4d1b-be5c-f3895b47db8c", 
+                                        "id": "96e5f0cc-1c3f-4380-a13d-44c6094b9c8a", 
+                                        "sortorder": "", 
+                                        "text": "Eaves, boxed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9bd3adc6-866e-476b-830c-ab61eca703cc", 
+                                        "id": "93c9b310-773b-4e7e-8948-c4aafce101a9", 
+                                        "sortorder": "", 
+                                        "text": "Eaves, flared"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "23beef4a-26a1-4c71-a506-566386485753", 
+                                        "id": "59346275-d7c3-4409-971e-3617e0b351ff", 
+                                        "sortorder": "", 
+                                        "text": "Eaves, open"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "aac67183-d569-41d8-a645-4515cae65d37", 
+                                        "id": "eb97234e-4321-4f44-b267-06321b721850", 
+                                        "sortorder": "", 
+                                        "text": "Eaves, rolled"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ba260910-a367-4296-8c77-39951af24347", 
+                                        "id": "19977266-ee1e-41e7-9369-aed489a73d94", 
+                                        "sortorder": "", 
+                                        "text": "Eaves, wide"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9bcb9876-ec08-4b09-895d-9ac0e01cc56c", 
+                                        "id": "c3f4f6d2-21bb-4b30-a7bf-bc2bf26d1587", 
+                                        "sortorder": "", 
+                                        "text": "Exposed purlins"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c60cd269-8c48-4960-8963-9d21152bf255", 
+                                        "id": "2d044f52-2741-4b37-bb78-e47e1999c684", 
+                                        "sortorder": "", 
+                                        "text": "Exposed rafter tails"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c1f05b66-24f3-4afa-b131-e34a5019124c", 
+                                        "id": "612a1546-d95f-4c7f-a405-d81846e67b77", 
+                                        "sortorder": "", 
+                                        "text": "Exposed rafters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "5cbe1b77-f123-4796-abaf-5f3cef5263dc", 
+                                        "id": "908a4ec4-320a-4587-bf3a-fb7fca968199", 
+                                        "sortorder": "", 
+                                        "text": "Exposed roof beams"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3c5e5baf-322f-4be2-9cbf-7d50011a8d56", 
+                                        "id": "7911d745-7e11-404c-aec7-7616f318617b", 
+                                        "sortorder": "", 
+                                        "text": "Finial"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "37b86b57-94b5-459c-a0bb-e3806fbf673d", 
+                                        "id": "b424d4ed-53f8-4df0-be75-ffd5e6bf7727", 
+                                        "sortorder": "", 
+                                        "text": "Flat"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "21abcbf1-92b6-4866-86e7-98d064bc5e95", 
+                                        "id": "81691b66-983f-41b6-a423-5ffe10f8afe9", 
+                                        "sortorder": "", 
+                                        "text": "Folded Plate"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "234ef6ae-8823-4069-a5bf-c4a2d31c0f60", 
+                                        "id": "e7202616-0c2e-455b-9974-5492136b8be6", 
+                                        "sortorder": "", 
+                                        "text": "Gable, crossed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "56e1ce53-b63d-49b7-a011-f958d0a6dc1c", 
+                                        "id": "6d70b279-9e20-4773-8eab-8f6ec67c921e", 
+                                        "sortorder": "", 
+                                        "text": "Gable, front"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f9014d33-b08e-4f09-9b39-152c56761208", 
+                                        "id": "886101e6-6ac5-4e6a-b6f2-39c57c35a9c6", 
+                                        "sortorder": "", 
+                                        "text": "Gable, side"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "42dc99e0-1f35-4186-bc78-9809f6aa584f", 
+                                        "id": "9859ee53-ebc0-4118-a0dd-c0b6e0b30534", 
+                                        "sortorder": "", 
+                                        "text": "Gambrel"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b3597a06-7d46-415b-a543-c91844958cc8", 
+                                        "id": "8b13de9e-6a5b-46a0-8f90-03dc3275b1b9", 
+                                        "sortorder": "", 
+                                        "text": "Hipped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a60d5b08-a24b-4a20-970f-182b7a0c8676", 
+                                        "id": "cc4551fa-8e31-4eba-a2f6-f09ec9ef90dc", 
+                                        "sortorder": "", 
+                                        "text": "Hipped, pyramidal"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a623caff-69c0-49e8-b662-deff4630b7fa", 
+                                        "id": "64dc0831-82a0-412f-9610-9e6f704b9daa", 
+                                        "sortorder": "", 
+                                        "text": "Jerkinhead"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c51c267c-acc8-4a2a-b598-34ab6f167a93", 
+                                        "id": "4ed8d1ef-e517-4864-97ee-fd686b4521f9", 
+                                        "sortorder": "", 
+                                        "text": "Mansard"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3dec3ec1-c927-4215-856d-901d646aca1f", 
+                                        "id": "5a97d5b1-9d18-4f14-93dd-b8ced3c952b2", 
+                                        "sortorder": "", 
+                                        "text": "Monitor"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7cea560c-5b67-437e-a3a1-3dc1c8f36145", 
+                                        "id": "71a57290-e93d-44e4-95b6-72f86b67169e", 
+                                        "sortorder": "", 
+                                        "text": "Other"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4e465215-ea00-473e-9bcb-9f825ee1b67b", 
+                                        "id": "733e0e0d-1bba-44b2-abfd-231cdae7cf11", 
+                                        "sortorder": "", 
+                                        "text": "Parapet"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d9fb1f84-ed24-4a8c-83fc-f17e0c1c3252", 
+                                        "id": "41c284d5-d784-4b96-8510-1650d0217478", 
+                                        "sortorder": "", 
+                                        "text": "Parapet, curved"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "db06c151-4b17-4c9b-af40-e5fd34abef31", 
+                                        "id": "fcebc790-f884-41b6-a8b8-c7ea719c1b7c", 
+                                        "sortorder": "", 
+                                        "text": "Parapet, flat"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ecedc623-55cd-4bbb-9590-38fef9d9e80b", 
+                                        "id": "9a048065-87ca-4a26-8995-fdb922edc45b", 
+                                        "sortorder": "", 
+                                        "text": "Parapet, stepped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9d954167-4262-41bb-93fd-795b4fd4b11b", 
+                                        "id": "23ba428f-1a9e-4460-bee9-a8cace75eb3c", 
+                                        "sortorder": "", 
+                                        "text": "Pent"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "30248961-41cc-40dc-b005-ca5f7a31b960", 
+                                        "id": "284196a4-d16c-42ef-a12e-6c3f78df6ec0", 
+                                        "sortorder": "", 
+                                        "text": "Saddle"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "96d862a6-7a3b-4c4d-a0fe-d9ae01743ec0", 
+                                        "id": "18ef9505-2d54-412e-89f3-db796f52cc7e", 
+                                        "sortorder": "", 
+                                        "text": "Sawtooth"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "6ce988d4-87d0-4a23-84cd-298a0cd5eab0", 
+                                        "id": "6d29ded0-6261-45f0-aaf7-de3da2dcd3a2", 
+                                        "sortorder": "", 
+                                        "text": "Scalloped bargeboards"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "13f74f4f-35c3-4f62-956f-294db4291b05", 
+                                        "id": "e1ef6727-ce2b-4062-8919-f572e23502dc", 
+                                        "sortorder": "", 
+                                        "text": "Shed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "70292c97-d9f6-44bf-a9e9-9cd46d4d2981", 
+                                        "id": "654ecaba-0b73-4e62-8040-dcf707bed757", 
+                                        "sortorder": "", 
+                                        "text": "Skirt"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "260a22ea-111f-453a-9420-e1ac4fd9afc1", 
+                                        "id": "974a97f1-935b-476c-8adf-0485683c1933", 
+                                        "sortorder": "", 
+                                        "text": "Skylight"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "115b177d-e9c3-432b-879e-a99b784ae72c", 
+                                        "id": "0666e409-656f-43c5-8e71-48118a45f889", 
+                                        "sortorder": "", 
+                                        "text": "Tower"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "075726b6-d283-495f-81eb-d4952b7d24d6", 
+                                        "id": "1823d2b4-1263-475f-99bf-a7ed0761e240", 
+                                        "sortorder": "", 
+                                        "text": "Turret"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "993d5b01-7b2e-4e4c-b792-7f2b0d349e8f", 
+                                        "id": "bb8eabb4-5055-4354-b50e-1242bfd3eab6", 
+                                        "sortorder": "", 
+                                        "text": "Weathervane"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "12e88c9c-2124-4831-8d6e-197f02d5f26f", 
+                                "id": "1815cdb4-f253-4456-a0fb-3febec9812ef", 
+                                "sortorder": "", 
+                                "text": "Roof"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4f2b6dbd-049c-49e5-95d1-5623ece47dda", 
+                                        "id": "158cffa9-2382-4cc5-a904-37be8577ac52", 
+                                        "sortorder": "", 
+                                        "text": "Angled"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1c447fdf-1c9d-41e0-8c6a-2cee686187d9", 
+                                        "id": "4c3cbd78-7be2-4b79-87c2-900054f6a0ad", 
+                                        "sortorder": "", 
+                                        "text": "Awning(s)"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "887562c4-6596-4248-b148-c135f523912e", 
+                                        "id": "e0ec5b73-624b-4049-90e9-573113ef39d8", 
+                                        "sortorder": "", 
+                                        "text": "Bulkhead"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8edf8c0b-21f0-49fa-b90e-6e9b23004e50", 
+                                        "id": "3949002a-54cf-444a-b9d2-c9f67ec6cfcd", 
+                                        "sortorder": "", 
+                                        "text": "Canopy"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "c09fd0f0-e09d-450f-aa96-ab70b0d7829f", 
+                                        "id": "1907b1ef-4a55-4b17-847a-4db9be0cbfdf", 
+                                        "sortorder": "", 
+                                        "text": "Canted"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "01653bc6-e2d0-4fef-8e3b-905402c8fee2", 
+                                        "id": "653174b9-6af8-4261-8903-cabfc6acc75f", 
+                                        "sortorder": "", 
+                                        "text": "Capitals"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "17f0fa8c-a5b0-4b9a-bf9e-b75c4c2b7caf", 
+                                        "id": "18ddbc1b-c2c2-4114-bb31-0bcb7b374728", 
+                                        "sortorder": "", 
+                                        "text": "Corner"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2f52ac94-8975-4c7b-9ba0-b099801908ad", 
+                                        "id": "fbe47088-89b0-454e-9fb6-b59e3871bc67", 
+                                        "sortorder": "", 
+                                        "text": "Entry paving, brick"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "693ce434-5e90-4384-b1ea-6a8d2a414e64", 
+                                        "id": "a7dac324-ca3b-4409-b2d0-15ea771db4ad", 
+                                        "sortorder": "", 
+                                        "text": "Entry paving, terazzo"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2df83d77-322c-4744-ae3d-8bc0c94eb2ff", 
+                                        "id": "539c6273-95b8-4ade-bb4f-8f0554d310ec", 
+                                        "sortorder": "", 
+                                        "text": "Entry paving, tile"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "644ebc0b-a854-4e64-9d14-8a023eb5a288", 
+                                        "id": "8c8de65f-fcfe-4d5b-905e-a62ed0359cff", 
+                                        "sortorder": "", 
+                                        "text": "Entry paving, tile"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "a9cb9481-56d7-46ce-be7a-f5e89f31fe97", 
+                                        "id": "c206fc4d-5246-4f6e-ae05-80d4a5808a0a", 
+                                        "sortorder": "", 
+                                        "text": "Flush"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "3eb8e750-6806-4bb4-8862-60ce814b2826", 
+                                        "id": "0f7adf61-7fb7-4ccd-8607-4a1ff72e2968", 
+                                        "sortorder": "", 
+                                        "text": "Frieze"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "82b735af-c855-4d25-82c2-4cc903d37818", 
+                                        "id": "2abbe924-64d0-4b76-bcd0-3743a886a74c", 
+                                        "sortorder": "", 
+                                        "text": "Ghost sign"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d97cfda0-67ed-4204-9c69-e66e83e9c719", 
+                                        "id": "26e96d7f-f520-4144-9966-24eb1cca17fb", 
+                                        "sortorder": "", 
+                                        "text": "Lighting"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ddbbf257-dc36-41e7-a219-168467de8238", 
+                                        "id": "46394b7d-8658-4415-8b0c-31a66d194ad3", 
+                                        "sortorder": "", 
+                                        "text": "Multiple"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7968df4a-4b8b-4262-882d-29776fb6dcf0", 
+                                        "id": "f7f930c0-4f75-443e-a610-a4cae8b553fd", 
+                                        "sortorder": "", 
+                                        "text": "Piers"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bafaab35-6ebf-4c7d-a6e2-3899a0c18ee7", 
+                                        "id": "d4f16600-4b8c-497c-bb52-c0c44f6c64b9", 
+                                        "sortorder": "", 
+                                        "text": "Pilasters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b077f187-7079-470a-921f-2ef44e6439e5", 
+                                        "id": "f1be7d53-3229-4397-8d99-b4dc2303e93b", 
+                                        "sortorder": "", 
+                                        "text": "Planters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8d22de17-2bd3-479a-b9ad-ebab90315406", 
+                                        "id": "61e39eca-85f6-4498-8110-b1c570b86993", 
+                                        "sortorder": "", 
+                                        "text": "Recessed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "11d97e2a-88cd-4de6-83ae-06aa5084d4fb", 
+                                        "id": "bf43869f-0dae-435b-96e7-8a66a12edf9a", 
+                                        "sortorder": "", 
+                                        "text": "Security gate/screen"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "eb2f97c5-fc90-4081-a41c-949e42ed7563", 
+                                        "id": "88e20e09-0082-4b44-9632-c71ccb402f24", 
+                                        "sortorder": "", 
+                                        "text": "Sign"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "850d67ed-2a9c-470f-b251-e4801090ce24", 
+                                "id": "90f5586f-6df6-4938-9877-270821120298", 
+                                "sortorder": "", 
+                                "text": "Storefront"
+                            }, 
+                            {
+                                "children": [
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f81bce66-3e84-46a8-8642-f680a5499184", 
+                                        "id": "c06e2527-a2c2-49d6-b3c1-618711ee0c51", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "288f5950-6e0c-419c-95fd-b2402545b170", 
+                                        "id": "7e1385ff-a92a-4b09-ba50-3abdefb62b26", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening, pointed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7bc4608e-0fc4-4640-acdc-9e684fdbfe17", 
+                                        "id": "45e1d6fe-39fe-4751-821e-34134bf0f3ba", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening, round"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "36eeec32-4614-4f24-a607-39e8d0251e08", 
+                                        "id": "37862b31-1981-4d1d-93f0-5243d9513d77", 
+                                        "sortorder": "", 
+                                        "text": "Arched opening, segmental"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "aab9190a-4c5d-40ac-a15f-b6be0233c7a9", 
+                                        "id": "a0fd4463-fb78-4468-ad07-a4505f6ecc1c", 
+                                        "sortorder": "", 
+                                        "text": "Awning"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "7ac21d61-352d-4e8e-91b1-8c5db3e02708", 
+                                        "id": "d3402272-8248-4692-acab-c9bf6c73359e", 
+                                        "sortorder": "", 
+                                        "text": "Bay, bowed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "412b5fdd-03bc-4382-96a5-c1d206153d35", 
+                                        "id": "6ceaec61-35f9-4bce-926e-1c746766bf8d", 
+                                        "sortorder": "", 
+                                        "text": "Bay, canted"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bc7688cf-fe6d-43c2-a39b-13fbaf746fb7", 
+                                        "id": "3bcf9af4-dc40-418a-b467-07ce779dcd11", 
+                                        "sortorder": "", 
+                                        "text": "Bay, rounded"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "568aee4a-da4e-4c7b-bc2e-1099cc648984", 
+                                        "id": "e05a8e29-9b81-4773-b028-5d7ca2d5e8d3", 
+                                        "sortorder": "", 
+                                        "text": "Bay, squared"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8bfe1e69-15ab-4388-824c-b8e7f936405a", 
+                                        "id": "54893741-1988-4292-8a91-351a0a1e648c", 
+                                        "sortorder": "", 
+                                        "text": "Butted glass"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "967bb1fc-0e87-4f82-96e2-b0d9439464f0", 
+                                        "id": "97d002f0-4cf6-4f51-903a-bdffa01cc075", 
+                                        "sortorder": "", 
+                                        "text": "Casement"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d9f8fbf7-cc52-4426-ae3c-8859663e0271", 
+                                        "id": "49895419-405d-4f29-95e3-d38742d95f43", 
+                                        "sortorder": "", 
+                                        "text": "Clerestory"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "17f5d453-bbda-4f09-82f6-edd25867ba8c", 
+                                        "id": "6e17e66f-e77b-4767-a9d9-1819988f2fdb", 
+                                        "sortorder": "", 
+                                        "text": "Corner"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "46ad341c-5b5d-41e0-8344-b8b7ec94137e", 
+                                        "id": "bf6d8517-14bb-48d6-a24e-63401843d0f5", 
+                                        "sortorder": "", 
+                                        "text": "Decorative surround"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "2a46fb2b-54f4-436f-ba4a-43f03ccf36f4", 
+                                        "id": "9f9f1743-b097-4036-bb8b-9e73eee8aa7a", 
+                                        "sortorder": "", 
+                                        "text": "Diamond pane"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "4e923866-e998-4597-a85c-f889696b7cba", 
+                                        "id": "802b8d82-2476-4cf0-9f7c-c05946819d6d", 
+                                        "sortorder": "", 
+                                        "text": "Display"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "742d9b9c-036c-4707-a223-051ad64ae6f4", 
+                                        "id": "88f2896f-4d1b-4c0a-9224-4374795a5804", 
+                                        "sortorder": "", 
+                                        "text": "Divided lights"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bfd78f7b-21e5-42ba-baa9-559afca5984f", 
+                                        "id": "f085c885-149c-4636-b930-a90d3ce02bc1", 
+                                        "sortorder": "", 
+                                        "text": "Divided lights, top sash"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "55d924c4-50f7-40d5-ba14-e4c4c9f87a24", 
+                                        "id": "63a6855b-8e33-40ce-8a6b-712513a6a35e", 
+                                        "sortorder": "", 
+                                        "text": "Double-hung"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ed47abd5-62bc-4621-b4e8-f70416e6a462", 
+                                        "id": "4c04f7f9-aed9-4f2e-862e-b18a71870f44", 
+                                        "sortorder": "", 
+                                        "text": "Fixed"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8d28c8cb-13f1-4c23-b918-43162a45bba0", 
+                                        "id": "26ab681f-4685-4fee-a91c-19f2e6bb7feb", 
+                                        "sortorder": "", 
+                                        "text": "Floor-to-ceiling"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1d166234-8e6c-42c1-8c1e-a969c620150c", 
+                                        "id": "c338b8a0-767d-458d-940b-04dc8d4fae69", 
+                                        "sortorder": "", 
+                                        "text": "Grouped"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "1ece5487-d3ef-4dc8-b3dc-d3a9e3832abe", 
+                                        "id": "023443b0-1aba-416b-8cd7-1d2a58c04b98", 
+                                        "sortorder": "", 
+                                        "text": "Historic Surround"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "d4e810c0-9498-40c5-9fe9-5b6a5c2b1b50", 
+                                        "id": "0fc4ba36-46b8-4aad-a8f8-0d07abf9cc47", 
+                                        "sortorder": "", 
+                                        "text": "Hopper"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "456b969e-4dbe-49b8-b316-8add2445a92a", 
+                                        "id": "09c6801c-45ca-4550-8961-20f4ff504de8", 
+                                        "sortorder": "", 
+                                        "text": "Jalousie/louver"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "b10ce779-b99d-468c-b490-7852a33f8e71", 
+                                        "id": "4ccccd14-88ee-4aec-a662-15f30199820d", 
+                                        "sortorder": "", 
+                                        "text": "Leaded glass"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9e7352fe-e046-4f83-a57d-58d195baf2ca", 
+                                        "id": "4a425c66-48ed-4376-819c-eaa02295242e", 
+                                        "sortorder": "", 
+                                        "text": "Multi-light"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "97ea2b2f-fced-4db7-9ed3-59df57d26296", 
+                                        "id": "331f4bf6-d62a-40b9-9cd3-bed5b826707c", 
+                                        "sortorder": "", 
+                                        "text": "Multi-light top sash"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "766d15aa-9c17-4e0a-9216-e3a3ed288c4b", 
+                                        "id": "515e3ca5-6e56-431d-bf15-4c318a2b0b8f", 
+                                        "sortorder": "", 
+                                        "text": "Obscure glass"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f07a41e8-6f8e-4a6b-b5ed-1c25284eb7a3", 
+                                        "id": "e92e116e-215f-4183-a185-030e61ff01da", 
+                                        "sortorder": "", 
+                                        "text": "Oriel"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "cf0f3360-be2e-46b5-82f8-4be4781219b9", 
+                                        "id": "227e525d-9639-4279-bfc4-e9fc4fe6fde8", 
+                                        "sortorder": "", 
+                                        "text": "Other"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ef96a02f-01be-4c50-8bb7-d1a653bd644a", 
+                                        "id": "1627ab6e-1a4a-4d05-a203-d2fa23f761f8", 
+                                        "sortorder": "", 
+                                        "text": "Paired"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "00708d06-ab1d-40ce-8b02-c3ad874ac18f", 
+                                        "id": "6198a885-cc7b-4722-99e2-75ddb9f954f4", 
+                                        "sortorder": "", 
+                                        "text": "Palladian"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "8db4aca3-a5e0-4d56-8676-3be311eb2483", 
+                                        "id": "73c88c14-6ce5-4be0-9a60-f21a7910ad97", 
+                                        "sortorder": "", 
+                                        "text": "Pivot"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "89392663-7e1b-4ecf-8a26-d4d15585b61f", 
+                                        "id": "5fa196d6-d78b-4afa-ab5a-df65e5ee3e17", 
+                                        "sortorder": "", 
+                                        "text": "Porthole"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "04d29f6d-7fa8-4ab3-855a-2f95aa619b9a", 
+                                        "id": "45745c79-caaa-461f-b2b7-cced3fc1d667", 
+                                        "sortorder": "", 
+                                        "text": "Ribbon"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "85d59130-b1a4-49da-bcd4-6f0c3ae22554", 
+                                        "id": "6a90f88a-1a06-45ef-942e-d2f61ad88a6e", 
+                                        "sortorder": "", 
+                                        "text": "Sawtooth"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "0c983718-1d93-4139-9bf3-b1127d7bfc95", 
+                                        "id": "3f769b66-fe82-4af2-9ab3-54adddcefb46", 
+                                        "sortorder": "", 
+                                        "text": "Security bars"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "77a79a10-c592-4d20-b913-47438aeadd24", 
+                                        "id": "4ee33276-f127-42d8-9b84-dc596a57af9d", 
+                                        "sortorder": "", 
+                                        "text": "Shutters"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "102169c8-eb47-495e-bb38-778807727025", 
+                                        "id": "f791a17e-aa45-4eb6-b78b-5c579803a9f1", 
+                                        "sortorder": "", 
+                                        "text": "Single"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "9f046d11-dced-4310-8420-a11e4d67eaef", 
+                                        "id": "21ac1caf-439e-41b8-987f-b41a91817560", 
+                                        "sortorder": "", 
+                                        "text": "Single-hung"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f65422d8-400d-43a1-bf7f-14e65a5858e8", 
+                                        "id": "50cb28b1-39b9-4762-a607-6d27fbfc062b", 
+                                        "sortorder": "", 
+                                        "text": "Sliding"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "f2f18e21-17c3-489f-8456-0ac3931ffe8a", 
+                                        "id": "f4799706-48b7-4aef-a732-d25997c16d08", 
+                                        "sortorder": "", 
+                                        "text": "Stained glass"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "22a3652f-0a5a-4a32-a310-24fb2321af2e", 
+                                        "id": "8cce4498-ea0b-4a5c-95a3-e1af3d20a8d2", 
+                                        "sortorder": "", 
+                                        "text": "Storefront"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "98698526-94a8-4797-8367-ebf005347bba", 
+                                        "id": "88c801c0-c40b-4251-a75b-f012c80f1f96", 
+                                        "sortorder": "", 
+                                        "text": "Transom"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "bb1f95fb-0b4a-4f08-9564-e851b540e952", 
+                                        "id": "b07724bc-41b8-43d6-acfb-77d96b15ca38", 
+                                        "sortorder": "", 
+                                        "text": "Tripartite"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "e12e39bb-9df8-477c-85c7-cc802c76b5ef", 
+                                        "id": "e3db3ec5-06f8-424b-8405-f815d2e9657e", 
+                                        "sortorder": "", 
+                                        "text": "Unknown"
+                                    }, 
+                                    {
+                                        "children": [], 
+                                        "collector": "", 
+                                        "conceptid": "ee5cc394-0cca-426a-b4d2-0c3f44aef37a", 
+                                        "id": "5081ea23-2a7b-4fb0-99cf-4a3ba1b9aba2", 
+                                        "sortorder": "", 
+                                        "text": "Vent"
+                                    }
+                                ], 
+                                "collector": "", 
+                                "conceptid": "0879fd52-2678-41aa-be66-d911ad8d314f", 
+                                "id": "e2401fd5-04a8-416a-b3e5-900049c51dec", 
+                                "sortorder": "", 
+                                "text": "Window"
+                            }
+                        ], 
+                        "placeholder": "Select the component's material"
+                    }, 
+                    "id": "440786e8-943d-11e8-b5a0-94659cf754d0", 
+                    "label": "Material", 
+                    "node_id": "440786e7-943d-11e8-a7e4-94659cf754d0", 
+                    "sortorder": 1, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                }, 
+                {
+                    "card_id": "086dce55-943d-11e8-8623-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Style", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "c974fa01-dc6e-11e8-9731-94659cf754d0", 
+                    "label": "Style", 
+                    "node_id": "086df56f-943d-11e8-b0fe-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "086df560-943d-11e8-82fc-94659cf754d0", 
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD", 
+                        "defaultValue": "", 
+                        "label": "Heritage Resource Type From Date", 
+                        "maxDate": false, 
+                        "minDate": false, 
+                        "placeholder": "Enter date", 
+                        "viewMode": "days"
+                    }, 
+                    "id": "bcdbe101-dc6e-11e8-b1e3-94659cf754d0", 
+                    "label": "Heritage Resource Type From Date", 
+                    "node_id": "086df56c-943d-11e8-aecb-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                }, 
+                {
+                    "card_id": "1c421991-943d-11e8-83ad-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Status", 
+                        "options": [], 
+                        "placeholder": "Select an option"
+                    }, 
+                    "id": "b7a58f5f-dc82-11e8-9619-94659cf754d0", 
+                    "label": "Status", 
+                    "node_id": "1c42198f-943d-11e8-a86a-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                }, 
+                {
+                    "card_id": "26730c37-943d-11e8-aff3-94659cf754d0", 
+                    "config": {
+                        "defaultValue": "", 
+                        "label": "Place Description", 
+                        "maxLength": null, 
+                        "placeholder": "Enter text", 
+                        "width": "100%"
+                    }, 
+                    "id": "72235ccf-aa70-11e9-a79f-94659cf754d0", 
+                    "label": "Place Description", 
+                    "node_id": "26733346-943d-11e8-9a3a-94659cf754d0", 
+                    "sortorder": null, 
+                    "visible": true, 
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
                 }, 
                 {
                     "card_id": "54188892-943d-11e8-8554-94659cf754d0", 
@@ -15627,21 +15691,21 @@
             "edges": [
                 {
                     "description": null, 
-                    "domainnode_id": "3c5799d0-943d-11e8-9bf1-94659cf754d0", 
-                    "edgeid": "3c57c0e2-943d-11e8-91a2-94659cf754d0", 
-                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
-                    "rangenode_id": "3c5799cf-943d-11e8-a34b-94659cf754d0"
-                }, 
-                {
-                    "description": null, 
                     "domainnode_id": "3c5799d1-943d-11e8-88bb-94659cf754d0", 
                     "edgeid": "3c57c0e1-943d-11e8-b217-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
                     "rangenode_id": "3c5799d2-943d-11e8-874e-94659cf754d0"
+                }, 
+                {
+                    "description": null, 
+                    "domainnode_id": "3c5799d0-943d-11e8-9bf1-94659cf754d0", 
+                    "edgeid": "3c57c0e2-943d-11e8-91a2-94659cf754d0", 
+                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                    "name": null, 
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "rangenode_id": "3c5799cf-943d-11e8-a34b-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -15807,6 +15871,15 @@
                 }, 
                 {
                     "description": null, 
+                    "domainnode_id": "086df568-943d-11e8-bb9b-94659cf754d0", 
+                    "edgeid": "086e6a95-943d-11e8-9012-94659cf754d0", 
+                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                    "name": null, 
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
+                    "rangenode_id": "086df56c-943d-11e8-aecb-94659cf754d0"
+                }, 
+                {
+                    "description": null, 
                     "domainnode_id": "5008a59f-943d-11e8-985e-94659cf754d0", 
                     "edgeid": "5008a5a7-943d-11e8-a436-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
@@ -15843,12 +15916,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "26730c32-943d-11e8-b3fb-94659cf754d0", 
-                    "edgeid": "2673815f-943d-11e8-b443-94659cf754d0", 
+                    "domainnode_id": "26730c3b-943d-11e8-8b15-94659cf754d0", 
+                    "edgeid": "26738160-943d-11e8-843b-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by", 
-                    "rangenode_id": "26733343-943d-11e8-9704-94659cf754d0"
+                    "rangenode_id": "2673334a-943d-11e8-ad3a-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -15879,12 +15952,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "54188890-943d-11e8-897e-94659cf754d0", 
-                    "edgeid": "5418afa4-943d-11e8-83cd-94659cf754d0", 
+                    "domainnode_id": "086dce50-943d-11e8-93c6-94659cf754d0", 
+                    "edgeid": "086e91a5-943d-11e8-b70c-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P40_observed_dimension", 
-                    "rangenode_id": "5418af9e-943d-11e8-810d-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned", 
+                    "rangenode_id": "086df564-943d-11e8-9803-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -15933,39 +16006,39 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "26730c3b-943d-11e8-8b15-94659cf754d0", 
-                    "edgeid": "26738160-943d-11e8-843b-94659cf754d0", 
+                    "domainnode_id": "26730c32-943d-11e8-b3fb-94659cf754d0", 
+                    "edgeid": "2673815f-943d-11e8-b443-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by", 
-                    "rangenode_id": "2673334a-943d-11e8-ad3a-94659cf754d0"
+                    "rangenode_id": "26733343-943d-11e8-9704-94659cf754d0"
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "99417384-b8fa-11e6-84a5-026d961c88e6", 
-                    "edgeid": "5008a5a9-943d-11e8-ace8-94659cf754d0", 
+                    "domainnode_id": "086df55e-943d-11e8-a6bc-94659cf754d0", 
+                    "edgeid": "086e91aa-943d-11e8-a96b-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
-                    "rangenode_id": "5008a59f-943d-11e8-985e-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
+                    "rangenode_id": "086df568-943d-11e8-bb9b-94659cf754d0"
                 }, 
                 {
                     "description": null, 
                     "domainnode_id": "26730c32-943d-11e8-b3fb-94659cf754d0", 
-                    "edgeid": "26735a55-943d-11e8-87a3-94659cf754d0", 
+                    "edgeid": "26735a54-943d-11e8-b71a-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P89_falls_within", 
-                    "rangenode_id": "26730c3b-943d-11e8-8b15-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "rangenode_id": "26730c38-943d-11e8-8c8a-94659cf754d0"
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "99417384-b8fa-11e6-84a5-026d961c88e6", 
-                    "edgeid": "4060c601-943d-11e8-89f1-94659cf754d0", 
+                    "domainnode_id": "40609ef3-943d-11e8-ad40-94659cf754d0", 
+                    "edgeid": "4060c600-943d-11e8-a987-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced", 
-                    "rangenode_id": "406077e2-943d-11e8-93f7-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "rangenode_id": "40609ef5-943d-11e8-9cce-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16032,12 +16105,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "086dce50-943d-11e8-93c6-94659cf754d0", 
-                    "edgeid": "086e91a5-943d-11e8-b70c-94659cf754d0", 
+                    "domainnode_id": "54188890-943d-11e8-897e-94659cf754d0", 
+                    "edgeid": "5418afa4-943d-11e8-83cd-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P42_assigned", 
-                    "rangenode_id": "086df564-943d-11e8-9803-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P40_observed_dimension", 
+                    "rangenode_id": "5418af9e-943d-11e8-810d-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16077,12 +16150,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "086df55e-943d-11e8-a6bc-94659cf754d0", 
-                    "edgeid": "086e91aa-943d-11e8-a96b-94659cf754d0", 
+                    "domainnode_id": "99417384-b8fa-11e6-84a5-026d961c88e6", 
+                    "edgeid": "5008a5a9-943d-11e8-ace8-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
-                    "rangenode_id": "086df568-943d-11e8-bb9b-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
+                    "rangenode_id": "5008a59f-943d-11e8-985e-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16122,21 +16195,21 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "40609ef3-943d-11e8-ad40-94659cf754d0", 
-                    "edgeid": "4060c600-943d-11e8-a987-94659cf754d0", 
+                    "domainnode_id": "99417384-b8fa-11e6-84a5-026d961c88e6", 
+                    "edgeid": "4060c601-943d-11e8-89f1-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
-                    "rangenode_id": "40609ef5-943d-11e8-9cce-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced", 
+                    "rangenode_id": "406077e2-943d-11e8-93f7-94659cf754d0"
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "1f816614-943d-11e8-8a63-94659cf754d0", 
-                    "edgeid": "1f81b431-943d-11e8-9f37-94659cf754d0", 
+                    "domainnode_id": "1f816611-943d-11e8-8418-94659cf754d0", 
+                    "edgeid": "1f81b430-943d-11e8-b670-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P94i_was_created_by", 
-                    "rangenode_id": "1f816611-943d-11e8-8418-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
+                    "rangenode_id": "1f818d22-943d-11e8-9a3c-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16173,15 +16246,6 @@
                     "name": null, 
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
                     "rangenode_id": "1f816614-943d-11e8-8a63-94659cf754d0"
-                }, 
-                {
-                    "description": null, 
-                    "domainnode_id": "99417384-b8fa-11e6-84a5-026d961c88e6", 
-                    "edgeid": "185b9095-943d-11e8-98af-94659cf754d0", 
-                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
-                    "rangenode_id": "185b6981-943d-11e8-8310-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16231,11 +16295,11 @@
                 {
                     "description": null, 
                     "domainnode_id": "26730c32-943d-11e8-b3fb-94659cf754d0", 
-                    "edgeid": "26735a54-943d-11e8-b71a-94659cf754d0", 
+                    "edgeid": "26735a55-943d-11e8-87a3-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
-                    "rangenode_id": "26730c38-943d-11e8-8c8a-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P89_falls_within", 
+                    "rangenode_id": "26730c3b-943d-11e8-8b15-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16347,12 +16411,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "086df568-943d-11e8-bb9b-94659cf754d0", 
-                    "edgeid": "086e6a95-943d-11e8-9012-94659cf754d0", 
+                    "domainnode_id": "99417384-b8fa-11e6-84a5-026d961c88e6", 
+                    "edgeid": "185b9095-943d-11e8-98af-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
-                    "rangenode_id": "086df56c-943d-11e8-aecb-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
+                    "rangenode_id": "185b6981-943d-11e8-8310-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16464,12 +16528,12 @@
                 }, 
                 {
                     "description": null, 
-                    "domainnode_id": "1f816611-943d-11e8-8418-94659cf754d0", 
-                    "edgeid": "1f81b430-943d-11e8-b670-94659cf754d0", 
+                    "domainnode_id": "1f816614-943d-11e8-8a63-94659cf754d0", 
+                    "edgeid": "1f81b431-943d-11e8-9f37-94659cf754d0", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "name": null, 
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
-                    "rangenode_id": "1f818d22-943d-11e8-9a3c-94659cf754d0"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P94i_was_created_by", 
+                    "rangenode_id": "1f816611-943d-11e8-8418-94659cf754d0"
                 }, 
                 {
                     "description": null, 
@@ -16518,7 +16582,7 @@
                     }, 
                     "function_id": "60000000-0000-0000-0000-000000000001", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "id": "f50ec451-fe4e-11e8-ac0b-94659cf754d0"
+                    "id": "1ba513d3-a8ae-11e9-8307-94659cf754d0"
                 }
             ], 
             "graphid": "99417385-b8fa-11e6-84a5-026d961c88e6", 
@@ -16542,7 +16606,7 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "48315a71-943d-11e8-90d3-94659cf754d0", 
                     "parentnodegroup_id": null
@@ -16572,7 +16636,7 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1c41f284-943d-11e8-8ef9-94659cf754d0", 
                     "parentnodegroup_id": "1c41f28a-943d-11e8-9c6d-94659cf754d0"
@@ -16590,31 +16654,31 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1c41f28d-943d-11e8-a0a5-94659cf754d0", 
                     "parentnodegroup_id": "1c41f28a-943d-11e8-9c6d-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1c42198f-943d-11e8-a86a-94659cf754d0", 
                     "parentnodegroup_id": "1c41f28a-943d-11e8-9c6d-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1c41f290-943d-11e8-a80a-94659cf754d0", 
                     "parentnodegroup_id": "1c41f28a-943d-11e8-9c6d-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1f816611-943d-11e8-8418-94659cf754d0", 
                     "parentnodegroup_id": "1f816614-943d-11e8-8a63-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "1c421992-943d-11e8-ae0a-94659cf754d0", 
                     "parentnodegroup_id": "1c41f28a-943d-11e8-9c6d-94659cf754d0"
@@ -16656,7 +16720,7 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "26730c35-943d-11e8-86b9-94659cf754d0", 
                     "parentnodegroup_id": "26730c32-943d-11e8-b3fb-94659cf754d0"
@@ -16692,13 +16756,13 @@
                     "parentnodegroup_id": "26730c32-943d-11e8-b3fb-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "086dce50-943d-11e8-93c6-94659cf754d0", 
                     "parentnodegroup_id": "086dce56-943d-11e8-ab5e-94659cf754d0"
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "086dce53-943d-11e8-807a-94659cf754d0", 
                     "parentnodegroup_id": "086dce56-943d-11e8-ab5e-94659cf754d0"
@@ -16710,7 +16774,7 @@
                     "parentnodegroup_id": null
                 }, 
                 {
-                    "cardinality": "1", 
+                    "cardinality": "n", 
                     "legacygroupid": null, 
                     "nodegroupid": "086df55e-943d-11e8-a6bc-94659cf754d0", 
                     "parentnodegroup_id": "086dce56-943d-11e8-ab5e-94659cf754d0"
@@ -16823,18 +16887,18 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "date", 
+                    "datatype": "semantic", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Date Condition Assessed", 
+                    "name": "Condition State", 
                     "nodegroup_id": "406077e2-943d-11e8-93f7-94659cf754d0", 
-                    "nodeid": "40609ef4-943d-11e8-821f-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E49_Time_Appellation", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
+                    "nodeid": "40609ef3-943d-11e8-ad40-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P35_has_identified", 
                     "sortorder": 0
                 }, 
                 {
@@ -16955,22 +17019,6 @@
                     "nodeid": "185b9091-943d-11e8-8c9e-94659cf754d0", 
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type", 
-                    "sortorder": 0
-                }, 
-                {
-                    "config": null, 
-                    "datatype": "date", 
-                    "description": "Represents a single node in a graph", 
-                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "is_collector": false, 
-                    "isrequired": false, 
-                    "issearchable": true, 
-                    "istopnode": false, 
-                    "name": "End Date of Existence", 
-                    "nodegroup_id": "3c5772c1-943d-11e8-9753-94659cf754d0", 
-                    "nodeid": "3c5772c6-943d-11e8-8ca6-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E49_Time_Appellation", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
                     "sortorder": 0
                 }, 
                 {
@@ -17215,18 +17263,18 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "semantic", 
+                    "datatype": "date", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Condition State", 
+                    "name": "Date Condition Assessed", 
                     "nodegroup_id": "406077e2-943d-11e8-93f7-94659cf754d0", 
-                    "nodeid": "40609ef3-943d-11e8-ad40-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P35_has_identified", 
+                    "nodeid": "40609ef4-943d-11e8-821f-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E49_Time_Appellation", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
                     "sortorder": 0
                 }, 
                 {
@@ -17246,21 +17294,19 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": {
-                        "rdmCollection": "c3474905-e426-4337-b23e-4be92a05adf1"
-                    }, 
-                    "datatype": "concept", 
-                    "description": "Represents a single node in a graph", 
+                    "config": null, 
+                    "datatype": "string", 
+                    "description": "", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "is_collector": false, 
+                    "is_collector": true, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Measurement Unit", 
-                    "nodegroup_id": "54188890-943d-11e8-897e-94659cf754d0", 
-                    "nodeid": "5418af9f-943d-11e8-8c73-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E58_Measurement_Unit", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P91_has_unit", 
+                    "name": "External XRef", 
+                    "nodegroup_id": "5008a59f-943d-11e8-985e-94659cf754d0", 
+                    "nodeid": "5008a59f-943d-11e8-985e-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
                     "sortorder": 0
                 }, 
                 {
@@ -17451,9 +17497,9 @@
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "1766d64e-2fcc-474d-b895-1af42e564098"
+                        "rdmCollection": null
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
@@ -17517,9 +17563,9 @@
                 }, 
                 {
                     "config": {
-                        "rdmCollection": "ff359101-00b3-4d49-bb3e-1b47f612fdea"
+                        "rdmCollection": null
                     }, 
-                    "datatype": "concept", 
+                    "datatype": "concept-list", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
@@ -17583,6 +17629,22 @@
                     "nodeid": "1c42198f-943d-11e8-a86a-94659cf754d0", 
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type", 
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned", 
+                    "sortorder": 0
+                }, 
+                {
+                    "config": null, 
+                    "datatype": "semantic", 
+                    "description": "Represents a single node in a graph", 
+                    "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                    "is_collector": true, 
+                    "isrequired": false, 
+                    "issearchable": true, 
+                    "istopnode": false, 
+                    "name": "Administration Subdivision", 
+                    "nodegroup_id": "26730c3b-943d-11e8-8b15-94659cf754d0", 
+                    "nodeid": "26730c3b-943d-11e8-8b15-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E53_Place", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P89_falls_within", 
                     "sortorder": 0
                 }, 
                 {
@@ -17668,19 +17730,21 @@
                     "sortorder": 0
                 }, 
                 {
-                    "config": null, 
-                    "datatype": "string", 
-                    "description": "", 
+                    "config": {
+                        "rdmCollection": "c3474905-e426-4337-b23e-4be92a05adf1"
+                    }, 
+                    "datatype": "concept", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "is_collector": true, 
+                    "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "External XRef", 
-                    "nodegroup_id": "5008a59f-943d-11e8-985e-94659cf754d0", 
-                    "nodeid": "5008a59f-943d-11e8-985e-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P130_shows_features_of", 
+                    "name": "Measurement Unit", 
+                    "nodegroup_id": "54188890-943d-11e8-897e-94659cf754d0", 
+                    "nodeid": "5418af9f-943d-11e8-8c73-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E58_Measurement_Unit", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P91_has_unit", 
                     "sortorder": 0
                 }, 
                 {
@@ -17756,17 +17820,17 @@
                 {
                     "config": null, 
                     "datatype": "semantic", 
-                    "description": "", 
+                    "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Beginning of Existence", 
+                    "name": "Beginning of Existence Time Span", 
                     "nodegroup_id": "3c5772c1-943d-11e8-9753-94659cf754d0", 
-                    "nodeid": "3c5799d0-943d-11e8-9bf1-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P116i_is_started_by", 
+                    "nodeid": "3c5799d1-943d-11e8-88bb-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
                     "sortorder": 0
                 }, 
                 {
@@ -17901,18 +17965,18 @@
                 }, 
                 {
                     "config": null, 
-                    "datatype": "semantic", 
+                    "datatype": "date", 
                     "description": "Represents a single node in a graph", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
-                    "is_collector": true, 
+                    "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Administration Subdivision", 
-                    "nodegroup_id": "26730c3b-943d-11e8-8b15-94659cf754d0", 
-                    "nodeid": "26730c3b-943d-11e8-8b15-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E53_Place", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P89_falls_within", 
+                    "name": "End Date of Existence", 
+                    "nodegroup_id": "3c5772c1-943d-11e8-9753-94659cf754d0", 
+                    "nodeid": "3c5772c6-943d-11e8-8ca6-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E49_Time_Appellation", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by", 
                     "sortorder": 0
                 }, 
                 {
@@ -18152,17 +18216,17 @@
                 {
                     "config": null, 
                     "datatype": "semantic", 
-                    "description": "Represents a single node in a graph", 
+                    "description": "", 
                     "graph_id": "99417385-b8fa-11e6-84a5-026d961c88e6", 
                     "is_collector": false, 
                     "isrequired": false, 
                     "issearchable": true, 
                     "istopnode": false, 
-                    "name": "Beginning of Existence Time Span", 
+                    "name": "Beginning of Existence", 
                     "nodegroup_id": "3c5772c1-943d-11e8-9753-94659cf754d0", 
-                    "nodeid": "3c5799d1-943d-11e8-88bb-94659cf754d0", 
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span", 
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span", 
+                    "nodeid": "3c5799d0-943d-11e8-9bf1-94659cf754d0", 
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence", 
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P116i_is_started_by", 
                     "sortorder": 0
                 }, 
                 {
@@ -18383,7 +18447,15 @@
                 }
             ], 
             "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd", 
-            "relatable_resource_model_ids": [], 
+            "relatable_resource_model_ids": [
+                "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                "99417385-b8fa-11e6-84a5-026d961c88e6", 
+                "243f8689-b8f6-11e6-84a5-026d961c88e6", 
+                "ccbd1537-ac5e-11e6-84a5-026d961c88e6", 
+                "fad0563b-b8f8-11e6-84a5-026d961c88e6", 
+                "f5624ce7-b66c-11e6-84a5-026d961c88e6", 
+                "3caf329f-b8f7-11e6-84a5-026d961c88e6"
+            ], 
             "resource_2_resource_constraints": [], 
             "root": {
                 "config": null, 
@@ -18400,6 +18472,7 @@
                 "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing", 
                 "sortorder": 0
             }, 
+            "slug": null, 
             "subtitle": "Describes heritage resources, which includes monuments, buildings, structures, etc.", 
             "template_id": "50000000-0000-0000-0000-000000000002", 
             "version": ""

--- a/tests/v3migration/v3_migration_cli_tests.py
+++ b/tests/v3migration/v3_migration_cli_tests.py
@@ -13,7 +13,7 @@ from arches.app.utils.data_management.resource_graphs.importer import import_gra
 from arches.app.utils.data_management.resources.formats.archesfile import ArchesFileReader
 from arches.app.utils.skos import SKOSReader
 from arches.app.utils import v3utils
-from arches.app.utils.v3migration import v3Importer, v3PreparedResource
+from arches.app.utils.v3migration import v3Importer, v3PreparedResource, DataValueConverter
 from tests import test_settings
 from tests.base_test import ArchesTestCase
 
@@ -256,11 +256,12 @@ class v3MigrationTests(ArchesTestCase):
             # test the value and tile counts during this process.
             for res in importer.v3_resources:
 
-                v3_resource = v3PreparedResource(res['entityid'], importer.v4_graph.graphid, res)
+                v3_resource = v3PreparedResource(res, importer.v4_graph.graphid, importer.node_lookup,
+                                                 importer.v3_mergenodes)
                 v3_value_ct = len(v3_resource.node_list)
 
-                v3_resource.process(importer.v4_nodes, importer.node_lookup)
-                v4_json = v3_resource.get_json()
+                v3_resource.process(importer.v4_nodes)
+                v4_json = v3_resource.get_resource_json()
 
                 out_json = {'business_data': {'resources': [v4_json]}}
                 with open(temp_file, 'wb') as openfile:

--- a/tests/v3migration/v3_migration_cli_tests.py
+++ b/tests/v3migration/v3_migration_cli_tests.py
@@ -226,7 +226,8 @@ class v3MigrationTests(ArchesTestCase):
         management.call_command('v3', 'write-v4-json',
                                 target=self.pkg,
                                 number=10,
-                                resource_models=all_models
+                                resource_models=all_models,
+                                verbose=True
                                 )
 
         # basic test to make sure the v4 file has been created. No tests on


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
To address #5024, I have made a big refactor of the v3-v4 migration code, which does a much more thorough job of interrogating the v3 JSON structure to properly group the new v4 tiles. Where groupings were previously deduced by comparing v4 cardinality with the number of v3 data points to transfer (along with a few other tests) this refactor goes straight to v3 mergenodes and groups tiles based on those. The result is that the code more or less transforms the v3 JSON back into a list of data points structured more or less like a v3 .arches file and then iterates those lines to save new tiles in v4.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5024

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Legion GIS, LLC
*   Designed by: @mradamcox

#### Further Comments
These commits should also be cherry-picked into master after this PR is successfully merged.
