### PR TITLE
Improve ontology loading during package load to check -y param #5238

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -466,9 +466,17 @@ class Command(BaseCommand):
             load_project_extensions=False):
 
         def load_ontology():
-            response = raw_input(
-                'Would you like to load the {0} ontology? (Y/N): '.format(settings.ONTOLOGY_BASE_NAME))
-            if response.lower() in ('t', 'true', 'y', 'yes'):
+            load_default_ontology = True
+            if settings.ONTOLOGY_BASE_NAME != None:
+                if yes is False:
+                    response = raw_input(
+                        'Would you like to load the {0} ontology? (Y/N): '.format(settings.ONTOLOGY_BASE_NAME))
+                    if response.lower() not in ('t', 'true', 'y', 'yes'):
+                        load_default_ontology = False
+            else:
+                load_default_ontology = False
+
+            if load_default_ontology == True:
                 print('loading the {0} ontology'.format(settings.ONTOLOGY_BASE_NAME))
                 extensions = [os.path.join(settings.ONTOLOGY_PATH, x) for x in settings.ONTOLOGY_EXT]
                 management.call_command('load_ontology', source=os.path.join(settings.ONTOLOGY_PATH, settings.ONTOLOGY_BASE),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The change improves the ontology loading when the package is loaded by checking -y parameter and ONTOLOGY_BASE_NAME. re#5238

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
The user can bypass the question asking if ontology will be loaded or not by -y parameter and check the specified ONTOLOGY_BASE_NAME to load ontology. If the name is None, ontology will not be loaded.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
