### PR TITLE
The ability to reset related instance datatype in graph designer, re #6363

### DIFF
--- a/arches/app/media/js/utils/ontology.js
+++ b/arches/app/media/js/utils/ontology.js
@@ -15,7 +15,7 @@ define(['arches'], function(arches) {
             return '';
         },
 
-        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder='Select an Ontology Property', allowClear=false) {
+        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear=false) {
             return {
                 value: value,
                 clickBubble: false,

--- a/arches/app/media/js/utils/ontology.js
+++ b/arches/app/media/js/utils/ontology.js
@@ -15,7 +15,7 @@ define(['arches'], function(arches) {
             return '';
         },
 
-        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear = false) {
+        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear=false) {
             return {
                 value: value,
                 clickBubble: false,

--- a/arches/app/media/js/utils/ontology.js
+++ b/arches/app/media/js/utils/ontology.js
@@ -1,7 +1,7 @@
 define(['arches'], function(arches) {
     var ontologyUtils = {
         /**
-         * makeFriendly - makes a shortened name from an fully qalified name 
+         * makeFriendly - makes a shortened name from an fully qalified name
          * (eg: "http://www.cidoc-crm.org/cidoc-crm/E74_Group")
          *
          * @param  {ontolgoyName} the request method name
@@ -15,13 +15,13 @@ define(['arches'], function(arches) {
             return '';
         },
 
-        getSelect2ConfigForOntologyProperties: function(value, domain, range) {
+        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder='Select an Ontology Property', allowClear=false) {
             return {
                 value: value,
                 clickBubble: false,
-                placeholder: 'Select an Ontology Property',
+                placeholder: placeholder,
                 closeOnSelect: true,
-                allowClear: false,
+                allowClear: allowClear,
                 ajax: {
                     url: function() {
                         return arches.urls.ontology_properties;

--- a/arches/app/media/js/utils/ontology.js
+++ b/arches/app/media/js/utils/ontology.js
@@ -15,7 +15,7 @@ define(['arches'], function(arches) {
             return '';
         },
 
-        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear=false) {
+        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear = false) {
             return {
                 value: value,
                 clickBubble: false,

--- a/arches/app/media/js/utils/ontology.js
+++ b/arches/app/media/js/utils/ontology.js
@@ -15,13 +15,13 @@ define(['arches'], function(arches) {
             return '';
         },
 
-        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear=false) {
+        getSelect2ConfigForOntologyProperties: function(value, domain, range, placeholder, allowClear) {
             return {
                 value: value,
                 clickBubble: false,
                 placeholder: placeholder,
                 closeOnSelect: true,
-                allowClear: allowClear,
+                allowClear: allowClear || false,
                 ajax: {
                     url: function() {
                         return arches.urls.ontology_properties;

--- a/arches/app/templates/views/components/datatypes/resource-instance.htm
+++ b/arches/app/templates/views/components/datatypes/resource-instance.htm
@@ -34,23 +34,23 @@
                 <div class="rr-table-row-panel" data-bind="if: self.selectedResourceType() === $data, visible: self.selectedResourceType() === $data, css: { 'rr-table-border': self.selectedResourceType() === $data} ">
                     <div class="row">
                         <div class="row" style="margin-bottom: 10px;">
-                            <label class="col-xs-12" style="font-weight: bold;">{% trans "Default relationship to" %} 
+                            <label class="col-xs-12" style="font-weight: bold;">{% trans "Default relationship to" %}
                                 <span data-bind="text: $data.name"></span>
                             </label>
-                        
+
                             <div class="row" style="padding: 0px 12px; margin-bottom: 10px;">
                                 <span class="col-xs-12" style="font-weight: bold;"
-                                    data-bind="text: self.graphName + ' (' + self.makeFriendly(self.rootOntologyClass) + ')'">    
+                                    data-bind="text: self.graphName + ' (' + self.makeFriendly(self.rootOntologyClass) + ')'">
                                 </span>
-                                
+
                                 <span class="col-xs-12">
                                     <input style="width:100%; display:inline-block; margin: 3px 0px;" data-bind="
                                         select2Query: {
-                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.ontologyProperty, self.rootOntologyClass, $data.ontologyClass)
+                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.ontologyProperty, self.rootOntologyClass, $data.ontologyClass, '{% trans 'Select an Ontology Property' %}', true)
                                         }
                                     ">
                                 </span>
-                                
+
                                 <span class="col-xs-12" data-bind="text: $data.name + ' (' + self.makeFriendly($data.ontologyClass) + ')'">
                                 </span>
                             </div>
@@ -58,23 +58,23 @@
 
 
                         <div class="row">
-                            <label class="col-xs-12" style="font-weight: bold;">{% trans "Default inverse relationship to" %} 
+                            <label class="col-xs-12" style="font-weight: bold;">{% trans "Default inverse relationship to" %}
                                 <span data-bind="text: $data.name"></span>
                             </label>
-                        
+
                             <div class="row" style="padding: 0px 12px; margin-bottom: 10px;">
                                 <span class="col-xs-12" style=""
-                                    data-bind="text: $data.name + ' (' + self.makeFriendly($data.ontologyClass) + ')'">    
+                                    data-bind="text: $data.name + ' (' + self.makeFriendly($data.ontologyClass) + ')'">
                                 </span>
-                                
+
                                 <span class="col-xs-12">
                                     <input style="width:100%; display:inline-block; margin: 3px 0px;" data-bind="
                                         select2Query: {
-                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.inverseOntologyProperty, $data.ontologyClass, self.rootOntologyClass)
+                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.inverseOntologyProperty, $data.ontologyClass, self.rootOntologyClass, '{% trans 'Select an Ontology Property' %}', true)
                                         }
                                     ">
                                 </span>
-                                
+
                                 <span class="col-xs-12" data-bind="text: self.graphName + ' (' + self.makeFriendly(self.rootOntologyClass) + ')'"></span>
                             </div>
                         </div>
@@ -96,7 +96,7 @@
 </div>
 <div class="col-md-8 col-lg-9 resource-instance-search">
     <!-- ko component: {
-        name:  datatype.datatype.includes('list') ? 'resource-instance-multiselect-widget' : 'resource-instance-select-widget', 
+        name:  datatype.datatype.includes('list') ? 'resource-instance-multiselect-widget' : 'resource-instance-select-widget',
         params: {
             config: {
                 placeholder: '{% trans "Select a resource" %}'

--- a/arches/app/templates/views/components/widgets/resource-instance-select.htm
+++ b/arches/app/templates/views/components/widgets/resource-instance-select.htm
@@ -33,10 +33,10 @@
                         }
                     ">
             </div>
-            
+
         </div>
     </div>
-    
+
     <div class="rr-widget">
         <!-- ko if: value() !== null && value().length > 5-->
         <div class="rr-widget-filter-panel">
@@ -46,7 +46,7 @@
             </div>
         </div>
         <!-- /ko -->
-    
+
         <!-- ko if: relationshipsInFilter().length > 0-->
         <div class="rr-table">
             <div data-bind='foreach: relationshipsInFilter' style="display: flex; flex-direction: column;">
@@ -82,7 +82,7 @@
                     </div>
                     <div class="rr-table-row-panel"
                         data-bind="visible: self.selectedResourceRelationship() === $data, if: self.selectedResourceRelationship() === $data, css: { 'rr-table-border': self.selectedResourceRelationship() === $data} ">
-                        
+
                         <div class="row">
                             <!-- Relationship from instance to rr -->
                             <div class="row" style="margin-bottom: 10px;">
@@ -93,14 +93,14 @@
                                     <span class="col-xs-12" style="text-align: left;"
                                         data-bind="text: self.resourceInstanceDisplayName + ' (' + self.makeFriendly(self.rootOntologyClass) + ')'">
                                     </span>
-                                    
+
                                     <!-- Property -->
                                     <span class="col-xs-12">
                                         <input style="max-width:100%; display:inline-block; margin: 3px 0px;" data-bind="
                                         select2Query: {
-                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.ontologyProperty, self.rootOntologyClass, $data.ontologyClass())}">
+                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.ontologyProperty, self.rootOntologyClass, $data.ontologyClass(), '{% trans 'Select an Ontology Property' %}')}">
                                     </span>
-                                    
+
                                     <!-- rr name -->
                                     <span class="col-xs-12" data-bind="text: $data.resourceName() + ' (' + self.makeFriendly($data.ontologyClass()) + ')'"></span>
                                 </div>
@@ -115,14 +115,14 @@
                                     <span class="col-xs-12" style="text-align: left;"
                                         data-bind="text: $data.resourceName() + ' (' + self.makeFriendly($data.ontologyClass()) + ')'">
                                     </span>
-                                    
+
                                     <!-- Property -->
                                     <span class="col-xs-12">
                                         <input style="width:100%; display:inline-block; margin: 3px 0px;" data-bind="
                                         select2Query: {
-                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.inverseOntologyProperty, $data.ontologyClass(), self.rootOntologyClass)}">
+                                            select2Config: self.getSelect2ConfigForOntologyProperties($data.inverseOntologyProperty, $data.ontologyClass(), self.rootOntologyClass, '{% trans 'Select an Ontology Property' %}')}">
                                     </span>
-                                    
+
                                     <!-- Instance name -->
                                     <span class="col-xs-12" data-bind="text: self.resourceInstanceDisplayName + ' (' + self.makeFriendly(self.rootOntologyClass) + ')'">
                                     </span>

--- a/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
+++ b/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
@@ -51,7 +51,7 @@
     <div id="rr-manager-content-id" class="rr-drag-panel-target" data-bind="style: {'margin-bottom': containerBottomMargin }">
 
         <div class="related-resources-header" data-bind="css: {'open-graph': showGraph() == true}, style: {height: resourceEditorContext === true ? '55px' : '40px'}">
-            
+
             <div class="editor-elements">
                 <!--ko if: resourceEditorContext && !showGraph() -->
                 <div class="">
@@ -83,7 +83,7 @@
                     <span class="clear-node-search" style="top: 5px;" data-bind="visible: filter().length > 0, click: function() { filter('');}"><i class="fa fa-times-circle"></i></span>
                 </div>
                 <span style="padding: 4px;" data-bind="if: totalRelationships() > 1">
-                    <span style="font-size: 13px;"" class='file-workbench-filecount' data-bind='text: totalRelationships() + "{% trans ' resource relations' %}"'></span>
+                    <span style="font-size: 13px;" class='file-workbench-filecount' data-bind='text: totalRelationships() + "{% trans ' resource relations' %}"'></span>
                 </span>
             </div>
 
@@ -95,7 +95,7 @@
                                 <button data-bind="click: function(){window.open(resource.resourceinstanceid)}, clickBubble: false">
                                     <i class="fa fa-pencil"></i>
                                 </button>
-                            </div>                        
+                            </div>
                             <div class='rr-table-column icon-column'>
                                 <button data-bind="click: !!relationship.tileid() ?  self.updateTile.bind(self, {'delete':true}) : self.deleteRelationships.bind(self), clickBubble: false">
                                     <i class="fa fa-trash"></i>
@@ -126,7 +126,7 @@
                                         <span class="col-sm-4">
                                             <input style="width:30%; display:inline-block;" data-bind="
                                                 select2Query: {
-                                                    select2Config: self.getSelect2ConfigForOntologyProperties(relationship.relationshiptype, self.rootOntologyClass, relationship.resource.root_ontology_class)
+                                                    select2Config: self.getSelect2ConfigForOntologyProperties(relationship.relationshiptype, self.rootOntologyClass, relationship.resource.root_ontology_class, '{% trans 'Select an Ontology Property' %}')
                                                 }
                                             ">
                                         </span>
@@ -143,7 +143,7 @@
                                         <span class="col-sm-4">
                                             <input style="width:30%; display:inline-block;" data-bind="
                                                 select2Query: {
-                                                    select2Config: self.getSelect2ConfigForOntologyProperties(relationship.inverserelationshiptype, relationship.resource.root_ontology_class, self.rootOntologyClass)
+                                                    select2Config: self.getSelect2ConfigForOntologyProperties(relationship.inverserelationshiptype, relationship.resource.root_ontology_class, self.rootOntologyClass, '{% trans 'Select an Ontology Property' %}')
                                                 }
                                             ">
                                         </span>
@@ -162,7 +162,7 @@
                                         <span class="col-sm-4">
                                             <input style="width:30%; display:inline-block;" data-bind="
                                                 select2Query: {
-                                                    select2Config: self.getSelect2ConfigForOntologyProperties(relationship.inverserelationshiptype, self.rootOntologyClass, relationship.resource.root_ontology_class)
+                                                    select2Config: self.getSelect2ConfigForOntologyProperties(relationship.inverserelationshiptype, self.rootOntologyClass, relationship.resource.root_ontology_class, '{% trans 'Select an Ontology Property' %}')
                                                 }
                                             ">
                                         </span>
@@ -179,7 +179,7 @@
                                             <span class="col-sm-4">
                                                 <input style="width:30%; display:inline-block;" data-bind="
                                                     select2Query: {
-                                                        select2Config: self.getSelect2ConfigForOntologyProperties(relationship.relationshiptype, relationship.resource.root_ontology_class, self.rootOntologyClass)
+                                                        select2Config: self.getSelect2ConfigForOntologyProperties(relationship.relationshiptype, relationship.resource.root_ontology_class, self.rootOntologyClass, '{% trans 'Select an Ontology Property' %}')
                                                     }
                                                 ">
                                             </span>
@@ -219,7 +219,7 @@
                                         </div>
                                     </div>
                                 </div>
-                    
+
                                 <!--ko if: self.graphIsSemantic === false -->
                                 <div class="row widget-container" style="padding-left: 0px;">
                                     <div class="form-group">
@@ -231,7 +231,7 @@
                                                     class="ion-ios-checkmark-outline"></i>
                                             </label>
                                         </div>
-                    
+
                                         <div class="relative">
                                             <div class="col-xs-6">
                                                 <input type="text" class="form-control input-lg widget-input" placeholder="date from"
@@ -244,14 +244,14 @@
                                         </div>
                                     </div>
                                 </div>
-                    
+
                                 <div class="row widget-container" style="padding-left: 0px;">
                                     <div class="form-group">
                                         <div class="relative">
                                             <label class="col-xs-12 control-label widget-input-label" for="">{% trans "Description" %} <i
                                                     class="ion-ios-checkmark-outline"></i></label>
                                         </div>
-                    
+
                                         <div class="col-xs-12">
                                             <input type="text" id="editor1" class="form-control input-lg widget-input"
                                                 data-bind="textInput: relationship.notes">


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Update the related instance datatype in graph designer to add capability to reset the default value, re #6363 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Resolve the issue of not being able to remove the selection once the default is set for the related instance datatype in graph designer

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
