### PR TITLE
Adds block to urls object so project developers can add their own urls

### DIFF
--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -248,7 +248,8 @@
                 api_search_component_data: "{% url 'api_search_component_data' 'aaaa'%}".replace('aaaa', ''),
                 geojson: "{% url 'geojson' %}",
                 icons: "{% url 'icons' %}",
-                iiifmanifest: "{% url 'iiifmanifest' %}"
+                iiifmanifest: "{% url 'iiifmanifest' %}",
+                {% block urls %}{% endblock urls %}
             },
             geocoderPlaceHolder: "{% trans 'Find an address...' %}",
             confirmNav: {


### PR DESCRIPTION
This allows developers to add their own urls in js files using the arches.urls object. re #6158
