### PR TITLE
Handle Windows .astimezone bug

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -341,12 +341,14 @@ class DateDataType(BaseDataType):
                     # should never happen but don't want a infinite loop
                     raise Exception("Backup timezone conversion failed: no matching year found")
             return new_year
+
         def is_same_calendar(year1, year2):
             year1_weekday_1 = datetime.strptime(str(year1) + "-01-01", "%Y-%m-%d").strftime("%w")
             year1_weekday_2 = datetime.strptime(str(year1) + "-03-01", "%Y-%m-%d").strftime("%w")
             year2_weekday_1 = datetime.strptime(str(year2) + "-01-01", "%Y-%m-%d").strftime("%w")
             year2_weekday_2 = datetime.strptime(str(year2) + "-03-01", "%Y-%m-%d").strftime("%w")
             return (year1_weekday_1 == year2_weekday_1) and (year1_weekday_2 == year2_weekday_2)
+
         converted_dt = dt.replace(year=same_calendar(dt.year)).astimezone().replace(year=dt.year)
         return converted_dt
 

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -337,16 +337,15 @@ class DateDataType(BaseDataType):
             new_year = 1971
             while not is_same_calendar(year, new_year):
                 new_year += 1
-                if new_year > 2020:
-                    # should never happen but don't want a infinite loop
+                if new_year > 2020: # should never happen but don't want a infinite loop
                     raise Exception("Backup timezone conversion failed: no matching year found")
             return new_year
 
         def is_same_calendar(year1, year2):
-            year1_weekday_1 = datetime.strptime(str(year1) + "-01-01", "%Y-%m-%d").strftime("%w")
-            year1_weekday_2 = datetime.strptime(str(year1) + "-03-01", "%Y-%m-%d").strftime("%w")
-            year2_weekday_1 = datetime.strptime(str(year2) + "-01-01", "%Y-%m-%d").strftime("%w")
-            year2_weekday_2 = datetime.strptime(str(year2) + "-03-01", "%Y-%m-%d").strftime("%w")
+            year1_weekday_1 = datetime.strptime(str(year1) + "-01-01", "%Y-%m-%d").weekday()
+            year1_weekday_2 = datetime.strptime(str(year1) + "-03-01", "%Y-%m-%d").weekday()
+            year2_weekday_1 = datetime.strptime(str(year2) + "-01-01", "%Y-%m-%d").weekday()
+            year2_weekday_2 = datetime.strptime(str(year2) + "-03-01", "%Y-%m-%d").weekday()
             return (year1_weekday_1 == year2_weekday_1) and (year1_weekday_2 == year2_weekday_2)
 
         converted_dt = dt.replace(year=same_calendar(dt.year)).astimezone().replace(year=dt.year)

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -335,7 +335,7 @@ class DateDataType(BaseDataType):
         return value
 
     def backup_astimezone(self, dt):
-        if dt.tzinfo == None:
+        if dt.tzinfo is None:
             converted_dt = dt.replace(tzinfo=tzlocal())
         else:
             converted_dt = (dt - dt.utcoffset()).replace(tzinfo=tzlocal())

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -337,7 +337,7 @@ class DateDataType(BaseDataType):
             new_year = 1971
             while not is_same_calendar(year, new_year):
                 new_year += 1
-                if new_year > 2020: # should never happen but don't want a infinite loop
+                if new_year > 2020:  # should never happen but don't want a infinite loop
                     raise Exception("Backup timezone conversion failed: no matching year found")
             return new_year
 

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -324,7 +324,9 @@ class DateDataType(BaseDataType):
             v = datetime.strptime(value, valid_date_format)
         else:
             v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
-        if (not sys.platform.startswith("win")) or (v >= datetime.fromtimestamp(0)): # The .astimezone() function throws an error on Windows for dates before 1970
+        if (not sys.platform.startswith("win")) or (
+            v >= datetime.fromtimestamp(0)
+        ):  # The .astimezone() function throws an error on Windows for dates before 1970
             v = v.astimezone()
         value = v.isoformat(timespec="milliseconds")
         return value

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -5,6 +5,7 @@ import base64
 import re
 import logging
 import os
+import sys
 from pathlib import Path
 import ast
 from distutils import util
@@ -320,10 +321,12 @@ class DateDataType(BaseDataType):
             value = value[0]
         valid_date_format, valid = self.get_valid_date_format(value)
         if valid:
-            value = datetime.strptime(value, valid_date_format).astimezone().isoformat(timespec="milliseconds")
+            v = datetime.strptime(value, valid_date_format)
         else:
             v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
-            value = v.astimezone().isoformat(timespec="milliseconds")
+        if (not sys.platform.startswith("win")) or (v >= datetime.fromtimestamp(0)): # The .astimezone() function throws an error on Windows for dates before 1970
+            v = v.astimezone()
+        value = v.isoformat(timespec="milliseconds")
         return value
 
     def transform_export_values(self, value, *args, **kwargs):

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -5,7 +5,6 @@ import base64
 import re
 import logging
 import os
-import sys
 from pathlib import Path
 import ast
 import time


### PR DESCRIPTION
*Recreating the PR after correctly linking my GitHub account to the commits at Adam Cox's suggestion*

There is a bug in python when calling `.astimezone()` on a Windows machine for `datetime` values before 1970 (start of epoch). [Here](https://bugs.python.org/issue36759) is the python bug post about it.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
I've added a check for dates when they are being converted to first see if the date falls under the error specifications and, if so, it simply skips the timezone conversion. This isn't supposed to be a permanent fix and when python fixes the bug it will no longer be needed. The reason I thought the change was worth doing now though is that when I'm trying to import data through CSV files using the CLI there is no way to get dates before 1970 to import correctly and I don't know how long before python fixes this bug.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
