### PR TITLE
#5182 Setting default log level to WARNING from DEBUG

### DIFF
--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -98,7 +98,7 @@ LOGGING = {
             'formatter': 'console'
         },
         'console': {
-            'level': 'DEBUG',
+            'level': 'WARNING',
             'class': 'logging.StreamHandler',
             'formatter': 'console'
         }
@@ -106,7 +106,7 @@ LOGGING = {
     'loggers': {
         'arches': {
             'handlers': ['file', 'console'],
-            'level': 'DEBUG',
+            'level': 'WARNING',
             'propagate': True
         }
     }

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -351,7 +351,7 @@ LOGGING = {
             'formatter': 'console'
         },
         'console': {
-            'level': 'DEBUG',
+            'level': 'WARNING',
             'class': 'logging.StreamHandler',
             'formatter': 'console'
         }
@@ -359,7 +359,7 @@ LOGGING = {
     'loggers': {
         'arches': {
             'handlers': ['file', 'console'],
-            'level': 'DEBUG',
+            'level': 'WARNING',
             'propagate': True
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Changing default settings for new projects

### Description of Change
Reasoning in #5182 but essentially this is so that new projects will default to a sensible level of logged information, allowing for more use of DEBUG level log messages without causing the log output to be cluttered without requiring this.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5182 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
