### PR TITLE
Prevent unintended re-rendering of file renderer components re #5881

### DIFF
--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -68,8 +68,6 @@ define([
                 return "unique_id_" + self.uniqueId;
             });
 
-            this.showThumbnails = ko.observable(false);
-
             this.selectDefault = function(){
                 var self = this;
                 return function() {
@@ -90,7 +88,9 @@ define([
                         return tile.selected() === true;
                     });
                 if (selected) {
-                    this.selected(selected);
+                    if (!this.selected() || (this.selected() && this.selected().tileid !== selected.tileid)) {
+                        this.selected(selected);
+                    }
                     file = this.getUrl(selected);
                 }
                 else {
@@ -105,7 +105,7 @@ define([
 
             this.selectItem = function(val){
                 if (val && val.selected) {
-                    if (ko.unwrap(val) !== true) {
+                    if (ko.unwrap(val) !== true && ko.unwrap(val.selected) !== true) {
                         val.selected(true);
                     }
                 }

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -48,6 +48,7 @@
     <div class="card-display-panel">
         <div>
             <div id="hidden-dz-previews" style="display:none"></div>
+
             <!--ko if: displayContent() -->
                 <!--ko foreach: fileFormatRenderers-->
                     <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) -->
@@ -234,6 +235,7 @@
                 <div data-bind="foreach: {
                         data: $parent.card.widgets, as: 'widget'
                     }">
+                    <!-- ko if: ko.unwrap(self.form.nodeLookup[widget.node_id()].datatype) !== 'file-list' -->
                     <div data-bind='component: {
                         name: self.form.widgetLookup[widget.widget_id()].name,
                         params: {
@@ -262,8 +264,9 @@
                         mouseout: function(){
                             if (self.preview) widget.hovered(null);
                         }
-                    }, visible: widget.visible && self.form.widgetLookup[widget.widget_id()].name !== "newfile-widget" && self.form.widgetLookup[widget.widget_id()].name !== "file-widget"'>
+                    }, visible: widget.visible'>
                 </div>
+                <!--/ko-->
                 </div>
             </form>
             <!--/ko-->
@@ -329,7 +332,7 @@
 
 <!--ko if: activeTab() === 'file-context' -->
     <!--ko foreach: fileFormatRenderers-->
-         <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) && $data.hastab -->
+         <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) -->
         <!-- ko component: {
             name: $data.name,
             params: {

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -50,15 +50,15 @@
             <div id="hidden-dz-previews" style="display:none"></div>
 
             <!--ko if: displayContent() -->
-                <!--ko foreach: fileFormatRenderers-->
-                    <!--ko if: ko.unwrap($parent.displayContent) && ($parent.typeMatch($data.type, $data.ext, $data.hastab)) -->
+            <!--ko foreach: fileFormatRenderers-->
+            <!--ko if: $parent.typeMatch($data.type, $data.ext, $data.hastab) -->
                         <!-- ko component: {
                             name: $data.name,
                             params: {
                                 card: $parent.card,
                                 selected: $parent.selected,
                                 state: $data.state,
-                                displayContent: ko.unwrap($parent.displayContent),
+                                displayContent: $parent.displayContent,
                                 context: 'render',
                                 loading: $parent.loading
                             }
@@ -339,7 +339,7 @@
                 card: $parent.card,
                 selected: $parent.selected,
                 state: $data.state,
-                displayContent: ko.unwrap($parent.displayContent),
+                displayContent: $parent.displayContent,
                 context: 'tab-contents'
             }
         } --> <!-- /ko -->

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -283,7 +283,7 @@
                 <!-- /ko -->
                 <!-- ko if: tile.dirty() -->
                     <!-- ko if: $parent.provisionalTileViewModel && !$parent.provisionalTileViewModel.tileIsFullyProvisional() && $parent.card.isWritable -->
-                    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: selected().reset">{% trans 'Cancel' %}</button>
+                    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: function(){tile.reset()}">{% trans 'Cancel' %}</button>
                     <!-- /ko -->
                     <!-- ko if: tile.tileid -->
                     <button class="btn btn-shim btn-labeled btn-lg fa fa-plus" data-bind="click: tile.save, css: {


### PR DESCRIPTION
Prevents unintended re-rendering of file renderer components when other tile values are edited and when the edit tab is opened. re #5881