### PR TITLE
Handle python .astimezone() bug on Windows

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -320,10 +320,15 @@ class DateDataType(BaseDataType):
             value = value[0]
         valid_date_format, valid = self.get_valid_date_format(value)
         if valid:
-            value = datetime.strptime(value, valid_date_format).astimezone().isoformat(timespec="milliseconds")
+            v = datetime.strptime(value, valid_date_format)
         else:
             v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
-            value = v.astimezone().isoformat(timespec="milliseconds")
+        if not sys.platform == "win32":
+            v = v.astimezone()
+        else: # current python bug causes error on Windows machines when calling .astimezone() on a datetime before 1970 (start of epoch)
+            if datetime >= datetime.fromtimestamp(0):
+            v = v.astimezone()
+        value = v.isoformat(timespec="milliseconds")
         return value
 
     def transform_export_values(self, value, *args, **kwargs):

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -323,11 +323,11 @@ class DateDataType(BaseDataType):
             v = datetime.strptime(value, valid_date_format)
         else:
             v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
-        if not sys.platform == "win32":
+        if not sys.platform.startswith("win"):
             v = v.astimezone()
         else: # current python bug causes error on Windows machines when calling .astimezone() on a datetime before 1970 (start of epoch)
             if datetime >= datetime.fromtimestamp(0):
-            v = v.astimezone()
+                v = v.astimezone()
         value = v.isoformat(timespec="milliseconds")
         return value
 

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -325,7 +325,7 @@ class DateDataType(BaseDataType):
             v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
         if not sys.platform.startswith("win"):
             v = v.astimezone()
-        else: # current python bug causes error on Windows machines when calling .astimezone() on a datetime before 1970 (start of epoch)
+        else:  # current python bug causes error on Windows machines when calling .astimezone() on a datetime before 1970 (start of epoch)
             if datetime >= datetime.fromtimestamp(0):
                 v = v.astimezone()
         value = v.isoformat(timespec="milliseconds")


### PR DESCRIPTION
There is a current python bug where the `.astimezone()` function will throw an error on Windows when used on a datetime before 1970. Once Python updates their code to fix this bug this is no longer required but I don't know the timeframe on that and for now it's breaking imports on Windows hosted Arches instances.

[Python Bug Tracker link](https://bugs.python.org/issue36759)
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Skips the `.astimezone()` function all on Windows for dates before 1970

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
