### PR TITLE
Related resource map improvements re #6905 #6906

### DIFF
--- a/arches/app/media/js/views/components/cards/related-resources-map.js
+++ b/arches/app/media/js/views/components/cards/related-resources-map.js
@@ -82,7 +82,9 @@ define([
                 console.error('Error:', error);
               });
         })
-        this.filterNodeIds = ko.observableArray(JSON.parse(JSON.stringify(this.nodeids)));
+        var parsedNodeIds = JSON.parse(JSON.stringify(this.nodeids));
+        var firstNode = parsedNodeIds.length > 0 ? [parsedNodeIds[0]] : [];
+        this.filterNodeIds = ko.observableArray(firstNode);
         this.relatedResourceWidgets = this.widgets.filter(function(widget){return widget.datatype.datatype === 'resource-instance' || widget.datatype.datatype === 'resource-instance-list';});
         this.showRelatedQuery = ko.observable(false);
         var resourceBounds = ko.observable();

--- a/arches/app/media/js/views/components/cards/related-resources-map.js
+++ b/arches/app/media/js/views/components/cards/related-resources-map.js
@@ -186,6 +186,18 @@ define([
             }
         };
 
+        this.unrelateResource = function(resourceData, widget) {
+            var id = widget.node_id();
+            var resourceinstanceid = ko.unwrap(resourceData.resourceinstanceid);
+            var related = resourceData.mapCard.tile.data[id]()
+            for( var i = 0; i < related.length; i++){ 
+                if ( ko.unwrap(related[i].resourceId) === resourceinstanceid) { 
+                    related.splice(i, 1); 
+                }
+            }
+            resourceData.mapCard.tile.data[id](related);
+        };
+
         this.isSelectable = function(feature) {
             var selectLayerIds = selectFeatureLayers.map(function(layer) {
                 return layer.id;

--- a/arches/app/templates/views/components/cards/related-resources-map-popup.htm
+++ b/arches/app/templates/views/components/cards/related-resources-map-popup.htm
@@ -5,10 +5,19 @@
 <!-- ko foreach: {data: mapCard.widgets, as: 'widget'} -->
     <!-- ko if: widget.datatype.datatype === 'resource-instance-list' || widget.datatype.datatype === 'resource-instance' -->
     <a href="javascript:void(0)" data-bind="if: $parent.mapCard.isSelectable($parent.feature), click: function() {
-        $parent.mapCard.relateResource($parent, widget);
+        if (!!$parent.mapCard.tile.data[widget.node_id()]() && $parent.mapCard.tile.data[widget.node_id()]().filter(function(val){return ko.unwrap(val.resourceId) === $parent.resourceinstanceid()}).length > 0) {
+            $parent.mapCard.unrelateResource($parent, widget);
+        } else {
+            $parent.mapCard.relateResource($parent, widget);
+        }
     }">
         <i class="ion-ios-refresh-empty"></i>
+        <!-- ko if: !!$parent.mapCard.tile.data[widget.node_id()]() && $parent.mapCard.tile.data[widget.node_id()]().filter(function(val){return ko.unwrap(val.resourceId) === $parent.resourceinstanceid()}).length > 0 -->
+        <span data-bind="text: 'Unrelate ' + widget.label()"></span>
+        <!-- /ko -->
+        <!-- ko if: !$parent.mapCard.tile.data[widget.node_id()]() || $parent.mapCard.tile.data[widget.node_id()]().filter(function(val){return ko.unwrap(val.resourceId) === $parent.resourceinstanceid()}).length === 0 -->
         <span data-bind="text: 'Relate ' + widget.label()"></span>
+        <!-- /ko -->
     </a>
     <!-- /ko -->
 <!-- /ko -->


### PR DESCRIPTION
Allows a user to unrelate resources using the map popup and turns on only the first select able layer by default. re #6905 #6906