### PR TITLE
6573 cbyrd add or remove node from grouped card breaks ui

### DIFF
--- a/arches/app/media/js/views/components/cards/grouping.js
+++ b/arches/app/media/js/views/components/cards/grouping.js
@@ -84,7 +84,7 @@ define([
         var updatedSortedWidgetsList = function(cards) {
             this.widgetInstanceDataLookup = {};
 
-            var sortedWidgetIds = this.sortedWidgetIds();
+            var sortedWidgetIds = ko.unwrap(this.sortedWidgetIds);
             var widgetNodeIdList = [];
 
             cards.forEach(function(card){
@@ -109,6 +109,12 @@ define([
 
         this.groupedCards.subscribe(function(cards) {
             updatedSortedWidgetsList.call(this, cards);
+        }, this);
+
+        ko.unwrap(this.groupedCards).forEach(function(card) {
+            card.widgets.subscribe(function(_widget) {
+                updatedSortedWidgetsList.call(this, cards);
+            }, this);
         }, this);
 
         if (!!params.preview) {

--- a/arches/app/media/js/views/components/cards/grouping.js
+++ b/arches/app/media/js/views/components/cards/grouping.js
@@ -84,7 +84,7 @@ define([
         var updatedSortedWidgetsList = function(cards) {
             this.widgetInstanceDataLookup = {};
 
-            var sortedWidgetIds = ko.unwrap(this.sortedWidgetIds);
+            var sortedWidgetIds = this.sortedWidgetIds();
             var widgetNodeIdList = [];
 
             cards.forEach(function(card){

--- a/arches/app/media/js/views/components/cards/grouping.js
+++ b/arches/app/media/js/views/components/cards/grouping.js
@@ -111,9 +111,9 @@ define([
             updatedSortedWidgetsList.call(this, cards);
         }, this);
 
-        ko.unwrap(this.groupedCards).forEach(function(card) {
-            card.widgets.subscribe(function(_widget) {
-                updatedSortedWidgetsList.call(this, cards);
+        _.each(this.groupedCards(), function(card) {
+            card.widgets.subscribe(function() {
+                updatedSortedWidgetsList.call(this, this.groupedCards());
             }, this);
         }, this);
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Grouping cards now respect widget addition / deletion.
UX seen here: http://g.recordit.co/2pcm7BZfMB.gif
This adds a widget subscription to the grouping card. This supersedes #6565 

A remaining bug is grouping both a node, and a newly-created node in the same card. `groupingViewModel.cardLookup` is not being updated with the correct card information. Will file a followup


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5710 #6573 #6522 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

### Further comments
Grouping cards now respect widget addition / deletion.
UX seen here: http://g.recordit.co/2pcm7BZfMB.gif
This adds a widget subscription to the grouping card. This supersedes #6565 

A remaining bug is grouping both a node, and a newly-created node in the same card. `groupingViewModel.cardLookup` is not being updated with the correct card information. Will file a followup