### PR TITLE
refactor test for resource reviewer status #5660

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -14,6 +14,7 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 from arches.app.utils.date_utils import ExtendedDateFormat
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Range, Term, Exists, RangeDSLException
 from arches.app.search.search_engine_factory import SearchEngineFactory
 from django.core.cache import cache
@@ -1047,7 +1048,7 @@ class FileListDataType(BaseDataType):
         user = request.user
         if hasattr(request.user, 'userprofile') is not True:
             models.UserProfile.objects.create(user=request.user)
-        user_is_reviewer = request.user.userprofile.is_reviewer()
+        user_is_reviewer = user_is_resource_reviewer(request.user)
         current_tile_data = self.get_tile_data(user_is_reviewer, str(user.id), current_tile)
         if previously_saved_tile.count() == 1:
             previously_saved_tile_data = self.get_tile_data(user_is_reviewer, str(user.id), previously_saved_tile[0])

--- a/arches/app/models/mobile_survey.py
+++ b/arches/app/models/mobile_survey.py
@@ -36,6 +36,7 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.geo_utils import GeoUtils
 from arches.app.utils.couch import Couch
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 import arches.app.views.search as search
 
 logger = logging.getLogger(__name__)
@@ -235,7 +236,7 @@ class MobileSurvey(models.MobileSurveyModel):
     def handle_reviewer_edits(self, user, tile):
         if hasattr(user, 'userprofile') is not True:
             models.UserProfile.objects.create(user=user)
-        if user.userprofile.is_reviewer():
+        if user_is_resource_reviewer(user):
             user_id = str(user.id)
             if tile.provisionaledits:
                 if user_id in tile.provisionaledits:

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -913,7 +913,12 @@ class UserProfile(models.Model):
     phone = models.CharField(max_length=16, blank=True)
 
     def is_reviewer(self):
-        return self.user.groups.filter(name='Resource Reviewer').exists()
+        """ DEPRECATED Use new pattern:
+
+            from arches.app.utils.permission_backend import user_is_resource_reviewer
+            is_reviewer = user_is_resource_reviewer(user)
+        """
+        pass
 
     @property
     def viewable_nodegroups(self):

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -32,6 +32,7 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query, Bool, Terms
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.exceptions import InvalidNodeNameException, MultipleNodesFoundException
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.datatypes.datatypes import DataTypeFactory
 
 
@@ -269,7 +270,7 @@ class Resource(models.ResourceInstance):
 
         permit_deletion = False
         if user != {}:
-            user_is_reviewer = user.groups.filter(name='Resource Reviewer').exists()
+            user_is_reviewer = user_is_resource_reviewer(user)
             if user_is_reviewer is False:
                 tiles = list(models.TileModel.objects.filter(resourceinstance=self))
                 resource_is_provisional = True if sum([len(t.data) for t in tiles]) == 0 else False

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -30,6 +30,7 @@ from arches.app.models.resource import Resource
 from arches.app.models.resource import EditLog
 from arches.app.models.system_settings import settings
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query, Bool, Terms
 from arches.app.datatypes.datatypes import DataTypeFactory
@@ -243,7 +244,7 @@ class Tile(models.TileModel):
             userid = str(request.user.id)
             if hasattr(request.user, 'userprofile') is not True:
                 models.UserProfile.objects.create(user=request.user)
-            user_is_reviewer = request.user.userprofile.is_reviewer()
+            user_is_reviewer = user_is_resource_reviewer(request.user)
         tile_data = self.get_tile_data(user_is_reviewer, userid)
         for nodeid, value in tile_data.items():
             datatype_factory = DataTypeFactory()
@@ -269,7 +270,7 @@ class Tile(models.TileModel):
         try:
             if user is None and request is not None:
                 user = request.user
-            user_is_reviewer = user.groups.filter(name='Resource Reviewer').exists()
+            user_is_reviewer = user_is_resource_reviewer(user)
         except AttributeError:  # no user - probably importing data
             user = None
 
@@ -343,9 +344,10 @@ class Tile(models.TileModel):
             tile.delete(*args, request=request, **kwargs)
         try:
             user = request.user
-            user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+            user_is_reviewer = user_is_resource_reviewer(user)
         except AttributeError:  # no user
             user = None
+            user_is_reviewer = True
 
         if user_is_reviewer is True or self.user_owns_provisional(user):
             query = Query(se)

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -182,3 +182,10 @@ def user_can_read_concepts(user):
     if user.is_authenticated():
         return user.groups.filter(name='RDM Administrator').exists()
     return False
