### PR TITLE
Moves node.name validation logic to graph.validate, re #6765

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1338,16 +1338,16 @@ class Graph(models.GraphModel):
                 names_in_nodegroup = [v.name for k, v in self.nodes.items() if v.nodegroup_id == node.nodegroup_id]
                 unique_names_in_nodegroup = {n for n in names_in_nodegroup}
                 if len(names_in_nodegroup) > len(unique_names_in_nodegroup):
-                    message = _("Duplicate name: {0}. All names in a nodegroup must be unique.".format(node.name))
+                    message = _("Duplicate node name: \"{0}\". All node names in a card must be unique.".format(node.name))
                     raise GraphValidationError(message)
                 elif node.is_editable() is False:
-                    message = "You cannot change the name of a node with associated business data."
+                    message = "The name of this node cannot be changed because business data has already been saved to a card that this node is part of."
                     raise GraphValidationError(_(message))
                 elif models.Edge.objects.filter(rangenode_id=node.nodeid).exists():
                     parent_node = models.Edge.objects.get(rangenode_id=node.nodeid).domainnode_id
                     sibling_nodes = [edge.rangenode.name for edge in models.Edge.objects.filter(domainnode_id=parent_node)]
                     if node.name in sibling_nodes:
-                        message = _("Duplicate name: {0}. All sibling names must be unique.".format(node.name))
+                        message = _("Duplicate node name: \"{0}\". All sibling node names must be unique.".format(node.name))
                         raise GraphValidationError(message)
 
     def validate(self):

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -338,43 +338,10 @@ class Graph(models.GraphModel):
     def _update_node(self, node, datatype_factory, se):
         already_saved = models.Node.objects.filter(pk=node.nodeid).exists()
         saved_node_datatype = None
-        saved_name = ""
-        is_name_valid = True
-
+        node.save()
         if already_saved:
             saved_node = models.Node.objects.get(pk=node.nodeid)
             saved_node_datatype = saved_node.datatype
-            saved_name = saved_node.name
-        if not node.istopnode and models.Edge.objects.filter(rangenode=node).exists():
-            parent_node = models.Edge.objects.get(rangenode=node).domainnode.nodeid
-            sibling_nodes = [edge.rangenode.name for edge in models.Edge.objects.filter(domainnode=parent_node)]
-            is_name_valid = (saved_name == node.name) or (saved_name != node.name and (node.name not in sibling_nodes))
-
-        if is_name_valid:
-            if self.is_editable() is True:
-                try:
-                    node.save()
-                except IntegrityError:
-                    raise GraphValidationError(
-                        _(
-                            "The node: {0}, you tried to save is invalid. Be sure that all node names in your card are unique.".format(
-                                node.name
-                            )
-                        )
-                    )
-            else:
-                raise GraphValidationError(
-                    _(
-                        "The node: {0}, you tried to save is invalid. Be sure that all sibling node names and node names in your card are unique.".format(
-                            node.name
-                        )
-                    )
-                )
-        else:
-            raise GraphValidationError(
-                _("The node: {0}, you tried to save is invalid. Be sure that all node names in your card are unique.".format(node.name))
-            )
-
         if saved_node_datatype != node.datatype:
             datatype = datatype_factory.get_instance(node.datatype)
             datatype_mapping = datatype.get_es_mapping(node.nodeid)
@@ -1357,6 +1324,32 @@ class Graph(models.GraphModel):
                         1006,
                     )
 
+    def _validate_node_name(self, node):
+        """
+        Verifies a node's name is unique to its nodegroup
+        Prevents a user from changing the name of a node that already has tiles.
+        Verifies a node's name is unique to its sibling nodes.
+        """
+        if node.istopnode or models.Node.objects.filter(pk=node.nodeid).exists() is False:
+            return
+        else:
+            changing_name = node.name != models.Node.objects.get(pk=node.nodeid).name
+            if changing_name:
+                names_in_nodegroup = [v.name for k, v in self.nodes.items() if v.nodegroup_id == node.nodegroup_id]
+                unique_names_in_nodegroup = {n for n in names_in_nodegroup}
+                if len(names_in_nodegroup) > len(unique_names_in_nodegroup):
+                    message = _("Duplicate name: {0}. All names in a nodegroup must be unique.".format(node.name))
+                    raise GraphValidationError(message)
+                elif node.is_editable() is False:
+                    message = "You cannot change the name of a node with associated business data."
+                    raise GraphValidationError(_(message))
+                elif models.Edge.objects.filter(rangenode_id=node.nodeid).exists():
+                    parent_node = models.Edge.objects.get(rangenode_id=node.nodeid).domainnode_id
+                    sibling_nodes = [edge.rangenode.name for edge in models.Edge.objects.filter(domainnode_id=parent_node)]
+                    if node.name in sibling_nodes:
+                        message = _("Duplicate name: {0}. All sibling names must be unique.".format(node.name))
+                        raise GraphValidationError(message)
+
     def validate(self):
         """
         validates certain aspects of resource graphs according to defined rules:
@@ -1408,6 +1401,7 @@ class Graph(models.GraphModel):
 
         fieldnames = {}
         for node_id, node in self.nodes.items():
+            self._validate_node_name(node)
             if node.exportable is True:
                 if node.fieldname is not None:
                     validated_fieldname = validate_fieldname(node.fieldname, fieldnames)

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1338,7 +1338,7 @@ class Graph(models.GraphModel):
                 names_in_nodegroup = [v.name for k, v in self.nodes.items() if v.nodegroup_id == node.nodegroup_id]
                 unique_names_in_nodegroup = {n for n in names_in_nodegroup}
                 if len(names_in_nodegroup) > len(unique_names_in_nodegroup):
-                    message = _("Duplicate node name: \"{0}\". All node names in a card must be unique.".format(node.name))
+                    message = _('Duplicate node name: "{0}". All node names in a card must be unique.'.format(node.name))
                     raise GraphValidationError(message)
                 elif node.is_editable() is False:
                     message = "The name of this node cannot be changed because business data has already been saved to a card that this node is part of."
@@ -1347,7 +1347,7 @@ class Graph(models.GraphModel):
                     parent_node = models.Edge.objects.get(rangenode_id=node.nodeid).domainnode_id
                     sibling_nodes = [edge.rangenode.name for edge in models.Edge.objects.filter(domainnode_id=parent_node)]
                     if node.name in sibling_nodes:
-                        message = _("Duplicate node name: \"{0}\". All sibling node names must be unique.".format(node.name))
+                        message = _('Duplicate node name: "{0}". All sibling node names must be unique.'.format(node.name))
                         raise GraphValidationError(message)
 
     def validate(self):


### PR DESCRIPTION
Moves node.name validation logic to graph.validate to prevent error when appending new nodes to a graph, re #6765