### PR TITLE
Use default business_data_load_order instead of ..._dev #6810

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -315,7 +315,7 @@ class Command(BaseCommand):
         with open(os.path.join(dest_dir, "package_config.json"), "w") as config_file:
             try:
                 constraints = models.Resource2ResourceConstraint.objects.all()
-                configs = {"permitted_resource_relationships": constraints}
+                configs = {"permitted_resource_relationships": constraints, "business_data_load_order": []}
                 config_file.write(JSONSerializer().serialize(configs))
             except Exception as e:
                 print(e)

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -632,13 +632,13 @@ class Command(BaseCommand):
                 configs = json.load(open(config_paths[0]))
 
             business_data = []
-            if dev and os.path.isdir(os.path.join(package_dir, "business_data", "sample_data")):
-                if "business_data_load_order_dev" in configs and len(configs["business_data_load_order_dev"]) > 0:
-                    for f in configs["business_data_load_order_dev"]:
-                        business_data.append(os.path.join(package_dir, "business_data", "sample_data", f))
+            if dev and os.path.isdir(os.path.join(package_dir, "business_data", "dev_data")):
+                if "business_data_load_order" in configs and len(configs["business_data_load_order"]) > 0:
+                    for f in configs["business_data_load_order"]:
+                        business_data.append(os.path.join(package_dir, "business_data", "dev_data", f))
                 else:
                     for ext in ["*.json", "*.jsonl", "*.csv"]:
-                        business_data += glob.glob(os.path.join(package_dir, "business_data", "sample_data", ext))
+                        business_data += glob.glob(os.path.join(package_dir, "business_data", "dev_data", ext))
             else:
                 if "business_data_load_order" in configs and len(configs["business_data_load_order"]) > 0:
                     for f in configs["business_data_load_order"]:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Uses default business_data_load_order instead of business_data_load_order_dev, re #6810
So, removes business_data_load_order_dev and also changes the directory name to /dev_data

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6810 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
