### PR TITLE
Fixes error if node value for file is None, re #6392

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1211,14 +1211,15 @@ class FileListDataType(BaseDataType):
 
     def pre_tile_save(self, tile, nodeid):
         # TODO If possible this method should probably replace 'handle request' and perhaps 'process mobile data'
-        for file in tile.data[nodeid]:
-            try:
-                file_model = models.File.objects.get(pk=file["file_id"])
-                if not file_model.tile_id:
-                    file_model.tile = tile
-                    file_model.save()
-            except ObjectDoesNotExist:
-                logger.warning(_("A file is not available for this tile"))
+        if tile.data[nodeid]:
+            for file in tile.data[nodeid]:
+                try:
+                    file_model = models.File.objects.get(pk=file["file_id"])
+                    if not file_model.tile_id:
+                        file_model.tile = tile
+                        file_model.save()
+                except ObjectDoesNotExist:
+                    logger.warning(_("A file is not available for this tile"))
 
     def transform_export_values(self, value, *args, **kwargs):
         return ",".join([settings.MEDIA_URL + "uploadedfiles/" + str(file["name"]) for file in value])


### PR DESCRIPTION
### Types of changes
Ensures that the node value for a tile with the filelist datatype has a value before trying to iterate over it. re #6392 
