### PR TITLE
Handle data-collecting nodes with label_based_graph compact flag, re #7139

### DIFF
--- a/arches/app/utils/label_based_graph.py
+++ b/arches/app/utils/label_based_graph.py
@@ -48,7 +48,10 @@ class LabelBasedNode(object):
                 else:
                     display_data[formatted_node_name] = [previous_val, formatted_node_value]
 
-        if compact and not display_data:  # if compact and no child nodes
+        if compact and display_data:
+            if self.value is not NON_DATA_COLLECTING_NODE:
+                display_data[VALUE_KEY] = self.value
+        elif compact and not display_data:  # if compact and no child nodes
             display_data = self.value
         elif not compact:
             display_data[NODE_ID_KEY] = self.node_id

--- a/tests/utils/label_based_graph_test.py
+++ b/tests/utils/label_based_graph_test.py
@@ -61,12 +61,7 @@ class LabelBasedNodeTests(TestCase):
 
         self.assertEqual(
             self.test_node.as_json(compact=True),
-            {
-                self.test_node.name: {
-                    self.child_node_1.name: self.child_node_1.value, 
-                    VALUE_KEY: self.test_node.value
-                }
-            }
+            {self.test_node.name: {self.child_node_1.name: self.child_node_1.value, VALUE_KEY: self.test_node.value}},
         )
 
     def test_as_json_single_child_node(self):

--- a/tests/utils/label_based_graph_test.py
+++ b/tests/utils/label_based_graph_test.py
@@ -56,6 +56,19 @@ class LabelBasedNodeTests(TestCase):
     def test_as_json_compact(self):
         self.assertEqual(self.test_node.as_json(compact=True), {self.test_node.name: self.test_node.value})
 
+    def test_as_json_compact_data_collecting_node_with_child(self):
+        self.test_node.child_nodes.append(self.child_node_1)
+
+        self.assertEqual(
+            self.test_node.as_json(compact=True),
+            {
+                self.test_node.name: {
+                    self.child_node_1.name: self.child_node_1.value, 
+                    VALUE_KEY: self.test_node.value
+                }
+            }
+        )
+
     def test_as_json_single_child_node(self):
         self.test_node.child_nodes.append(self.child_node_1)
 


### PR DESCRIPTION
Cherry picks `update label_based_graph compact flag to handle data-collecting nodes with children #7139` from stable/5.2.x