### PR TITLE
Resolves map popup error, re #2725

### DIFF
--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -204,6 +204,9 @@ define([
                         'graph_name': '',
                         'map_popup': ''
                     });
+                    if (data.permissions) {
+                        data.permissions = JSON.parse(data.permissions);
+                    }
                     data = ko.mapping.fromJS(data);
                     data.reportURL = arches.urls.resource_report;
                     data.editURL = arches.urls.resource_editor;

--- a/arches/app/media/js/views/components/search/search-results.js
+++ b/arches/app/media/js/views/components/search/search-results.js
@@ -44,6 +44,14 @@ function($, _, BaseFilter, bootstrap, arches, select2, ko, koMapping, viewdata) 
                 this.mapFilter = this.getFilter('map-filter');
                 this.details = this.getFilter('search-result-details');
                 this.relatedResourcesManager = this.getFilter('related-resources-filter');
+                this.selectedTab.subscribe(function(tab){
+                    var self = this;
+                    if (tab === 'map-filter') {
+                        if (ko.unwrap(this.mapFilter.map)) {
+                            setTimeout(function() { self.mapFilter.map().resize(); }, 1);
+                        }
+                    }
+                }, this);
             },
 
             mouseoverInstance: function() {

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -259,6 +259,7 @@ def search_results(request):
     dsl.include("permissions.users_without_read_perm")
     dsl.include("permissions.users_without_edit_perm")
     dsl.include("permissions.users_without_delete_perm")
+    dsl.include("permissions.users_with_no_access")
     dsl.include("geometries")
     dsl.include("displayname")
     dsl.include("displaydescription")


### PR DESCRIPTION
Resolves error when parsing permissions in the map popup and resizes map so that it fills the entire map element when the map tab is selected in search. re #2725