### PR TITLE
fix datatype_to_rdf tests; deal with missing class in data; #5579

### DIFF
--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -156,14 +156,16 @@ class ConceptDataType(BaseConceptDataType):
         ext_ids = [
             ident.value for ident in models.Value.objects.all().filter(concept_id__exact=c.conceptid, valuetype__category="identifiers")
         ]
-        for id_uri in ext_ids:
-            if str(id_uri).startswith(settings.PREFERRED_CONCEPT_SCHEME):
-                return URIRef(id_uri)
+        for p in settings.PREFERRED_CONCEPT_SCHEMES:
+            for id_uri in ext_ids:
+                if str(id_uri).startswith(p):
+                    return URIRef(id_uri)
         return URIRef(archesproject[f"concepts/{c.conceptid}"])
 
     def to_rdf(self, edge_info, edge):
         g = Graph()
-        if edge_info["r_uri"] == self.get_rdf_uri(None, edge_info["range_tile_data"]):
+        myuri = self.get_rdf_uri(None, edge_info["range_tile_data"])
+        if edge_info["r_uri"] == myuri:
             c = ConceptValue(str(edge_info["range_tile_data"]))
             g.add((edge_info["r_uri"], RDF.type, URIRef(edge.rangenode.ontologyclass)))
             g.add((edge_info["d_uri"], URIRef(edge.ontologyproperty), edge_info["r_uri"]))

--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -288,7 +288,7 @@ class JsonLdReader(Reader):
         for c in cdata:
             cids = [x.value for x in models.Value.objects.all().filter(concept_id__exact=c[0], valuetype__category="identifiers")]
             ids.extend(cids)
-        if value.startswith("http://localhost:8000/"):
+        if value.startswith(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT):
             value = value.rsplit("/", 1)[-1]
         return str(value) in ids
 

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -114,7 +114,10 @@ ONTOLOGY_DIR = os.path.join(ROOT_DIR, "ontologies")
 # Used in the JSON-LD export for determining which external concept scheme URI
 # to use in preference for the URI of a concept. If there is no match, the default
 # Arches host URI will be used (eg http://localhost/concepts/123f323f-...)
-PREFERRED_CONCEPT_SCHEME = "http://vocab.getty.edu/aat/"
+PREFERRED_CONCEPT_SCHEMES = [
+    "http://vocab.getty.edu/aat/",
+    "http://www.cidoc-crm.org/cidoc-crm/"
+]
 
 # This is the namespace to use for export of data (for RDF/XML for example)
 # Ideally this should point to the url where you host your site

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -56,10 +56,6 @@ class RDFExportUnitTests(ArchesTestCase):
             with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "rU") as f:
                 archesfile = JSONDeserializer().deserialize(f)
             ResourceGraphImporter(archesfile["graph"])
-        # Fixture Instance Data for tests
-        # for instance_name in ['document', 'object']:
-        #     BusinessDataImporter(
-        #             'tests/fixtures/data/rdf_export_{0}.json'.format(instance_name)).import_business_data()
 
     def setUp(self):
         # for RDF/JSON-LD export tests
@@ -152,30 +148,49 @@ class RDFExportUnitTests(ArchesTestCase):
             self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, Literal(item)) in graph)
         self.assertFalse((edge_info["d_uri"], edge.ontologyproperty, Literal("Not Domain Text")) in graph)
 
-    # def test_rdf_concept(self):
-    #     dt = self.DT.get_instance("concept")
-    #     # d75977c1-635b-41d5-b53d-1c82d2237b67 should be the ConceptValue for "junk sculpture"
-    #     # Main concept should be 0ad97528-0fb0-43bf-afee-0fb9dde78b99
-    #     # should also have an identifier of http://vocab.getty.edu/aat/300047196
-    #     edge_info, edge = mock_edge(
-    #         1, CIDOC_NS["some_value"], None, "", "d75977c1-635b-41d5-b53d-1c82d2237b67", o_type_str=CIDOC_NS["E55_Type"]
-    #     )
-    #     graph = dt.to_rdf(edge_info, edge)
-    #     self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, URIRef("http://vocab.getty.edu/aat/300047196")) in graph)
-    #     self.assertTrue((URIRef("http://vocab.getty.edu/aat/300047196"), RDFS.label, Literal("junk sculpture")) in graph)
+    def test_rdf_concept(self):
+        dt = self.DT.get_instance("concept")
+        # d75977c1-635b-41d5-b53d-1c82d2237b67 should be the ConceptValue for "junk sculpture"
+        # Main concept should be 0ad97528-0fb0-43bf-afee-0fb9dde78b99
+        # should also have an identifier of http://vocab.getty.edu/aat/300047196
 
