### PR TITLE
Prevents non-required steps from getting skipped

### DIFF
--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -206,6 +206,7 @@ define([
                 function(savedTileData) {
                     self.savedData.removeAll();
                     self.savedData.unshift(savedTileData);
+                    self.complete(true);
                 },
             );
         };
@@ -274,6 +275,13 @@ define([
 
         this.save = function() {
             self.loading(true);
+            var processedTiles = ko.observableArray([]);
+            processedTiles.subscribe(function(tiles){
+                var allData = self.addedData().length + self.savedData().length;
+                if (tiles.length <= allData) {
+                    self.complete(true);
+                }
+            })
 
             /* save new tiles */ 
             self.addedData().forEach(function(data) {
@@ -292,6 +300,7 @@ define([
                         function(){/* onFail */}, 
                         function(savedTileData) {
                             self.savedData.unshift(savedTileData);
+                            processedTiles.push(savedTileData);
                         },
                     );
                 }
@@ -329,6 +338,7 @@ define([
 
                             self.savedData.replace(previousTileData, savedTileData);
                             self.addedData.replace(previousTileData.data, savedTileData.data);
+                            processedTiles.push(savedTileData);
                         },
                     )
 
@@ -341,6 +351,7 @@ define([
                 tile.tileid = data.tileid;
 
                 tile.deleteTile();
+                processedTiles.push(data)
             });
 
             self.savedData.removeAll(removedTiles);
@@ -385,7 +396,7 @@ define([
 
     function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, resourceId, title, complete) {
         var self = this;
-
+        this.complete = complete;
         this.resourceId = resourceId;
         this.componentData = componentData;
         this.previouslyPersistedComponentData = previouslyPersistedComponentData;

--- a/arches/app/templates/views/components/plugins/tabbed-workflow.htm
+++ b/arches/app/templates/views/components/plugins/tabbed-workflow.htm
@@ -176,7 +176,6 @@
                     data-bind="
                         click: function() {
                             activeStep().save();
-                            next();
                         },
                     "
                 >


### PR DESCRIPTION
Prevents non-required steps from getting skipped due to workflow.next getting called twice - once when a user clicks `Save and Continue`, and a second time during the subscription on complete, re #7227

