### PR TITLE
Add email_link for href tag in export notify email

### DIFF
--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -74,6 +74,7 @@ def export_search_results(self, userid, request_values, format):
         closing="Thank you",
         email=email,
         name=export_name,
+        email_link=str(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT).rstrip("/") + "/files/" + str(search_history_obj.downloadfile),
     )
     response = {"taskid": self.request.id, "msg": export_name, "notiftype_name": "Search Export Download Ready", "context": context}
 

--- a/arches/app/templates/email/download_ready_email_notification.htm
+++ b/arches/app/templates/email/download_ready_email_notification.htm
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<style>
-</style>
+    <style>
+    </style>
 </head>
+
 <body style="width: 400px;">
     <p>{{greeting}}</p>
     {% if link != "" %}
-    <a class="btn" href="{{link}}"><button class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'>{{button_text}}</button></a>
+    <a class="btn" href="{{email_link}}"><button
+            class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'>{{button_text}}</button></a>
     {% endif %}
     <p>{{closing}}</p>
 </body>
+
 </html>


### PR DESCRIPTION
As per bug #6675 , the e-mail template now uses email_link in the href tag so the URL where the export files are held can be accessed rather than just returning a UUID.

Passed unit tests run on local copy of code.