### PR TITLE
Fix the bug while resource type selector download, arches-her#560

### DIFF
--- a/arches/app/media/js/bindings/select2-query.js
+++ b/arches/app/media/js/bindings/select2-query.js
@@ -56,7 +56,7 @@ define([
                         $(el).select2("enable");
                     }
                 });
-            };
+            }
 
             $(el).on("select2-opening", function() {
                 if (select2Config.clickBubble) {

--- a/arches/app/media/js/bindings/select2-query.js
+++ b/arches/app/media/js/bindings/select2-query.js
@@ -51,7 +51,12 @@ define([
 
             if (ko.unwrap(select2Config.disabled)) {
                 $(el).select2("disable");
-            }
+                select2Config.disabled.subscribe(function(val){
+                    if (val === false) {
+                        $(el).select2("enable");
+                    }
+                });
+            };
 
             $(el).on("select2-opening", function() {
                 if (select2Config.clickBubble) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fix the bug that resource type selector stop working with an error, if all the graphs are not downloaded for resource instance type. archesproject/arches-her#560

by disabling the resource selector until all the graphs are downloaded.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
archesproject/arches-her#560

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
