### PR TITLE
File viewer improvements re #5881

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -921,9 +921,11 @@ ul.tabbed-report-tab-list {
     width: 92px;
     background-color: rgb(247, 247, 247);
     border-left: 1px solid rgb(216, 216, 216);
+    z-index: 200;
 }
 
 .workbench-card-sidebar-tab {
+    z-index: 200;
     color: rgb(33, 62, 95);
     padding: 16px;
     text-align: center;
@@ -933,6 +935,7 @@ ul.tabbed-report-tab-list {
 }
 
 .workbench-card-sidebar-tab.active {
+    z-index: 200;
     background-color: white;
     border-left: solid 1px white;
     margin-left: -1px;
@@ -942,35 +945,6 @@ ul.tabbed-report-tab-list {
     font-size: 1.7em;
     display: block;
     padding-bottom: 6px;
-}
-
-.workbench-card-sidepanel {
-    position:absolute;
-    z-index: 10;
-    right: 92px;
-    height: 100%;
-    width: 400px;
-    background: white;
-    border-left: 1px solid rgb(216, 216, 216);
-    padding: 16px;
-    overflow-y: scroll;
-}
-
-.workbench-card-sidepanel-header {
-    cursor: pointer;
-    color: rgb(33, 62, 95);
-}
-
-.workbench-card-sidepanel-header:before {
-    content: "\f00d";
-    font-family: FontAwesome;
-    margin-right: 6px;
-    color: rgb(158, 158, 158);
-    font-weight:lighter;
-}
-
-.workbench-card-sidepanel-header:hover:before {
-    color: rgb(33, 62, 95);
 }
 
 .workbench-card-sidepanel.expanded {
@@ -1093,8 +1067,8 @@ ul.tabbed-report-tab-list {
 }
 
 .workbench-card-sidepanel {
-    position:absolute;
-    z-index: 10;
+    position: absolute;
+    z-index: 250;
     right: 75px;
     height: 100%;
     width: 400px;

--- a/arches/app/media/js/bindings/c3.js
+++ b/arches/app/media/js/bindings/c3.js
@@ -31,7 +31,7 @@ define([
             }, this);
 
             // Handle disposal if KO removes an chart through template binding
-            ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
                 chart.destroy();
             }, this); 
         },

--- a/arches/app/media/js/bindings/c3.js
+++ b/arches/app/media/js/bindings/c3.js
@@ -25,10 +25,15 @@ define([
                     }
                 }
             });
-            this.chart = c3.generate(options);
+            var chart = c3.generate(options);
             config.data.subscribe(function(val){
                 this.chart.load({columns: val});
             }, this);
+
+            // Handle disposal if KO removes an chart through template binding
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                chart.destroy();
+            }, this); 
         },
     };
     return ko.bindingHandlers.c3;

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -115,9 +115,10 @@ define([
                 setTimeout(self.defaultSelector, 150);
             };
 
-            this.typeMatch = function(type){
+            this.typeMatch = function(type, ext, hastab){
                 var rawFileType = ko.unwrap(self.displayContent).type;
-                if (type === rawFileType) {
+                var rawExtension = ko.unwrap(self.displayContent).url.split('.').pop();
+                if (type === rawFileType && ext === rawExtension)  {
                     return true;
                 }
                 var splitFileType = ko.unwrap(self.displayContent).type.split('/');
@@ -147,7 +148,7 @@ define([
                     url: null,
                     file_id: null,
                     index: 0,
-                    content: URL.createObjectURL(file),
+                    content: window.URL.createObjectURL(file),
                     error: file.error
                 };
                 Object.keys(newtile.data).forEach(function(val){

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -438,6 +438,7 @@
                 {'name': '{{ renderer.name }}',
                 'component': '{{ renderer.component }}',
                 'type': '{{ renderer.type }}',
+                'ext': '{{ renderer.ext }}',
                 'hastab': '{{ renderer.hastab }}'},
                 {% endfor %}{% endautoescape %}];
     });

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -19,7 +19,7 @@
     <span class="map-sidebar-text">{% trans "Add" %}</span>
 </div>
 <!--ko foreach: fileFormatRenderers-->
-        <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type)) && $data.hastab -->
+        <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) && $data.hastab -->
         <div class="workbench-card-sidebar-tab" data-bind="click: function() {
         $parent.toggleTab('file-context');
     }, css: {
@@ -50,7 +50,7 @@
             <div id="hidden-dz-previews" style="display:none"></div>
             <!--ko if: displayContent() -->
                 <!--ko foreach: fileFormatRenderers-->
-                    <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type)) -->
+                    <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) -->
                         <!-- ko component: {
                             name: $data.name,
                             params: {
@@ -58,7 +58,8 @@
                                 selected: $parent.selected,
                                 state: $data.state,
                                 displayContent: ko.unwrap($parent.displayContent),
-                                context: 'render'
+                                context: 'render',
+                                loading: $parent.loading
                             }
                         } --> <!-- /ko -->
                     <!--/ko-->
@@ -325,7 +326,7 @@
 
 <!--ko if: activeTab() === 'file-context' -->
     <!--ko foreach: fileFormatRenderers-->
-         <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type)) && $data.hastab -->
+         <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) && $data.hastab -->
         <!-- ko component: {
             name: $data.name,
             params: {


### PR DESCRIPTION
Prevents file viewer content from appearing on top of workbench sidepanel. Disposes of c3 charts when no longer used. Adds support for three.js file extensions. re #5881