### PR TITLE
Adds sidepanel active class outside of content_management block 

### DIFF
--- a/arches/app/templates/views/components/workbench.htm
+++ b/arches/app/templates/views/components/workbench.htm
@@ -11,9 +11,12 @@
     {% endblock sidepanel %}
     </div>
     <!--/ko -->
+    <div data-bind="css: {
+        'workbench-card-container-sidepanel-active': activeTab()
+    }">
     {% block content_management %}
-    <div class="workbench-card-container">
-        <div>Main content goes here</div>
-    </div>
+        <div class="workbench-card-container">
+        </div>
     {% endblock content_management %}
+    </div>
 </div>


### PR DESCRIPTION
This makes to makes it available to elements within content_management regardless of how the databind on the `workbench-card-container` element is defined. re #5103