### PR TITLE
Fix workflow tab overlap, re #7207

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -882,6 +882,7 @@ div.wf-multi-tile-card-info div {
 
 .workflow-nav-tab-container {
     overflow-x: scroll;
+    min-height: 45px;
 }
 
 .tabbed-workflow-step-container {


### PR DESCRIPTION
Prevents the workflow step content from obscuring workflow tabs, re #7207