### PR TITLE
Widgets now appear after node creation

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -124,7 +124,7 @@ define([
                 var res = [];
                 var graphlist = this.preview ? arches.graphs : arches.resources;
                 if (params.node && params.state !== 'report') {
-                    res = params.node.config.graphs().map(function(item){
+                    res = ko.unwrap(params.node.config.graphs).map(function(item){
                         var graph = graphlist.find(function(graph){
                             return graph.graphid === item.graphid;
                         });

--- a/arches/app/media/js/views/graph/graph-designer/card-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/card-tree.js
@@ -229,6 +229,8 @@ define([
                 return updatedCards;
             },
             updateCards: function(selectedNodegroupId, data) {
+                self.updateNode(self.topCards(), data.updated_values.node);
+                
                 if (data.updated_values.card) {
                     var card = data.updated_values.card;
                     var defaultCardName = data.default_card_name;
@@ -246,7 +248,6 @@ define([
                     card.parentnodegroupId = _.filter(data.nodegroups, function(ng){return data.updated_values.card.nodegroup_id === ng.nodegroupid;})[0].parentnodegroup_id;
                     self.updateCard(self.topCards(), card, data);
                 } else {
-                    self.updateNode(self.topCards(), data.updated_values.node);
                     if (data.updated_values.node.nodegroup_id !== data.updated_values.node.nodeid) {
                         var oldCard = _.find(self.flattenTree(self.topCards(), []), function(card) {
                             return card.nodegroupid === data['updated_values'].node.nodeid;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This fixes the issue of widgets not appearing after creating new nodes. This is accomplished by having card-tree call `updateNode` regardless of any logic involving `data.updated_values.card`.

UX seen here: http://g.recordit.co/yuA8H0XMKm.gif

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6033 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

UX seen here: http://g.recordit.co/yuA8H0XMKm.gif
