### PR TITLE
Remove python-dev as it seems to be causing the build to fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Java, GDAL, and other system dependencies
         run: |
-          sudo apt-get install libxml2-dev libpq-dev openjdk-8-jdk python-dev libgdal-dev
+          sudo apt-get install libxml2-dev libpq-dev openjdk-8-jdk libgdal-dev
           echo Postgres and ES dependencies installed
 
       - uses: ankane/setup-elasticsearch@v1


### PR DESCRIPTION
 Remove python-dev as it seems to be causing the build to fail and is probably unnecessary in latest.