+
+def user_is_resource_reviewer(user):
+    """
+    Single test for whether a user is in the Resource Reviewer group
+    """
+
+    return user.groups.filter(name='Resource Reviewer').exists()

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -183,6 +183,7 @@ def user_can_read_concepts(user):
         return user.groups.filter(name='RDM Administrator').exists()
     return False
 
+
 def user_is_resource_reviewer(user):
     """
     Single test for whether a user is in the Resource Reviewer group

--- a/arches/app/views/auth.py
+++ b/arches/app/views/auth.py
@@ -42,6 +42,7 @@ from arches.app.models import models
 from arches.app.models.system_settings import settings
 from arches.app.utils.arches_crypto import AESCipher
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +231,7 @@ class UserProfileView(View):
                 models.UserProfile.objects.create(user=user)
             userDict = JSONSerializer().serializeToPython(user)
             userDict['password'] = None
-            userDict['is_reviewer'] = user.userprofile.is_reviewer()
+            userDict['is_reviewer'] = user_is_resource_reviewer(user)
             userDict['viewable_nodegroups'] = user.userprofile.viewable_nodegroups
             userDict['editable_nodegroups'] = user.userprofile.editable_nodegroups
             userDict['deletable_nodegroups'] = user.userprofile.deletable_nodegroups
@@ -276,7 +277,7 @@ class GetClientIdView(View):
                 if user:
                     if hasattr(user, 'userprofile') is not True:
                         models.UserProfile.objects.create(user=user)
-                    is_reviewer = user.userprofile.is_reviewer()
+                    is_reviewer = user_is_resource_reviewer(user)
                     user = JSONSerializer().serializeToPython(user)
                     user['password'] = None
                     user['is_reviewer'] = is_reviewer

--- a/arches/app/views/base.py
+++ b/arches/app/views/base.py
@@ -23,7 +23,7 @@ from arches.app.models.resource import Resource
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from django.views.generic import TemplateView
 from arches.app.datatypes.datatypes import DataTypeFactory
-from arches.app.utils.permission_backend import get_createable_resource_types
+from arches.app.utils.permission_backend import get_createable_resource_types, user_is_resource_reviewer
 
 
 class BaseManagerView(TemplateView):
@@ -63,7 +63,7 @@ class BaseManagerView(TemplateView):
             'login': True,
             'print': False,
         }
-        context['user_is_reviewer'] = self.request.user.groups.filter(name='Resource Reviewer').exists()
+        context['user_is_reviewer'] = user_is_resource_reviewer(self.request.user)
         context['app_name'] = settings.APP_NAME
         context['iiif_manifests'] = models.IIIFManifest.objects.all()
         return context

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -39,6 +39,7 @@ from arches.app.utils.decorators import can_edit_resource_instance
 from arches.app.utils.decorators import can_read_resource_instance
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.response import JSONResponse
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query, Terms
 from arches.app.views.base import BaseManagerView, MapBaseManagerView
@@ -118,7 +119,7 @@ class NewResourceEditorView(MapBaseManagerView):
         widgets = models.Widget.objects.all()
         card_components = models.CardComponent.objects.all()
         datatypes = models.DDataType.objects.all()
-        user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+        user_is_reviewer = user_is_resource_reviewer(request.user.userprofile)
         is_system_settings = False
 
         if resource_instance is None:
@@ -310,7 +311,7 @@ class ResourceEditorView(MapBaseManagerView):
                     'description', 'ontologyclass', 'isrequired', 'issearchable', 'istopnode']),
                 saved_searches=JSONSerializer().serialize(settings.SAVED_SEARCHES),
                 resource_instance_exists=resource_instance_exists,
-                user_is_reviewer=json.dumps(request.user.groups.filter(name='Resource Reviewer').exists()),
+                user_is_reviewer=json.dumps(user_is_resource_reviewer(request.user)),
                 userid=request.user.id
             )
 

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -119,7 +119,7 @@ class NewResourceEditorView(MapBaseManagerView):
         widgets = models.Widget.objects.all()
         card_components = models.CardComponent.objects.all()
         datatypes = models.DDataType.objects.all()
-        user_is_reviewer = user_is_resource_reviewer(request.user.userprofile)
+        user_is_reviewer = user_is_resource_reviewer(request.user)
         is_system_settings = False
 
         if resource_instance is None:

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -43,7 +43,7 @@ from arches.app.utils.data_management.resources.exporter import ResourceExporter
 from arches.app.views.base import BaseManagerView, MapBaseManagerView
 from arches.app.views.concept import get_preflabel_from_conceptid
 from arches.app.datatypes.datatypes import DataTypeFactory
-from arches.app.utils.permission_backend import get_nodegroups_by_perm
+from arches.app.utils.permission_backend import get_nodegroups_by_perm, user_is_resource_reviewer
 
 
 
@@ -91,7 +91,7 @@ class SearchView(MapBaseManagerView):
             resource_graphs=resource_graphs,
             datatypes=datatypes,
             datatypes_json=JSONSerializer().serialize(datatypes),
-            user_is_reviewer=request.user.groups.filter(name='Resource Reviewer').exists()
+            user_is_reviewer=user_is_resource_reviewer(request.user),
         )
 
         graphs = JSONSerializer().serialize(
@@ -129,7 +129,7 @@ def search_terms(request):
     se = SearchEngineFactory().create()
     searchString = request.GET.get('q', '')
     query = Query(se, start=0, limit=0)
-    user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+    user_is_reviewer = user_is_resource_reviewer(request.user)
 
     boolquery = Bool()
     boolquery.should(Match(field='value', query=searchString.lower(), type='phrase_prefix', fuzziness='AUTO'))
@@ -230,7 +230,7 @@ def search_results(request):
     results = dsl.search(index='resource', doc_type=get_doc_type(request))
 
     if results is not None:
-        user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+        user_is_reviewer = user_is_resource_reviewer(request.user)
         total = results['hits']['total']
         page = 1 if request.GET.get('page') == '' else int(request.GET.get('page', 1))
 
@@ -298,7 +298,7 @@ def get_provisional_type(request):
 
     result = False
     provisional_filter = JSONDeserializer().deserialize(request.GET.get('provisionalFilter', '[]'))
-    user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+    user_is_reviewer = user_is_resource_reviewer(request.user)
     if user_is_reviewer != False:
         if len(provisional_filter) == 0:
             result = True

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -27,6 +27,7 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.response import JSONResponse
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.decorators import can_edit_resource_instance
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.views.tileserver import clean_resource_cache
 from django.contrib.auth.models import User
 from django.http import HttpResponseNotFound
@@ -204,7 +205,7 @@ class TileData(View):
                     tile = Tile.objects.get(tileid = data['tileid'])
                 except ObjectDoesNotExist:
                     return JSONResponse({'status':'false','message': [_('This tile is no longer available'), _('It was likely already deleted by another user')]}, status=500)
-                user_is_reviewer = request.user.groups.filter(name='Resource Reviewer').exists()
+                user_is_reviewer = user_is_resource_reviewer(request.user)
                 if user_is_reviewer or tile.is_provisional() == True:
                     if tile.filter_by_perm(request.user, 'delete_nodegroup'):
                         nodegroup = models.NodeGroup.objects.get(pk=tile.nodegroup_id)

--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -34,6 +34,7 @@ from arches.app.utils.decorators import group_required
 from arches.app.views.base import BaseManagerView
 from arches.app.utils.forms import ArchesUserProfileForm
 from arches.app.utils.response import JSONResponse
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 
 class UserManagerView(BaseManagerView):
     action = ''
@@ -103,7 +104,7 @@ class UserManagerView(BaseManagerView):
 
         if self.action == 'get_user_names':
             data = {}
-            if self.request.user.is_authenticated() and request.user.groups.filter(name='Resource Reviewer').exists():
+            if self.request.user.is_authenticated() and user_is_resource_reviewer(request.user):
                 userids = json.loads(request.POST.get('userids', '[]'))
                 data = {u.id:u.username for u in User.objects.filter(id__in=userids)}
                 return JSONResponse(data)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This is a refactor of how the app checks for whether a user is a resource reviewer. Previously, there were numerous hard-coded tests of whether a user is in the "Resource Reviewer" group. There were also some tests that used the UserProfile.is_reviewer() method. This refactor creates a new function in permission_backend and changes all references across the app to use that new function. The UserProfile.is_reviewer() method is deprecated. See full explanation in #5660.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5660 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: FPAN
*   Found by: @mradamcox
*   Tested by: @mradamcox
*   Designed by: @mradamcox 