### PR TITLE
Prevents UUID validation error if resourceid is and empty string. 

### DIFF
--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -316,7 +316,7 @@ def user_can_read_resources(user, resourceid=None):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if resourceid not in [None, '']:
+        if resourceid not in [None, ""]:
             result = check_resource_instance_permissions(user, resourceid, "view_resourceinstance")
             if result is not None:
                 if result["permitted"] == "unknown":
@@ -339,7 +339,7 @@ def user_can_edit_resources(user, resourceid=None):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if resourceid not in [None, '']:
+        if resourceid not in [None, ""]:
             result = check_resource_instance_permissions(user, resourceid, "change_resourceinstance")
             if result is not None:
                 if result["permitted"] == "unknown":
@@ -363,7 +363,7 @@ def user_can_delete_resources(user, resourceid=None):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if resourceid not in [None, '']:
+        if resourceid not in [None, ""]:
             result = check_resource_instance_permissions(user, resourceid, "delete_resourceinstance")
             if result is not None:
                 if result["permitted"] == "unknown":

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -316,7 +316,7 @@ def user_can_read_resources(user, resourceid=None):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if resourceid is not None:
+        if resourceid not in [None, '']:
             result = check_resource_instance_permissions(user, resourceid, "view_resourceinstance")
             if result is not None:
                 if result["permitted"] == "unknown":
@@ -339,7 +339,7 @@ def user_can_edit_resources(user, resourceid=None):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if resourceid is not None:
+        if resourceid not in [None, '']:
             result = check_resource_instance_permissions(user, resourceid, "change_resourceinstance")
             if result is not None:
                 if result["permitted"] == "unknown":
@@ -363,7 +363,7 @@ def user_can_delete_resources(user, resourceid=None):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if resourceid is not None:
+        if resourceid not in [None, '']:
             result = check_resource_instance_permissions(user, resourceid, "delete_resourceinstance")
             if result is not None:
                 if result["permitted"] == "unknown":


### PR DESCRIPTION
re #6301
