### PR TITLE
grouped cards now handle node deletion

### DIFF
--- a/arches/app/media/js/views/components/cards/grouping.js
+++ b/arches/app/media/js/views/components/cards/grouping.js
@@ -56,29 +56,32 @@ define([
         }, this);
 
         this.groupedCards = ko.computed(function(){
-            var gc = _.map([this.card.model.id].concat(this.groupedCardIds()), function(cardid) {
+            return _.reduce([this.card.model.id].concat(this.groupedCardIds()), function(acc, cardid) {
                 var card = this.cardLookup[cardid]; 
-                var subscription = card.model.cardinality.subscribe(function(cardinality){
-                    if (cardinality !== '1') {
-                        card.model.cardinality('1');
-                        var errorTitle = 'Settings Conflict: Remove this card from grouped card?';
-                        var errorMesssage = 'The cardinality of this card can\'t be changed until you remove it from being grouped with the "' + self.card.model.name() + '" card.  Do you want to remove this card from being grouped with the "' + self.card.model.name() + '" card';
-                        params.pageVm.alert(new AlertViewModel('ep-alert-red', errorTitle, errorMesssage, function(){}, function(){
-                            var newgroup = _.filter(self.groupedCardIds(), function(cardid) {
-                                return cardid !== card.model.id;
-                            });
-                            self.groupedCardIds(newgroup);
-                            self.subscriptions[cardid].dispose();
-                            card.model.cardinality('n');
-                            self.card.model.save();
-                        }));
-                    }
-                }, this);
-                this.subscriptions[cardid] = subscription;
-                return card;
-            }, this);
 
-            return gc;
+                if (card) {
+                    var subscription = card.model.cardinality.subscribe(function(cardinality){
+                        if (cardinality !== '1') {
+                            card.model.cardinality('1');
+                            var errorTitle = 'Settings Conflict: Remove this card from grouped card?';
+                            var errorMesssage = 'The cardinality of this card can\'t be changed until you remove it from being grouped with the "' + self.card.model.name() + '" card.  Do you want to remove this card from being grouped with the "' + self.card.model.name() + '" card';
+                            params.pageVm.alert(new AlertViewModel('ep-alert-red', errorTitle, errorMesssage, function(){}, function(){
+                                var newgroup = _.filter(self.groupedCardIds(), function(cardid) {
+                                    return cardid !== card.model.id;
+                                });
+                                self.groupedCardIds(newgroup);
+                                self.subscriptions[cardid].dispose();
+                                card.model.cardinality('n');
+                                self.card.model.save();
+                            }));
+                        }
+                    }, this);
+
+                    this.subscriptions[cardid] = subscription;
+                    acc.push(card);
+                }
+                return acc;
+            }, [], this);
         }, this);
 
         var updatedSortedWidgetsList = function(cards) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This filters out deleted cards from the `groupedCards` observable. This fixes some minor undocumented UI issues, as well as fixes the UI break that happens when deleting a node from a grouped card. 

UX seen here: https://recordit.co/DzmmUhOfQa
NOTE: There are still some issues ( like deleting the child node of a grouped card doesn't register in either card ) that are likely addressed in #6546 


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5710 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [X] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)


### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

UX seen here: https://recordit.co/DzmmUhOfQa
NOTE: There are still some issues ( like deleting the child node of a grouped card doesn't register in either card ) that are likely addressed in #6546 
