### PR TITLE
Prevents jsonld error when saving a graph

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1348,6 +1348,10 @@ class Graph(models.GraphModel):
         context = self.jsonldcontext
         try:
             context = JSONDeserializer().deserialize(context)
+            if context is None:
+                context = {
+                    "@context": {}
+                }
         except ValueError:
             if context == '':
                 context = {}


### PR DESCRIPTION
Applies fix to saving graphs without an ontology by setting jsonld context to a default value when the json serializer returns None after serializing the context. re #5372