### PR TITLE
#6443 performance fix 5.0.x

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -79,7 +79,7 @@ class BaseDataType(object):
         source_config = {"type": "vector", "tiles": [tileserver_url]}
         count = None
         if preview == True:
-            count = models.TileModel.objects.filter(data__has_key=str(node.nodeid)).count()
+            count = models.TileModel.objects.filter(nodegroup_id=node.nodegroup_id, data__has_key=str(node.nodeid)).count()
             if count == 0:
                 source_config = {
                     "type": "geojson",

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -586,7 +586,7 @@ class GeojsonFeatureCollectionDataType(BaseDataType):
             return None
         elif node.config is None:
             return None
-        count = models.TileModel.objects.filter(data__has_key=str(node.nodeid)).count()
+        count = models.TileModel.objects.filter(nodegroup_id=node.nodegroup_id, data__has_key=str(node.nodeid)).count()
         if not preview and (count < 1 or not node.config["layerActivated"]):
             return None
 

--- a/arches/app/views/map.py
+++ b/arches/app/views/map.py
@@ -75,7 +75,7 @@ class MapLayerManagerView(MapBaseManagerView):
             datatype = datatype_factory.get_instance(node.datatype)
             map_layer = datatype.get_map_layer(node=node, preview=True)
             if map_layer is not None:
-                count = models.TileModel.objects.filter(data__has_key=str(node.nodeid)).count()
+                count = models.TileModel.objects.filter(nodegroup_id=node.nodegroup_id, data__has_key=str(node.nodeid)).count()
                 if count > 0:
                     map_layer["bounds"] = get_resource_bounds(node)
                 else:


### PR DESCRIPTION
This adds performance improvements as discussed in ticket #6443 

When you have a lot of resources the tiles table stops performing well. Ensuring that queries include an index scan will help drastically.

All unit tests passed.