### PR TITLE
Prevents related instance datatype config changes after tile is saved

### DIFF
--- a/arches/app/media/js/views/components/datatypes/resource-instance.js
+++ b/arches/app/media/js/views/components/datatypes/resource-instance.js
@@ -23,7 +23,7 @@ define([
             if (!this.search) {
                 this.makeFriendly = ontologyUtils.makeFriendly;
                 this.getSelect2ConfigForOntologyProperties = ontologyUtils.getSelect2ConfigForOntologyProperties;
-                this.isEditable = true;
+                this.isEditable = params.isEditable;
                 this.graphIsSemantic = !!params.graph.get('ontology_id');
                 this.rootOntologyClass = params.graph.get('root').ontologyclass();
                 this.graphName = params.graph.get('root').name();

--- a/arches/app/templates/views/components/datatypes/resource-instance.htm
+++ b/arches/app/templates/views/components/datatypes/resource-instance.htm
@@ -7,27 +7,27 @@
     </div>
     <div style="padding-bottom: 10px;">
         <select multiple data-bind="
-            disabled: isEditable === false || disabled,
             placeholder: 'Select a resource model',
             selectedOptions: selectedResourceModel,
             options: resourceModels,
             optionsText: 'name',
             chosen: {
-                width: '100%'
+                width: '100%',
+                disabled: isEditable === false
             }
         "></select>
     </div>
-    <div class="rr-table" style="">
+    <div class="rr-table">
         <div data-bind="foreach: config.graphs" style="display: flex; flex-direction: column;">
             <div class='rr-table-row'>
-                <div class="rr-table-row-initial">
+                <div class="rr-table-row-initial" data-bind="style:{color: $parent.isEditable === true || '#aaa'}">
                     <div class='rr-table-column icon-column'>
-                        <button data-bind="click: $data.removeRelationship, clickBubble: false">
+                        <button data-bind="click: function(){if ($parent.isEditable !== false) {$data.removeRelationship($data)}}, clickBubble: false, attr:{'disabled': $parent.isEditable === false}, style:{color: $parent.isEditable === true || '#aaa'}">
                             <i class="fa fa-trash"></i>
                         </button>
                     </div>
                     <div class="rr-table-column" style="flex-grow: 1; padding-left: 10px;"
-                       data-bind="click: function() { if(self.graphIsSemantic){self.toggleSelectedResource($data)}; }, clickBubble: false, style:{cursor: self.graphIsSemantic ? 'pointer': 'inherit'}" style="cursor: pointer;">
+                       data-bind="click: function() { if(self.graphIsSemantic && $parent.isEditable !== false){self.toggleSelectedResource($data)}; }, clickBubble: false, style:{cursor: self.graphIsSemantic ? 'pointer': 'inherit'}" style="cursor: pointer;">
                         <div class="rr-table-instance-label" data-bind="text: $data.name"></div>
                     </div>
                 </div>

--- a/arches/app/templates/views/graph/graph-designer/node-form.htm
+++ b/arches/app/templates/views/graph/graph-designer/node-form.htm
@@ -138,7 +138,7 @@
                                 <div class="col-xs-12 crm-selector">
                                     <div data-bind='component: {
                                         name: node().datatypeConfigComponent,
-                                        params: node()}' style="width: 500px;">
+                                        params: _.extend(node(), {isEditable: !checkIfImmutable()})}' style="width: 500px;">
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Prevents a user from changing the datatype configuration of a related instance node once a tile is saved to the corresponding node's nodegroup. re #5688