### PR TITLE
Uses file name in file widget display name with only 1 file uploaded, re #5881

### DIFF
--- a/arches/app/media/js/viewmodels/file-widget.js
+++ b/arches/app/media/js/viewmodels/file-widget.js
@@ -229,7 +229,7 @@ define([
         };
 
         this.displayValue = ko.computed(function() {
-            return self.uploadedFiles().length === 1 ? self.uploadedFiles()[0].name() : self.uploadedFiles().length; 
+            return self.uploadedFiles().length === 1 ? ko.unwrap(self.uploadedFiles()[0].name) : self.uploadedFiles().length; 
         });
 
         this.reportFiles = ko.computed(function() {

--- a/arches/app/media/js/viewmodels/file-widget.js
+++ b/arches/app/media/js/viewmodels/file-widget.js
@@ -229,7 +229,7 @@ define([
         };
 
         this.displayValue = ko.computed(function() {
-            return self.uploadedFiles().length;
+            return self.uploadedFiles().length === 1 ? self.uploadedFiles()[0].name() : self.uploadedFiles().length; 
         });
 
         this.reportFiles = ko.computed(function() {

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -145,7 +145,7 @@
     <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
 </div>
 
-<input type="text" class="form-control" style="width: 100%; height:initial" placeholder="Filter" data-bind="textInput: filter"></input>
+<input type="text" class="form-control" style="width: 100%; height:initial" placeholder="{% trans 'filter file list...' %}" data-bind="textInput: filter"></input>
 <div class='file-workbench-files'>
 <!-- ko foreach: { data: card.tiles(), as: 'tile'} -->
     <!--ko if: $parent.getUrl(tile) && ($parent.filter().length === 0 || $parent.isFiltered(tile)) -->

--- a/arches/app/templates/views/components/widgets/file.htm
+++ b/arches/app/templates/views/components/widgets/file.htm
@@ -189,5 +189,5 @@
 {% endblock report %}
 
 {% block display_value %}
-<span data-bind="text: displayValue() + ' {% trans "files uploaded" %}'"></span>
+<span data-bind="text: Number.isInteger(displayValue()) ? displayValue() + ' {% trans "files uploaded" %}' : displayValue()"></span>
 {% endblock display_value %}


### PR DESCRIPTION
If a file widget has only one file uploaded to its tile's node, the file name rather than the file count is used for the display name. re #5881