### PR TITLE
center slider handle in graph designer

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -11993,14 +11993,13 @@ ul.select2-choices:after {
     height: 100%;
     z-index: 3;
     font-size: 10px;
+    display: flex;
+    align-items: center;
 }
 
 .sidepanel-draggable div {
     cursor: col-resize;
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    margin: 1px;
+    margin: 2px;
 }
 
 .sidepanel-draggable div i {


### PR DESCRIPTION
Center draggable slider handle in Graph designer

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The CSS of the draggable slider handle has borked. The handle is top-aligned to its parent when it should be center-aligned.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6470 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

### Further comments
UI changes seen here: https://ibb.co/vhRJNNP
