### PR TITLE
Sets up indexes after database is created. re #5876

### DIFF
--- a/arches/app/models/migrations/2691_ES_upgrade.py
+++ b/arches/app/models/migrations/2691_ES_upgrade.py
@@ -16,79 +16,8 @@ class Migration(migrations.Migration):
     ]
 
     def forwards_func(apps, schema_editor):
-        if settings.SEARCH_BACKEND != 'tests.base_test.TestSearchEngine':
-            se = SearchEngineFactory().create()
-            se_old = SearchEngineFactory().create(hosts=[settings.ELASTICSEARCH_TEMP_HTTP_ENDPOINT])
-            prefix = settings.ELASTICSEARCH_PREFIX
-            if (se.es.indices.exists(index="%s_terms" % prefix) is False and 
-                    se_old.es.indices.exists(index="%s_strings" % prefix) is True):
-                prepare_terms_index(create=True)
-                doc = {
-                    "source": {
-                        "remote": {
-                            "host": settings.ELASTICSEARCH_TEMP_HTTP_ENDPOINT
-                        },
-                        "index": "%s_strings" % prefix,
-                        "type": "term"
-                    },
-                    "dest": {
-                        "index": "%s_terms" % prefix,
-                        "type": "_doc"
-                    }
-                }
-                se.es.reindex(body=doc)
+        pass
 
-            if (se.es.indices.exists(index="%s_concepts" % prefix) is False and 
-                    se_old.es.indices.exists(index="%s_strings" % prefix) is True):
-                prepare_concepts_index(create=True)
-                doc = {
-                    "source": {
-                        "remote": {
-                            "host": settings.ELASTICSEARCH_TEMP_HTTP_ENDPOINT
-                        },
-                        "index": "%s_strings" % prefix,
-                        "type": "concept"
-                    },
-                    "dest": {
-                        "index": "%s_concepts" % prefix,
-                        "type": "_doc"
-                    }
-                }
-                se.es.reindex(body=doc)
-
-            if(se.es.indices.exists(index="%s_resources" % prefix) is False and 
-                    se_old.es.indices.exists(index="%s_resource" % prefix) is True):
-                prepare_search_index(create=True)
-                doc = {
-                    "source": {
-                        "remote": {
-                            "host": settings.ELASTICSEARCH_TEMP_HTTP_ENDPOINT
-                        },
-                        "index": "%s_resource" % prefix
-                    },
-                    "dest": {
-                        "index": "%s_resources" % prefix,
-                        "type": "_doc"
-                    }
-                }
-                se.es.reindex(body=doc)
-
-            if(se.es.indices.exists(index="%s_resource_relations" % prefix) is False and 
-                    se_old.es.indices.exists(index="%s_resource_relations" % prefix) is True):
-                prepare_resource_relations_index(create=True)
-                doc = {
-                    "source": {
-                        "remote": {
-                            "host": settings.ELASTICSEARCH_TEMP_HTTP_ENDPOINT
-                        },
-                        "index": "%s_resource_relations" % prefix
-                    },
-                    "dest": {
-                        "index": "%s_resource_relations" % prefix,
-                        "type": "_doc"
-                    }
-                }
-                se.es.reindex(body=doc)
 
     def reverse_func(apps, schema_editor):
         pass

--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -345,8 +345,10 @@ class CsvReader(Reader):
             else:
                 try:
                     newresourceinstance.save()
+
                 except TransportError as e:
-                    cause = json.dumps(e.info["error"]["caused_by"], indent=1)
+
+                    cause = json.dumps(e.info["error"]["reason"], indent=1)
                     msg = "%s: WARNING: failed to index document in resource: %s %s. Exception detail:\n%s\n" % (
                         datetime.datetime.now(),
                         resourceinstanceid,

--- a/arches/management/commands/setup_db.py
+++ b/arches/management/commands/setup_db.py
@@ -187,12 +187,14 @@ To create it, use:
         else:
             self.reset_db(cursor)
 
-        # delete and setup initial Elasticsearch indexes
+        # delete existing indexes
         management.call_command("es", operation="delete_indexes")
-        management.call_command("es", operation="setup_indexes")
 
         # run all migrations
         management.call_command("migrate")
+
+        # setup initial Elasticsearch indexes
+        management.call_command("es", operation="setup_indexes")
 
         # import system settings graph and any saved system settings data
         settings_graph = os.path.join(settings.ROOT_DIR, "db", "system_settings", "Arches_System_Settings_Model.json")


### PR DESCRIPTION
Removes code to upgrade ES index in 2691_ES_upgrade.py migration and sets up index after database is migrated, re #5876
