### PR TITLE
Add check to graph validation for duplicate slug value, re #6071, #5089

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1449,6 +1449,14 @@ class Graph(models.GraphModel):
             out = compact({}, context)
         except JsonLdError:
             raise GraphValidationError(_("The json-ld context you supplied wasn't formatted correctly."), 1006)
+            
+        #check that slug does not already exist
+        slugs = models.GraphModel.objects.exclude(slug__isnull=True).values_list("slug", flat=True) 
+        if self.slug != None and self.slug in slugs:
+            try:
+                self.slug = None
+            except:
+                raise GraphValidationError(_("The slug for this model/branch already exists."), 1007)
 
 
 class GraphValidationError(Exception):

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1452,7 +1452,7 @@ class Graph(models.GraphModel):
             
         #check that slug does not already exist
         slugs = models.GraphModel.objects.exclude(slug__isnull=True).values_list("slug", flat=True) 
-        if self.slug != None and self.slug in slugs:
+        if self.slug is not None and self.slug in slugs:
             try:
                 self.slug = None
             except:

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1450,8 +1450,8 @@ class Graph(models.GraphModel):
         except JsonLdError:
             raise GraphValidationError(_("The json-ld context you supplied wasn't formatted correctly."), 1006)
 
-        #check that slug does not already exist
-        slugs = models.GraphModel.objects.exclude(slug__isnull=True).values_list("slug", flat=True) 
+        # check that slug does not already exist
+        slugs = models.GraphModel.objects.exclude(slug__isnull=True).values_list("slug", flat=True)
         if self.slug is not None and self.slug in slugs:
             try:
                 self.slug = None


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds logic to graph validation to check for duplicate slugs when cloning a graph or exporting a branch. Right now it sets the slug to None if a duplicate slug already exists in Arches.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6071 #5589 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
