### PR TITLE
Updates iiif drawings during provisional edit review

### DIFF
--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -95,6 +95,9 @@ define([
                         var defaultconfig = w.widgetLookup[w.widget_id()].defaultconfig;
                         if (JSON.parse(defaultconfig).rerender === true && self.selectedTile().parent.allowProvisionalEditRerender() === true) {
                             self.selectedTile().parent.widgets()[0].label.valueHasMutated();
+                        } 
+                        if (self.selectedTile().parent.triggerUpdate) {
+                            self.selectedTile().parent.triggerUpdate();
                         }
                     });
             }

--- a/arches/app/media/js/views/components/iiif-annotation.js
+++ b/arches/app/media/js/views/components/iiif-annotation.js
@@ -222,6 +222,10 @@ define([
             }
         });
 
+        if (this.card) {
+            this.card.triggerUpdate = updateDrawFeatures; // can be called by the provisional tile view model to update the drawing
+        }
+
         this.disableDrawing = ko.computed(function() {
             return !self.canvas();
         });


### PR DESCRIPTION
Allows iiif card to update when swapping between provisional and authoritative edits. re #6049