### PR TITLE
Removes need to the add load extension ('-ex') argument from package command 

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -8,6 +8,7 @@ import uuid
 import sys
 import urllib
 import os
+import logging
 from arches.app.search.mappings import prepare_terms_index, prepare_concepts_index, prepare_resource_relations_index
 from arches.setup import get_elasticsearch_download_url, download_elasticsearch, unzip_file
 from arches.management.commands import utils
@@ -35,6 +36,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.core import management
 from datetime import datetime
+logger = logging.getLogger(__name__)
+
 '''
 ARCHES - a program developed to inventory and manage immovable cultural heritage.
 Copyright (C) 2013 J. Paul Getty Trust and World Monuments Fund

--- a/arches/management/commands/project.py
+++ b/arches/management/commands/project.py
@@ -62,6 +62,7 @@ class Command(BaseCommand):
         self.register('widgets', 'widget')
         self.register('card_components', 'card_component')
         self.register('functions', 'fn')
+        self.register('search', 'search')
         self.register('plugins', 'plugin')
         self.register('reports', 'report')
         self.register('datatypes', 'datatype')


### PR DESCRIPTION
Adds logging to packages.py. Adds search component registration to package command. Removes load_ext_from_prj option from the packages command and instead loads extensions from the project and then from the package. Extensions in the project are not overwritten by the package. re #5305