### PR TITLE
Supports both JSON and python literal strings during csv import of resource instance data

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1719,12 +1719,15 @@ class ResourceInstanceDataType(BaseDataType):
                     document["strings"].append(
                         {"string": relatedResourceItem["resourceName"], "nodegroup_id": tile.nodegroup_id, "provisional": provisional}
                     )
-
+    
     def transform_value_for_tile(self, value, **kwargs):
-        return ast.literal_eval(value)
+        try:
+            return json.loads(value)
+        except ValueError:
+            return ast.literal_eval(value)
 
     def transform_export_values(self, value, *args, **kwargs):
-        return value
+        return json.dumps(value)
 
     def append_search_filters(self, value, node, query, request):
         try:

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1724,6 +1724,7 @@ class ResourceInstanceDataType(BaseDataType):
         try:
             return json.loads(value)
         except ValueError:
+            # do this if json (invalid) is formatted with single quotes, re #6390
             return ast.literal_eval(value)
 
     def transform_export_values(self, value, *args, **kwargs):

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1719,7 +1719,7 @@ class ResourceInstanceDataType(BaseDataType):
                     document["strings"].append(
                         {"string": relatedResourceItem["resourceName"], "nodegroup_id": tile.nodegroup_id, "provisional": provisional}
                     )
-    
+
     def transform_value_for_tile(self, value, **kwargs):
         try:
             return json.loads(value)


### PR DESCRIPTION
Handles for loading of proper, double-quote JSON and single quote (python dictionary strings) during csv import of resource instance values. re #6390