### PR TITLE
removes self.complete() from viewmodel onSave method; adds Complete b…

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -582,6 +582,7 @@ input[type="checkbox"] {
     display: flex;
     flex-direction: column;
     flex-grow: 3;
+    position: relative;
 }
 
 .wf-multi-tile-step-list {

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -587,8 +587,8 @@ input[type="checkbox"] {
 
 .wf-multi-tile-btn-complete {
     position: absolute;
-    top: 266px;
-    left: 350px;
+    top: 267px;
+    left: 508px;
     font-weight: 800;
 }
 

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -585,6 +585,13 @@ input[type="checkbox"] {
     position: relative;
 }
 
+.wf-multi-tile-btn-complete {
+    position: absolute;
+    top: 266px;
+    left: 350px;
+    font-weight: 800;
+}
+
 .wf-multi-tile-step-list {
     display: flex;
     flex-direction: column;

--- a/arches/app/media/js/views/components/workflows/new-multi-tile-step.js
+++ b/arches/app/media/js/views/components/workflows/new-multi-tile-step.js
@@ -1,9 +1,8 @@
 define([
     'knockout',
     'views/components/workflows/new-tile-step',
-    'viewmodels/alert',
-    'jquery'
-], function(ko, NewTileStepViewModel, AlertViewModel, $) {
+    'viewmodels/alert'
+], function(ko, NewTileStepViewModel, AlertViewModel) {
 
     /** 
      * A generic viewmodel for workflow steps that can add multiple tiles

--- a/arches/app/media/js/views/components/workflows/new-multi-tile-step.js
+++ b/arches/app/media/js/views/components/workflows/new-multi-tile-step.js
@@ -1,8 +1,9 @@
 define([
     'knockout',
     'views/components/workflows/new-tile-step',
-    'viewmodels/alert'
-], function(ko, NewTileStepViewModel, AlertViewModel) {
+    'viewmodels/alert',
+    'jquery'
+], function(ko, NewTileStepViewModel, AlertViewModel, $) {
 
     /** 
      * A generic viewmodel for workflow steps that can add multiple tiles
@@ -35,7 +36,6 @@ define([
             params.resourceid(tile.resourceinstance_id);
             params.tileid(tile.tileid);
             self.resourceId(tile.resourceinstance_id);
-            self.complete(true);
             self.tile(self.card().getNewTile());
             self.tile().reset();
             setTimeout(function() {

--- a/arches/app/templates/views/components/workflows/new-multi-tile-step.htm
+++ b/arches/app/templates/views/components/workflows/new-multi-tile-step.htm
@@ -14,7 +14,7 @@
                     form: $data
                 }
             }"></div>
-            <button style="position: absolute; top: 266px; left: 350px; font-weight: 800;" class="btn btn-shim btn-labeled btn-lg fa fa-caret-right btn-mint" data-bind="click: function(){complete(true)}">Complete</button>
+            <button class="btn btn-shim btn-labeled btn-lg fa fa-caret-right btn-mint wf-multi-tile-btn-complete" data-bind="click: function(){complete(true)}">Complete</button>
         </div>
         <div class="wf-multi-tile-step-list">
             <div><h4 data-bind="text: (itemName())"></h4></div>

--- a/arches/app/templates/views/components/workflows/new-multi-tile-step.htm
+++ b/arches/app/templates/views/components/workflows/new-multi-tile-step.htm
@@ -20,7 +20,7 @@
             <div><h4 data-bind="text: (itemName())"></h4></div>
             <!-- ko if: card().tiles().length === 0 -->
             <div class="wf-multi-tile-step-list-empty">
-                <p data-bind="text: ('No '+itemName()+' added yet.')"></p>
+                <p data-bind="text: ('No '+itemName()+' added yet. Add one or multiple '+itemName()+'.')"></p>
             </div>
             <!-- /ko -->
             <!-- ko foreach: {data: card().tiles, as: 'tile'} -->

--- a/arches/app/templates/views/components/workflows/new-multi-tile-step.htm
+++ b/arches/app/templates/views/components/workflows/new-multi-tile-step.htm
@@ -14,6 +14,7 @@
                     form: $data
                 }
             }"></div>
+            <button style="position: absolute; top: 266px; left: 350px; font-weight: 800;" class="btn btn-shim btn-labeled btn-lg fa fa-caret-right btn-mint" data-bind="click: function(){complete(true)}">Complete</button>
         </div>
         <div class="wf-multi-tile-step-list">
             <div><h4 data-bind="text: (itemName())"></h4></div>


### PR DESCRIPTION
…utton to template with handler for self.complete() onclick, re consultations-prj #27

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
amends workflow step for multiple tiles (saved by one card) so that the step isn't marked 'complete' until the user clicks a 'complete' button.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
https://github.com/archesproject/consultations-prj/issues/27

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
