### PR TITLE
Supports chart renderer in Arches for Science 

### DIFF
--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -51,6 +51,7 @@
                                 <!-- ko component: {
                                     name: $data.name,
                                     params: {
+                                        fileViewer: $parent,
                                         card: $parent.card,
                                         selected: $parent.selected,
                                         state: $data.state,


### PR DESCRIPTION
Fixes missing parameter for chart renderer. re archesproject/arches-for-science#214
