### PR TITLE
Fixes to resource instance deletion permissions

### DIFF
--- a/arches/app/utils/decorators.py
+++ b/arches/app/utils/decorators.py
@@ -20,6 +20,7 @@ import warnings
 import functools
 import logging
 import datetime
+from django.shortcuts import redirect
 from arches.app.utils.permission_backend import get_editable_resource_types
 from arches.app.utils.permission_backend import get_resource_types_by_perm
 from arches.app.utils.permission_backend import user_can_read_resource
@@ -27,7 +28,6 @@ from arches.app.utils.permission_backend import user_can_edit_resource
 from arches.app.utils.permission_backend import user_can_delete_resource
 from arches.app.utils.permission_backend import user_can_read_concepts
 from django.contrib.auth.decorators import user_passes_test
-from django.core.exceptions import PermissionDenied
 
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ def can_edit_resource_instance(function):
         if user_can_edit_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
-            raise PermissionDenied
+            return redirect(f'/auth/?next={request.path}')
         return function(request, *args, **kwargs)
 
     return wrapper
@@ -98,7 +98,7 @@ def can_read_resource_instance(function):
         if user_can_read_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
-            raise PermissionDenied
+            return redirect(f'/auth/?next={request.path}')
         return function(request, *args, **kwargs)
 
     return wrapper
@@ -116,7 +116,7 @@ def can_delete_resource_instance(function):
         if user_can_delete_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
-            raise PermissionDenied
+            return redirect(f'/auth/?next={request.path}')
         return function(request, *args, **kwargs)
 
     return wrapper

--- a/arches/app/utils/decorators.py
+++ b/arches/app/utils/decorators.py
@@ -20,7 +20,7 @@ import warnings
 import functools
 import logging
 import datetime
-from django.shortcuts import redirect
+from django.core.exceptions import PermissionDenied
 from arches.app.utils.permission_backend import get_editable_resource_types
 from arches.app.utils.permission_backend import get_resource_types_by_perm
 from arches.app.utils.permission_backend import user_can_read_resource
@@ -80,7 +80,7 @@ def can_edit_resource_instance(function):
         if user_can_edit_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
-            return redirect(f'/auth/?next={request.path}')
+            raise PermissionDenied
         return function(request, *args, **kwargs)
 
     return wrapper
@@ -98,7 +98,7 @@ def can_read_resource_instance(function):
         if user_can_read_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
-            return redirect(f'/auth/?next={request.path}')
+            raise PermissionDenied
         return function(request, *args, **kwargs)
 
     return wrapper
@@ -116,7 +116,7 @@ def can_delete_resource_instance(function):
         if user_can_delete_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
-            return redirect(f'/auth/?next={request.path}')
+            raise PermissionDenied
         return function(request, *args, **kwargs)
 
     return wrapper

--- a/arches/app/utils/decorators.py
+++ b/arches/app/utils/decorators.py
@@ -22,10 +22,10 @@ import logging
 import datetime
 from arches.app.utils.permission_backend import get_editable_resource_types
 from arches.app.utils.permission_backend import get_resource_types_by_perm
-from arches.app.utils.permission_backend import user_can_read_resources
-from arches.app.utils.permission_backend import user_can_edit_resources
+from arches.app.utils.permission_backend import user_can_read_resource
+from arches.app.utils.permission_backend import user_can_edit_resource
+from arches.app.utils.permission_backend import user_can_delete_resource
 from arches.app.utils.permission_backend import user_can_read_concepts
-from arches.app.utils.permission_backend import user_can_delete_resources
 from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied
 
@@ -77,7 +77,7 @@ def can_edit_resource_instance(function):
     @functools.wraps(function)
     def wrapper(request, *args, **kwargs):
         resourceid = kwargs["resourceid"] if "resourceid" in kwargs else None
-        if user_can_edit_resources(request.user, resourceid=resourceid):
+        if user_can_edit_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
             raise PermissionDenied
@@ -95,7 +95,7 @@ def can_read_resource_instance(function):
     @functools.wraps(function)
     def wrapper(request, *args, **kwargs):
         resourceid = kwargs["resourceid"] if "resourceid" in kwargs else None
