### PR TITLE
Improves export feedback

### DIFF
--- a/arches/app/media/js/views/components/search/search-export.js
+++ b/arches/app/media/js/views/components/search/search-export.js
@@ -45,7 +45,7 @@ function($, ko, arches) {
             this.executeExport = function(limit){
                 if (this.total() > limit) {
                     this.getExportData();
-                } else {
+                } else if (this.total() > 0) {
                     window.open(this.url());
                 }
             };

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1335,10 +1335,8 @@ class Graph(models.GraphModel):
 
         fieldnames = {}
         for node_id, node in self.nodes.items():
-            if node.datatype == "":
-                raise GraphValidationError(_("A valid node datatype must be selected"), 1007)
             if node.exportable is True:
-                validated_fieldname = validate_fieldname(node.fieldname, fieldnames, node.datatype)
+                validated_fieldname = validate_fieldname(node.fieldname, fieldnames)
                 if validated_fieldname != node.fieldname:
                     node.fieldname = validated_fieldname
                     node.save()

--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -170,8 +170,6 @@ class SearchResultsExporter(object):
         dest = StringIO()
         csvwriter = csv.DictWriter(dest, delimiter=",", fieldnames=headers)
         csvwriter.writeheader()
-        # csvs_for_export.append({"name": csv_name, "outputfile": dest})
-        # print(f"{name} = {len(instances)}")
         for instance in instances:
             csvwriter.writerow({k: str(v) for k, v in list(instance.items())})
         return {"name": f"{name}.csv", "outputfile": dest}

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -3,7 +3,7 @@
     <div class="filter-title">{% trans "Export Search Results" %}
     </div>
     <hr class="title-underline">
-    
+
     <div class="search-export">
         <div class="instruction">
             <h2 class=""> {% trans "1. Format" %} </h2>
@@ -22,7 +22,7 @@
                 </label>
             </div>
         </div>
-          
+
         <div class="instruction">
                 <h2 class=""> {% trans "2. Coordinate Precision" %} </h2>
                 <h4 class=""> {% trans "Tell us how many decimal places of precision you'd like for geo-data results" %} </h4>
@@ -46,7 +46,7 @@
         <button class="btn btn-lg btn-primary btn-active-primary"
             type="button"
             aria-expanded="true"
-            data-bind="click: function(){executeExport( {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} )}"> {% trans "Download" %}
+            data-bind="css: {disabled: total() === 0},click: function(){executeExport( {{app_settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD}} )}"> {% trans "Download" %}
         </button>
     </div>
     <div class="download-message" data-bind="text: result, fadeVisible: downloadStarted, delay:0, fade: 600">

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -204,6 +204,15 @@ def export_results(request):
     else:
         exporter = SearchResultsExporter(search_request=request)
         export_files = exporter.export(format)
+        if len(export_files) == 0 and format == "shp":
+            message = _(
+                "Either no instances were identified for export or no resources have exportable geometry nodes\
+                Please confirm that the models of instances you would like to export have geometry nodes and that\
+                those nodes are set as exportable"
+            )
+            dest = StringIO()
+            dest.write(message)
+            export_files.append({"name": "error.txt", "outputfile": dest})
         return zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
 
 

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -11,6 +11,7 @@ try:
 except ImportError:
     pass
 
+APP_NAME = {{ project_name }}
 APP_ROOT = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 STATICFILES_DIRS =  (os.path.join(APP_ROOT, 'media'),) + STATICFILES_DIRS
 


### PR DESCRIPTION
Prevents user from conducting export when there are no search results. Fixes error in field name validation. Informs user that if no instances had exportable geometry nodes, no shapefiles were exported. re #5545