### PR TITLE
Fix error when deleting a model w/ resources re # 5311

### DIFF
--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -411,9 +411,9 @@ class GraphDataView(View):
             try:
                 graph = Graph.objects.get(graphid=graphid)
                 if graph.isresource:
+                    graph.delete_instances()
                     graph.isactive = False
                     graph.save(validate=False)
-                    graph.delete_instances()
                 graph.delete()
                 return JSONResponse({'success': True})
             except GraphValidationError as e:


### PR DESCRIPTION
This fixes the error when deleting the resource models that has resource instances in it. re #5311
No it deletes the instances and the model altogether.
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
It changes the order of process when deleting resource instances. It deletes the resource instances before it change the active status

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
# It fixes the error deleting a resource model with resource instances.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
