### PR TITLE
gets acceptedFiles from widget corresponding to fileListNodeId, condi…

### DIFF
--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -215,7 +215,6 @@ define([
                     self.activeTab(openTab);
                 };
             };
-
             this.defaultSelector = this.selectDefault();
 
             this.checkIfRendererIsValid = function(file, renderer){

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -61,6 +61,7 @@ define([
             };
 
             this.fileListNodeId = getfileListNode();
+            this.acceptedFiles = ko.observable(null);
 
             this.displayWidgetIndex = self.card.widgets().indexOf(self.card.widgets().find(function(widget) {
                 return widget.datatype.datatype === 'file-list';
@@ -375,12 +376,24 @@ define([
                 self.card.newTile = undefined;
             };
 
+            this.getWidgetConfig = function(){
+                self.card.widgets().forEach(function(w) {
+                    if (w.node_id() === self.fileListNodeId) {
+                        if (ko.unwrap(w.attributes.config.acceptedFiles)) {
+                            self.acceptedFiles(ko.unwrap(w.attributes.config.acceptedFiles));
+                        }
+                    }
+                });
+            };
+            this.getWidgetConfig();
+
             this.dropzoneOptions = {
                 url: "arches.urls.root",
                 dictDefaultMessage: '',
                 autoProcessQueue: false,
                 uploadMultiple: true,
                 autoQueue: false,
+                acceptedFiles: self.acceptedFiles(),
                 clickable: ".fileinput-button." + this.uniqueidClass(),
                 previewsContainer: '#hidden-dz-previews',
                 init: function() {

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -158,7 +158,12 @@
 
                </div>
                <div class="file-upload-footer">
+                   <!-- ko if: acceptedFiles() !== null -->
+                   <span data-bind="text: ('Files formatted as '+acceptedFiles()+' may be uploaded.')"></span>
+                   <!-- /ko -->
+                   <!-- ko if: acceptedFiles() === null -->
                    <span>{% trans 'Images formatted as .jpg, .png, .tiff files may be uploaded. Other formats may require a loader.' %}</span>
+                   <!-- /ko -->
                </div>
            </div>
 


### PR DESCRIPTION
…tionally shows in widget UI instruction, sends to dropzoneOptions for file upload, re #6013

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
If a user specifies acceptable filetypes in the widget config via the card manager, this gets passed from the widget config to the dropzone config in the file-viewer card component.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6013

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
