### PR TITLE
Fix check for whether child tile creation is needed

### DIFF
--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -1,4 +1,3 @@
-from pprint import pprint as pp
 import csv
 import pickle
 import datetime
@@ -919,6 +918,7 @@ class CsvReader(Reader):
                                 target_tile_cardinality = "1"
                             else:
                                 target_tile_cardinality = "n"
+
                             if str(target_tile.nodegroup_id) not in populated_nodegroups[resourceinstanceid]:
                                 target_tile.nodegroup_id = str(target_tile.nodegroup_id)
                                 # Check if we are populating a parent tile by inspecting the target_tile.data array.

--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -1,3 +1,4 @@
+from pprint import pprint as pp
 import csv
 import pickle
 import datetime
@@ -918,11 +919,11 @@ class CsvReader(Reader):
                                 target_tile_cardinality = "1"
                             else:
                                 target_tile_cardinality = "n"
-
                             if str(target_tile.nodegroup_id) not in populated_nodegroups[resourceinstanceid]:
                                 target_tile.nodegroup_id = str(target_tile.nodegroup_id)
                                 # Check if we are populating a parent tile by inspecting the target_tile.data array.
-                                if target_tile.data != {}:
+                                source_data_has_target_tile_nodes = len(set([list(obj.keys())[0] for obj in source_data]) & set(target_tile.data.keys())) > 0
+                                if source_data_has_target_tile_nodes:
                                     # Iterate through the target_tile nodes and begin populating by iterating througth source_data array.
                                     # The idea is to populate as much of the target_tile as possible,
                                     # before moving on to the next target_tile.


### PR DESCRIPTION
Fixes check for whether child tile creation is needed, re #7332

Prior to this [refactor](https://github.com/archesproject/arches/commit/250b7bc78dd8458cf0dbee5e66e8e9da39175757#diff-009b1fa3c3618e758589d21b4512631be7da49ff01e8b422e78cfa4ad78f255a), get blank tile would return a parent tile with an empty data object,`{}`. Because that was fixed, checking whether child tiles needed to be created within csv import no longer worked. This PR corrects the conditional in csvfile.py.