### PR TITLE
Modify binding to set placeholder to " " when placeholder set to "" i…

### DIFF
--- a/arches/app/media/js/bindings/select2-query.js
+++ b/arches/app/media/js/bindings/select2-query.js
@@ -26,6 +26,9 @@ define([
                     $(el).select2("destroy").select2(select2Config);
                 });
                 select2Config.placeholder = select2Config.placeholder();
+                if (select2Config.allowClear) {
+                    select2Config.placeholder = select2Config.placeholder === "" ? " " : select2Config.placeholder;
+                }
             }
 
             select2Config.value = value();


### PR DESCRIPTION
…n order to activate allowClear button on select2 dropdowns, re #5088

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixes issue where 'clear selection' button would not show up if placeholder was set to null in select2 dropdowns

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5088 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