-    # def test_rdf_concept_list(self):
-    #     dt = self.DT.get_instance("concept-list")
-    #     concept_list = [
-    #         "d75977c1-635b-41d5-b53d-1c82d2237b67",  # junk sculpture@en, has aat identifier
-    #         "4beb7055-8a6e-45a3-9bfb-32984b6f82e0",  # "example document type"@en-us, no ext id}
-    #     ]
-    #     edge_info, edge = mock_edge(1, CIDOC_NS["some_value"], None, "", concept_list, o_type_str=CIDOC_NS["E55_Type"])
-    #     graph = dt.to_rdf(edge_info, edge)
-    #     self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, URIRef("http://vocab.getty.edu/aat/300047196")) in graph)
-    #     self.assertTrue((URIRef("http://vocab.getty.edu/aat/300047196"), RDFS.label, Literal("junk sculpture")) in graph)
-    #     self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, ARCHES_NS["concepts/037daf4d-054a-44d2-9c0a-108b59e39109"]) in graph)
-    #     self.assertTrue((ARCHES_NS["concepts/037daf4d-054a-44d2-9c0a-108b59e39109"], RDFS.label, Literal("example document type")) in graph)
+        edge_info = {}
+        edge_info['range_tile_data'] = "d75977c1-635b-41d5-b53d-1c82d2237b67"
+        edge_info['r_uri'] = URIRef("http://vocab.getty.edu/aat/300047196")
+        edge_info['d_uri'] = URIRef("test")
+        edge = Mock()
+        edge.ontologyproperty = CIDOC_NS["P2_has_type"]
+        edge.rangenode.ontologyclass = CIDOC_NS["E55_Type"]
+
+        graph = dt.to_rdf(edge_info, edge)
+        print(graph.serialize(format='ttl'))
+        self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, URIRef("http://vocab.getty.edu/aat/300047196")) in graph)
+        self.assertTrue((URIRef("http://vocab.getty.edu/aat/300047196"), RDFS.label, Literal("junk sculpture")) in graph)
+
+    def test_rdf_concept_list(self):
+        dt = self.DT.get_instance("concept-list")
+        concept_list = [
+            "d75977c1-635b-41d5-b53d-1c82d2237b67",  # junk sculpture@en, has aat identifier
+            "4beb7055-8a6e-45a3-9bfb-32984b6f82e0",  # "example document type"@en-us, no ext id}
+        ]
+
+        edge_info = {}
+        edge_info['range_tile_data'] = concept_list
+        edge_info['r_uri'] = URIRef("http://vocab.getty.edu/aat/300047196")
+        edge_info['d_uri'] = URIRef("test")
+        edge = Mock()
+        edge.ontologyproperty = CIDOC_NS["P2_has_type"]
+        edge.rangenode.ontologyclass = CIDOC_NS["E55_Type"]
+        graph = dt.to_rdf(edge_info, edge)
+
+
+        edge_info['r_uri'] = ARCHES_NS["concepts/037daf4d-054a-44d2-9c0a-108b59e39109"]
+        graph += dt.to_rdf(edge_info, edge)
+
+        self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, URIRef("http://vocab.getty.edu/aat/300047196")) in graph)
+        self.assertTrue((URIRef("http://vocab.getty.edu/aat/300047196"), RDFS.label, Literal("junk sculpture")) in graph)
+        self.assertTrue((edge_info["d_uri"], edge.ontologyproperty, ARCHES_NS["concepts/037daf4d-054a-44d2-9c0a-108b59e39109"]) in graph)
+        self.assertTrue((ARCHES_NS["concepts/037daf4d-054a-44d2-9c0a-108b59e39109"], RDFS.label, Literal("example document type")) in graph)
 
 
 def append_domain_config_to_node(node):
@@ -208,6 +223,8 @@ def mock_edge(
     edge.domainnode_id = edge.domainnode.pk = s_id
     edge_info["d_uri"] = ARCHES_NS["{0}/{1}".format(s_pref, s_id)]
     edge_info["r_uri"] = None
+    edge_info['d_datatype'] = None
+    edge_info['r_datatype'] = None
     edge.rangenode_id = edge.rangenode.pk = o_id
     if o_id:
         edge_info["r_uri"] = ARCHES_NS["{0}/{1}".format(o_pref, o_id)]


### PR DESCRIPTION
This PR does the following:

* changes settings.PREFERRED_CONCEPT_SCHEME to be an ordered list of preferred schemes to test for.  This closes #5579, and is needed for referring to both AAT and CRM properties as concepts.
* Fixes the datatype_to_rdf tests to reflect the new RdfWriter's add_edge_to_graph function. The change is to use get_rdf_uri() on the datatype to calculate its own URI, such that resource-instances can have concepts and vice versa without having to duplicate the code artificialy
* Deals with incoming data for import when a node does not have a defined class, but there is only one possible property/class combination that it could match.
* Takes out some unnecessary debugging time()s
* Replaces hardcoded localhost with correct settings.ARCHES_NAMESPACE_FOR_EXPORT

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5579

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Found by: @apeters somewhat by brute force of pushing to master ;) 

