### PR TITLE
Fix PhotoGallery card thumbnail arrows to respect user interaction

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -1221,6 +1221,7 @@ ul.tabbed-report-tab-list {
     border-top: 1px solid #ddd;
     border-bottom: solid 1px #ddd;
     color: #555;
+    cursor: pointer;
 }
 
 .thumbnail-gallery-controls.left {

--- a/arches/app/media/js/views/components/cards/photo-gallery-card.js
+++ b/arches/app/media/js/views/components/cards/photo-gallery-card.js
@@ -9,7 +9,8 @@ define([
     'viewmodels/photo-gallery',
     'bindings/slide',
     'bindings/fadeVisible',
-    'bindings/dropzone'
+    'bindings/dropzone',
+    'bindings/gallery'
 ], function(ko, koMapping, _, Dropzone, uuid, CardComponentViewModel, WorkbenchComponentViewModel, PhotoGallery) {
     return ko.components.register('photo-gallery-card', {
         viewModel: function(params) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
My updated understanding of the function of these arrows is not to cycle through the currently selected photo, as previously thought, but rather to shift the currently viewed section of the thumbnail gallery. This functionality was borked as well, with the fix being to import the binding into the compenent.

Old UX seen here: http://recordit.co/RNnI0jnVLV.gif
New UX seen here: https://recordit.co/VhT3mnHAMQ ( NOTE: screencapture software doesn't show changed cursor )


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6504 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


A minor followup issue to this is that a photo is selected, the thumbnail gallery view is set to the beginning. Will file a followup ticket. UX seen here: https://recordit.co/Jk9NlCuQbT
