### PR TITLE
6711 cbyrd update graph ux

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -7687,6 +7687,7 @@ a.mega-dropdown-toggle.disabled {
     border-radius: 2px;
     padding: 0px 12px 0px 7px;
     margin-top: -1px;
+    overflow-y: hidden;
 }
 
 #container .table-bordered td,

--- a/arches/app/media/js/bindings/related-resources-graph.js
+++ b/arches/app/media/js/bindings/related-resources-graph.js
@@ -33,7 +33,7 @@ define([
                 .force("charge", d3.forceCollide().radius(100))
                 .force("radial", d3.forceRadial(300, width/2, height/2))
                 .force("center", d3.forceCenter(width / 2, height / 2))
-                .alpha(0.01)
+                .alpha(0.01);
                 
             var nodeList = options.nodeList;
             var currentResource = options.currentResource;
@@ -289,7 +289,7 @@ define([
                         .on("end", dragended));
 
                     function dragstarted(event, d) {
-                        if (!event.active) simulation.alphaTarget(0.01).restart();
+                        if (!event.active) { simulation.alphaTarget(0.01).restart() };
                         d.fx = d.x;
                         d.fy = d.y;
                     }
@@ -300,7 +300,7 @@ define([
                     }
                     
                     function dragended(event, d) {
-                        if (!event.active) simulation.alphaTarget(0);
+                        if (!event.active) { simulation.alphaTarget(0) };
                         d.fx = null;
                         d.fy = null;
                     }    

--- a/arches/app/media/js/bindings/related-resources-graph.js
+++ b/arches/app/media/js/bindings/related-resources-graph.js
@@ -6,7 +6,7 @@ define([
     'd3'
 ], function(ko, $, _, arches, d3) {
     ko.bindingHandlers.relatedResourcesGraph = {
-        init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        init: function(element, valueAccessor) {
             var modelMap = arches.resources.reduce(function(a, v) {
                 a[v.graphid] = v;
                 return a;
@@ -289,22 +289,22 @@ define([
                         .on("end", dragended)
                     );
 
-                    function dragstarted(event, d) {
-                        if (!event.active) { simulation.alphaTarget(0.01).restart(); }
-                        d.fx = d.x;
-                        d.fy = d.y;
-                    }
-                    
-                    function dragged(event, d) {
-                        d.fx = event.x;
-                        d.fy = event.y;
-                    }
-                    
-                    function dragended(event, d) {
-                        if (!event.active) { simulation.alphaTarget(0); }
-                        d.fx = null;
-                        d.fy = null;
-                    }    
+                function dragstarted(event, d) {
+                    if (!event.active) { simulation.alphaTarget(0.01).restart(); }
+                    d.fx = d.x;
+                    d.fy = d.y;
+                }
+                
+                function dragged(event, d) {
+                    d.fx = event.x;
+                    d.fy = event.y;
+                }
+                
+                function dragended(event, d) {
+                    if (!event.active) { simulation.alphaTarget(0); }
+                    d.fx = null;
+                    d.fy = null;
+                }    
 
                 if (texts) {
                     texts.remove();
@@ -323,8 +323,8 @@ define([
 
                 simulation.on("tick", function() {
                     link.attr("x1", function(d) {
-                            return d.source.x;
-                        })
+                        return d.source.x;
+                    })
                         .attr("y1", function(d) {
                             return d.source.y;
                         })
@@ -336,8 +336,8 @@ define([
                         });
 
                     node.attr("cx", function(d) {
-                            return d.x;
-                        })
+                        return d.x;
+                    })
                         .attr("cy", function(d) {
                             return d.y;
                         })
@@ -428,13 +428,14 @@ define([
                             page: page > 0 ? page : 1
                         },
                         error: function(e) {
+                            // eslint-disable-next-line no-console
                             console.log('request failed', e);
                         },
                         success: function(response) {
                             var links = [];
                             var nodes = [];
                             var rr = response.related_resources;
-                            var total_loaded;
+                            var totalLoaded;
                             if (isRoot) {
                                 nodeSelection.removeAll();
                                 selectedState(false);
@@ -458,8 +459,8 @@ define([
                                 nodeMap[resourceId] = rootNode;
                                 newNodeId += 1;
                             } else if (rootNode.relationCount) {
-                                total_loaded = rootNode.relationCount.loaded + rr.resource_relationships.length;
-                                rootNode.relationCount.loaded = total_loaded <= rr.total.value ? total_loaded : rr.total.value;
+                                totalLoaded = rootNode.relationCount.loaded + rr.resource_relationships.length;
+                                rootNode.relationCount.loaded = totalLoaded <= rr.total.value ? totalLoaded : rr.total.value;
                             } else {
                                 rootNode.relationCount = {
                                     total: rr.total.value,
@@ -469,40 +470,40 @@ define([
                             rootNode.loading = false;
                             updateNodeInfo(rootNode);
 
-                            var getRelated = function(related_resource) {
+                            var getRelated = function(relatedResource) {
                                 var nodeConfigLookup = rr.node_config_lookup;
-                                if (!nodeMap[related_resource.resourceinstanceid]) {
+                                if (!nodeMap[relatedResource.resourceinstanceid]) {
                                     var node = {
                                         id: newNodeId,
-                                        entityid: related_resource.resourceinstanceid,
-                                        entitytypeid: related_resource.graph_id,
-                                        name: related_resource.displayname,
-                                        description: related_resource.displaydescription,
-                                        color: nodeConfigLookup[related_resource.graph_id].fillColor,
-                                        iconclass: nodeConfigLookup[related_resource.graph_id].iconclass,
-                                        graphname: nodeConfigLookup[related_resource.graph_id].name,
+                                        entityid: relatedResource.resourceinstanceid,
+                                        entitytypeid: relatedResource.graph_id,
+                                        name: relatedResource.displayname,
+                                        description: relatedResource.displaydescription,
+                                        color: nodeConfigLookup[relatedResource.graph_id].fillColor,
+                                        iconclass: nodeConfigLookup[relatedResource.graph_id].iconclass,
+                                        graphname: nodeConfigLookup[relatedResource.graph_id].name,
                                         isRoot: false,
                                         relationType: 'Ancestor',
                                         relationCount: {
-                                            total: related_resource.total_relations.value,
+                                            total: relatedResource.total_relations.value,
                                             loaded: 1
                                         }
                                     };
                                     nodes.push(node);
-                                    nodeMap[related_resource.resourceinstanceid] = node;
+                                    nodeMap[relatedResource.resourceinstanceid] = node;
                                     newNodeId += 1;
                                 }
                             };
                             _.each(rr.related_resources, getRelated);
 
-                            _.each(rr.resource_relationships, function(resource_relationships) {
-                                var sourceId = nodeMap[resource_relationships.resourceinstanceidfrom];
-                                var targetId = nodeMap[resource_relationships.resourceinstanceidto];
-                                var relationshipSource = resource_relationships.relationshiptype_label;
-                                var relationshipTarget = resource_relationships.relationshiptype_label;
-                                if (resource_relationships.relationshiptype_label.split('/').length === 2) {
-                                    relationshipSource = resource_relationships.relationshiptype_label.split('/')[0].trim();
-                                    relationshipTarget = resource_relationships.relationshiptype_label.split('/')[1].trim();
+                            _.each(rr.resource_relationships, function(resourceRelationships) {
+                                var sourceId = nodeMap[resourceRelationships.resourceinstanceidfrom];
+                                var targetId = nodeMap[resourceRelationships.resourceinstanceidto];
+                                var relationshipSource = resourceRelationships.relationshiptype_label;
+                                var relationshipTarget = resourceRelationships.relationshiptype_label;
+                                if (resourceRelationships.relationshiptype_label.split('/').length === 2) {
+                                    relationshipSource = resourceRelationships.relationshiptype_label.split('/')[0].trim();
+                                    relationshipTarget = resourceRelationships.relationshiptype_label.split('/')[1].trim();
                                 }
 
                                 links.push({

--- a/arches/app/media/js/bindings/related-resources-graph.js
+++ b/arches/app/media/js/bindings/related-resources-graph.js
@@ -29,11 +29,11 @@ define([
             var selectedNode;
 
             var simulation = d3.forceSimulation(data.nodes)
-                .force("link", d3.forceLink(data.links).id(d => d.id).distance(function(d){
-                    return 200;
-                }))
-                .force("charge", d3.forceManyBody().strength(-500))
-                .force("center", d3.forceCenter(width / 2, height / 2)); 
+                .force("link", d3.forceLink(data.links))
+                .force("charge", d3.forceCollide().radius(100))
+                .force("radial", d3.forceRadial(300, width/2, height/2))
+                .force("center", d3.forceCenter(width / 2, height / 2))
+                .alpha(0.01)
                 
             var nodeList = options.nodeList;
             var currentResource = options.currentResource;
@@ -129,7 +129,7 @@ define([
                 .attr("viewBox", [0, 0, width, height])
                 .call(d3.zoom()
                     .extent([[0, 0], [width, height]])
-                    .scaleExtent([1, 8])
+                    .scaleExtent([0.25, 8])
                     .on("zoom", function(event) {
                         groupElement.attr("transform", event.transform);
                     }));
@@ -140,11 +140,11 @@ define([
 
             var update = function() {
                 var linkMap = linkMap;
-        
+
                 $(window).trigger("resize");
                 simulation.nodes(data.nodes);
                 simulation.force("link").links(data.links);
-                simulation.restart();
+                simulation.alpha(0.01).restart();
 
                 var link = linksElement.selectAll("line")
                     .data(data.links)
@@ -289,7 +289,7 @@ define([
                         .on("end", dragended));
 
                     function dragstarted(event, d) {
-                        if (!event.active) simulation.alphaTarget(0.3).restart();
+                        if (!event.active) simulation.alphaTarget(0.01).restart();
                         d.fx = d.x;
                         d.fy = d.y;
                     }
@@ -339,8 +339,13 @@ define([
                         })
                         .attr("cy", function(d) {
                             return d.y;
+                        })
+                        .attr("x", function() {
+                            return width / 2;
+                        })
+                        .attr("y", function() {
+                            return height / 2;
                         });
-
                     texts
                         .attr("x", function(d) {
                             return d.x;
@@ -350,7 +355,6 @@ define([
                         });
 
                 });
-
             };
 
             var updateNodeInfo = function(d) {
@@ -603,9 +607,7 @@ define([
             }, this);
 
             nodeList([]);
-
         }
     };
-
     return ko.bindingHandlers.relatedResourcesGraph;
 });

--- a/arches/app/media/js/bindings/related-resources-graph.js
+++ b/arches/app/media/js/bindings/related-resources-graph.js
@@ -289,7 +289,7 @@ define([
                         .on("end", dragended));
 
                     function dragstarted(event, d) {
-                        if (!event.active) { simulation.alphaTarget(0.01).restart() };
+                        if (!event.active) { simulation.alphaTarget(0.01).restart(); }
                         d.fx = d.x;
                         d.fy = d.y;
                     }
@@ -300,7 +300,7 @@ define([
                     }
                     
                     function dragended(event, d) {
-                        if (!event.active) { simulation.alphaTarget(0) };
+                        if (!event.active) { simulation.alphaTarget(0); }
                         d.fx = null;
                         d.fy = null;
                     }    

--- a/arches/app/media/js/bindings/related-resources-graph.js
+++ b/arches/app/media/js/bindings/related-resources-graph.js
@@ -286,12 +286,11 @@ define([
                     .call(d3.drag()
                         .on("start", dragstarted)
                         .on("drag", dragged)
-                        .on("end", dragended));
+                        .on("end", dragended)
+                    );
 
                     function dragstarted(event, d) {
-                        if (!event.active) { 
-                            simulation.alphaTarget(0.01).restart(); 
-                        }
+                        if (!event.active) { simulation.alphaTarget(0.01).restart(); }
                         d.fx = d.x;
                         d.fy = d.y;
                     }
@@ -302,9 +301,7 @@ define([
                     }
                     
                     function dragended(event, d) {
-                        if (!event.active) { 
-                            simulation.alphaTarget(0); 
-                        }
+                        if (!event.active) { simulation.alphaTarget(0); }
                         d.fx = null;
                         d.fy = null;
                     }    

--- a/arches/app/media/js/bindings/related-resources-graph.js
+++ b/arches/app/media/js/bindings/related-resources-graph.js
@@ -289,7 +289,9 @@ define([
                         .on("end", dragended));
 
                     function dragstarted(event, d) {
-                        if (!event.active) { simulation.alphaTarget(0.01).restart(); }
+                        if (!event.active) { 
+                            simulation.alphaTarget(0.01).restart(); 
+                        }
                         d.fx = d.x;
                         d.fy = d.y;
                     }
@@ -300,7 +302,9 @@ define([
                     }
                     
                     function dragended(event, d) {
-                        if (!event.active) { simulation.alphaTarget(0); }
+                        if (!event.active) { 
+                            simulation.alphaTarget(0); 
+                        }
                         d.fx = null;
                         d.fy = null;
                     }    

--- a/arches/app/media/js/views/search.js
+++ b/arches/app/media/js/views/search.js
@@ -167,6 +167,7 @@ define([
                     }
                 },
                 complete: function(request, status) {
+                    this.viewModel.loading(false);
                     this.updateRequest = undefined;
                     window.history.pushState({}, '', '?' + $.param(queryString).split('+').join('%20'));
                 }

--- a/arches/app/media/js/views/search.js
+++ b/arches/app/media/js/views/search.js
@@ -167,7 +167,6 @@ define([
                     }
                 },
                 complete: function(request, status) {
-                    this.viewModel.loading(false);
                     this.updateRequest = undefined;
                     window.history.pushState({}, '', '?' + $.param(queryString).split('+').join('%20'));
                 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

force-directed graph now has better UX. The double-scroll has been removed, the user can now 'zoom out' to a scale of 0.25, and nodes no longer clump in the upper-left corner. 

An issue remains, if the user selects 'Related Resources' from the search page before the application has completely loaded, some non-breaking incorrect node behavior persists.A good rule of thumb for testing this behavior is if the `Related Resources` link changes the cursor to a pointer. If it's not yet a pointer, the app has not completely loaded and we can observe the incorrect behavior.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6711 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
