### PR TITLE
File viewer bug fixes. re #5881

### DIFF
--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -208,6 +208,19 @@ define([
                 val.deleteTile(null, self.defaultSelector);
             };
 
+            if (this.card.resourceinstanceid === undefined) {
+                this.card.resourceinstanceid = uuid.generate();
+            }
+
+            function sleep(milliseconds) {
+                var start = new Date().getTime();
+                for (var i = 0; i < 1e7; i++) {
+                    if ((new Date().getTime() - start) > milliseconds){
+                        break;
+                    }
+                }
+            }
+
             this.addTile = function(file){
                 var newtile;
                 newtile = self.card.getNewTile();
@@ -236,6 +249,10 @@ define([
                 });
                 newtile.data[targetNode]([tilevalue]);
                 newtile.formData.append('file-list_' + targetNode, file, file.name);
+                newtile.resourceinstance_id = self.card.resourceinstanceid;
+                if (self.card.tiles().length === 0) {
+                    sleep(50);
+                }
                 newtile.save();
                 self.card.newTile = undefined;
             };

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -49,6 +49,10 @@ define([
 
             this.fileListNodeId = getfileListNode();
 
+            this.displayWidgetIndex = self.card.widgets().indexOf(self.card.widgets().find(function(widget) {
+                return widget.datatype.datatype === 'file-list';
+            }));
+
             WorkbenchComponentViewModel.apply(this, [params]);
 
             if (this.card && this.card.activeTab) {

--- a/arches/app/templates/views/components/cards/file-viewer.htm
+++ b/arches/app/templates/views/components/cards/file-viewer.htm
@@ -5,3 +5,84 @@
 {% block form %}
 {% include 'views/components/file-workbench.htm' %}
 {% endblock form %}
+
+{% block editor_tree %}
+<li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded()), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0}, scrollTo: card.scrollTo, container: '.resource-editor-tree'">
+    <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}"></i>
+    <a class="jstree-anchor" href="#" tabindex="-1" data-bind="css:{'filtered': card.highlight(), 'jstree-clicked': card.selected, 'child-selected': card.isChildSelected(), 'func-node': card.isFuncNode(),'unsaved-edit': card.isDirty() === true}, event: {
+        mousedown: function(d, e) {
+            e.stopPropagation();
+            card.canAdd() ? card.selected(true) : card.tiles()[0].selected(true);
+        }
+    }">
+        <!-- ko if: !card.isFuncNode() -->
+        <i class="fa fa-file-o" role="presentation" data-bind="css:{'filtered': card.highlight(), 'has-provisional-edits fa-file': card.doesChildHaveProvisionalEdits()}"></i>
+        <!-- /ko -->
+        <!-- ko if: card.isFuncNode() -->
+        <i class="fa fa-code" role="presentation" data-bind="css:{'filtered': card.highlight(), 'has-provisional-edits fa-file': card.doesChildHaveProvisionalEdits()}"></i>
+        <!-- /ko -->
+        <span style="padding-right: 5px;" data-bind="text: card.model.name"></span>
+        <!-- ko if: card.canAdd() -->
+        <i class="fa fa-plus-circle add-new-tile" role="presentation" data-bind="css:{'jstree-clicked': card.selected}" data-toggle="tooltip" data-original-title="{% trans "Add New" %}"></i>
+        <!-- /ko -->
+    </a>
+    <ul class="jstree-children" aria-expanded="true">
+        <div data-bind="sortable: {
+            data: card.tiles,
+            options: {
+                start: self.startDrag
+            },
+            beforeMove: self.beforeMove,
+            afterMove: card.reorderTiles
+        }">
+            <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0}, event: {'dragstart': function () { console.log('dragging...') }}">
+                <i class="jstree-icon jstree-ocl" role="presentation" data-bind="click: function(){expanded(!expanded())}"></i>
+                <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.form.selection($data);}, css:{'jstree-clicked': selected, 'child-selected': isChildSelected(), 'filtered-leaf': card.highlight(), 'unsaved-edit': !!$data.dirty()}">
+                    <i class="fa " role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits(),'fa-pencil':$data.dirty()===true,'fa-file':!$data.dirty()}"></i>
+                    <strong style="margin-right: 10px;">
+                        {% block editor_tree_node_content %}
+                        <!-- ko if: card.widgets().length > 0 && card.widgets()[$parent.displayWidgetIndex].visible -->
+                        <span data-bind="text: card.widgets()[$parent.displayWidgetIndex].label || card.model.name"></span>:
+                        <div style="display: inline;" data-bind="component: {
+                            name: self.form.widgetLookup[card.widgets()[$parent.displayWidgetIndex].widget_id()].name,
+                            params: {
+                                tile: $data,
+                                node: self.form.nodeLookup[card.widgets()[$parent.displayWidgetIndex].node_id()],
+                                config: self.form.widgetLookup[card.widgets()[$parent.displayWidgetIndex].widget_id()].config,
+                                label: self.form.widgetLookup[card.widgets()[$parent.displayWidgetIndex].widget_id()].label,
+                                value: $data.data[card.widgets()[$parent.displayWidgetIndex].node_id()],
+                                type: 'resource-editor',
+                                state: 'display_value',
+                                disabled: !card.isWritable && !self.preview
+                            }
+                        }"></div>
+                        <!-- /ko -->
+                        <!-- ko if: card.widgets().length === 0 || !card.widgets()[$parent.displayWidgetIndex].visible -->
+                        <span data-bind="text: card.model.name"></span>
+                        <!-- /ko -->
+                        {% endblock editor_tree_node_content %}
+                    </strong>
+                </a>
+                <!-- ko if: cards.length > 0 -->
+                <ul class="jstree-children" aria-expanded="true" data-bind="foreach: {
+                        data: cards,
+                        as: 'card'
+                    }">
+                    <!-- ko component: {
+                        name: self.form.cardComponentLookup[card.model.component_id()].componentname,
+                        params: {
+                            state: 'editor-tree',
+                            card: card,
+                            tile: null,
+                            loading: self.loading,
+                            form: self.form,
+                            pageVm: $root
+                        }
+                    } --> <!-- /ko -->
+                </ul>
+                <!-- /ko -->
+            </li>
+        </div>
+    </ul>
+</li>
+{% endblock editor_tree %}

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -232,9 +232,9 @@
             disabled: false,
             data: fileFormatRenderers,
             value: fileRenderer,
