### PR TITLE
Add a time format to datepicker/es/validation to support time, re # 5256

### DIFF
--- a/arches/app/media/js/views/components/widgets/datepicker.js
+++ b/arches/app/media/js/views/components/widgets/datepicker.js
@@ -44,6 +44,9 @@ define([
 
         // these options should be set in the global admin page
         this.dateFormatOptions = ko.observableArray([{
+            'id': 'YYYY-MM-DD HH:mm:ssZ',
+            'name': 'ISO 8601 (YYYY-MM-DD HH:mm:ssZ)'
+        }, {
             'id': 'YYYY-MM-DD',
             'name': 'ISO 8601 (YYYY-MM-DD)'
         }, {

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -426,13 +426,14 @@ CACHE_BY_USER = {"anonymous": 3600 * 24}
 DATE_IMPORT_EXPORT_FORMAT = "%Y-%m-%d"  # Custom date format for dates imported from and exported to csv
 
 DATE_FORMATS = {
-    "Python": ["-%Y", "%Y", "%Y-%m", "%Y-%m-%d", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S.%f%z"],
-    "JavaScript": ["-YYYY", "YYYY", "YYYY-MM", "YYYY-MM-DD", "YYYY-MM-DDTHH:mm:ssZ", "YYYY-MM-DDTHH:mm:ss.sssZ"],
+    "Python": ["-%Y", "%Y", "%Y-%m", "%Y-%m-%d", "%Y-%m-%d %H:%M:%S%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S.%f%z"],
+    "JavaScript": ["-YYYY", "YYYY", "YYYY-MM", "YYYY-MM-DD", "YYYY-MM-DD HH:mm:ssZ", "YYYY-MM-DDTHH:mm:ssZ", "YYYY-MM-DDTHH:mm:ss.sssZ"],
     "Elasticsearch": [
         "-yyyy",
         "yyyy",
         "yyyy-MM",
         "yyyy-MM-dd",
+        "yyyy-MM-dd HH:mm:ssZZZZZ",
         "yyyy-MM-dd'T'HH:mm:ssZ",
         "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
         "yyyy-MM-dd'T'HH:mm:ss.SSSZ",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Add a new time format in Javascript datetime picker to support the time in Arches, re #5256 
 (YYYY-MM-DD HH:mm:ssZ, eg. 2020-08-02 17:53:30-07:00)
Also, the format was added to Python validation and ElasticSearch index format.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
