### PR TITLE
Main page no longer throws error if a user is not assigned to any groups

### DIFF
--- a/arches/app/utils/context_processors.py
+++ b/arches/app/utils/context_processors.py
@@ -36,7 +36,10 @@ def map_info(request):
     else:
         hex_bin_bounds = (0, 0, 1, 1)
         default_center = {"coordinates": [6.602384, 0.245926]}  # an island off the coast of Africa
-    query = GroupMapSettings.objects.filter(group=request.user.groups.all()[0])
+    if request.user.groups.count() == 0:
+        query = GroupMapSettings.objects.none()
+    else:
+        query = GroupMapSettings.objects.filter(group=request.user.groups.all()[0])
     if query.exists():
         group_map_settings = query.first()
         min_zoom = group_map_settings.min_zoom


### PR DESCRIPTION
…ups. Fixes #6587 in Arches core repo.

### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Currently, if a user is created but not assigned to any groups, the user is able to log in, but attempting to view the index page will cause a Django error to be thrown. The error is thrown from utils/context_processors.py, and happens because the code attempts to filter a QuerySet based on the first group of which the user is a member, without first checking that the user is in any groups, causing an index out of bounds error. I have simply put the filter into a condition which ensures that the filter is only applied if the number of groups is not zero.

### Issues Solved
#6587

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ads04r 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

