### PR TITLE
Fix error when saving files with the same name. re #7142

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1294,7 +1294,7 @@ class FileListDataType(BaseDataType):
                             try:
                                 file_model = models.File.objects.get(pk=file["file_id"])
                             except ObjectDoesNotExist: 
-                                # Do not use get_or_create here because django can create a different file_path
+                                # Do not use get_or_create here because django can create a different file name applied to the file_path
                                 # for the same file_id causing a 'create' when a 'get' was intended
                                 file_model = models.File.objects.create(pk=file["file_id"], path=file_path)
                             if not file_model.tile_id:

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1291,7 +1291,12 @@ class FileListDataType(BaseDataType):
                         if file["url"] == "/files/{}".format(file["file_id"]):
                             val = uuid.UUID(file["file_id"])  # to test if file_id is uuid
                             file_path = "uploadedfiles/" + file["name"]
-                            file_model, created = models.File.objects.get_or_create(pk=file["file_id"], path=file_path)
+                            try:
+                                file_model = models.File.objects.get(pk=file["file_id"])
+                            except ObjectDoesNotExist: 
+                                # Do not use get_or_create here because django can create a different file_path
+                                # for the same file_id causing a 'create' when a 'get' was intended
+                                file_model = models.File.objects.create(pk=file["file_id"], path=file_path)
                             if not file_model.tile_id:
                                 file_model.tile = tile
                                 file_model.save()

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1293,7 +1293,7 @@ class FileListDataType(BaseDataType):
                             file_path = "uploadedfiles/" + file["name"]
                             try:
                                 file_model = models.File.objects.get(pk=file["file_id"])
-                            except ObjectDoesNotExist: 
+                            except ObjectDoesNotExist:
                                 # Do not use get_or_create here because django can create a different file name applied to the file_path
                                 # for the same file_id causing a 'create' when a 'get' was intended
                                 file_model = models.File.objects.create(pk=file["file_id"], path=file_path)


### PR DESCRIPTION
Prevent error when using get_or_create to save files that already exist. 
