### PR TITLE
Fix es indexing of provisional edit for the filelist datatype re#5873

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1069,9 +1069,15 @@ class FileListDataType(BaseDataType):
         return errors
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
-        for f in tile.data[str(nodeid)]:
-            val = {"string": f["name"], "nodegroup_id": tile.nodegroup_id, "provisional": provisional}
-            document["strings"].append(val)
+        try:
+            for f in tile.data[str(nodeid)]:
+                val = {"string": f["name"], "nodegroup_id": tile.nodegroup_id, "provisional": provisional}
+                document["strings"].append(val)
+        except KeyError as e:
+            for k, pe in tile.provisionaledits.items():
+                for f in pe["value"][nodeid]:
+                    val = {"string": f["name"], "nodegroup_id": tile.nodegroup_id, "provisional": provisional}
+                    document["strings"].append(val)
 
     def get_display_value(self, tile, node):
         data = self.get_tile_data(tile)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
The es indexing of filelist when it is provisional fails, which prevents the user to add file or re-index.
The append_to_document method was updated to properly index the file list when it is provisional.

<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
A try block was added around the code for appending, so when the tile.data is not available, it will look for provisionaledits to get info.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
