### PR TITLE
Resolves error if same domain applied to different nodes

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1366,6 +1366,7 @@ class DomainDataType(BaseDomainDataType):
                             is mapped to for a list of valid domain ids. This data was not imported.",
                         }
                     )
+                """
                 elif len(domain_val_node_query) > 1:
                     errors.append(
                         {
@@ -1374,6 +1375,7 @@ class DomainDataType(BaseDomainDataType):
                         Please use an explicit id instead of a domain string value. This data was not imported.",
                         }
                     )
+                """
         return errors
 
     def get_search_terms(self, nodevalue, nodeid=None):

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1033,11 +1033,6 @@ class FileListDataType(BaseDataType):
                 node = models.Node.objects.get(nodeid=nodeid)
                 self.node_lookup[str(nodeid)] = node
 
-        config = node.config
-        errors = []
-        limit = config["maxFiles"]
-        max_size = config["maxFileSize"] if "maxFileSize" in config.keys() else None
-
         def format_bytes(size):
             # 2**10 = 1024
             power = 2 ** 10
@@ -1048,7 +1043,12 @@ class FileListDataType(BaseDataType):
                 n += 1
             return size, power_labels[n] + "bytes"
 
+        errors = []
         try:
+            config = node.config
+            limit = config["maxFiles"]
+            max_size = config["maxFileSize"] if "maxFileSize" in config.keys() else None
+
             if value is not None and config["activateMax"] is True and len(value) > limit:
                 errors.append({"type": "ERROR", "message": f"This node has a limit of {limit} files. Please reduce files."})
 


### PR DESCRIPTION
Allows same domain values to be used on different nodes and prevents error if file datatype is missing configs value.