### PR TITLE
Fixes issue with date widget always displaying current date

### DIFF
--- a/arches/app/media/js/views/components/widgets/datepicker.js
+++ b/arches/app/media/js/views/components/widgets/datepicker.js
@@ -85,21 +85,20 @@ define([
         }, this);
 
         if (self.form && this.defaultValue() === 'Date of Data Entry') {
-            var today = new Date();
-            var dd = today.getDate();
-            var mm = today.getMonth()+1;
-            var yyyy = today.getFullYear();
-
-            if(dd<10) {
-                dd = '0'+dd;
+            if (this.value() === 'Date of Data Entry') {
+                var today = new Date();
+                var dd = today.getDate();
+                var mm = today.getMonth()+1;
+                var yyyy = today.getFullYear();
+                if(dd<10) {
+                    dd = '0'+dd;
+                }
+                if(mm<10) {
+                    mm = '0'+mm;
+                }
+                today = yyyy + '-' + mm + '-' + dd;
+                self.value(today);
             }
-
-            if(mm<10) {
-                mm = '0'+mm;
-            }
-
-            today = yyyy + '-' + mm + '-' + dd;
-            self.value(today);
         }
 
         this.disposables.push(this.getdefault);


### PR DESCRIPTION
This occurred when the default date was set to date of entry even if a different date had already been saved to the tile. re archesproject/consultations-prj#106