### PR TITLE
Disable editor/image tabs in iiif annotation when an image (canvas) is not loaded

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -1617,6 +1617,7 @@ div.final-cons-step-separator>h4 {
 .workbench-card-sidebar-tab.disabled {
     color: #aaa;
     cursor: auto;
+    pointer-events: none;
 }
 
 .workbench-card-sidebar-tab i {

--- a/arches/app/media/js/views/components/iiif-annotation.js
+++ b/arches/app/media/js/views/components/iiif-annotation.js
@@ -127,6 +127,12 @@ define([
             }
         });
 
+        this.expandGallery.subscribe(function(val){
+            if (val) {
+                self.hideSidePanel();
+            }
+        });
+
         this.getAnnotationCount = function(canvas) {
             return drawFeatures().filter(function(feature) {
                 return feature.properties.canvas === canvas;

--- a/arches/app/media/js/views/components/iiif-annotation.js
+++ b/arches/app/media/js/views/components/iiif-annotation.js
@@ -117,8 +117,12 @@ define([
         };
         updateDrawFeatures();
 
-        params.activeTab = 'editor';
         IIIFViewerViewmodel.apply(this, [params]);
+
+        var setTab = this.canvas.subscribe(function(val){
+            if (val) {self.activeTab('editor')}
+            setTab.dispose();
+         });
 
         this.getAnnotationCount = function(canvas) {
             return drawFeatures().filter(function(feature) {

--- a/arches/app/media/js/views/components/iiif-annotation.js
+++ b/arches/app/media/js/views/components/iiif-annotation.js
@@ -120,9 +120,12 @@ define([
         IIIFViewerViewmodel.apply(this, [params]);
 
         var setTab = this.canvas.subscribe(function(val){
-            if (val) {self.activeTab('editor')}
-            setTab.dispose();
-         });
+            if (val) {
+                self.expandGallery(false);
+                self.activeTab('editor');
+                setTab.dispose();
+            };
+        });
 
         this.getAnnotationCount = function(canvas) {
             return drawFeatures().filter(function(feature) {

--- a/arches/app/media/js/views/components/iiif-annotation.js
+++ b/arches/app/media/js/views/components/iiif-annotation.js
@@ -124,7 +124,7 @@ define([
                 self.expandGallery(false);
                 self.activeTab('editor');
                 setTab.dispose();
-            };
+            }
         });
 
         this.getAnnotationCount = function(canvas) {

--- a/arches/app/templates/views/components/iiif-annotation.htm
+++ b/arches/app/templates/views/components/iiif-annotation.htm
@@ -5,7 +5,7 @@
 <div class="workbench-card-sidebar-tab" data-bind="click: function() {
     toggleTab('editor');
 }, css: {
-    'active': activeTab() === 'editor', 'disabled': !canvas()
+    'active': activeTab() === 'editor', 'disabled': !canvas() || expandGallery()
 }">
     <i class="fa fa-pencil"></i>
     <span class="map-sidebar-text">{% trans "Edit" %}</span>

--- a/arches/app/templates/views/components/iiif-annotation.htm
+++ b/arches/app/templates/views/components/iiif-annotation.htm
@@ -5,7 +5,7 @@
 <div class="workbench-card-sidebar-tab" data-bind="click: function() {
     toggleTab('editor');
 }, css: {
-    'active': activeTab() === 'editor'
+    'active': activeTab() === 'editor', 'disabled': !canvas()
 }">
     <i class="fa fa-pencil"></i>
     <span class="map-sidebar-text">{% trans "Edit" %}</span>

--- a/arches/app/templates/views/components/iiif-viewer.htm
+++ b/arches/app/templates/views/components/iiif-viewer.htm
@@ -6,7 +6,7 @@
 <div class="workbench-card-sidebar-tab" data-bind="click: function() {
     toggleTab('imageTools');
 }, css: {
-    'active': activeTab() === 'imageTools'
+    'active': activeTab() === 'imageTools', 'disabled': !canvas() || expandGallery()
 }">
     <i class="fa fa-image"></i>
     <span class="map-sidebar-text">{% trans "Image" %}</span>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Disable editor/image tabs in iiif annotation when an image (canvas) is not loaded, re #6895

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#6895

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