+            allowClear: false,
             multiple: false,
-            placeholder: 'File Renderer'
-        }}">
+            placeholder: {% trans "'File Renderer'" %}}}">
 </div>
 
 <div data-bind="css: card.model.cssclass">

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -102,7 +102,7 @@
                                                     <!-- card Tools -->
                                                     <div class="r-select-card-footer">
                                                         <div class="">
-                                                            <div data-bind="click: $parent.applyFileRenderer" style="border-top: 1px solid #c4c4c4;" class="btn btn-primary btn-resource-select" role="button">
+                                                            <div data-bind="click: function(){$parent.applyFileRenderer($data)}" style="border-top: 1px solid #c4c4c4;" class="btn btn-primary btn-resource-select" role="button">
                                                             {% trans 'Select and Apply' %}
                                                             </div>
                                                         </div>
@@ -234,6 +234,7 @@
             value: fileRenderer,
             allowClear: false,
             multiple: false,
+            onSelect: $parent.applyFileRenderer,
             placeholder: {% trans "'File Renderer'" %}}}">
 </div>
 

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -103,8 +103,7 @@ class TileData(View):
                     try:
                         resource = Resource(uuid.UUID(data["resourceinstance_id"]))
                     except ValueError:
-                    resource = Resource()
-
+                        resource = Resource()
                     graphid = models.Node.objects.filter(nodegroup=data["nodegroup_id"])[0].graph_id
                     resource.graph_id = graphid
                     try:

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -100,7 +100,11 @@ class TileData(View):
                 try:
                     models.ResourceInstance.objects.get(pk=data["resourceinstance_id"])
                 except ObjectDoesNotExist:
+                    try:
+                        resource = Resource(uuid.UUID(data["resourceinstance_id"]))
+                    except ValueError:
                     resource = Resource()
+
                     graphid = models.Node.objects.filter(nodegroup=data["nodegroup_id"])[0].graph_id
                     resource.graph_id = graphid
                     try:


### PR DESCRIPTION
Prevents multiple resource instances from getting created when a user uploads multiple files in the file viewer card before a target instance is created. Fixes display of file name in card tree. Allows user to switch file renderer after it has already been assigned. re #5881