### PR TITLE
changes dates, date_ranges to integer, interger_range types respectiv…

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -317,7 +317,7 @@ class DateDataType(BaseDataType):
                     operators[value["op"]] = date_value
                     search_query = Range(field="tiles.data.%s" % (str(node.pk)), **operators)
                 else:
-                    search_query = Match(field="tiles.data.%s" % (str(node.pk)), query=date_value, type="phrase_prefix")
+                    search_query = Match(field="tiles.data.%s" % (str(node.pk)), query=date_value, type="phrase")
                 query.must(search_query)
         except KeyError as e:
             pass

--- a/arches/app/search/mappings.py
+++ b/arches/app/search/mappings.py
@@ -183,7 +183,7 @@ def prepare_search_index(create=False):
                     "dates": {
                         "type": "nested",
                         "properties": {
-                            "date": {"type": "float"},
+                            "date": {"type": "integer"},
                             "nodegroup_id": {"type": "keyword"},
                             "nodeid": {"type": "keyword"},
                             "provisional": {"type": "boolean"},
@@ -200,7 +200,7 @@ def prepare_search_index(create=False):
                     "date_ranges": {
                         "type": "nested",
                         "properties": {
-                            "date_range": {"type": "float_range"},
+                            "date_range": {"type": "integer_range"},
                             "nodegroup_id": {"type": "keyword"},
                             "provisional": {"type": "boolean"},
                         },


### PR DESCRIPTION
…ely; Match query type changed to phrase from phrase-prefix for DateDataType, re #5845

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
- Changes ES index mapping for dates and date_ranges to integer and integer_range, respectively
- replaces `phrase_prefix` type with just `phrase` in query definition for Date datatype

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5845 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
