### PR TITLE
Removes the photo gallery card during migration re #4751

### DIFF
--- a/arches/app/models/migrations/4751_adds_photo_gallery_card.py
+++ b/arches/app/models/migrations/4751_adds_photo_gallery_card.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql="""
+            DELETE FROM card_components WHERE componentid = '4e40b397-d6bc-4660-a398-4a72c90dba07';
             INSERT INTO card_components(componentid, name, description, component, componentname, defaultconfig)
                 VALUES ('4e40b397-d6bc-4660-a398-4a72c90dba07', 'Photo Gallery Card', 'Photo gallery card UI', 'views/components/cards/photo-gallery-card', 'photo-gallery-card', '{}');
             """,


### PR DESCRIPTION
Removes the photo gallery card during migration if it already exists in the project database. re #4751