### PR TITLE
Adds support for customization of the main panel of a tabbed report

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -10355,6 +10355,31 @@ a.jstree-anchor.permissions-widget {
     height: 500px;
 }
 
+.tabbed-report-mainpanel {
+    top: 25px;
+    width: calc(100% - 50px);
+}
+
+.tabbed-report-mainpanel-content {
+    width: calc(100% - 50px);
+}
+
+.tabbed-report-mainpanel-title {
+    padding: 5px 15px;
+    font-size: 12px;
+    border-bottom: 1px solid #ddd;
+    background-color: rgb(237, 237, 237);
+}
+
+.tabbed-tile-value {
+    padding-left: 0px;
+}
+
+.tabbed-report-tile-title {
+    margin-bottom: 0;
+    padding: 12px 5px 0 0;
+}
+
 .tabbed-report-sidepanel {
     width: 300px;
     margin: 0 25px;

--- a/arches/app/media/js/views/components/widgets/rich-text.js
+++ b/arches/app/media/js/views/components/widgets/rich-text.js
@@ -7,7 +7,11 @@ define(['knockout', 'underscore', 'viewmodels/widget', 'bindings/ckeditor'], fun
     * @param {function} params.config - observable containing config object
     */
     return ko.components.register('rich-text-widget', {
-        viewModel: WidgetViewModel,
+        viewModel: function(params) {
+            params.configKeys = ['displayfullvalue'];
+            WidgetViewModel.apply(this, [params]);
+            this.displayfullvalue(params.displayfullvalue);
+        },
         template: { require: 'text!widget-templates/rich-text' }
     });
 });

--- a/arches/app/templates/views/components/widgets/rich-text.htm
+++ b/arches/app/templates/views/components/widgets/rich-text.htm
@@ -21,8 +21,11 @@
 {% endblock report %}
 
 {% block display_value %}
-<!-- ko if: value() -->
+<!-- ko if: value() && !ko.unwrap(displayfullvalue) -->
 <em>[{% trans "rich text" %}]</em>
+<!-- /ko -->
+<!-- ko if: value() && ko.unwrap(displayfullvalue) === true -->
+<div data-bind="html: value() || '{% trans "None" %}'"></div>
 <!-- /ko -->
 <!-- ko if: !value() -->
 {% trans "None" %}

--- a/arches/app/templates/views/report-templates/tabbed.htm
+++ b/arches/app/templates/views/report-templates/tabbed.htm
@@ -114,18 +114,33 @@
         </div>
         <!-- /ko -->
         <div class="rp-report-section-title", data-bind="css: {'tabbed-report-sidepanel-active': tabs()[activeTabIndex()].side_component}">
+            <!-- ko if: tabs()[activeTabIndex()].main_component  -->
+            <div class="tabbed-report-sidepanel-wrapper">
+                <div class="tabbed-report-mainpanel" data-bind="component: {
+                    name: tabs()[activeTabIndex()].main_component,
+                    params: $data
+                }"></div>
+            </div>
+            <!-- /ko -->
+            <!-- ko ifnot: tabs()[activeTabIndex()].main_component  -->
             <!-- ko foreach: { data: activeCards(), as: 'card' } -->
                 <!-- ko if: $index() !== 0 --><hr class="rp-tile-separator"><!-- /ko -->
                 <div class="rp-card-section">
-                    <!-- ko component: {
-                        name: card.model.cardComponentLookup[card.model.component_id()].componentname,
-                        params: {
-                            state: 'report',
-                            card: card,
-                            pageVm: $root
-                        }
-                    } --> <!-- /ko -->
+                    <!--ko if: card && card.alternateReportComponent -->
+                    <!--/ko -->
+                    <!--ko ifnot: card.model && card.alternateReportComponent -->
+                        <!-- ko component: {
+                            name: card.model.cardComponentLookup[card.model.component_id()].componentname,
+                            params: {
+                                state: 'report',
+                                card: card,
+                                pageVm: $root
+                            }
+                        } -->
+                        <!-- /ko -->
+                    <!-- /ko -->
                 </div>
+                <!-- /ko -->
             <!-- /ko -->
         </div>
     </div>

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -183,7 +183,7 @@ def search_results(request):
             if search_filter:
                 search_filter.append_dsl(search_results_object, permitted_nodegroups, include_provisional)
     except Exception as err:
-        return JSONResponse(err.message, status=500)
+        return JSONResponse(err, status=500)
 
     dsl = search_results_object.pop('query', None)
     dsl.include('graph_id')


### PR DESCRIPTION
Also adds developers to configure the rich text widget to display it's entire value (in a tabbed report for example) rather than the abbreviation `[rich text]` that is displayed in the card tree. re #5385, archesproject/consultations-prj#343