### PR TITLE
Files changed for app specific email config

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1212,7 +1212,7 @@ def send_email_on_save(sender, instance, **kwargs):
                 email_to = instance.recipient.email
             else:
                 email_to = context["email"]
-            subject, from_email, to = instance.notif.notiftype.name, "from@example.com", email_to
+            subject, from_email, to = instance.notif.notiftype.name, settings.DEFAULT_FROM_EMAIL, email_to
             msg = EmailMultiAlternatives(subject, text_content, from_email, [to])
             msg.attach_alternative(html_content, "text/html")
             msg.send()

--- a/arches/app/views/user.py
+++ b/arches/app/views/user.py
@@ -107,7 +107,9 @@ class UserManagerView(BaseManagerView):
     def get(self, request):
 
         if self.request.user.is_authenticated and self.request.user.username != "anonymous":
-            context = self.get_context_data(main_script="views/user-profile-manager", )
+            context = self.get_context_data(
+                main_script="views/user-profile-manager",
+            )
 
             user_details = self.get_user_details(request.user)
 
@@ -139,7 +141,9 @@ class UserManagerView(BaseManagerView):
 
             user_details = self.get_user_details(request.user)
 
-            context = self.get_context_data(main_script="views/user-profile-manager", )
+            context = self.get_context_data(
+                main_script="views/user-profile-manager",
+            )
             context["errors"] = []
             context["nav"]["icon"] = "fa fa-user"
             context["nav"]["title"] = _("Profile Manager")
@@ -166,10 +170,13 @@ class UserManagerView(BaseManagerView):
                 try:
                     admin_info = settings.ADMINS[0][1] if settings.ADMINS else ""
                     message = _(
-                        "Your arches profile was just changed.  If this was unexpected, please contact your Arches administrator at %s."
-                        % (admin_info)
+                        "Your "
+                        + settings.APP_NAME
+                        + " profile was just changed.  If this was unexpected, please contact your "
+                        + settings.APP_NAME
+                        + " administrator at %s." % (admin_info)
                     )
-                    user.email_user(_("You're Arches Profile Has Changed"), message)
+                    user.email_user(_("Your " + settings.APP_NAME + " Profile Has Changed"), message)
                 except Exception as e:
                     print(e)
                 request.user = user

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -179,12 +179,15 @@ NOCAPTCHA = True
 if DEBUG is True:
     SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
 
+
 # EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  #<-- Only need to uncomment this for testing without an actual email server
 # EMAIL_USE_TLS = True
 # EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_HOST_USER = 'xxxx@xxx.com'
+EMAIL_HOST_USER = "xxxx@xxx.com"
 # EMAIL_HOST_PASSWORD = 'xxxxxxx'
 # EMAIL_PORT = 587
+
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 CELERY_BROKER_URL = "" # RabbitMQ --> "amqp://guest:guest@localhost",  Redis --> "redis://localhost:6379/0"
 CELERY_ACCEPT_CONTENT = ['json']
@@ -211,8 +214,8 @@ RESTRICT_MEDIA_ACCESS = False
 # to see how the language code is derived in the actual code
 
 ####### TO GENERATE .PO FILES DO THE FOLLOWING ########
-# run the following commands 
-# language codes used in the command should be in the form (which is slightly different 
+# run the following commands
+# language codes used in the command should be in the form (which is slightly different
 # form the form used in the LANGUAGE_CODE and LANGUAGES settings below):
 # --local={countrycode}_{REGIONCODE} <-- countrycode is lowercase, regioncode is uppercase, also notice the underscore instead of hyphen
 # commands to run (to generate files for "British English, German, and Spanish"):
@@ -226,7 +229,7 @@ RESTRICT_MEDIA_ACCESS = False
 # a list of language codes can be found here http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = "en"
 
-# list of languages to display in the language switcher, 
+# list of languages to display in the language switcher,
 # if left empty or with a single entry then the switch won't be displayed
 # language codes need to be all lower case with the form:
 # {langcode}-{regioncode} eg: en, en-gb ....

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -150,9 +150,11 @@ SESSION_COOKIE_NAME = "arches"
 # EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  #<-- Only need to uncomment this for testing without an actual email server
 # EMAIL_USE_TLS = True
 # EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_HOST_USER = 'xxxx@xxx.com'
+EMAIL_HOST_USER = "xxxx@xxx.com"
 # EMAIL_HOST_PASSWORD = 'xxxxxxx'
 # EMAIL_PORT = 587
+
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 POSTGIS_VERSION = (3, 0, 0)
 
@@ -375,7 +377,11 @@ except Exception as e:
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {"console": {"format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",},},
+    "formatters": {
+        "console": {
+            "format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+        },
+    },
     "handlers": {
         "file": {
             "level": "WARNING",  # DEBUG, INFO, WARNING, ERROR, CRITICAL


### PR DESCRIPTION
Changes as detailed in Arches ticket 6673 for stable/5.1.x branch

- Replaces hard-coded 'from' email address in models.py with email address set in settings.DEFAULT_FROM_EMAIL
- Replaces hard-coded application name with the application name set in settings.APP_NAME
- Replaces "You're" in subject line for user update email with "Your"
- Adds DEFAULT_FROM_EMAIL to settings.py and settings.py-tpl