### PR TITLE
Sets slug to none when cloning to prevent duplicate slug error. re #5589

### DIFF
--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -368,6 +368,7 @@ class GraphDataView(View):
                 elif self.action == "clone_graph":
                     clone_data = graph.copy()
                     ret = clone_data["copy"]
+                    ret.slug = None
                     ret.save()
                     ret.copy_functions(graph, [clone_data["nodes"], clone_data["nodegroups"]])
 


### PR DESCRIPTION
Sets slug to None to prevent duplicate slug error when cloning a resource model. re #5589