### PR TITLE
Allow additional params to be passed into the search component

### DIFF
--- a/arches/app/media/js/views/components/search/search-results.js
+++ b/arches/app/media/js/views/components/search/search-results.js
@@ -22,6 +22,7 @@ function($, _, BaseFilter, bootstrap, arches, select2, ko, koMapping, viewdata) 
             },
 
             initialize: function(options) {
+                this.params = options.params;
                 options.name = 'Search Results';
                 BaseFilter.prototype.initialize.call(this, options);
 


### PR DESCRIPTION
This is needed when it is instantiated outside of search, re archesproject/arches-for-science#274