### PR TITLE
rm node.save() during graph.validate as this happens in _update_node,…

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1378,7 +1378,6 @@ class Graph(models.GraphModel):
                     validated_fieldname = validate_fieldname(node.fieldname, fieldnames)
                     if validated_fieldname != node.fieldname:
                         node.fieldname = validated_fieldname
-                        node.save()
 
         # validate that nodes in a resource graph belong to the ontology assigned to the resource graph
         if self.ontology is not None:


### PR DESCRIPTION
… re original ticket #5641

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This PR removes a call of `node.save()` during graph.validate method as `node.save()` gets called anyway during graph.save and this redundancy serves no purpose.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#5641

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
