### PR TITLE
Use editor object (ckeditor) instead of '$element.ckeditorGet()'

### DIFF
--- a/arches/app/media/js/bindings/ckeditor.js
+++ b/arches/app/media/js/bindings/ckeditor.js
@@ -49,11 +49,11 @@ define([
                 var self = this;
                 var $element = $(element);
                 var newValue = ko.utils.unwrapObservable(valueAccessor());
-                if ($element.ckeditorGet().getData() != newValue) {
+                if (editor.getData() != newValue) {
                     // remove the listener and then add back to prevent `setData`
                     // from triggering the onChange event
                     editor.removeListener('change', onChange );
-                    $element.ckeditorGet().setData(newValue);
+                    editor.setData(newValue);
                     editor.on('change', onChange, modelValue, element);
                 }
             }, this)


### PR DESCRIPTION
This fixes the error of not being properly check dirty status of the rich text editor when the user moves between different cards. re #5235
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Update the ckeditor.js to use editor object instead of $element.ckeditorGet()

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
# Fix the rich text editor not detecting the dirty state properly when you are between different cards.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
