### PR TITLE
move URI test to datatype as function

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -204,6 +204,9 @@ class BaseDataType(object):
         """
         return False
 
+    def accepts_rdf_uri(self, uri):
+        return False
+
     def get_rdf_uri(self, node, data, which="r"):
         if self.is_a_literal_in_rdf():
             return None

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1657,6 +1657,9 @@ class ResourceInstanceDataType(BaseDataType):
             return [URIRef(archesproject[f"resources/{x}"]) for x in data]
         return URIRef(archesproject[f"resources/{data}"])
 
+    def accepts_rdf_uri(self, uri):
+        return uri.startswith("urn:uuid:") or uri.startswith(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT + "resources/")
+
     def to_rdf(self, edge_info, edge):
         g = Graph()
 

--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -416,11 +416,6 @@ class JsonLdReader(Reader):
     def is_semantic_node(self, graph_node):
         return self.datatype_factory.datatypes[graph_node["datatype_type"]].defaultwidget is None
 
-    def is_resource_instance_node(self, graph_node, uri):
-        return (
-            uri.startswith("urn:uuid:") or uri.startswith(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT + "resources/")
-        ) and not self.is_semantic_node(graph_node)
-
     def is_concept_node(self, uri):
         pcs = settings.PREFERRED_CONCEPT_SCHEMES[:]
         pcs.append(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT + "concepts/")
@@ -479,9 +474,9 @@ class JsonLdReader(Reader):
                 options = tree_node["children"][key]
                 possible = []
                 ignore = []
-                # print(f"\nConsidering {len(options)} options ...")
+
                 for o in options:
-                    # print(f"Considering:\n  {vi}\n  {o}")
+                    #print(f"Considering:\n  {vi}\n  {o['name']}")
                     if is_literal and o["datatype"].is_a_literal_in_rdf():
                         if len(o["datatype"].validate(value)) == 0:
                             possible.append([o, value])
@@ -494,10 +489,11 @@ class JsonLdReader(Reader):
                                 possible.append([o, uri])
                             else:
                                 print(f"Concept URI {uri} not in Collection {collid}")
-                        elif self.is_resource_instance_node(o, uri):
-                            possible.append([o, uri])
                         elif self.is_semantic_node(o):
                             possible.append([o, ""])
+                        elif o['datatype'].accepts_rdf_uri(uri):
+                            # print(f"datatype for {o['name']} accepts uri")
+                            possible.append([o, uri])
                         else:
                             # This is when the current option doesn't match, but could be
                             # non-ambiguous resource-instance vs semantic node
@@ -505,7 +501,10 @@ class JsonLdReader(Reader):
                     else:
                         raise ValueError("No possible match?")
 
+                #print(f"Possible is: {[x[0]['name'] for x in possible]}")
+
                 if not possible:
+                    #print(f"Tried: {options}")
                     raise ValueError(f"Data does not match any actual node, despite prop/class combination {k} {clss}:\n{vi}")
                 elif len(possible) > 1:
                     # descend into data to check if there are further clarifying features
@@ -521,7 +520,7 @@ class JsonLdReader(Reader):
                     if not possible2:
                         raise ValueError("Considering branches, data does not match any node, despite a prop/class combination")
                     elif len(possible2) > 1:
-                        raise ValueError("Even after considering branches, data still matches more than one node")
+                        raise ValueError(f"Even after considering branches, data still matches more than one node: {[x[0]['name'] for x in possible2]}")
                     else:
                         branch = possible2[0]
                 else:
@@ -580,7 +579,7 @@ class JsonLdReader(Reader):
                     else:
                         bnode["data"].append(branch[1])
                         if not self.is_semantic_node(branch[0]):
-                            print(f"Adding to existing (n): {node_value}")
+                            # print(f"Adding to existing (n): {node_value}")
                             tile.data[bnodeid] = node_value
                         result[bnodeid].append(bnode)
                 else:
@@ -597,4 +596,4 @@ class JsonLdReader(Reader):
         for path in tree_node["children"].values():
             for kid in path:
                 if kid["required"] and not f"{kid['node_id']}" in result:
-                    raise ValueError("Required field not present")
+                    raise ValueError(f"Required field not present: {kid['name']}")

--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -485,10 +485,13 @@ class JsonLdReader(Reader):
                     elif not is_literal and not o["datatype"].is_a_literal_in_rdf():
                         if self.is_concept_node(uri):
                             collid = o["config"]["collection_id"]
-                            if self.validate_concept_in_collection(uri, collid):
-                                possible.append([o, uri])
-                            else:
-                                print(f"Concept URI {uri} not in Collection {collid}")
+                            try:
+                                if self.validate_concept_in_collection(uri, collid):
+                                    possible.append([o, uri])
+                                else:
+                                    print(f"Concept URI {uri} not in Collection {collid}")
+                            except:
+                                print(f"Errored testing concept {uri} in collection {collid}")
                         elif self.is_semantic_node(o):
                             possible.append([o, ""])
                         elif o['datatype'].accepts_rdf_uri(uri):


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)

### Description of Change

Move URI pattern tests on to datatypes so that they can be customized for externally developed datatypes, such as https://github.com/thegetty/arches-urldatatype

(Also incidentally makes the debugging output slightly better by adding in the name of the branch / datatype where things go wrong)

Tests still pass, and the code is slightly more efficient as it catches some cases that would have been ruled out in the following code that tries to recursively load the graph per branch when there are multiple possible.


### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
