### PR TITLE
Handles for image mime (tif and psd) that are not browser supported

### DIFF
--- a/arches/app/media/js/viewmodels/card.js
+++ b/arches/app/media/js/viewmodels/card.js
@@ -405,7 +405,7 @@ define([
                 if(self.newTile.dirty()) { 
                     var res = {};
                     self.widgets().forEach(function(w){
-                        res[w.node.nodeid] = w.config.defaultValue();
+                        res[w.node.nodeid] = ko.unwrap(w.config.defaultValue);
                     });
                     for (var k in self.newTile.data) {
                         if (Object.keys(res).indexOf(k) > -1) {

--- a/arches/app/media/js/viewmodels/file-widget.js
+++ b/arches/app/media/js/viewmodels/file-widget.js
@@ -24,6 +24,8 @@ define([
         this.uploadMulti = ko.observable(true);
         this.filesForUpload = ko.observableArray();
         this.uploadedFiles = ko.observableArray();
+        this.unsupportedImageTypes = ['tif', 'tiff', 'vnd.adobe.photoshop'];
+
 
         if (this.form) {
             this.form.on('after-update', function(req, tile) {
@@ -234,13 +236,15 @@ define([
 
         this.reportFiles = ko.computed(function() {
             return self.uploadedFiles().filter(function(file) {
-                return ko.unwrap(file.type).indexOf('image') < 0;
+                var ext = ko.unwrap(file.type).split('/').pop();
+                return ko.unwrap(file.type).indexOf('image') < 0 || self.unsupportedImageTypes.indexOf(ext) > -1;
             });
         });
 
         this.reportImages = ko.computed(function() {
             return self.uploadedFiles().filter(function(file) {
-                return ko.unwrap(file.type).indexOf('image') >= 0;
+                var ext = ko.unwrap(file.type).split('/').pop();
+                return ko.unwrap(file.type).indexOf('image') >= 0 && self.unsupportedImageTypes.indexOf(ext) <= 0;
             });
         });
     };

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -409,7 +409,6 @@ define([
                     });
                     this.on("addedfile", self.addTile, self);
                     this.on("error", function(file, error) {
-                        console.log('error', error)
                         file.error = error;
                     });
                 }

--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -134,6 +134,7 @@ define([
             this.getDefaultRenderers = function(type, file){
                 var defaultRenderers = [];
                 this.fileFormatRenderers.forEach(function(renderer){
+                    var excludeExtensions = renderer.exclude ? renderer.exclude.split(",") : [];
                     var rawFileType = type;
                     var rawExtension = file.url ? ko.unwrap(file.url).split('.').pop() : ko.unwrap(file).split('.').pop();
                     if (renderer.type === rawFileType && renderer.ext === rawExtension)  {
@@ -144,7 +145,7 @@ define([
                     var splitAllowableType = renderer.type.split('/');
                     var allowableType = splitAllowableType[0];
                     var allowableSubType = splitAllowableType[1];
-                    if (allowableSubType === '*' && fileType === allowableType) {
+                    if (allowableSubType === '*' && fileType === allowableType && excludeExtensions.indexOf(rawExtension) < 0) {
                         defaultRenderers.push(renderer);
                     }
                 }); 
@@ -408,6 +409,7 @@ define([
                     });
                     this.on("addedfile", self.addTile, self);
                     this.on("error", function(file, error) {
+                        console.log('error', error)
                         file.error = error;
                     });
                 }

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -432,6 +432,7 @@
                 'text': '{{ renderer.title }}',
                 'type': '{{ renderer.type }}',
                 'ext': '{{ renderer.ext }}',
+                'exclude': '{{ renderer.exclude }}',
                  },
                 {% endfor %}{% endautoescape %}];
     });

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -557,6 +557,7 @@ RENDERERS = [
         "component": "views/components/cards/file-renderers/imagereader",
         "ext": "",
         "type": "image/*",
+        "exclude": "tif,tiff,psd"
     }
 ]
 


### PR DESCRIPTION
Fix applied in the file widget report and file viewer. re archesproject/arches-for-science#88
