### PR TITLE
Shapefile export - multiple geom nodes per resource model. 

### DIFF
--- a/arches/app/utils/data_management/resources/formats/shpfile.py
+++ b/arches/app/utils/data_management/resources/formats/shpfile.py
@@ -7,6 +7,7 @@ from .format import Writer
 import datetime
 import shapefile
 from io import BytesIO
+import copy
 
 
 class ShpWriter(Writer):
@@ -86,15 +87,16 @@ class ShpWriter(Writer):
         for instance in instances:
             feature_geoms = self.process_feature_geoms(instance, geometry_field)
             for geometry in feature_geoms:
-                instance[geometry_field] = geometry
+                feature = copy.copy(instance)
+                feature[geometry_field] = geometry
                 if geometry.geom_typeid == 4:
-                    features_by_geom_type["point"].append(instance)
+                    features_by_geom_type["point"].append(feature)
 
                 elif geometry.geom_typeid == 5:
-                    features_by_geom_type["line"].append(instance)
+                    features_by_geom_type["line"].append(feature)
 
                 elif geometry.geom_typeid == 6:
-                    features_by_geom_type["poly"].append(instance)
+                    features_by_geom_type["poly"].append(feature)
 
         return features_by_geom_type
 

--- a/arches/app/utils/data_management/resources/formats/shpfile.py
+++ b/arches/app/utils/data_management/resources/formats/shpfile.py
@@ -25,7 +25,7 @@ class ShpWriter(Writer):
             multi_geom = MultiPolygon(geos_geom)
             shp_geom = [c[0] for c in multi_geom.coords]
         if geos_geom.geom_type == "MultiPoint":
-            shp_geom = [[c for c in geos_geom.coords]]
+            shp_geom = [c for c in geos_geom.coords]
         if geos_geom.geom_type == "MultiLineString":
             shp_geom = [c for c in geos_geom.coords]
         if geos_geom.geom_type == "MultiPolygon":
@@ -133,7 +133,9 @@ class ShpWriter(Writer):
 
                 for feature in features:
                     shp_geom = self.convert_geom(feature[geometry_field])
-                    if geom_type in ["point", "line"]:
+                    if geom_type == "point":
+                        writer.multipoint(shp_geom)
+                    if geom_type == "line":
                         writer.line(shp_geom)
                     elif geom_type == "poly":
                         writer.poly(shp_geom)


### PR DESCRIPTION
Creates a shapefile for every spatial node identified for export in a resource model, fixes bugs in exporting nodes with combinations of geometry types in a single tile, and fixes bug with writing multipoint shapefile. re #5545