-        if user_can_read_resources(request.user, resourceid=resourceid):
+        if user_can_read_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
             raise PermissionDenied
@@ -113,7 +113,7 @@ def can_delete_resource_instance(function):
     @functools.wraps(function)
     def wrapper(request, *args, **kwargs):
         resourceid = kwargs["resourceid"] if "resourceid" in kwargs else None
-        if user_can_delete_resources(request.user, resourceid=resourceid):
+        if user_can_delete_resource(request.user, resourceid=resourceid):
             return function(request, *args, **kwargs)
         else:
             raise PermissionDenied

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -307,7 +307,7 @@ def check_resource_instance_permissions(user, resourceid, permission):
     return result
 
 
-def user_can_read_resources(user, resourceid=None):
+def user_can_read_resource(user, resourceid=None):
     """
     Requires that a user be able to read an instance and read a single nodegroup of a resource
 
@@ -330,7 +330,7 @@ def user_can_read_resources(user, resourceid=None):
     return False
 
 
-def user_can_edit_resources(user, resourceid=None):
+def user_can_edit_resource(user, resourceid=None):
     """
     Requires that a user be able to edit an instance and delete a single nodegroup of a resource
 
@@ -355,7 +355,7 @@ def user_can_edit_resources(user, resourceid=None):
     return False
 
 
