### PR TITLE
Resolves provisional edit error in file viewer

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -22,6 +22,10 @@
 @import url(../packages/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css);
 
 
+img {
+    image-orientation: from-image;
+}
+
 .regular-link {
     color: #337ab7;
     text-decoration: none;

--- a/arches/app/media/js/viewmodels/card.js
+++ b/arches/app/media/js/viewmodels/card.js
@@ -166,7 +166,7 @@ define([
                 var provisionalindex;
                 var summary = _.map(this.tiles(), function(tile){
                     var dataEmpty = _.keys(koMapping.toJS(tile.data)).length === 0;
-                    if (tile.provisionaledits() !== null && dataEmpty) {
+                    if (ko.unwrap(tile.provisionaledits) !== null && dataEmpty) {
                         return 2;
                     } else if (tile.provisionaledits() !== null && !dataEmpty) {
                         return 1;


### PR DESCRIPTION
Fixes error when saving provisional edits and fixes image rotation in the file viewer for FF and future versions of Chrome. re archesproject/arches-for-science#81, archesproject/arches-for-science#82