### PR TITLE
Fixes missing attribute info in shapefile export fields. re #5793, #5740

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -157,7 +157,7 @@ class SearchResultsExporter(object):
                 if node.exportable:
                     datatype = datatype_factory.get_instance(node.datatype)
                     node_value = datatype.get_display_value(tile, node)
-                    label = node.fieldname if use_fieldname == True else node.name
+                    label = node.fieldname if use_fieldname is True else node.name
 
                     if compact:
                         if node.datatype == "geojson-feature-collection":

--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -60,7 +60,8 @@ class SearchResultsExporter(object):
         output = {}
 
         for resource_instance in instances:
-            resource_obj = self.flatten_tiles(resource_instance["_source"]["tiles"], self.datatype_factory, compact=self.compact)
+            use_fieldname = self.format in ("shp",)
+            resource_obj = self.flatten_tiles(resource_instance["_source"]["tiles"], self.datatype_factory, compact=self.compact, use_fieldname=use_fieldname)
             has_geom = resource_obj.pop("has_geometry")
             skip_resource = self.format in ("shp",) and has_geom is False
             if skip_resource is False:
@@ -143,7 +144,7 @@ class SearchResultsExporter(object):
                     resource_json[tile["card_name"]] = tile[tile["card_name"]]
         return resource_json
 
-    def flatten_tiles(self, tiles, datatype_factory, compact=True):
+    def flatten_tiles(self, tiles, datatype_factory, compact=True, use_fieldname=False):
         feature_collections = {}
         compacted_data = {}
         lookup = {}
@@ -155,10 +156,8 @@ class SearchResultsExporter(object):
                 node = self.get_node(nodeid)
                 if node.exportable:
                     datatype = datatype_factory.get_instance(node.datatype)
-                    # node_value = datatype.transform_export_values(tile['data'][str(node.nodeid)])
                     node_value = datatype.get_display_value(tile, node)
-                    # label = node.fieldname
-                    label = node.name
+                    label = node.fieldname if use_fieldname == True else node.name
 
                     if compact:
                         if node.datatype == "geojson-feature-collection":


### PR DESCRIPTION
Uses fieldname for shapefiles and node name for csv. re #5793, #5740