-def user_can_delete_resources(user, resourceid=None):
+def user_can_delete_resource(user, resourceid=None):
     """
     Requires that a user be permitted to delete an instance
 

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -43,9 +43,9 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from arches.app.utils.data_management.resources.exporter import ResourceExporter
 from arches.app.utils.data_management.resources.formats.rdffile import JsonLdReader
 from arches.app.utils.permission_backend import (
-    user_can_read_resources,
-    user_can_edit_resources,
-    user_can_delete_resources,
+    user_can_read_resource,
+    user_can_edit_resource,
+    user_can_delete_resource,
     user_can_read_concepts,
     user_is_resource_reviewer,
     get_restricted_instances,
@@ -517,7 +517,7 @@ class Resources(APIBase):
     # }]
 
     def get(self, request, resourceid=None, slug=None, graphid=None):
-        if user_can_read_resources(user=request.user, resourceid=resourceid):
+        if user_can_read_resource(user=request.user, resourceid=resourceid):
             allowed_formats = ["json", "json-ld"]
             format = request.GET.get("format", "json-ld")
             include_tiles = request.GET.get("includetiles", True)
@@ -611,7 +611,7 @@ class Resources(APIBase):
     #         indent = None
 
     #     try:
-    #         if user_can_edit_resources(user=request.user):
+    #         if user_can_edit_resource(user=request.user):
     #             data = JSONDeserializer().deserialize(request.body)
     #             reader = JsonLdReader()
     #             reader.read_resource(data, use_ids=True)
@@ -649,7 +649,7 @@ class Resources(APIBase):
         except Exception:
             indent = None
 
-        if not user_can_edit_resources(user=request.user, resourceid=resourceid):
+        if not user_can_edit_resource(user=request.user, resourceid=resourceid):
             return JSONResponse(status=403)
         else:
             with transaction.atomic():
@@ -691,7 +691,7 @@ class Resources(APIBase):
             indent = None
 
         try:
-            if user_can_edit_resources(user=request.user, resourceid=resourceid):
+            if user_can_edit_resource(user=request.user, resourceid=resourceid):
                 data = JSONDeserializer().deserialize(request.body)
                 reader = JsonLdReader()
                 if slug is not None:
@@ -721,7 +721,7 @@ class Resources(APIBase):
             return JSONResponse({"error": "resource data could not be saved: %s" % e}, status=500, reason=e)
 
     def delete(self, request, resourceid, slug=None, graphid=None):
-        if user_can_edit_resources(user=request.user, resourceid=resourceid) and user_can_delete_resources(
+        if user_can_edit_resource(user=request.user, resourceid=resourceid) and user_can_delete_resource(
             user=request.user, resourceid=resourceid
         ):
             try:
@@ -1056,9 +1056,9 @@ class InstancePermission(APIBase):
         user = request.user
         result = {}
         resourceinstanceid = request.GET.get("resourceinstanceid")
-        result["read"] = user_can_read_resources(user, resourceinstanceid)
-        result["edit"] = user_can_edit_resources(user, resourceinstanceid)
-        result["delete"] = user_can_delete_resources(user, resourceinstanceid)
+        result["read"] = user_can_read_resource(user, resourceinstanceid)
+        result["edit"] = user_can_edit_resource(user, resourceinstanceid)
+        result["delete"] = user_can_delete_resource(user, resourceinstanceid)
         return JSONResponse(result)
 
 

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1,15 +1,20 @@
+import importlib
 import json
 import logging
 import os
 import re
 import sys
 import uuid
-import importlib
 from io import StringIO
+from oauth2_provider.views import ProtectedResourceView
+from pyld.jsonld import compact, frame, from_rdf
+from rdflib import RDF
+from rdflib.namespace import SKOS, DCTERMS
+from revproxy.views import ProxyView
+from slugify import slugify
+from urllib import parse
 from django.shortcuts import render
 from django.views.generic import View
-from django.views.decorators.csrf import csrf_exempt
-from django.utils.decorators import method_decorator
 from django.db import transaction, connection
 from django.db.models import Q
 from django.http import Http404, HttpResponse
@@ -17,11 +22,10 @@ from django.http.request import QueryDict
 from django.core import management
 from django.core.cache import cache
 from django.urls import reverse
-from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.core.files.base import ContentFile
-from revproxy.views import ProxyView
-from oauth2_provider.views import ProtectedResourceView
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.decorators import method_decorator
 from arches.app.models import models
 from arches.app.models.concept import Concept
 from arches.app.models.card import Card as CardProxyModel
@@ -34,10 +38,8 @@ from arches.app.views.tile import TileData as TileView
 from arches.app.utils.skos import SKOSWriter
 from arches.app.utils.response import JSONResponse
 from arches.app.utils.decorators import (
-    can_read_resource_instance,
-    can_edit_resource_instance,
-    can_delete_resource_instance,
     can_read_concept,
+    group_required
 )
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.data_management.resources.exporter import ResourceExporter
@@ -52,15 +54,10 @@ from arches.app.utils.permission_backend import (
     check_resource_instance_permissions,
     get_nodegroups_by_perm,
 )
-from arches.app.utils.decorators import group_required
 from arches.app.utils.geo_utils import GeoUtils
 from arches.app.search.components.base import SearchFilterFactory
 from arches.app.datatypes.datatypes import DataTypeFactory
-from pyld.jsonld import compact, frame, from_rdf
-from rdflib import RDF
-from rdflib.namespace import SKOS, DCTERMS
-from slugify import slugify
-from urllib import parse
+
 from arches.celery import app
 
 logger = logging.getLogger(__name__)

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -112,6 +112,7 @@ def get_instance_creator(resource_instance, user=None):
 class ResourceEditorView(MapBaseManagerView):
     action = None
 
+    @method_decorator(can_edit_resource_instance, name="dispatch")
     def get(
         self,
         request,
@@ -126,8 +127,6 @@ class ResourceEditorView(MapBaseManagerView):
 
         creator = None
         user_created_instance = None
-        if not user_can_edit_resource(request.user, resourceid):
-            raise PermissionDenied
         if resourceid is None:
             resource_instance = None
             graph = models.GraphModel.objects.get(pk=graphid)

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import uuid
 import json
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.contrib.auth.models import User, Group, Permission
 from django.db import transaction
 from django.forms.models import model_to_dict
@@ -44,7 +44,7 @@ from arches.app.utils.decorators import can_edit_resource_instance
 from arches.app.utils.decorators import can_delete_resource_instance
 from arches.app.utils.decorators import can_read_resource_instance
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
-from arches.app.utils.permission_backend import user_is_resource_reviewer, user_can_delete_resources
+from arches.app.utils.permission_backend import user_is_resource_reviewer, user_can_delete_resource, user_can_edit_resource, user_can_read_resource
 from arches.app.utils.response import JSONResponse, JSONErrorResponse
 from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query, Terms
@@ -68,7 +68,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@method_decorator(can_edit_resource_instance, name="dispatch")
+@method_decorator(can_edit_resource_instance, name="dispatch") #TODO Confirm if decorator is needed
 class ResourceListView(BaseManagerView):
     def get(self, request, graphid=None, resourceid=None):
         context = self.get_context_data(main_script="views/resource")
@@ -112,7 +112,6 @@ def get_instance_creator(resource_instance, user=None):
 class ResourceEditorView(MapBaseManagerView):
     action = None
 
-    @method_decorator(can_edit_resource_instance, name="dispatch")
     def get(
         self,
         request,
@@ -127,7 +126,8 @@ class ResourceEditorView(MapBaseManagerView):
 
         creator = None
         user_created_instance = None
-
+        if not user_can_edit_resource(request.user, resourceid):
+            raise PermissionDenied
         if resourceid is None:
             resource_instance = None
             graph = models.GraphModel.objects.get(pk=graphid)
@@ -218,7 +218,7 @@ class ResourceEditorView(MapBaseManagerView):
             card["is_writable"] = False
             if str(card["nodegroup_id"]) in editable_nodegroup_ids:
                 card["is_writable"] = True
-        user_can_delete_resource = user_can_delete_resources(request.user, resourceid)
+        can_delete = user_can_delete_resource(request.user, resourceid)
         context = self.get_context_data(
             main_script=main_script,
             resourceid=resourceid,
@@ -245,7 +245,7 @@ class ResourceEditorView(MapBaseManagerView):
             map_sources=map_sources,
             geocoding_providers=geocoding_providers,
             user_is_reviewer=json.dumps(user_is_reviewer),
-            user_can_delete_resource=user_can_delete_resource,
+            user_can_delete_resource=can_delete,
             creator=json.dumps(creator),
             user_created_instance=json.dumps(user_created_instance),
             report_templates=templates,
@@ -263,20 +263,30 @@ class ResourceEditorView(MapBaseManagerView):
 
         return render(request, view_template, context)
 
-    @method_decorator(can_delete_resource_instance, name="dispatch")
+
     def delete(self, request, resourceid=None):
-        if resourceid is not None:
-            ret = Resource.objects.get(pk=resourceid)
-            try:
-                deleted = ret.delete(user=request.user)
-            except ModelInactiveError as e:
-                message = _("Unable to delete. Please verify the model status is active")
-                return JSONResponse({"status": "false", "message": [_(e.title), _(str(message))]}, status=500)
-            if deleted is True:
-                return JSONResponse(ret)
-            else:
-                return JSONErrorResponse("Unable to Delete Resource", "Provisional users cannot delete resources with authoritative data")
-        return HttpResponseNotFound()
+        delete_error = _("Unable to Delete Resource")
+        delete_msg = _("User does not have permissions to delete this instance because the instance or its data is restricted")
+        try:
+            if resourceid is not None:
+                if user_can_delete_resource(request.user, resourceid) is False:
+                    return JSONErrorResponse(delete_error, delete_msg)
+                ret = Resource.objects.get(pk=resourceid)
+                try:
+                    deleted = ret.delete(user=request.user)
+                except ModelInactiveError as e:
+                    message = _("Unable to delete. Please verify the model status is active")
+                    return JSONResponse({"status": "false", "message": [_(e.title), _(str(message))]}, status=500)
+                except PermissionDenied:
+                    return JSONErrorResponse(delete_error, delete_msg)
+                if deleted is True:
+                    return JSONResponse(ret)
+                else:
+                    return JSONErrorResponse(delete_error, delete_msg)
+            return HttpResponseNotFound()
+        except PermissionDenied:
+            return JSONErrorResponse(delete_error, delete_msg)
+
 
     def copy(self, request, resourceid=None):
         resource_instance = Resource.objects.get(pk=resourceid)

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -73,7 +73,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@method_decorator(can_edit_resource_instance, name="dispatch")  # TODO Confirm if decorator is needed
+@method_decorator(can_edit_resource_instance, name="dispatch")
 class ResourceListView(BaseManagerView):
     def get(self, request, graphid=None, resourceid=None):
         context = self.get_context_data(main_script="views/resource")

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -30,7 +30,7 @@ from arches.app.utils.response import JSONResponse, JSONErrorResponse
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.search.search_engine_factory import SearchEngineFactory
-from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Query, Terms, MaxAgg, Aggregation
+from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Query, Nested, Terms, MaxAgg, Aggregation
 from arches.app.search.search_export import SearchResultsExporter
 from arches.app.search.time_wheel import TimeWheel
 from arches.app.search.components.base import SearchFilterFactory
@@ -228,7 +228,8 @@ def append_instance_permission_filter_dsl(request, search_results_object):
     if request.user.is_superuser is False:
         has_access = Bool()
         terms = Terms(field="permissions.users_with_no_access", terms=[str(request.user.id)])
-        has_access.must_not(terms)
+        nested_term_filter = Nested(path="permissions", query=terms)
+        has_access.must_not(nested_term_filter)
         search_results_object["query"].add_query(has_access)
 
 

--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -38,10 +38,9 @@ from arches.app.models.models import ResourceInstance, Node
 from arches.app.models.resource import Resource
 from arches.app.utils.permission_backend import get_editable_resource_types
 from arches.app.utils.permission_backend import get_resource_types_by_perm
-from arches.app.utils.permission_backend import user_can_read_resources
-from arches.app.utils.permission_backend import user_can_edit_resources
+from arches.app.utils.permission_backend import user_can_read_resource
+from arches.app.utils.permission_backend import user_can_edit_resource
 from arches.app.utils.permission_backend import user_can_read_concepts
-from arches.app.utils.permission_backend import user_can_delete_resources
 from arches.app.utils.permission_backend import user_has_resource_model_permissions
 from arches.app.utils.permission_backend import get_restricted_users
 from arches.app.search.mappings import (
@@ -120,12 +119,12 @@ class PermissionTests(ArchesTestCase):
 
         """
 
