### PR TITLE
Fixes to correct export email link

### DIFF
--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -40,6 +40,7 @@ def message(arg):
 @shared_task(bind=True)
 def sync(self, surveyid=None, userid=None, synclogid=None):
     from arches.app.models.mobile_survey import MobileSurvey
+
     create_user_task_record(self.request.id, self.name, userid)
     survey = MobileSurvey.objects.get(id=surveyid)
     survey._sync(synclogid, userid)
@@ -67,6 +68,7 @@ def export_search_results(self, userid, request_values, format):
     exporter = SearchResultsExporter(search_request=new_request)
     files, export_info = exporter.export(format)
     exportid = exporter.write_export_zipfile(files, export_info)
+    search_history_obj = models.SearchExportHistory.objects.get(pk=exportid)
 
     return {
         "taskid": self.request.id,
@@ -81,6 +83,7 @@ def export_search_results(self, userid, request_values, format):
             closing=_("Thank you"),
             email=email,
             name=export_name,
+            email_link=str(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT).rstrip("/") + "/files/" + str(search_history_obj.downloadfile),
         ),
     }
 

--- a/arches/app/templates/email/download_ready_email_notification.htm
+++ b/arches/app/templates/email/download_ready_email_notification.htm
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<style>
-</style>
+    <style>
+    </style>
 </head>
+
 <body style="width: 400px;">
     <p>{{greeting}}</p>
     {% if link != "" %}
-    <a class="btn" href="{{link}}"><button class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'>{{button_text}}</button></a>
+    <a class="btn" href="{{email_link}}"><button
+            class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'>{{button_text}}</button></a>
     {% endif %}
     <p>{{closing}}</p>
 </body>
+
 </html>


### PR DESCRIPTION
Changes as detailed in Arches ticket 6675 for stable/5.1.x branch

- Added search_history_obj to user.py which returns the Search Export History object for the given export
- Added code to generate the full path of the export object as email_link within user.py within the return object for export_search_results
- changed {{link}} to {{email_link}} in download_ready_email_notification.htm

Tested by running an export of over 2000 records in a local installation 