### PR TITLE
Track parent tile id for workflow component base step, arches-her#613 

### DIFF
--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -189,7 +189,11 @@ define([
                         handlers[eventName].push(handler);
                     }
                 };
-    
+
+                if (self.externalStepData[self.componentData.parameters.parenttilesourcestep]){
+                    self.componentData.parameters.parenttileid = self.externalStepData[self.componentData.parameters.parenttilesourcestep].data.tileid;
+                }
+
                 self.flattenTree(self.topCards, []).forEach(function(item) {
                     if (item.constructor.name === 'CardViewModel' && item.nodegroupid === ko.unwrap(self.componentData.parameters.nodegroupid)) {
                         if (ko.unwrap(self.componentData.parameters.parenttileid) && item.parent && ko.unwrap(self.componentData.parameters.parenttileid) !== item.parent.tileid) {

--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -86,7 +86,7 @@ define([
                         tile.tileid = datum.tileId;
                         tile.resourceinstance_id = datum.resourceInstanceId;        
                     }
-                })
+                });
             });
         };
 
@@ -190,6 +190,10 @@ define([
                     }
                 };
 
+                /*
+                    If a step modifies a child tile, get the correct parent tile id from the step that created the parent tile. 
+                    This requires that your step has a parameter 'parenttilesourcestep' that identifies the step with the parent tile.
+                */
                 if (self.externalStepData[self.componentData.parameters.parenttilesourcestep]){
                     self.componentData.parameters.parenttileid = self.externalStepData[self.componentData.parameters.parenttilesourcestep].data.tileid;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Add component based step to track the parent tile id when necessary, archesproject/arches-her#613

Required to add `parentteilsourcestep` and `externalStepData` in the workflow definition js.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
archesproject/arches-her#613

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
