### PR TITLE
Updates total in export url 

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -2805,8 +2805,9 @@ div.dropdown-menu.open {
   }
 
 .ep-edits-header {
-    border: none;
-    display: table-row;
+    display: inline-flex;
+    width: 100%;
+    justify-content: space-between;
     height: 50px;
 }
 

--- a/arches/app/media/js/views/components/search/search-export.js
+++ b/arches/app/media/js/views/components/search/search-export.js
@@ -19,6 +19,7 @@ function($, ko, arches) {
                 var urlparams = ko.unwrap(self.query);
                 urlparams.format = self.format();
                 urlparams.precision = self.precision();
+                urlparams.total = self.total();
                 url = url + '?' + $.param(urlparams);
                 return url;
             });

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -177,7 +177,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
                     <!-- Notifications Panel -->
                     <div id="ep-notifs-panel" class="ep-notifs" style="display:none;">
-                            <div class="" style="padding-right:0px">
+                            <div class="ep-edits-header">
                                 <div class="ep-help-title">
                                     <span>{% trans 'Notifications' %}</span>
                                 </div>
@@ -187,17 +187,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                     </div>
                                 </a>
                             </div>
-    
+
                             <div class="ep-edits-body provisional-edit-history" style="float:left" data-bind="css: {'loading-mask': helploading()}">
                                 <div class="ep-edits-content">
                                     {% include 'views/notifications-list.htm' %}
                                 </div>
                             </div>
                         </div>
-                    
+
                     <!-- Edits Panel -->
                     <div id="ep-edits-panel" class="ep-edits" style="display:none;">
-                        <div class="ep-edits-header" style="padding-right:0px">
+                        <div class="ep-edits-header">
                             <div class="ep-edits-title">
                                 <span>{% trans 'My Edit History' %}</span>
                             </div>
@@ -217,7 +217,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
                     <!-- Help Panel -->
                     <div id="ep-help-panel" class="ep-help" style="display: none" data-bind="slide: helpOpen, duration: 400, direction: {direction: 'right'}, easing: 'slide'">
-                        <div class="ep-help-header" style="padding-right:0px">
+                        <div class="ep-edits-header">
                             <div class="ep-help-title">
                                 <span>{% trans nav.help.title %}</span>
                             </div>


### PR DESCRIPTION
Previously it would default to the total number of instances - not the total in the query when the page was loaded with a query already in the search url. re #5545
