### PR TITLE
Fixes geojson search endpoint url when localization in applied. re #6908

### DIFF
--- a/arches/app/media/js/views/components/search/search-export.js
+++ b/arches/app/media/js/views/components/search/search-export.js
@@ -31,7 +31,8 @@ function($, ko, arches) {
 
             this.geojsonUrl = ko.pureComputed(function(){
                 if (ko.unwrap(self.format()) === 'geojson') {
-                    return window.location.origin + '/api' + self.url();
+                    var exportPath = self.url().replace('search/export_results', 'api/search/export_results');
+                    return window.location.origin + exportPath;
                 } else {
                     return null;
                 }


### PR DESCRIPTION
Geojson search endpoint URL properly formed even if a language identifier is specified in the URL. re #6908