-        implicit_permission = user_can_read_resources(self.user, self.resource_instance_id)
+        implicit_permission = user_can_read_resource(self.user, self.resource_instance_id)
         resource = ResourceInstance.objects.get(resourceinstanceid=self.resource_instance_id)
         assign_perm("change_resourceinstance", self.group, resource)
-        can_access_without_view_permission = user_can_read_resources(self.user, self.resource_instance_id)
+        can_access_without_view_permission = user_can_read_resource(self.user, self.resource_instance_id)
         assign_perm("view_resourceinstance", self.group, resource)
-        can_access_with_view_permission = user_can_read_resources(self.user, self.resource_instance_id)
+        can_access_with_view_permission = user_can_read_resource(self.user, self.resource_instance_id)
         self.assertTrue(
             implicit_permission is True and can_access_without_view_permission is False and can_access_with_view_permission is True
         )

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -196,7 +196,7 @@ class CommandLineTests(ArchesTestCase):
         resource = ResourceInstance.objects.get(resourceinstanceid=self.resource_instance_id)
         assign_perm("change_resourceinstance", group, resource)
         response = self.client.delete(url)
-        self.assertTrue(response.status_code == 403)
+        self.assertTrue(response.status_code == 500)
 
     def test_user_cannot_access_with_no_access(self):
         """
@@ -216,7 +216,7 @@ class CommandLineTests(ArchesTestCase):
         view = self.client.get(view_url)
         edit = self.client.get(edit_url)
         delete = self.client.delete(edit_url)
-        self.assertTrue(view.status_code == 403 and edit.status_code == 403 and delete.status_code == 403)
+        self.assertTrue(view.status_code == 403 and edit.status_code == 403 and delete.status_code == 500)
 
     def test_user_can_view_with_permission(self):
         """


### PR DESCRIPTION
### Types of changes
Renames instance permission methods so that their use is easier to understand. Fixes decorators so that they route a user to login if the permission check returns false. Fixes the can_user_delete _resource method so that a user cannot delete an instance with protected tiles. Updates the resource delete view so that a user gets an error message if they are not permitted to delete an instance rather than being redirected. re #2725, #5992 