### PR TITLE
Set proper branch to package.json when version is a beta or '.x' branch

### DIFF
--- a/arches/__init__.py
+++ b/arches/__init__.py
@@ -6,7 +6,7 @@ try:
 except ModuleNotFoundError as e:
     print(e)
 
-VERSION = (5, 2, 0, "final", 0)  # VERSION[3] options = "alpha", "beta", "rc", or "final"
+VERSION = (5, 2, 0, "beta", 0)  # VERSION[3] options = "alpha", "beta", "rc", or "final"
 
 __version__ = get_version(VERSION)
 

--- a/arches/install/arches-project
+++ b/arches/install/arches-project
@@ -53,9 +53,12 @@ class ArchesCommand(TemplateCommand):
         # this is used in the package.json file generated when "arches-project create" is called
         # if this is not a final released version of arches (for developers) then arches_version will be blank
         # and the arches dependency defined in the generated package.json file will point to "master"
+        complete_version = get_complete_version()
         options["arches_version"] = "master"
-        if get_complete_version()[3] == 'final':
-            options["arches_version"] = __version__
+        if complete_version[3] == 'final':
+            options["arches_version"] = f"stable/{__version__}"
+        elif complete_version[3] == 'beta':
+            options["arches_version"] = f"stable/{complete_version[0]}.{complete_version[1]}.x"
 
         super(ArchesCommand, self).handle('project', project_name, target, **options)
 


### PR DESCRIPTION
Assigns the proper branch name to package.json depending on whether the branch is a final, beta (.x branch), or alpha (master) branch, re #7210
