### PR TITLE
sets params.resourceid to the value from params.workflow.state.resour…

### DIFF
--- a/arches/app/media/js/views/components/workflows/final-step.js
+++ b/arches/app/media/js/views/components/workflows/final-step.js
@@ -11,6 +11,7 @@ define([
         var self = this;
         this.urls = arches.urls;
         this.workflowid = params.workflow.state.workflowid;
+        if (!params.resourceid()) { params.resourceid(params.workflow.state.resourceid); }
         this.resourceid = params.resourceid();
         var url = arches.urls.api_card + (ko.unwrap(this.resourceid));
         this.report = ko.observable();


### PR DESCRIPTION
…ceid, re #5151

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
minor change to the final-step workflow step viewmodel, grabbing the resourceid from workflow.state if not in params

