### PR TITLE
Modify the InstancePermission API to return a dict of permissions

### DIFF
--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -33,7 +33,12 @@ from arches.app.models.tile import Tile as TileProxyModel
 from arches.app.views.tile import TileData as TileView
 from arches.app.utils.skos import SKOSWriter
 from arches.app.utils.response import JSONResponse
-from arches.app.utils.decorators import can_read_resource_instance, can_edit_resource_instance, can_delete_resource_instance, can_read_concept
+from arches.app.utils.decorators import (
+    can_read_resource_instance,
+    can_edit_resource_instance,
+    can_delete_resource_instance,
+    can_read_concept,
+)
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.data_management.resources.exporter import ResourceExporter
 from arches.app.utils.data_management.resources.formats.rdffile import JsonLdReader
@@ -1051,9 +1056,9 @@ class InstancePermission(APIBase):
         user = request.user
         result = {}
         resourceinstanceid = request.GET.get("resourceinstanceid")
-        result['read'] = user_can_read_resources(user, resourceinstanceid)
-        result['edit'] = user_can_edit_resources(user, resourceinstanceid)
-        result['delete'] = user_can_delete_resources(user, resourceinstanceid)
+        result["read"] = user_can_read_resources(user, resourceinstanceid)
+        result["edit"] = user_can_edit_resources(user, resourceinstanceid)
+        result["delete"] = user_can_delete_resources(user, resourceinstanceid)
         return JSONResponse(result)
 
 

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -33,13 +33,14 @@ from arches.app.models.tile import Tile as TileProxyModel
 from arches.app.views.tile import TileData as TileView
 from arches.app.utils.skos import SKOSWriter
 from arches.app.utils.response import JSONResponse
-from arches.app.utils.decorators import can_read_resource_instance, can_edit_resource_instance, can_read_concept
+from arches.app.utils.decorators import can_read_resource_instance, can_edit_resource_instance, can_delete_resource_instance, can_read_concept
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.data_management.resources.exporter import ResourceExporter
 from arches.app.utils.data_management.resources.formats.rdffile import JsonLdReader
 from arches.app.utils.permission_backend import (
     user_can_read_resources,
     user_can_edit_resources,
+    user_can_delete_resources,
     user_can_read_concepts,
     user_is_resource_reviewer,
     get_restricted_instances,
@@ -1048,14 +1049,11 @@ class Node(APIBase):
 class InstancePermission(APIBase):
     def get(self, request):
         user = request.user
-        perm = request.GET.get("perms")
+        result = {}
         resourceinstanceid = request.GET.get("resourceinstanceid")
-        if perm == "view_resourceinstance":
-            result = user_can_read_resources(user, resourceinstanceid)
-        elif perm == "change_resourceinstance":
-            result = user_can_edit_resources(user, resourceinstanceid)
-        elif perm == "delete_resourceinstance":
-            result = user_can_delete_resources(user, resourceinstanceid)
+        result['read'] = user_can_read_resources(user, resourceinstanceid)
+        result['edit'] = user_can_edit_resources(user, resourceinstanceid)
+        result['delete'] = user_can_delete_resources(user, resourceinstanceid)
         return JSONResponse(result)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Now InstancePermission API returns a dictionary of three permissions (read, edit, delete) instead of single permission requested.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#
It will make the api more flexible to any resource instance level permission related request

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
