### PR TITLE
Handles for cases when a graph is not available in the graph list.

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -128,8 +128,10 @@ define([
                         var graph = graphlist.find(function(graph){
                             return graph.graphid === item.graphid;
                         });
-                        graph.config = item;
-                        return graph;
+                        if (graph) { // graph  may not exist in arches.resources if it is 'inactive'
+                            graph.config = item;
+                            return graph;
+                        }
                     });
                 }
                 return res;

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -128,7 +128,7 @@ define([
                         var graph = graphlist.find(function(graph){
                             return graph.graphid === item.graphid;
                         });
-                        if (graph) { // graph  may not exist in arches.resources if it is 'inactive'
+                        if (graph) { // graph may not exist in arches.resources if it is 'inactive'
                             graph.config = item;
                             return graph;
                         }


### PR DESCRIPTION
Prevents error if graph is undefined in cases where the graph is not available because it's set as inactive in the graph designer. re archesproject/arches-for-science#216