### PR TITLE
Fix failing Pillow install for Python 3.9

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -21,5 +21,5 @@ pycryptodome<4.0.0,>=3.3.1
 pyshp==2.1.2
 requests[security]>=2.18.1
 python-slugify==4.0.0
-pillow==7.0.0
+pillow>=7.0.0
 arcgis2geojson==2.0.0


### PR DESCRIPTION
Allows for installation of Pillow > 7.0