### PR TITLE
Minimally fix filelist datatype

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1203,6 +1203,27 @@ class FileListDataType(BaseDataType):
         result = json.loads(json.dumps(tile_data))
         return result
 
+    def is_a_literal_in_rdf(self):  
+        return False
+
+    def get_rdf_uri(self, node, data, which="r"):
+        if type(data) == list:
+            l = []
+            for x in data:
+                if x["url"].startswith("/"):
+                    l.append(URIRef(archesproject[x["url"][1:]]))
+                else:
+                    l.append(URIRef(archesproject[x["url"]]))
+            return l
+        elif data:
+            if data["url"].startswith("/"):
+                return URIRef(archesproject[data["url"][1:]])
+            else:
+                return URIRef(archesproject[data["url"]])        
+        else:
+            return node
+
+
     def to_rdf(self, edge_info, edge):
         # outputs a graph holding an RDF representation of the file stored in the Arches instance
 
@@ -1233,10 +1254,10 @@ class FileListDataType(BaseDataType):
 
         def add_dimension(graphobj, domain_uri, unittype, unit, value):
             dim_node = BNode()
-            graphobj.add((domain_uri, cidoc["P43_has_dimension"], dim_node))
-            graphobj.add((dim_node, RDF.type, cidoc["E54_Dimension"]))
-            graphobj.add((dim_node, cidoc["P2_has_type"], aatrefs[unittype]))
-            graphobj.add((dim_node, cidoc["P91_has_unit"], aatrefs[unit]))
+            graphobj.add((domain_uri, cidoc_nm["P43_has_dimension"], dim_node))
+            graphobj.add((dim_node, RDF.type, cidoc_nm["E54_Dimension"]))
+            graphobj.add((dim_node, cidoc_nm["P2_has_type"], aatrefs[unittype]))
+            graphobj.add((dim_node, cidoc_nm["P91_has_unit"], aatrefs[unit]))
             graphobj.add((dim_node, RDF.value, Literal(value)))
 
         for f_data in edge_info["range_tile_data"]:
@@ -1264,14 +1285,14 @@ class FileListDataType(BaseDataType):
                 lm = f_data["lastModified"]
                 if lm > 9999999999:  # not a straight timestamp, but includes milliseconds
                     lm = f_data["lastModified"] / 1000
-                graph.add((f_uri, DCTERMS.modified, Literal(datetime.utcfromtimestamp(lm).isoformat())))
+                g.add((f_uri, DCTERMS.modified, Literal(datetime.utcfromtimestamp(lm).isoformat())))
 
             if "size" in f_data:
-                add_dimension(graph, f_uri, "file size", "bytes", f_data["size"])
+                add_dimension(g, f_uri, "file size", "bytes", f_data["size"])
             if "height" in f_data:
-                add_dimension(graph, f_uri, "height", "pixels", f_data["height"])
+                add_dimension(g, f_uri, "height", "pixels", f_data["height"])
             if "width" in f_data:
-                add_dimension(graph, f_uri, "width", "pixels", f_data["width"])
+                add_dimension(g, f_uri, "width", "pixels", f_data["width"])
 
         return g
 

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1203,7 +1203,7 @@ class FileListDataType(BaseDataType):
         result = json.loads(json.dumps(tile_data))
         return result
 
-    def is_a_literal_in_rdf(self):  
+    def is_a_literal_in_rdf(self):
         return False
 
     def get_rdf_uri(self, node, data, which="r"):
@@ -1219,10 +1219,9 @@ class FileListDataType(BaseDataType):
             if data["url"].startswith("/"):
                 return URIRef(archesproject[data["url"][1:]])
             else:
-                return URIRef(archesproject[data["url"]])        
+                return URIRef(archesproject[data["url"]])
         else:
             return node
-
 
     def to_rdf(self, edge_info, edge):
         # outputs a graph holding an RDF representation of the file stored in the Arches instance


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

Update the to_rdf() function for the filelist datatype, plus the v5 internal API functions of `get_rdf_uri` and `is_a_literal_in_rdf`.

Currently the variables don't resolve because they were renamed at some point.
e.g. `cidoc` --> `cidoc_nm` ; `graph` --> `g`

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->

#6066

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

This does not fix another related issue, which is that downstream nodes of files within the filelist do not get their metadata attached.

The cause is that the get_rdf_uri function is not passed the tile data, from which it expects to extract the `url` key. Instead it is passed `None`.  I can't find how to get the data that it receives for the directly associated cards (e.g. a concept node and a string node) into the related semantic nodes as well.