### PR TITLE
Expands provisional edit tabs in workbench cards, re archesproject/arches-for-science#79

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -926,11 +926,9 @@ ul.tabbed-report-tab-list {
 
 .file-workbench-filter {
     position: relative;
-    margin-top: 60px;
+    margin-top: 25px;
     margin-bottom: -10px;
 }
-
-
 
 .file-workbench-filter .clear-node-search {
     margin-top: 25px;
@@ -954,7 +952,6 @@ ul.tabbed-report-tab-list {
     color: steelblue;
     font-size: 11px;
     padding-left: 5px;
-    margin-bottom: 0px;
 }
 
 .file-workbench-files::-webkit-scrollbar {
@@ -1453,7 +1450,8 @@ ul.tabbed-report-tab-list {
 }
 
 .workbench-card-sidepanel.expanded {
-    width: 600px
+    width: 600px;
+    z-index: 1001;
 }
 
 .basemap-listing, .overlay-listing, .legend-listing {
@@ -1571,8 +1569,11 @@ ul.tabbed-report-tab-list {
 }
 
 .workbench-sidepanel-card-container {
-    margin: -40px -10px 10px -10px;
+    /* margin: -40px -10px 10px -10px; */
+}
 
+.workbench-sidepanel-body {
+    margin-top: 50px;
 }
 
 .workbench-card-sidepanel .install-buttons {
@@ -1588,7 +1589,7 @@ ul.tabbed-report-tab-list {
 }
 
 .workbench-card-sidepanel.expanded .install-buttons {
-    width: 599px
+    width: 599px;
 }
 
 .workbench-card-sidepanel div .new-provisional-edit-card-container {
@@ -1611,7 +1612,13 @@ ul.tabbed-report-tab-list {
 }
 
 .expanded .workbench-card-sidepanel-header-container {
-    width: 582px;
+    width: 599px;
+    margin-left: -16px;
+    padding-left: 15px;
+}
+
+.workbench-header-buffer {
+    height: 40px
 }
 
 .workbench-card-sidepanel-header {
@@ -5744,8 +5751,8 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 .workbench-card-sidepanel.expanded .edit-message-container {
     z-index: 5000;
     width: 600px;
-    margin-top: 60px;
-    margin-left: -7px;
+    margin-top: 8px;
+    margin-left: -16px;
 }
 
 .edit-message-container .reset-authoritative {
@@ -5784,7 +5791,7 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 }
 
 .workbench-card-sidepanel.expanded .new-provisional-edits-list {
-    margin-right: -10px;
+    margin-right: -16px;
 }
 
 .new-provisional-edit-card-container {

--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -1508,6 +1508,11 @@ ul.tabbed-report-tab-list {
     border-top: 1px solid #ddd;
 }
 
+.workbench-card-wrapper.autoheight {
+    height: auto;
+    min-height: 100%;
+}
+
 .card-component-wrapper-editor .workbench-card-wrapper {
     border-top: 1px solid #041B33;
 }
@@ -1582,12 +1587,15 @@ ul.tabbed-report-tab-list {
     padding-left: 35px;
 }
 
+.workbench-card-sidepanel.expanded .install-buttons {
+    width: 599px
+}
+
 .workbench-card-sidepanel div .new-provisional-edit-card-container {
     padding-left: 5px;
 }
 
 .workbench-card-sidepanel .new-provisional-edit-card-container {
-    margin-top: 55px;
     padding-bottom: 40px;
 }
 
@@ -1600,6 +1608,10 @@ ul.tabbed-report-tab-list {
     background: #fff;
     z-index: 20;
     width: 370px;
+}
+
+.expanded .workbench-card-sidepanel-header-container {
+    width: 582px;
 }
 
 .workbench-card-sidepanel-header {
@@ -5724,16 +5736,16 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     border-bottom: 1px solid #FFB700;
     height: 50px;
     margin-top: -25px;
-    margin-bottom: 15px;
     margin-left: -35px;
     margin-right: -35px;
     padding: 15px 25px;
 }
 
 .workbench-card-sidepanel.expanded .edit-message-container {
-    margin-top: -15px;
-    margin-left: -20px;
-    margin-right: -20px;
+    z-index: 5000;
+    width: 600px;
+    margin-top: 60px;
+    margin-left: -7px;
 }
 
 .edit-message-container .reset-authoritative {
@@ -5762,7 +5774,6 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 .new-provisional-edits-list {
     display: flex;
     flex-direction: column;
-    top: -15px;
     position: relative;
     margin-right: -50px;
     width: 250px;
@@ -5773,7 +5784,7 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 }
 
 .workbench-card-sidepanel.expanded .new-provisional-edits-list {
-    margin-right: -30px;
+    margin-right: -10px;
 }
 
 .new-provisional-edit-card-container {
@@ -5784,6 +5795,7 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
 
 .new-provisional-edit-card-container .card {
     width: 100%;
+    padding-top: 15px;
 }
 
 
@@ -5824,7 +5836,7 @@ ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
     height: 40px;
     margin-left: -5px;
     /*margin-right: -40px;*/
-    margin-top: -5px;
+    /* margin-top: -5px; */
     padding: 10px 25px 10px 10px;
     height: 80px;
 }

--- a/arches/app/media/js/viewmodels/card.js
+++ b/arches/app/media/js/viewmodels/card.js
@@ -75,6 +75,7 @@ define([
         var loading = params.loading || ko.observable();
         var perms = ko.observableArray();
         var permsLiteral = ko.observableArray();
+        var allowProvisionalEditRerender = ko.observable(true);
         var nodegroups = params.graphModel.get('nodegroups');
         var multiselect = params.multiselect || false;
         var isWritable = params.card.is_writable || false;
@@ -147,6 +148,7 @@ define([
             isWritable: isWritable,
             model: cardModel,
             appliedFunctions: appliedFunctions,
+            allowProvisionalEditRerender: allowProvisionalEditRerender,
             multiselect: params.multiselect,
             widgets: cardModel.widgets,
             parent: params.tile,

--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -93,7 +93,7 @@ define([
                 self.selectedTile().parent.widgets().forEach(
                     function(w){
                         var defaultconfig = w.widgetLookup[w.widget_id()].defaultconfig;
-                        if (JSON.parse(defaultconfig).rerender === true) {
+                        if (JSON.parse(defaultconfig).rerender === true && self.selectedTile().parent.allowProvisionalEditRerender() === true) {
                             self.selectedTile().parent.widgets()[0].label.valueHasMutated();
                         }
                     });

--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -106,7 +106,7 @@ define([
         };
 
         self.tileIsFullyProvisional = ko.computed(function() {
-            return self.selectedProvisionalEdit() && self.selectedProvisionalEdit().isfullyprovisional() === true;
+            return self.selectedProvisionalEdit() && ko.unwrap(self.selectedProvisionalEdit().isfullyprovisional) === true;
         });
 
         self.updateProvisionalEdits(self.selectedTile);

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -67,6 +67,7 @@ define([
             }));
 
             WorkbenchComponentViewModel.apply(this, [params]);
+            this.workbenchWrapperClass = ko.observable('autoheight');
 
             if (this.card && this.card.activeTab) {
                 self.activeTab(this.card.activeTab);

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -99,35 +99,37 @@ define([
                     return item.id === rendererid;
                 });
             };
-
-            this.card.staging.subscribe(function(){
-                var compatible = [];
-                var compatibleIds = [];
-                var allCompatible = true;
-                var staging = self.card ? self.card.staging() : [];
-                var staged = self.card.tiles().filter(function(tile){
-                    return staging.indexOf(tile.tileid) >= 0;  
+            
+            if (!this.card.checkrenderers) {
+                this.card.checkrenderers = this.card.staging.subscribe(function(){
+                    var compatible = [];
+                    var compatibleIds = [];
+                    var allCompatible = true;
+                    var staging = self.card ? self.card.staging() : [];
+                    var staged = self.card.tiles().filter(function(tile){
+                        return staging.indexOf(tile.tileid) >= 0;  
+                    });
+                    staged.forEach(function(tile){
+                        var file = tile.data[self.fileListNodeId]()[0];
+                        var defaultRenderers = self.getDefaultRenderers(ko.unwrap(file.type), ko.unwrap(file.name));
+                        if (compatible.length === 0) {
+                            compatible = defaultRenderers;
+                            compatibleIds = compatible.map(function(x){return x.id;});
+                        } else {
+                            allCompatible = defaultRenderers.every(function(renderer){
+                                return compatibleIds.indexOf(renderer.id) > -1;
+                            }); 
+                        }
+                    });
+                    self.fileFormatRenderers.forEach(function(r){
+                        if (compatibleIds.indexOf(r.id) === -1 || allCompatible === false) {
+                            r.disabled = true;
+                        } else {
+                            r.disabled = false;
+                        }
+                    });
                 });
-                staged.forEach(function(tile){
-                    var file = tile.data[self.fileListNodeId]()[0];
-                    var defaultRenderers = self.getDefaultRenderers(ko.unwrap(file.type), ko.unwrap(file.name));
-                    if (compatible.length === 0) {
-                        compatible = defaultRenderers;
-                        compatibleIds = compatible.map(function(x){return x.id;});
-                    } else {
-                        allCompatible = defaultRenderers.every(function(renderer){
-                            return compatibleIds.indexOf(renderer.id) > -1;
-                        }); 
-                    }
-                });
-                self.fileFormatRenderers.forEach(function(r){
-                    if (compatibleIds.indexOf(r.id) === -1 || allCompatible === false) {
-                        r.disabled = true;
-                    } else {
-                        r.disabled = false;
-                    }
-                });
-            });
+            }
 
 
             this.getDefaultRenderers = function(type, file){

--- a/arches/app/media/js/views/components/cards/map.js
+++ b/arches/app/media/js/views/components/cards/map.js
@@ -52,6 +52,8 @@ define([
             }
         });
 
+        this.card.allowProvisionalEditRerender(false);
+
         if (!this.card.overlaysObservable) {
             this.card.overlaysObservable = this.overlays;
             this.card.activeBasemap = this.activeBasemap;

--- a/arches/app/media/js/views/components/workbench.js
+++ b/arches/app/media/js/views/components/workbench.js
@@ -13,6 +13,14 @@ define([
             self.activeTab(undefined);
         };
         this.card.allowProvisionalEditRerender(false);
+        this.expandSidePanel = ko.computed(function(){
+            if (self.tile) {
+                return self.tile.hasprovisionaledits() && self.reviewer === true;
+            } else {
+                return false;
+            }
+        });
+        this.workbenchWrapperClass = ko.observable();
 
         this.toggleTab = function(tabName) {
             if (self.activeTab() === tabName) {

--- a/arches/app/media/js/views/components/workbench.js
+++ b/arches/app/media/js/views/components/workbench.js
@@ -12,7 +12,11 @@ define([
         this.hideSidePanel = function() {
             self.activeTab(undefined);
         };
-        this.card.allowProvisionalEditRerender(false);
+
+        if (this.card) {
+            this.card.allowProvisionalEditRerender(false);
+        }
+
         this.expandSidePanel = ko.computed(function(){
             if (self.tile) {
                 return self.tile.hasprovisionaledits() && self.reviewer === true;
@@ -20,6 +24,7 @@ define([
                 return false;
             }
         });
+        
         this.workbenchWrapperClass = ko.observable();
 
         this.toggleTab = function(tabName) {

--- a/arches/app/media/js/views/components/workbench.js
+++ b/arches/app/media/js/views/components/workbench.js
@@ -12,6 +12,7 @@ define([
         this.hideSidePanel = function() {
             self.activeTab(undefined);
         };
+        this.card.allowProvisionalEditRerender(false);
 
         this.toggleTab = function(tabName) {
             if (self.activeTab() === tabName) {

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -325,7 +325,7 @@
             <!-- ko if: card.widgets().length > 0 -->
             {% block form_widgets %}
             <!-- ko foreach: { data: card.tiles(), as: 'tile'} -->
-                <!--ko if: $parent.getUrl(tile) && tile.selected()-->
+                <!--ko if: $parent.getUrl(tile) && tile.selected() -->
             <form class="widgets" style="margin-bottom: 20px;">
                 <div data-bind="foreach: {
                         data: $parent.card.widgets, as: 'widget'

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -233,8 +233,10 @@
 <!--/ko-->
 
 <!--ko if: activeTab() === 'edit' -->
-<div class="workbench-card-sidepanel-header-container file-workbench">
-    <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
+<div class="workbench-header-buffer">
+    <div class="workbench-card-sidepanel-header-container">
+        <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
+    </div>
 </div>
 <div class="file-workbench-filter">
     <h2 class="file-workbench-filter-header">File Filter</h2>
@@ -423,6 +425,7 @@
         </div>
     </div>
 </div>
+
 <!--/ko-->
 
 <!--ko foreach: fileFormatRenderers-->

--- a/arches/app/templates/views/components/iiif-annotation.htm
+++ b/arches/app/templates/views/components/iiif-annotation.htm
@@ -15,10 +15,11 @@
 
 {% block sidepanel %}
 <!--ko if: activeTab() === 'editor' -->
-    <div class="workbench-card-sidepanel-header-container">
-        <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
+    <div class="workbench-header-buffer">
+        <div class="workbench-card-sidepanel-header-container">
+            <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
+        </div>
     </div>
-
     <div data-bind="css: card.model.cssclass">
 
         <!-- ko if: reviewer && provisionalTileViewModel.selectedProvisionalEdit() -->
@@ -336,6 +337,7 @@
             </div>
         </div>
     </div>
+
 <!--/ko -->
 {{ block.super }}
 {% endblock sidepanel %}

--- a/arches/app/templates/views/components/map-editor.htm
+++ b/arches/app/templates/views/components/map-editor.htm
@@ -15,14 +15,15 @@
 
 {% block sidepanel %}
 <!--ko if: activeTab() === 'editor' -->
-    <div class="workbench-card-sidepanel-header-container">
-        <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
+    <div class="workbench-header-buffer">
+        <div class="workbench-card-sidepanel-header-container">
+            <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: card.model.name"></h4>
+        </div>
     </div>
-
     <div data-bind="css: card.model.cssclass">
 
         <!-- ko if: reviewer && provisionalTileViewModel.selectedProvisionalEdit() -->
-        <div class="edit-message-container" style="margin-left: -16px; margin-top: 48px;">
+        <div class="edit-message-container" style="margin-left: -16px;">
             <span>{% trans 'Showing edits by' %}</span>
             <span class="edit-message-container-user" data-bind="text: provisionalTileViewModel.selectedProvisionalEdit().username() + '.'"></span>
             <!-- ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
@@ -35,7 +36,7 @@
         <!-- /ko-->
 
         <!-- ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 && !provisionalTileViewModel.selectedProvisionalEdit()-->
-        <div class="edit-message-container approved" style="margin-left: -16px; margin-top: 48px;">
+        <div class="edit-message-container approved" style="margin-left: -16px;">
             <div>{% trans 'Currently showing the most recent approved edits' %}</div>
         </div>
         <!-- /ko-->

--- a/arches/app/templates/views/components/map-editor.htm
+++ b/arches/app/templates/views/components/map-editor.htm
@@ -22,7 +22,7 @@
     <div data-bind="css: card.model.cssclass">
 
         <!-- ko if: reviewer && provisionalTileViewModel.selectedProvisionalEdit() -->
-        <div class="edit-message-container">
+        <div class="edit-message-container" style="margin-left: -16px; margin-top: 48px;">
             <span>{% trans 'Showing edits by' %}</span>
             <span class="edit-message-container-user" data-bind="text: provisionalTileViewModel.selectedProvisionalEdit().username() + '.'"></span>
             <!-- ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
@@ -35,7 +35,7 @@
         <!-- /ko-->
 
         <!-- ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 && !provisionalTileViewModel.selectedProvisionalEdit()-->
-        <div class="edit-message-container approved">
+        <div class="edit-message-container approved" style="margin-left: -16px; margin-top: 48px;">
             <div>{% trans 'Currently showing the most recent approved edits' %}</div>
         </div>
         <!-- /ko-->
@@ -45,7 +45,7 @@
         <div class="new-provisional-edit-card-container">
             <!-- ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 -->
             <!-- ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
-            <div class='new-provisional-edits-list'>
+            <div class='new-provisional-edits-list' style="margin-right: -20px">
                 <div class='new-provisional-edits-header'>
                     <div class='new-provisional-edits-title'>{% trans 'Provisional Edits' %}</div>
                     <div class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all" style="padding: 3px;" data-bind="click: function(){

--- a/arches/app/templates/views/components/workbench.htm
+++ b/arches/app/templates/views/components/workbench.htm
@@ -1,12 +1,12 @@
 {% load i18n %}
 
-<div class="workbench-card-wrapper">
+<div class="workbench-card-wrapper" data-bind="class: ko.unwrap(workbenchWrapperClass)">
     <div class="workbench-card-sidebar">
         {% block tabs %}
         {% endblock tabs %}
     </div>
     <!--ko if: activeTab() -->
-    <div class="workbench-card-sidepanel">
+    <div class="workbench-card-sidepanel" data-bind="css:{'expanded': expandSidePanel()}">
     {% block sidepanel %}
     {% endblock sidepanel %}
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
Expands provisional edit tabs in workbench cards, resolves css issues with provisional banners, extends file viewer to height of large images, and fixes issue with provisional edits not loading for review.  re #6021, archesproject/arches-for-science#79