### PR TITLE
Resolves error in node datatype config

### DIFF
--- a/arches/app/media/js/views/components/datatypes/node-value.js
+++ b/arches/app/media/js/views/components/datatypes/node-value.js
@@ -37,25 +37,27 @@ define([
                         var node = _.find(params.graph.get('nodes')(), function(node) {
                             return node.id === self.config.nodeid();
                         });
-                        $.ajax({
-                            dataType: "json",
-                            url: arches.urls.graph + node.graph.get('graphid') + '/get_related_nodes/' + node.id,
-                            data: {
-                                parent_nodeid: params.id
-                            },
-                            success: function (response) {
-                                self.properties(
-                                    properties.concat(
-                                        _.map(response, function (prop) {
-                                            return {
-                                                name: node.getFriendlyOntolgyName(prop.ontology_property),
-                                                id: prop.ontology_property
-                                            }
-                                        })
-                                    )
-                                );
-                            }
-                        });
+                        if (node) {
+                            $.ajax({
+                                dataType: "json",
+                                url: arches.urls.graph + node.graph.get('graphid') + '/get_related_nodes/' + node.id,
+                                data: {
+                                    parent_nodeid: params.id
+                                },
+                                success: function (response) {
+                                    self.properties(
+                                        properties.concat(
+                                            _.map(response, function (prop) {
+                                                return {
+                                                    name: node.getFriendlyOntolgyName(prop.ontology_property),
+                                                    id: prop.ontology_property
+                                                }
+                                            })
+                                        )
+                                    );
+                                }
+                            });
+                        }
                     } else {
                         self.properties(properties);
                     }


### PR DESCRIPTION
Error was occurring when the nodeid assigned to a node-value datatype config no longer existed in the resource model's nodes. re #5163