### PR TITLE
Improves card config performance

### DIFF
--- a/arches/app/media/js/models/report.js
+++ b/arches/app/media/js/models/report.js
@@ -17,6 +17,7 @@ define(['arches',
 
         initialize: function(options) {
             var self = this;
+            var template = self.get('graph').template_id;
             this.cards = options.cards || [];
             this.preview = options.preview;
             this.userisreviewer = options.userisreviewer;
@@ -29,14 +30,16 @@ define(['arches',
 
             this.configJSON = ko.observable({});
             this.configState;
+            this.defaultConfig = JSON.parse(reportLookup[template].defaultconfig);
             this.configKeys.subscribe(function(val){
                 var config;
                 if (val.length) {
                     self.configState = {};
                     config = self.get('config');
-                    // var defaultConfigJSON.parse(reportLookup[value].defaultconfig);
                     _.each(val, function(key) {
-                        self.configState[key] = ko.unwrap(config[key]);
+                        if (self.defaultConfig.hasOwnProperty(key)) {
+                            self.configState[key] = ko.unwrap(config[key]);
+                        }
                     });
                     self.configState = koMapping.fromJS(self.configState);
                 }
@@ -44,8 +47,10 @@ define(['arches',
 
             this.resetConfigs = function(previousConfigs) {
                 this.configKeys().forEach(function(key){
-                    if (JSON.stringify(self.configState[key]()) !== JSON.stringify(previousConfigs[key])) {
-                        koMapping.fromJS(previousConfigs, self.configState);
+                    if (self.defaultConfig.hasOwnProperty(key)) {
+                        if (JSON.stringify(self.configState[key]()) !== JSON.stringify(previousConfigs[key])) {
+                            koMapping.fromJS(previousConfigs, self.configState);
+                        }
                     }
                 });
             };

--- a/arches/app/models/migrations/4684_adds_config_to_tabbed_report.py
+++ b/arches/app/models/migrations/4684_adds_config_to_tabbed_report.py
@@ -19,5 +19,6 @@ class Migration(migrations.Migration):
             """,
             """
             UPDATE report_templates SET defaultconfig = defaultconfig - 'activeTabIndex' WHERE templateid = '50000000-0000-0000-0000-000000000004';
+            UPDATE graphs SET config = config - 'activeTabIndex' WHERE templateid = '50000000-0000-0000-0000-000000000004';
             """
         )]


### PR DESCRIPTION
Improve performance of card configuration by only apply ko mapping to properties in a report template's default configs and fixes tabbed report reverse migration re #4684 