### PR TITLE
Fix geojson api to use the limit parameter, re #6317

### DIFF
--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -307,7 +307,7 @@ class GeoJSON(APIBase):
         if limit is not None:
             start = (page - 1) * limit
             end = start + limit
-            last_page = tiles.count() < end
+            last_page = len(tiles) < end
             tiles = tiles[start:end]
         for tile in tiles:
             data = tile.data


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fix the error when geojson api requested with limit parameter, re #6317
Change the check the tiles (Python list of tiles) from tiles.count() to len(tiles)

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
The limit parameter on geojson api fails.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
