### PR TITLE
Ensures nodeid is in feature.properties, re #7167

### DIFF
--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -357,7 +357,7 @@ class GeoJSON(APIBase):
                                 feature["properties"]["primary_name"] = self.get_name(tile.resourceinstance)
                             feature["properties"]["resourceinstanceid"] = tile.resourceinstance_id
                             feature["properties"]["tileid"] = tile.pk
-                            if nodeid is None:
+                            if "nodeid" not in feature["properties"]:
                                 feature["properties"]["nodeid"] = node.pk
                             if include_geojson_link:
                                 feature["properties"]["geojson"] = "%s?tileid=%s&nodeid=%s" % (reverse("geojson"), tile.pk, node.pk)


### PR DESCRIPTION
Ensures `nodeid` is in feature.properties regardless whether `nodeId` already exists, re #7167