### PR TITLE
adds support for Sass preprocessing

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -1,0 +1,13889 @@
+@import url(fonts/openSans.css);
+@import url(../packages/bootstrap/dist/css/bootstrap.min.css);
+@import url(../packages/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css);
+@import url(../packages/bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css);
+@import url(nifty.min.css);
+@import url(../packages/font-awesome/css/font-awesome.min.css);
+@import url(../packages/ionicons/css/ionicons.min.css);
+@import url(../packages/lt-themify-icons/themify-icons.css);
+@import url(../packages/chosen-js/chosen.css);
+@import url(../packages/select2/select2.css);
+@import url(../packages/select2/select2-bootstrap.css);
+@import url(../packages/mapbox-gl/dist/mapbox-gl.css);
+@import url(../packages/nouislider/distribute/nouislider.min.css);
+@import url(../packages/codemirror/lib/codemirror.css);
+@import url(../packages/codemirror/theme/monokai.css);
+@import url(../packages/datatables.net-bs/css/dataTables.bootstrap.css);
+@import url(../packages/datatables.net-responsive-bs/css/responsive.bootstrap.css);
+@import url(../packages/datatables.net-buttons-bs/css/buttons.bootstrap.min.css);
+@import url(../packages/leaflet/dist/leaflet.css);
+@import url(../packages/leaflet-draw/dist/leaflet.draw.css);
+@import url(../css/tree/tree.css);
+@import url(../packages/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css);
+@import url(../packages/leaflet.fullscreen/Control.FullScreen.css);
+img {
+    image-orientation: from-image;
+}
+
+[class^="col-"]:not(.pad-no) {
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+.regular-link {
+    color: #337ab7;
+    text-decoration: none;
+}
+
+.regular-link:hover {
+    text-decoration: underline;
+}
+
+
+/*.navbar-top-links:last-child>li {
+    border-right: 1px solid rgba(0,0,0,0.07);
+}*/
+
+.btn:not(.disabled):not(:disabled).active {
+    box-shadow: none;
+}
+
+.svg-container {
+    display: inline-block;
+    position: relative;
+    width: 100%;
+    padding-bottom: 100%;
+    vertical-align: top;
+    overflow: hidden;
+}
+
+.svg-content {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+dl.inline-flex {
+    display: flex;
+    flex-flow: row;
+    flex-wrap: wrap;
+    width: 300px;
+    /* set the container width*/
+    overflow: visible;
+}
+
+dl.inline-flex dt {
+    flex: 0 0 50%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+dl.inline-flex dd {
+    flex: 0 0 50%;
+    margin-left: auto;
+    text-align: left;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+#navbar {
+    width: 50px;
+}
+
+.nav-item-disabled {
+    background-color: #9eacc1;
+    color: black;
+    pointer-events: none;
+    cursor: default;
+}
+
+.nav-item-disabled i {
+    color: black;
+}
+
+.navbar-header {
+    height: 50px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.4);
+}
+
+.username {
+    margin: 0px;
+    padding-left: 10px;
+    padding-right: 10px;
+    border-left: 1px solid #ddd;
+}
+
+.username:hover {
+    background: #f2f2f2;
+}
+
+.navbar-top-links>.mega-dropdown>.dropdown-menu.mega-dropdown-menu {
+    left: 0px;
+    max-width: 100%;
+    top: 39px;
+    right: -10px;
+    bottom: 0;
+    padding: 0;
+}
+
+.one-page-header .navbar-nav>li>a:before {
+    content: "";
+}
+
+
+/*Remove pointer from Mega drop panel button*/
+
+.open.mega-dropdown>.mega-dropdown-toggle:before {
+    display: none;
+}
+
+.open.mega-dropdown>.mega-dropdown-toggle:after {
+    display: none;
+}
+
+.brand-icon {
+    height: 20px !important;
+    width: 20px !important;
+    margin-top: 14px !important;
+    margin-left: 15px !important;
+    margin-right: 15px !important;
+}
+
+.brand-title {
+    display: block;
+    line-height: 48px;
+    font-size: 20px;
+}
+
+#mainnav-container {
+    padding-top: 50px;
+    background-color: #2d3c4b;
+}
+
+#mainnav-menu .arches {
+    margin-left: -25px;
+}
+
+.list-group.bg-trans .list-group-item:not(.active):not(.disabled) {
+    border-bottom: 1px solid #eee;
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.list-group.bg-trans a.list-group-item.active:hover {
+    background-color: #fff;
+}
+
+.list-group-item.active {
+    background-color: #fff;
+    border-bottom: 1px solid #eee;
+    border-top: 1px solid #eee;
+    color: #5f5f5f;
+    border-width: 0;
+}
+
+.card-grid-item .panel-footer .disabled {
+    color: #ccc;
+}
+
+.card-grid-item.card-locked .mar-no {
+    background-color: #fafafa;
+}
+
+.card-locked div div>.library-card-panel-title {
+    color: #888;
+}
+
+.card-locked div div a.pull-right.disabled {
+    color: #888;
+}
+
+.panel hr {
+    border-color: rgba(0, 0, 0, 0.075);
+}
+
+.switchery {
+    background-color: #fff;
+    border: 1px solid #dfdfdf;
+    border-radius: 20px;
+    cursor: pointer;
+    display: inline-block;
+    height: 30px;
+    position: relative;
+    vertical-align: middle;
+    width: 50px;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    box-sizing: content-box;
+    background-clip: content-box;
+}
+
+.arches-toggle-sm.disabled {
+    color: #888;
+}
+
+.switch.switch-small.switch-widget {
+    width: 35px;
+}
+
+.iiif-image-tool-slider .switch.switch-small.switch-widget {
+    width: 25px;
+}
+
+.switch.switch-widget.on>small {
+    left: 22px;
+}
+
+.iiif-image-tool-slider .switch.switch-widget.on>small {
+    left: 12px;
+}
+
+.switch.switch-widget.null>small {
+    left: 12px;
+}
+
+#card-preview {
+    margin-bottom: 10px;
+}
+
+.library-tools-icon.card-container-trash-icon {
+    float: right;
+    margin-top: -50px;
+}
+
+.card-container-trash-icon .record-delete {
+    position: relative;
+    top: 0;
+    right: 0;
+    color: lightcoral;
+}
+
+.card-main-title {
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.card-panel {
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+    border-bottom-width: 0;
+}
+
+.card-body {
+    padding: 0 20px 0 20px;
+}
+
+.card-content-container {
+    border: 0 solid #eee;
+    position: relative;
+    margin: -2px 0 18px 0px;
+}
+
+.outline {
+    border: 1px solid #eee;
+}
+
+.outline.open-container {
+    border: 1px solid #bbb;
+}
+
+.card-nav-container {
+    background: #f4f4f4;
+    margin-left: 0;
+    margin-bottom: 5px;
+}
+
+.card-content-tab {
+    min-height: 300px;
+    margin-top: 15px;
+    margin-left: -15px;
+    box-shadow: none;
+    padding: 5px 0 0;
+}
+
+.card-panel-body {
+    background-color: #FFF;
+    padding-top: 15px;
+    padding-bottom: 10px;
+    margin-top: 10px;
+}
+
+.card-instructions {
+    color: #888;
+    margin-bottom: 5px;
+}
+
+.card-content {
+    margin: -20px -35px 20px -20px;
+    padding: 0;
+}
+
+.card-tab-title {
+    font-size: 14px;
+}
+
+.crud-record-item {
+    background: #fbfbfb;
+    padding: 0px;
+}
+
+.crud-record-item:nth-child(even) {
+    background: #fefefe;
+}
+
+.data-card-alert {
+    margin-bottom: 5px;
+    margin-top: 5px;
+}
+
+.card-help {
+    padding-right: 20px;
+    font-size: 14px;
+    margin-top: -34px;
+}
+
+.card-form-container {
+    padding-bottom: 10px;
+    padding-right: 20px;
+}
+
+.help-panel-title {
+    padding: 0 10px 0 10px;
+}
+
+.card-help-panel {
+    width: 495px;
+    padding-top: 0;
+    top: 0px;
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
+    background: #fbfbfb;
+    z-index: 500;
+    overflow-y: scroll;
+    color: #123;
+    border-left: 1px solid #ddd;
+}
+
+input[type="checkbox"] {
+    width: 30px;
+    height: 30px;
+}
+
+.wizard-data-card-alert {
+    box-shadow: none;
+    margin: 1px 0 0;
+}
+
+.content-instructions {
+    font-size: 13px;
+    color: #8d8d8d;
+    margin-top: -50px;
+    line-height: 1.25;
+    margin-bottom: 20px;
+}
+
+.record-delete {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    height: 20px;
+    width: 20px;
+    color: lightcoral;
+}
+
+.gsheets-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: #454545;
+}
+
+.gsheets-descr {
+    font-size: 14px;
+    color: #777;
+}
+
+.graph-settings-crud {
+    margin-right: 0px;
+    position: absolute;
+    right: 10px;
+}
+
+.workflow-step-container {
+    height: calc(100% + 41px);
+}
+
+.workflowstep-nav {
+    display: flex;
+    flex-direction: row;
+    width: calc(100% - 220px);
+    border-bottom: solid 1px #ddd;
+    height: fit-content;
+    padding: 12px 25px;
+    background-color: #fff;
+    overflow-x: scroll;
+}
+
+.workflowstep-nav div {
+    padding: 0 20px;
+}
+
+.workflowstep-nav div.workflow-nav-controls {
+    position: absolute;
+    padding: 19px 0px;
+    right: 0px;
+    top: 0;
+    font-size: 25px;
+    width: 230px;
+    background: #fafafa;
+    border-left: 1px solid #f1f1f1;
+    border-bottom: 1px solid #ddd;
+}
+
+.workflowstep-nav div .step-title {
+    position: absolute;
+    z-index: 2000;
+    color: white;
+    padding: 2px;
+    margin-top: 30px;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+}
+
+.workflowstep-nav .selectable i {
+    cursor: pointer;
+}
+
+.arrow-up {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid #000;
+}
+
+.workflowstep-nav div .step-title .arrow-up {
+    padding: 0px;
+}
+
+.workflowstep-nav div .step-title .step-title-text {
+    background-color: #000;
+    padding: 3px 10px;
+}
+
+.workflowstep-nav .nav-group {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.workflowstep-nav div.workflow-nav-controls button {
+    font-weight: 800;
+}
+
+.workflowstep-nav div.workflow-nav-controls button:first-child {
+    margin-right: 5px;
+}
+
+.workflow-nav-controls .btn-labeled:not(.btn-block):not(.form-icon) {
+    color: #f9f9f9;
+}
+
+.workflow-step-body div .new-provisional-edit-card-container div .install-buttons button {
+    font-weight: 800;
+}
+
+.workflow-step-icon {
+    border-radius: 50%;
+    display: block;
+    margin: 0 auto;
+    height: 45px;
+    line-height: 43px;
+    text-align: center;
+    width: 45px;
+    font-size: 17px;
+    color: #bbb;
+    border: 1px solid #ddd;
+    background: #f4f4f4;
+}
+
+.selectable .workflow-step-icon {
+    background-color: rgb(244, 244, 244);
+    border: 1px solid rgb(221, 221, 221);
+    color: #26476a;
+}
+
+.workflow-step-icon.active {
+    background-color: rgb(110, 160, 216);
+    border: 1px solid rgb(56, 110, 178);
+    color: #fff;
+    cursor: pointer;
+}
+
+.workflow-step-icon.complete {
+    border: 1px solid #3A74B0;
+    background-color: #B4D1F0;
+    color: #fff;
+}
+
+.workflow-step-icon.can-advance {
+    border: 1px solid rgb(110, 160, 216);
+    ;
+    background-color: rgb(189, 214, 241);
+    color: #fff;
+}
+
+.workflow-step-description-container {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    min-height: 100px;
+    border-bottom: solid 1px #ddd;
+}
+
+.workflow-step-description {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background-color: #fff;
+    padding: 10px 10px;
+    overflow-x: hidden;
+    overflow-y: hidden;
+    width: 100%;
+}
+
+.workflow-step-description .title {
+    font-size: 1.3em;
+    font-weight: 600;
+    color: #004577;
+    padding-top: 10px;
+}
+
+.workflow-step-description .workflow-name {
+    font-size: 1.2em;
+    font-weight: 400;
+    line-height: 1.01;
+    color: #004577;
+}
+
+.workflow-step-description .subtitle {
+    font-size: 14px;
+    font-weight: 400;
+    color: #004577;
+}
+
+.workflow-step-description .step {
+    font-size: 1.1em;
+    font-weight: 400;
+    color: #999;
+    padding-bottom: 15px;
+}
+
+.workflow-step-body {
+    background-color: #f9f9f9;
+    height: 100%;
+    overflow-y: auto;
+    padding: 0 0 218px 25px;
+}
+
+.tabbed-workflow {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.tabbed-workflow-title-bar {
+    display: flex;
+    background-color: #eceef0;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid #ddd;
+    padding: 6px 12px;
+    font-size: medium;
+    font-weight: 600;
+}
+
+.tabbed-workflow-step-body {
+    background-color: #fff;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.tabbed-workflow-step-body .search-selection-controls {
+    display: none !important;
+}
+
+.tabbed-workflow-information-box-marker {
+    font-size: 14px;
+    padding-left: 2px;
+    padding-right: 6px;
+    margin-top: 3px;
+    cursor: pointer;
+    color: #454545;
+}
+
+.tabbed-workflow-information-box-marker.seen {
+    visibility: visible;
+    opacity: 1;
+    transition: all 0.6s linear;
+}
+
+.tabbed-workflow-information-box-marker.unseen {
+    visibility: hidden;
+    position: absolute;
+    opacity: 0;
+}
+
+.tabbed-workflow-step-information-box-container.seen {
+    visibility: visible;
+    opacity: 1;
+    transition: all 0.6s linear;
+}
+
+.tabbed-workflow-step-information-box-container.unseen {
+    visibility: hidden;
+    position: absolute;
+    width: 100%;
+    opacity: 0;
+}
+
+.tabbed-workflow-step-information-box {
+    padding: 10px 35px 20px 35px;
+    background-color: #eaeaea;
+    border: 1px solid #ddd;
+    color: grey;
+    margin: -16px -21px 0px -21px;
+    height: 100px;
+    overflow-y: scroll;
+    position: relative;
+}
+
+.btn-workflow-tile {
+    padding: 8px 20px;
+    min-width: 100px;
+}
+
+.btn-workflow-tile.btn-success {
+    border: 1px solid #508A14;
+}
+
+.btn-workflow-tile.btn-danger {
+    border: 1px solid #B02107;
+}
+
+.tabbed-workflow-step-information-box h4 {
+    font-size: 14px;
+    margin-bottom: 2px;
+}
+
+.tabbed-workflow-step-information-box span {
+    margin-bottom: 10px;
+}
+
+.tabbed-workflow-step-body .create-resource-instance-card-component .card-component {
+    width: unset;
+}
+
+.tabbed-workflow-step-body .create-resource-instance-card-component .install-buttons {
+    display: unset;
+}
+
+.tabbed-workflow-step-body .card-title,
+.tabbed-workflow-step-body .card-instructions {
+    display: none;
+}
+
+.tabbed-workflow-step-body .display-in-workflow-step.install-buttons {
+    bottom: 53px;
+    display: unset;
+}
+
+.tabbed-workflow-step-body > div {
+    background-color: #fff !important;
+    border: none !important;
+}
+
+.tabbed-workflow-step-body .install-buttons {
+    display: none;
+}
+
+.tabbed-workflow-step-body .manifest-editor .install-buttons {
+    display: unset;
+}
+
+.tabbed-workflow-footer {
+    background-color: #fafafa;
+    border-top: 1px solid #ddd;
+    padding: 10px 12px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.tabbed-workflow-footer .step-counter {
+    display: flex;
+    align-items: center;
+    border-right: 1px solid #ddd;
+    padding-left: 12px;
+    padding-right: 24px;
+    margin-right: 18px;
+}
+
+.tabbed-workflow-footer .toggle-container {
+    padding: unset;
+    padding-top: 6px;
+}
+
+.tabbed-workflow-footer .toggle-container .arches-toggle-subtitle{
+    display: none;
+}
+
+.tabbed-workflow-footer .btn,
+.tabbed-workflow-title-bar .btn {
+    border-radius: 2px;
+    padding: 8px 15px;
+}
+
+.tabbed-workflow-title-bar .btn > i,
+.tabbed-workflow-title-bar .btn > span,
+.tabbed-workflow-footer .btn > i,
+.tabbed-workflow-footer .btn > span {
+    padding: 0px 2px;
+}
+
+.workflow-step-body .workbench-card-wrapper {
+    margin-left: -25px;
+}
+
+.tabbed-workflow-step-body .card-component {
+    border: none;
+   /* padding: 0px;*/
+    margin: 10px 35px;
+}
+
+.padded-workflow-step .card-component {
+    border: none;
+    padding: 0px;
+    margin: 0px 15px;
+}
+
+.padded-workflow-step,
+.workflow-step-body .card-component {
+    padding: 20px 35px 82px 40px;
+    border: none;
+    background: #fafafa;
+}
+
+.workflow-step-body .padded-workflow-step .card-component {
+    padding: 15px 25px;
+}
+
+.workflow-step-body div div .new-provisional-edit-card-container div .widgets div div .widget-wrapper div div .widget-input {
+    max-width: 600px;
+}
+
+.workflow-step-body div .new-provisional-edit-card-container .card form div div .widget-wrapper .form-group .resource-instance-wrapper .select2-container {
+    max-width: 600px !important;
+}
+
+.workflow-step-body div .new-provisional-edit-card-container .card form div div .widget-wrapper .form-group div .columns {
+    border: 1px solid #ddd;
+    padding: 20px;
+}
+
+.new-provisional-edit-card-container .card form div div .widget-wrapper .form-group div .select2-container {
+    max-width: 600px !important;
+}
+
+.wf-multi-tile-step-container {
+    display: flex;
+    flex-direction: row;
+}
+
+.wf-multi-tile-step-form {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 3;
+    position: relative;
+}
+
+.wf-multi-tile-btn-complete {
+    position: absolute;
+    bottom: 250px;
+    right: 250px;
+    font-weight: 800;
+}
+
+.wf-multi-tile-step-list {
+    display: flex;
+    flex-direction: column;
+    padding: 24px 24px 0 24px;
+    border-left: 1px solid #ddd;
+    background: #eeeeee;
+    height: 100%;
+    width: 500px;
+    overflow-y: scroll;
+}
+
+.wf-multi-tile-step-list-container {
+
+}
+
+.wf-step-multi-tile-container {
+    width: 60%;
+    padding: 30px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    background-color: #f1f1f1;
+    margin-top: 0px;
+    margin-right: 0px;
+    display: flex;
+    flex-direction: column;
+}
+
+.wf-step-multi-tile-container h4 {
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.wf-multi-tile-step-list-empty {
+    border: #cfcfcf solid 1px;
+    border-radius: 2px;
+    background-color: #e9e9e9;
+    padding: 80px 20px 120px 20px;
+    text-align: center;
+}
+
+.wf-multi-tile-step-card {
+    border: 1px solid #ddd;
+    margin-bottom: 5px;
+    border-radius: 2px;
+    background-color: #fff;
+}
+
+.wf-multi-tile-card-info {
+    display: flex;
+    flex-direction: row;
+    padding: 10px 15px;
+}
+
+.wf-multi-tile-card-info .workflow-step-icon {
+    margin-top: 10px;
+}
+
+div.wf-multi-tile-card-info div {
+    margin-left: 12px;
+}
+
+.wf-multi-tile-card-info-details {
+    color: #5d768f;
+    padding-left: 12px;
+}
+
+.wf-multi-tile-card-info-details>h4 {
+    margin-bottom: 2px;
+    /* margin-left: 12px; */
+}
+
+.wf-multi-tile-card-info-details dd a {
+    color: #999;
+}
+
+.wf-multi-tile-card-info-details dd {
+    margin-bottom: 3px;
+    color: #999;
+}
+
+.wf-multi-tile-step-card div div {
+    margin: 0;
+    margin-right: 5px;
+}
+
+.wf-multi-tile-step-card>div.wf-multi-tile-card-info~div {
+    display: flex;
+    flex-direction: row;
+    color: #4f9ce9;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    padding-top: 10px;
+    height: 40px;
+    /* align-self: flex-end; */
+}
+
+.wf-multi-tile-step-card>div.wf-multi-tile-card-info~div span {
+    margin-right: 3px;
+}
+
+.wf-multi-tile-step-card>div.wf-multi-tile-card-info~div span:nth-child(2) {
+    margin-right: 15px;
+}
+
+.wf-multi-tile-step-card>div.wf-multi-tile-card-info~div span:hover {
+    color: #0D70CF;
+}
+
+.wf-multi-tile-step-card-controls {
+    padding: 5px 15px;
+    background: #f8f8f8;
+    border-top: 1px solid #ddd;
+}
+
+.workflow-nav-tab-container {
+    overflow-x: scroll;
+    min-height: 45px;
+}
+
+.tabbed-workflow-step-container {
+    flex: 1 1 auto;
+    overflow-y: scroll;
+}
+
+.workflow-nav-tab-list {
+    padding: 0px 10px 0px 10px;
+    background-color: #fafafa;
+    display: flex;
+    min-width: max-content;
+}
+
+.workflow-nav-tab-list-item {
+    display: flex !important; /* override navs.less */
+    align-items: center;
+}
+.workflow-nav-tab {
+    min-width: 220px;
+    padding: 12px 20px;
+    border-left: 1px solid #BBD1EA;
+    background: #F7F9FB;
+    border-bottom: 1px solid #BBD1EA;
+    height: 45px;
+}
+
+.workflow-nav-tab.active {
+    background-color: #fff;
+    border-bottom: 1px solid #fff;
+    font-weight: 600;
+    padding-top: 10px;
+}
+
+.workflow-nav-tab-list-item:last-child {
+    border-right: 1px solid #ddd;
+}
+
+.workflow-nav-tab.inactive {
+    cursor: pointer;
+}
+
+.workflow-nav-tab.disabled {
+    color: darkgrey;
+    cursor: not-allowed;
+}
+
+.workflow-nav-tab-arrow {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 4px;
+    padding-top: 6px;
+    font-size: 15px;
+}
+
+.workflow-nav-tab-arrow.disabled {
+    color: #a9a9a9;
+    cursor: default;
+}
+
+.workflow-nav-controls {
+    width: 60px;
+    display: flex;
+    background-color: #fff;
+    align-items: center;
+    font-size: 32px;
+    justify-content: center;
+    color: #004577;
+}
+
+.workflow-nav-controls:hover {
+    color: #007799;
+}
+
+.card .install-buttons .btn-labeled {
+    font-weight: 600;
+}
+
+
+/*.workflow-nav-controls.left {
+    border-left: solid 1px #aaa;
+}*/
+
+
+/*.workflow-nav-controls.right {
+    border-right: solid 1px #aaa;
+}*/
+
+.workflow-nav-controls .inactive {
+    color: #ccc;
+}
+
+.workflow-plugin {
+    flex-grow: inherit;
+    background-color: #fff;
+}
+
+.workflow-select-plugin {
+    padding: 20px;
+}
+
+#workflow-container {
+    display: flex;
+    flex-direction: row;
+}
+
+
+/* general styling for all tabs */
+
+.tabbed-report-tab-list {
+    display: flex;
+    flex-direction: row;
+    list-style-type: none;
+    flex-wrap: wrap;
+}
+
+ul.tabbed-report-tab-list {
+    margin: 0;
+    padding: 0 20px;
+}
+
+.report-tab {
+    background: #f4f4f4;
+    border: #e9e9e9 solid 1px;
+    border-radius: 100%;
+    display: flex;
+    height: 50px;
+    width: 50px;
+    line-height: 50px;
+    flex-direction: column;
+    margin: 15px 50px 15px 0px;
+}
+
+.report-tab:hover {
+    cursor: pointer;
+    background: #BADAF7;
+    border: 1px solid #1E6FB7;
+}
+
+.report-tab i {
+    color: #bbbbbb;
+    font-size: 19px;
+    line-height: 23px;
+    display: block;
+    margin: 0 4px;
+    text-align: center;
+    padding: 13px;
+}
+
+.report-tab i:hover {
+    color: #fff;
+}
+
+.report-tab.active {
+    border: #4389c9 solid 2px;
+    border-radius: 100%;
+    background: #5fa2dd;
+}
+
+.report-tab.active i {
+    color: white;
+}
+
+.report-tab-form.active {
+    border: #4389c9 solid 2px;
+}
+
+.report-tab-form {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    margin: 15px 0px 15px;
+    padding: 5px;
+    background-color: #fff;
+}
+
+.report-tab-form-title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 5px;
+}
+
+.tab-banner {
+    background: #5fa2dd;
+    padding: 5px 20px 7px 20px;
+}
+
+.tab-banner>div+div span {
+    font-size: 13px;
+    padding-left: 20px;
+}
+
+.tab-banner span {
+    font-size: 15px;
+    color: white;
+}
+
+.tab-summary-container {
+    display: flex;
+    flex-direction: row;
+}
+
+.summary-panel {
+    background: #f9f9f9;
+    margin-top: -30px;
+}
+
+.mouse-pointer canvas {
+    cursor: pointer;
+}
+
+.photo-workbench-photos::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 9px;
+    border-left: 1px solid #ddd;
+}
+
+.photo-workbench-photos::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(0, 0, 0, .28);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
+
+.photo-workbench-photo {
+    position: relative;
+    padding: 4px;
+}
+
+.photo-workbench-photo:nth-child(even) {
+    background: #fff;
+    border-bottom: 1px solid #D3E5F4;
+}
+
+.photo-workbench-photo:nth-child(odd) {
+    background: #F5FAFE;
+    border-bottom: 1px solid #D3E5F4;
+}
+
+.photo-workbench-photo.selected-photo {
+    background-color: #9CC3E4;
+    color: #fff;
+    font-weight: 600;
+    padding: 4px;
+}
+
+.photo-workbench-photo:not(.selected-photo):hover {
+    background: #CAE2F5;
+    cursor: pointer;
+}
+
+.workbench-tile-picker-label {
+    font-weight: 600;
+    color: #666;
+    margin-left: 10px;
+    margin-top: 60px;
+}
+
+.workbench-card-sidepanel-header-container.file-workbench {
+    margin-right: 0px;
+    margin-left: 0px;
+}
+
+.file-workbench-selected-buttons {
+    display: flex;
+    flex-direction: column;
+    height: 87px;
+    justify-content: space-between;
+}
+
+.file-workbench-filter {
+    position: relative;
+    margin-top: 20px;
+    margin-bottom: -10px;
+}
+
+.file-workbench-filter .clear-node-search {
+    margin-top: 25px;
+}
+
+.file-workbench-filter-header {
+    font-size: 15px;
+    font-weight: 400;
+}
+
+.file-workbench-files {
+    height: 136px;
+    overflow-y: scroll;
+    border: solid 1px #ddd;
+    display: flex;
+    flex-direction: column;
+    margin: 15px 0px 5px 0px;
+}
+
+.file-workbench-filecount {
+    color: steelblue;
+    font-size: 11px;
+    padding-left: 5px;
+}
+
+.file-workbench-files::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 9px;
+    border-left: 1px solid #ddd;
+}
+
+.file-workbench-files::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(0, 0, 0, .1);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
+
+.file-workbench-button-container {
+    display: inline-flex;
+    justify-content: space-between;
+    width: 100%;
+    padding-top: 15px;
+    padding-bottom: 5px
+}
+
+.file-workbench-buttons {
+    display: inline-flex;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.btn-workbench {
+    width: 100%;
+    font-size: 15px;
+}
+
+.file-workbench-file {
+    position: relative;
+    padding: 4px;
+    display: inline-flex;
+    justify-content: left;
+    align-items: center;
+}
+
+.file-workbench-file .file-name {
+    padding-left: 5px;
+}
+
+.file-workbench-file:nth-child(even) {
+    background: #fff;
+    border-bottom: 1px solid #D3E5F4;
+}
+
+.file-workbench-file:nth-child(odd) {
+    background: #F5FAFE;
+    border-bottom: 1px solid #D3E5F4;
+}
+
+.file-workbench-file.selected-photo {
+    background-color: #9CC3E4;
+    color: #fff;
+    font-weight: 600;
+    padding: 4px;
+}
+
+.file-workbench-file:not(.selected-photo):hover {
+    background: #CAE2F5;
+    cursor: pointer;
+}
+
+.file-workbench-file.chart-series-selector {
+    display: inline-flex;
+    width: 100%;
+}
+
+.file-workbench-file.chart-series-selector div {
+    padding-left: 5px;
+}
+
+.chart-config-panel {
+    margin-top: 50px;
+}
+
+.add-data-series {
+    width: 27px;
+    height: 27px;
+    border-bottom: 1px solid #D3E5F4;
+    background: #9CC3E4;
+    color: #fff;
+    margin: -4px 0px -5px -4px;
+    padding-top: 4px;
+    padding-left: 8px ! important;
+}
+
+.add-data-series:hover {
+    background: #497DA9;
+}
+
+.selected-photo .add-data-series {
+    border-bottom: 1px solid #D3E5F4;
+    background: #497DA9;
+    color: #fff;
+}
+
+.staged {
+    background-color: #90DFFF;
+}
+
+.staged:hover {
+    background-color: #7FC7E3;
+}
+
+.file-workbench-file.staged {
+    background-color: #90DFFF;
+    color: #fff;
+    font-weight: 600;
+    padding: 4px;
+}
+
+.file-workbench-file:not(.staged):hover {
+    background: #CAE2F5;
+    cursor: pointer;
+}
+
+.file-viewer {
+    position: relative;
+}
+
+.file-viewer.chart-header {
+    position: relative;
+    padding-left: 20px;
+    background: #f1f1f1;
+    width: 100%;
+    display: inline-block;
+    border-left: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+}
+
+.chart-header h3 {
+    font-size: 15px;
+    margin-top: 15px;
+    margin-bottom: 15px;
+    font-size: 15px ! important;
+}
+
+.chart-style-panel h2 {
+    font-size: 15px;
+    margin-bottom: 0px;
+}
+
+.chart-style-panel .input-group-addon {
+    background: #26d664;
+    height: 40px;
+    border: 1px solid black;
+}
+
+.file-viewer .loading-mask,
+.search-result-details .loading-mask {
+    position: relative;
+    opacity: .5;
+    background-color: gray;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 240;
+}
+
+.file-viewer .loading-mask::before,
+.search-result-details .loading-mask::before {
+    position: fixed;
+    opacity: .5;
+    color: #7b7b7b;
+    content: '\f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 10vw;
+    margin-top: 42vh;
+    margin-left: 32vw;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.file-viewer .loading-mask:after,
+.search-result-details .loading-mask::after {
+    position: fixed;
+    opacity: .5;
+    color: #7b7b7b;
+    content: '\f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 10vw;
+    margin-top: 42vh;
+    margin-left: 32vw;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.chart .plotly {
+    border: 1px solid #ddd;
+    padding-top: 10px ! important;
+    padding-bottom: 30px ! important;
+    border-radius: 2px;
+    background: #fff;
+}
+
+.plotly .legend .bg {
+    fill: #fafafa ! important;
+    transform: translate(-5px, -5px) scaleX(1.05)scaleY(1.2);
+    stroke-width: 1px ! important;
+    stroke: #eee ! important;
+}
+
+/* photo gallery */
+
+.gallery-container .tab-container .tab-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.thumbnail-gallery-controls {
+    width: 35px;
+    height: 105px;
+    display: flex;
+    background-color: rgba(242,242,242, 0.65);
+    align-items: center;
+    font-size: 41px;
+    justify-content: center;
+    border-top: 1px solid #ddd;
+    border-bottom: solid 1px #ddd;
+    color: #555;
+    cursor: pointer;
+}
+
+.thumbnail-gallery-controls.left {
+    border-left: solid 1px #ddd;
+}
+
+.thumbnail-gallery-controls.right {
+    border-right: solid 1px #ddd;
+}
+
+.thumbnail-container {
+    display: flex;
+    justify-content: space-between;
+    width: inherit;
+}
+
+.workbench-card-container-sidepanel-active .thumbnail-container {
+    display: flex;
+    justify-content: space-between;
+    width: calc(100% - 400px);
+}
+
+.show-thumbnails-btn {
+    padding: 4px 10px;
+    font-size: 14px;
+    margin-left: 35px;
+    width: 130px;
+    color: #222;
+    font-weight: 600;
+    background-color: rgba(242,242,242, 0.65);
+    text-align: center;
+}
+
+.show-thumbnails-btn:hover {
+    cursor: pointer;
+}
+
+.show-thumbnails-btn.open {
+    position: relative;
+}
+
+.show-thumbnails-btn.closed {
+    position: absolute;
+    bottom: 0;
+}
+
+.thumbnail-gallery-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.workflow-step-body .thumbnail-gallery-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    position: fixed;
+    bottom: 0px;
+    width: calc(100% + 311px);
+    left: 50px;
+}
+
+.workflow-step-container .thumbnail-gallery-container {
+    bottom: 0px;
+    left: 50px;
+}
+
+.workflow-panel {
+    background: #26476a;
+    /* width: 12%; */
+    color: white;
+}
+
+div.workflow-panel {
+    min-width: 250px;
+}
+
+.workflow-panel ul {
+    /* text-decoration: none; */
+    list-style-type: none;
+    /* padding-left: 12px; */
+    margin-bottom: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    /* min-height: 200px; */
+    padding-left: 0;
+    /* border-bottom: #fff; */
+    border-width: 2px;
+}
+
+.workflow-panel i {
+    margin-right: 0px;
+    font-size: 13px;
+    color: #ddd;
+    width: 20px;
+    text-align: center;
+    margin-left: -5px;
+}
+
+.workflow-panel li {
+    padding-top: 12px;
+    padding-left: 20px;
+    padding-bottom: 12px;
+}
+
+.workflow-panel li:hover {
+    background: rgba(70, 130, 180, 0.4);
+    border-left: 4px solid steelblue;
+}
+
+.workflow-panel:not(.navbarclosed) li:hover a {
+    margin-left: -4px;
+}
+
+.workflow-panel:not(.navbarclosed) .active-sub:hover li {
+    cursor: default;
+    background: steelblue;
+}
+
+.workflow-panel .active-sub:hover a {
+    cursor: default;
+    background: steelblue;
+}
+
+.workflow-panel>hr {
+    border-color: white;
+    margin-left: 30px;
+    margin-right: 30px;
+    margin-bottom: 20px;
+}
+
+.workflow-panel.navbarclosed>hr {
+    border-color: #0B0737;
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+}
+
+.workflow-panel .navbarclosed>hr {
+    border-color: white;
+    margin-bottom: 0px;
+}
+
+.workflow-panel li a span {
+    color: white;
+    font-size: 15px;
+    margin-top: 15px;
+    margin-left: 5px;
+}
+
+.workflow-select-wf-icon {
+    color: white;
+    font-size: 28px;
+    padding-top: 0px;
+}
+
+.widget-wrapper .col-xs-12.dropzone .dz-default.dz-message button {
+    display: none;
+}
+
+.workflow-select-title {
+    font-size: 1.4em;
+    font-weight: 500;
+}
+
+.workflow-select-wf-circle {
+    width: 70px;
+    height: 70px;
+    display: inline-block;
+    text-align: center;
+    padding: 18px 12px;
+    border-radius: 40px;
+    border: 1px solid #747474;
+}
+
+.workflow-select-desc {
+    font-size: 12px;
+    padding-top: 10px;
+    font-weight: 600;
+}
+
+.workflow-select-card-container-title {
+    font-size: 1.5em;
+    font-weight: 500;
+    padding-left: 30px;
+    margin-top: 5px;
+    margin-bottom: -15px;
+}
+
+.workflow-select-card-container {
+    display: flex;
+    flex-grow: inherit;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding: 20px;
+}
+
+.workflow-select-card {
+    width: 200px;
+    height: 200px;
+    padding: 10px;
+    color: white;
+    text-align: center;
+    border: 1px solid #777;
+    border-radius: 1px;
+    margin: 5px;
+    opacity: 0.85;
+}
+
+.workflow-select-card:hover {
+    opacity: 1.0;
+    border: 1px solid black;
+}
+
+div.final-cons-step-splash {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 1%;
+}
+
+div.final-cons-step-splash>a {
+    max-width: 180px;
+}
+
+div.final-cons-step-splash>button {
+    border-radius: 2px;
+}
+
+div.final-cons-step-separator {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: stretch;
+    margin-top: 15px;
+    margin-bottom: 8px;
+    color: #777;
+}
+
+div.final-cons-step-separator>hr {
+    margin-top: 25px;
+    margin-bottom: 8px;
+    margin-left: 0;
+    margin-right: 0;
+    flex-grow: 9;
+    border: 1px solid #ddd;
+}
+
+div.final-cons-step-separator>h4 {
+    margin-left: 24px;
+    margin-right: 24px;
+    margin-top: 12px;
+    font-size: 21px;
+    font-weight: 500;
+    flex-grow: 1;
+    text-align: center;
+}
+
+.gallery-container {
+    position: relative;
+}
+
+.gallery-thumbnails {
+    display: inline-flex;
+    align-items: center;
+    text-align: center;
+    background-color: rgba(142,142,142, 0.65);
+    height: 105px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    width: 100%;
+    border-top: solid 1px #bbb;
+}
+
+.gallery-thumbnails img {
+    height: 80px;
+    margin: 3px 6px;
+    border: solid 1.5px #bbb;
+}
+
+.gallery-thumbnails img:hover {
+    cursor: pointer;
+    border: 1.5px solid #FFF;
+}
+
+.gallery-thumbnails .dz-cancel {
+    color: black;
+    background-color: #ccc;
+    position: absolute;
+    right: 0;
+    opacity: 0.75;
+    position: absolute;
+}
+
+.gallery-thumbnails .dz-cancel:hover {
+    background-color: #eee;
+    opacity: 1;
+}
+
+.gallery-thumbnails .btn-xs {
+    padding: 0.5px 3.5px;
+}
+
+.gallery-controls {
+    display: flex;
+    right: 0px;
+    top: 0px;
+    height: 100%;
+}
+
+.gallery-controls.new-tile {
+    background: #ededed;
+    justify-content: center;
+    width: 100%
+}
+
+.gallery-controls.new-tile .dropzone-photo-upload {
+    margin-top: 0;
+    padding: 45px;
+    background-color: #ffffff;
+    width: 100%;
+}
+
+.dropzone-photo-upload {
+    margin-top: 40px;
+}
+
+.photo-workbench-photos {
+    height: 136px;
+    overflow-y: scroll;
+    border: solid 1px #ddd;
+    display: flex;
+    flex-direction: column;
+    margin: 5px 10px 10px 10px;
+}
+
+.photo-workbench-photo {
+    position: relative;
+    padding: 4px;
+}
+
+.photo-workbench-photo:nth-child(even) {
+    background: #fff;
+    border-bottom: 1px solid #D3E5F4;
+}
+
+.photo-workbench-photo:nth-child(odd) {
+    background: #F5FAFE;
+    border-bottom: 1px solid #D3E5F4;
+}
+
+.photo-workbench-photo.selected-photo {
+    background-color: #9CC3E4;
+    color: #fff;
+    font-weight: 600;
+    padding: 4px;
+}
+
+.photo-workbench-photo:not(.selected-photo):hover {
+    background: #CAE2F5;
+    cursor: pointer;
+}
+
+.gallery-controls.new-tile .dropzone-photo-upload {
+    margin-top: 0;
+    padding: 45px;
+    background-color: #ffffff;
+    width: 100%;
+}
+
+.workbench-card-sidepanel .gallery-controls.new-tile .dropzone-photo-upload {
+    margin-top: 0;
+    padding: 15px;
+    background-color: #ffffff;
+    width: 100%;
+}
+
+.workbench-card-sidepanel .gallery-controls.new-tile .dropzone-photo-upload {
+    margin-top: 0;
+    padding: 15px;
+    background-color: #ffffff;
+    width: 100%;
+}
+
+/* end photo gallery */
+
+.workbench-model-card-container {
+    margin-top: 50px;
+    padding-bottom: 40px;
+}
+
+.workbench-card-sidebar {
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 92px;
+    background-color: rgb(247, 247, 247);
+    border-left: 1px solid rgb(216, 216, 216);
+    z-index: 200;
+}
+
+.workbench-card-sidebar-tab.disabled {
+    color: #aaa;
+    cursor: auto;
+    pointer-events: none;
+}
+
+.workbench-card-sidebar-tab i {
+    font-size: 1.1em;
+    display: block;
+    padding-bottom: 2px;
+}
+
+.workbench-card-sidebar-tab:hover {
+    background: #fbfbfb;
+    color: #454545;
+}
+
+.workbench-card-sidebar-tab.disabled:hover {
+    color: #aaa;
+    background-color: #f1f1f1;
+}
+
+.workbench-card-sidebar-tab.active {
+    z-index: 200;
+    background-color: white;
+    border-left: solid 1px white;
+    margin-left: -1px;
+    color: #454545;
+}
+
+.workbench-card-sidepanel.expanded {
+    width: 600px;
+    z-index: 1001;
+}
+
+.manifest-manager-canvas-name {
+    width: 315px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.manifest-manager-nav-tab {
+    height: 50px;
+    min-width: 220px;
+    padding: 10px 20px;
+    border-right: 1px solid #f1f1f1;
+    background-color: #ddd;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.manifest-manager-nav-tab.active {
+    background-color: #f6f6f6;
+    font-weight: 600;
+    border-left: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+}
+
+.manifest-manager-nav-tab .tab-label {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.manifest-manager-main-menu-circle {
+    width: 75px;
+    height: 75px;
+    display: inline-block;
+    text-align: center;
+    padding: 20px;
+    border-radius: 50%;
+    background-color: #ccc;
+}
+
+.manifest-manager .dropzone-photo-upload {
+    margin-top: 15px;
+}
+
+.manifest-manager .loader-select {
+    height: 100%;
+    padding-top: 125px;
+}
+
+.manifest-manager .rr-splash-description {
+    width: 700px;
+}
+
+.basemap-listing,
+.overlay-listing,
+.legend-listing {
+    padding: 20px;
+    border-bottom: 1px solid rgb(216, 216, 216);
+}
+
+.basemap-listing,
+.overlay-listing .overlay-opacity-control,
+.overlay-listing .overlay-name {
+    cursor: pointer;
+}
+
+.overlay-listing,
+.legend-listing {
+    cursor: grab;
+}
+
+.basemap-listing,
+.overlay-listing {
+    font-size: 16px;
+    color: rgb(158, 158, 158);
+}
+
+.basemap-listing:before,
+.overlay-listing .overlay-name:before {
+    margin-right: 4px;
+    font-family: FontAwesome;
+}
+
+.basemap-listing:before {
+    content: "\f10c";
+}
+
+.overlay-listing .overlay-name:before {
+    content: "\f204";
+}
+
+.overlay-listing {
+    position: relative;
+}
+
+.overlay-listing.rr-map-card .overlay-name:before {
+    content: "\f070";
+}
+
+.active-overlay .overlay-listing.rr-map-card .overlay-name {
+    color: #666;
+    content: "\f06e";
+}
+
+.active-overlay .overlay-listing.rr-map-card .overlay-name:before {
+    color: #666;
+    content: "\f06e";
+}
+
+.rr-map-card.related-instances .related-instance {
+    color: #9e9e9e;
+    font-size: 12px;
+    padding: 3px 0 0 12px;
+}
+
+.active-overlay .rr-map-card.related-instances .related-instance {
+    color: #666;
+}
+
+.active-overlay .rr-map-card.related-instances .related-instance.hovered {
+    background-color: #eee;
+}
+
+.summary-panel {
+    background: #f9f9f9;
+    margin-top: -30px;
+}
+
+.mouse-pointer canvas {
+    cursor: pointer;
+}
+
+.workbench-card-wrapper {
+    flex: 1;
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+    background-color: #fafafa;
+    border-top: 1px solid #ddd;
+}
+
+.workbench-card-wrapper.autoheight {
+    height: auto;
+    min-height: 100%;
+}
+
+.card-component-wrapper-editor .workbench-card-wrapper {
+    border-top: 1px solid #041B33;
+}
+
+.widgets .workbench-card-wrapper {
+    border: 1px solid #a8a8a8;
+}
+
+.widgets .workbench-card-wrapper {
+    height: 500px;
+}
+
+.workbench-card-container {
+    height: 100%;
+}
+
+.workbench-card-container.workbench-card-container-sidepanel-active {
+    margin-right: 400px;
+}
+
+.workbench-card-container-wrapper.workbench-card-container-sidepanel-active {
+    z-index: 249;
+}
+
+.workbench-card-sidebar {
+    position: absolute;
+    right: 0;
+    top: 0px;
+    height: 100%;
+    width: 75px;
+    background-color: #f1f1f1;
+    border-left: 1px solid #ddd;
+}
+
+.workbench-card-sidebar-tab {
+    color: #787878;
+    height: 65px;
+    padding: 16px;
+    text-align: center;
+    font-size: 1.1em;
+    border-bottom: 1px solid rgb(216, 216, 216);
+    cursor: pointer;
+}
+
+.map-sidebar-text {
+    font-size: 11px;
+}
+
+.workbench-card-sidepanel {
+    position: absolute;
+    z-index: 250;
+    right: 75px;
+    height: 100%;
+    width: 400px;
+    background: white;
+    border-left: 1px solid rgb(216, 216, 216);
+    padding: 16px;
+    overflow-y: scroll;
+}
+
+.workbench-sidepanel-card-container {
+    /* margin: -40px -10px 10px -10px; */
+}
+
+.workbench-sidepanel-body {
+    margin-top: 50px;
+}
+
+.install-buttons .btn-warning {
+    background: #f75d3f;
+    border-color: #E53211;
+}
+
+.install-buttons .btn-warning:hover {
+    background: #E53211;
+    border-color: #B02107;
+}
+
+.install-buttons .btn-danger {
+    background: #FF836C;
+    border-color: #E53211;
+}
+
+.install-buttons .btn-danger:hover {
+    background: #f75d3f;
+    border-color: #E53211;
+}
+
+.install-buttons .btn-mint {
+    background: #3acaa1;
+    border-color: #42cca5;
+}
+
+.install-buttons .btn-mint:hover {
+    background: #1ABA8E;
+    border-color: #009E72;
+}
+
+.workbench-card-sidepanel .install-buttons {
+    background: #f9f9f9;
+    position: fixed;
+    margin-right: 75px;
+    bottom: 0px;
+    border-top: 1px solid #ddd;
+    padding: 10px 35px;
+    right: 0;
+    width: 399px;
+}
+
+.graph-designer .workbench-card-sidepanel .install-buttons {
+    margin-right: 375px;
+}
+
+.workbench-card-sidepanel.expanded .install-buttons {
+    width: 599px;
+}
+
+.workbench-card-sidepanel div .new-provisional-edit-card-container {
+    padding-left: 5px;
+}
+
+.workbench-card-sidepanel .new-provisional-edit-card-container {
+    padding-bottom: 40px;
+}
+
+.workbench-card-sidepanel-header-container {
+    border-bottom: 1px solid #ddd;
+    padding: 17px 30px 10px 0px;
+    margin-left: 0px;
+    margin-top: -16px;
+    position: fixed;
+    background: #fff;
+    z-index: 20;
+    width: 370px;
+}
+
+
+
+.expanded .workbench-card-sidepanel-header-container {
+    width: 599px;
+    margin-left: -16px;
+    padding-left: 15px;
+}
+
+.workbench-header-buffer {
+    height: 40px
+}
+
+.workbench-card-sidepanel-header {
+    cursor: pointer;
+    color: rgb(33, 62, 95);
+    font-size: 15px;
+}
+
+.workbench-card-sidepanel-header:before {
+    content: "\f00d";
+    font-family: FontAwesome;
+    margin-right: 6px;
+    color: rgb(158, 158, 158);
+    font-weight: lighter;
+}
+
+.workbench-card-sidepanel-header:hover:before {
+    color: rgb(33, 62, 95);
+}
+
+.basemap-listing,
+.overlay-listing,
+.legend-listing {
+    padding: 16px 20px;
+    min-height: 60px;
+    border-bottom: 1px solid rgb(216, 216, 216);
+}
+
+.basemap-listing,
+.overlay-listing .overlay-opacity-control,
+.overlay-listing .overlay-name {
+    cursor: pointer;
+}
+
+.overlay-listing,
+.legend-listing {
+    cursor: grab;
+}
+
+.basemap-listing,
+.overlay-listing {
+    font-size: 14px;
+    color: rgb(158, 158, 158);
+}
+
+.basemap-listing-container {
+    margin-top: 50px;
+}
+
+.overlays-listing-container {
+    margin-top: 50px;
+}
+
+.legend-listing-container {
+    margin-top: 50px;
+}
+
+.basemap-listing:before,
+.overlay-listing .overlay-name:before {
+    margin-right: 4px;
+    font-family: FontAwesome;
+}
+
+.basemap-listing:before {
+    content: "\f10c";
+}
+
+.overlay-listing .overlay-name:before {
+    content: "\f204";
+}
+
+.overlay-listing {
+    position: relative;
+}
+
+.overlay-listing .overlay-name {
+    display: inline-block;
+    width: 300px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    position: relative;
+    top: 4px;
+}
+
+.overlay-opacity-control .overlay-opacity-slider,
+.overlay-opacity-control i {
+    display: inline-block;
+}
+
+.overlay-opacity-control .overlay-opacity-slider {
+    transition-property: width, opacity;
+    transition-delay: 0ms;
+    transition: 0ms;
+    -webkit-transition-delay: 0ms;
+    width: 0px;
+    opacity: 0;
+    position: relative;
+    top: 2px;
+    right: -8px;
+}
+
+.overlay-opacity-control .overlay-opacity-slider input {
+    width: 0px;
+    height: 0px;
+}
+
+.overlay-opacity-control:hover .overlay-opacity-slider input,
+.overlay-opacity-control:focus .overlay-opacity-slider input {
+    width: 150px;
+    height: 20px;
+}
+
+.overlay-listing .overlay-opacity-control {
+    transition: 300ms;
+    transition-property: all;
+    transition-delay: 100ms;
+    position: absolute;
+    padding: 6px 6px 6px 8px;
+    top: 16px;
+    right: 6px;
+    width: 30px;
+    height: 38px;
+    border: 1px solid transparent;
+    border-radius: 3px;
+}
+
+.overlay-listing .overlay-opacity-control:hover,
+.overlay-listing .overlay-opacity-control:focus {
+    border: 1px solid rgb(217, 217, 217);
+    background-color: white;
+    width: 200px;
+}
+
+.overlay-listing .overlay-opacity-control:hover .overlay-opacity-slider,
+.overlay-listing .overlay-opacity-control:focus .overlay-opacity-slider {
+    transition-delay: 400ms;
+    transition: 200ms;
+    -webkit-transition-delay: 400ms;
+    width: 150px;
+    opacity: 1;
+}
+
+.legend-listing .legend-name {
+    font-size: 14px;
+}
+
+.legend-listing .legend-content {
+    padding: 10px 10px 0;
+}
+
+.layer-listing-icon {
+    display: inline-block;
+}
+
+.layer-listing-icon::before {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: solid 1px rgb(216, 216, 216);
+    border-radius: 100%;
+    background-color: rgb(247, 247, 247);
+}
+
+.basemap-listing.active-basemap,
+.basemap-listing:hover,
+.overlay-listing.active-overlay,
+.overlay-listing:hover,
+.legend-listing .legend-name {
+    color: rgb(33, 62, 95);
+}
+
+.basemap-listing.active-basemap,
+.basemap-listing:hover,
+.overlay-listing:hover {
+    background-color: rgb(247, 247, 247);
+}
+
+.basemap-listing.active-basemap:before {
+    content: "\f05d";
+}
+
+.overlay-listing.active-overlay .overlay-name:before {
+    content: "\f205";
+}
+
+.map-card-feature-item {
+    cursor: zoom-in;
+}
+
+.map-card-feature-item:hover {
+    background-color: rgb(250, 250, 250);
+}
+
+.map-card-feature-item.active .map-card-feature-name {
+    font-weight: 600;
+}
+
+.geojson-card {
+    margin-top: 65px;
+}
+
+.geojson-editor {
+    border: 1px solid #808080;
+    margin-bottom: 5px;
+    margin-top: 5px;
+}
+
+.geojson-error-list {
+    padding: 10px;
+    color: rgb(161, 0, 0);
+}
+
+.map-card-feature-list .table {
+    margin-bottom: 0;
+}
+
+.map-card-feature-tool {
+    width: 65px;
+}
+
+.map-card-feature-tool.intersect {
+    width: 80px;
+}
+
+.rr-map-card-intersect-panel {
+    margin-top: 7px;
+    margin-bottom: 32px;
+}
+
+.rr-map-card-intersect-panel .intersection-result {
+    padding: 3px 0 0 12px;
+}
+
+.rr-map-card-intersect-panel .intersection-result.hovered {
+    background-color: #ddd;
+}
+
+.map-card-zoom-tool,
+.map-card-feature-tool {
+    font-size: 0.9em;
+}
+
+.map-card-zoom-tool a,
+.map-card-feature-tool a {
+    color: #2f527a;
+}
+
+.map-card-zoom-tool {
+    float: right;
+    padding: 10px;
+}
+
+.map-card-zoom-tool a {
+    display: inline-block;
+    padding: 0px 3px;
+}
+
+#map-settings {
+    position: relative;
+    margin: -40px -35px 10px -20px;
+}
+
+.help-close {
+    color: #868686;
+    position: absolute;
+    right: 10px;
+    top: 20px;
+    z-index: 600;
+}
+
+.scroll-y {
+    height: calc(100vh - 50px); /* top-nav height */
+    overflow-y: auto;
+}
+
+.scroll-y-hidden {
+    overflow-y: hidden;
+}
+
+.scroll-y-auto {
+    overflow-y: auto;
+}
+
+.tab-base .nav-tabs>li:not(.active)>a:hover {
+    border-top: 1px solid #eee;
+    border-right: 1px solid #eee;
+    border-left: 1px solid #eee;
+    border-bottom: 1px solid #fff;
+    background: #eee;
+}
+
+.tab-base .tab-content {
+    box-shadow: none;
+    padding-bottom: 0;
+    margin: 0;
+}
+
+.panel .panel-heading,
+.panel>:first-child {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+.form-text.form-checkbox:not(.btn),
+.form-text.form-radio:not(.btn) {
+    padding-right: 25px;
+    padding-top: 5px;
+    padding-left: 22px;
+}
+
+.option-input {
+    display: flex;
+    flex-wrap: wrap;
+    max-width: 100%;
+}
+
+.option-input-config {
+    display: flex;
+    flex-direction: column;
+}
+
+span.icon-wrap.icon-circle.bg-gray-dark:hover {
+    background: #94A6BC;
+    color: #123;
+}
+
+.input-group.date .input-group-addon {
+    background: #fafafa;
+}
+
+.widget-input-label {
+    font-size: 12px;
+    margin-top: 2px;
+    font-weight: 600;
+    color: #666;
+}
+
+.widget-input {
+    border-radius: 2px;
+}
+
+.widget-file {
+    width: 100px;
+}
+
+.form-contol {
+    height: 36px;
+}
+
+.form-control.input-lg.widget-input {
+    height: 36px;
+}
+
+.date .form-control {
+    height: 36px;
+}
+
+.tile {
+    border-left: 2px solid #0594BC;
+    border-right: 1px solid #ddd;
+    border-top: 0 solid #ddd;
+    border-bottom: 1px solid #ddd;
+    background: #fbfbfb;
+    color: #5f5f5f;
+    width: 200px;
+    height: 170px;
+    position: relative;
+    overflow-y: scroll;
+    padding: 5px 5px 7px;
+}
+
+.help-text-small {
+    font-size: 12px;
+    padding-right: 5px;
+}
+
+.grid-container {
+    overflow: scroll;
+}
+
+.list-wrapper {
+    overflow-y: auto;
+    height: calc(100% - 60px);
+    /*60px accounts for header so list scrolls to bottom*/
+}
+
+.grid {
+    background: #ebeef0;
+    max-width: 1200px;
+    margin-left: -8px;
+    margin-right: -6px;
+    border-top: 1px solid #ddd;
+    overflow: auto;
+}
+
+.grid-item {
+    float: left;
+    width: 100px;
+    height: 100px;
+    background: #0D8;
+    border: 1px solid #333;
+    border-color: hsla(0, 0%, 0%, 0.7);
+    margin: 3px;
+}
+
+.select2-container {
+    width: 100% !important;
+    border: 1px solid #ddd;
+}
+
+.form-group div input {
+    max-width: 600px;
+    border: 1px solid #eee;
+}
+
+.resource-instance-wrapper .select2-container {
+    max-width: 600px !important;
+    border: 1px solid #eee;
+}
+
+.select2-container.select2-container-active.select2-dropdown-open {
+    border: 1px solid steelblue;
+}
+
+.mpm-resource-selection .select2-container {
+    height: 32px;
+}
+
+.select2-choice {
+    border: 1px solid #E9E9E9!important;
+    border-radius: 2px!important;
+    background-image: none!important;
+    height: 36px!important;
+    padding: 4px 0 0 16px !important;
+}
+
+.select2-container .select2-choice {
+    display: block;
+    height: 26px;
+    padding: 0 0 0 8px;
+    overflow: hidden;
+    position: relative;
+    border: 1px solid #aaa;
+    white-space: nowrap;
+    line-height: 26px;
+    color: #444;
+    text-decoration: none;
+    border-radius: 4px;
+    background-clip: padding-box;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    background-color: #fff;
+    background-image: -webkit-gradient(linear, left bottom, left top, color-stop(0, #eee), color-stop(0.5, #fff));
+    background-image: -webkit-linear-gradient(center bottom, #eee 0, #fff 50%);
+    background-image: -moz-linear-gradient(center bottom, #eee 0, #fff 50%);
+    background-image: linear-gradient(to top, #eee 0, #fff 50%);
+}
+
+a.select2-choice {
+    background: #42a5f5;
+}
+
+.select2-dropdown-open .select2-choice {
+    background-color: #fff!important;
+}
+
+.select2-arrow {
+    border: none!important;
+    background: none!important;
+    background-image: none!important;
+    padding-top: 2px;
+}
+
+.select2-container .select2-choice .select2-arrow b:before {
+    content: "";
+}
+
+.select2-container.select2-container-disabled .select2-choice {
+    background: #eee;
+}
+
+.select2-container-multi .select2-choices {
+    border: 1px solid #e1e5ea;
+    background-image: none;
+}
+
+.select2-container-multi.select2-container-active .select2-choices {
+    border: 1px solid #e1e5ea;
+    box-shadow: none;
+}
+
+.select2-drop {
+    border-radius: 0px;
+    color: inherit;
+}
+
+.select2-drop-active {
+    border: 1px solid steelblue;
+    border-top: none;
+    box-shadow: none;
+}
+
+.select2-result.disabled {
+    background-color: #eee;
+    color: #999;
+    pointer-events: none;
+}
+
+.select2-results {
+    padding: 0px;
+    margin: 0px;
+}
+
+.select2-results li {
+    /*padding: 4px 6px;*/
+    padding: 0px;
+    line-height: 22px;
+    color: #595959;
+}
+
+.select2-results .select2-no-results,
+.select2-results .select2-searching,
+.select2-results .select2-results .select2-ajax-error {
+    background: #f4f4f4;
+    line-height: 30px;
+    padding-left: 5px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+}
+
+.select2-results .select2-ajax-error {
+    color: #9e1515;
+}
+
+.select2-container-multi .select2-choices .select2-search-choice {
+    padding: 3px 10px 5px 18px;
+    margin: 4px 0 0px 5px;
+    background: #42a5f5;
+    position: relative;
+    line-height: 13px;
+    color: #fff;
+    cursor: default;
+    border: 1px solid #3b8dd5;
+    border-radius: 2px;
+    -webkit-box-shadow: none;
+    -webkit-touch-callout: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    background-image: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.filter-flag {
+    background: #30ad24 !important;
+}
+
+.select2-container-multi .select2-choices li {
+    float: left;
+    list-style: none;
+}
+
+.select2-container-multi .select2-search-choice-close {
+    left: 3px;
+    color: #fff;
+}
+
+a.select2-search-choice-close {
+    background-color: #fff;
+    border-radius: 3px;
+}
+
+.select2-search-choice div {
+    margin-top: 1px;
+}
+
+.btn-display-toggle {
+    height: 35px;
+}
+
+.btn-display-toggle:focus {
+    background: #9490EE;
+    color: #fff;
+}
+
+.time-wheel-display-toggle .btn-display-toggle:last-child {
+    border-left-color: #fff;
+}
+
+.btn-group .btn+.btn {
+    margin-left: 0px;
+}
+
+.switch {
+    background-color: #fff;
+    border: 1px solid #dfdfdf;
+    border-radius: 20px;
+    cursor: pointer;
+    display: inline-block;
+    height: 30px;
+    position: relative;
+    vertical-align: middle;
+    width: 50px;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    box-sizing: content-box;
+    background-clip: content-box;
+    transition-duration: .1s;
+}
+
+.switch>small {
+    transition-duration: .1s;
+    left: 0;
+}
+
+.switch.on {
+    background-color: #64bd63;
+    border-color: #64bd63;
+}
+
+.switch.null {
+    background-color: #ddd;
+    border-color: #ddd;
+}
+
+.switch.on>small {
+    left: 13px;
+}
+
+.switch.disabled {
+    background-color: #f1f1f1;
+    border-color: #ddd;
+}
+
+.switch.disabled.on {
+    background-color: #87c586;
+    border-color: #87c586;
+}
+
+.switch.disabled>small {
+    background-color: #f1f1f1;
+}
+
+.library {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    opacity: .95;
+    border-radius: 0;
+    z-index: 200;
+    padding: 0 20px 20px 0;
+}
+
+.clear-search {
+    position: absolute;
+    right: -5px;
+    top: 3px;
+    color: #123;
+    font-size: 19px;
+}
+
+.clear-search:hover {
+    cursor: pointer;
+    color: rgba(0, 0, 0, 0.95);
+}
+
+.list-filter {
+    position: relative;
+    margin-bottom: 8px;
+    margin-right: 0px;
+}
+
+.key {
+    margin-top: 98px;
+}
+
+.library-close-btn {
+    position: absolute;
+    right: 10px;
+    top: -22px;
+    font-size: 15px;
+    color: #666;
+}
+
+.alert {
+    padding: 15px;
+}
+
+.library-card {
+    height: 60px;
+    margin-left: -1px;
+    position: relative;
+    padding: 5px;
+    color: #666;
+    border-bottom: 1px solid #ddd;
+    /*border-right: 1px solid #e9e9e9;*/
+    background: #f8f8f8;
+    border-left: 5px solid #f8f8f8;
+}
+
+.related-resources-nodes .library-card {
+    height: 80px;
+}
+
+.library-card.active {
+    background: #ffffff;
+    border-left: 5px solid steelblue;
+}
+
+.library-card.active:hover {
+    background: #fff;
+    border-left: 5px solid steelblue;
+}
+
+.selected-card {
+    opacity: 1.0;
+    color: #fff;
+    background-color: #fbfbfb;
+}
+
+.selected div .listitem_name {
+    font-weight: 600;
+}
+
+.disabled .listitem_name {
+    font-weight: 600;
+    color: #999;
+}
+
+.selected div .name {
+    font-weight: 600;
+}
+
+.library-card.selected.selected-card {
+    background: #fff;
+    border-left: 5px solid steelblue;
+    cursor: default;
+}
+
+.library-card.permissions.selected.selected-card {
+    background: #fff;
+    color: #656665;
+    border-left: 0px;
+    cursor: default;
+}
+
+.library-card:hover {
+    background-color: #fff;
+    cursor: pointer;
+    border-left: 5px solid steelblue;
+    opacity: 1.0;
+}
+
+.branch-library {
+    background-color: white;
+    height: auto;
+}
+
+.branch-library-icon {
+    font-size: 15px;
+}
+
+#branch-library,
+#card-crud-permissions .library-card {
+    width: 100%;
+    margin-left: 1px;
+}
+
+.middle-column-container.card-configuration {
+    padding: 60px 15px;
+}
+
+.middle-column-container.card-configuration.expanded {
+    flex-basis: 450px;
+}
+
+.card-configuration.expanded + div div div div div .install-buttons {
+    margin-right: 525px;
+}
+
+.constraint-selection {
+    padding-top: 10px;
+    border-bottom: solid 1px #eee;
+}
+
+.constraint-selection .dropdown {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.library-icon {
+    width: 30px;
+    position: absolute;
+    left: 10px;
+    top: 10px;
+}
+
+.user-groups {
+    font-size: 11px;
+    color: #999;
+}
+
+.library-card-main {
+    width: 255px;
+    position: absolute;
+    left: 58px;
+    top: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+}
+
+.library-card-main a {
+    color: #1E6FB7;
+}
+
+.library-card-subtitle {
+    text-transform: capitalize;
+    width: 225px;
+    position: absolute;
+    left: 58px;
+    top: 25px;
+    color: #888;
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 2px 2px 3px 0;
+}
+
+.crud-card {
+    float: left;
+    width: 274px;
+    height: 58px;
+    margin: -5px 0 0 0;
+    position: relative;
+    padding: 5px;
+    color: #666;
+    background: #fcfcfc;
+    opacity: .7;
+}
+
+.crud-card:not(.selected):hover {
+    background: #fff;
+    cursor: pointer;
+    opacity: 1.0;
+    color: #123;
+    border-bottom: 1px solid #eee;
+}
+
+.crud-card-main {
+    width: 200px;
+    position: absolute;
+    left: 60px;
+    top: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 13px;
+    height: 36px;
+}
+
+.crud-card-main a {
+    color: #1E6FB7;
+}
+
+.crud-card-subtitle {
+    width: 200px;
+    position: absolute;
+    left: 60px;
+    top: 27px;
+    padding: 2px 2px 3px 0px;
+    color: #888;
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    height: 19px;
+}
+
+.related-resources-nodes .crud-card-subtitle {
+    top: 50px;
+    display: flex;
+    flex-direction: row;
+    color: #25476A;
+    margin-left: -2px;
+    padding-bottom: 2px;
+    width: 250px;
+    height: 25px;
+    margin-top: -3px;
+}
+
+.related-resources-nodes .crud-card-subtitle span {
+    padding-left: 2px;
+    padding-right: 2px;
+    padding-top: 2px;
+}
+
+.related-resources-nodes .crud-card-main {
+    width: 250px;
+}
+
+.related-resources-nodes.form-list .header {
+    border-left: 1px solid #e0e0e0;
+}
+
+.load-relations {
+    color: #fff;
+    padding: 3px 5px;
+    background: steelblue;
+    position: absolute;
+    right: -5px;
+    margin-right: 5px;
+    top: 0px;
+    border-radius: 2px;
+    font-weight: 600;
+}
+
+.load-relations.disabled {
+    color: #888;
+    margin-left: 5px;
+    background: #ddd;
+}
+
+.selected-group-user-permissions {
+    position: absolute;
+    left: 30px;
+    width: 100%;
+}
+
+.permissions-options {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-checkbox.form-normal.form-primary.permission-option {
+    padding-left: 22px;
+    padding-bottom: 5px;
+}
+
+.selected-group-user-permissions .library-icon-permissions {
+    top: 0px;
+}
+
+.permission-manager {
+    width: 100%;
+}
+
+.permissions-instructions-panel {
+    border: 1px solid #ddd;
+    padding: 30px;
+    margin-bottom: 30px;
+    background: #fbfbfb;
+}
+
+.mpm-instruction-title {
+    font-size: 15px;
+}
+
+.mpm-instruction {
+    padding: 2px 15px;
+}
+
+.settings-panel-heading+.permissions-instructions-panel {
+    margin-top: 55px;
+}
+
+.permission-manager.panel-body {
+    display: flex;
+    background-color: white;
+    margin: 1px;
+    height: 675px;
+}
+
+.permission-manager .card-content-container {
+    padding: 10px 50px 10px;
+    background-color: white;
+}
+
+.permission-manager-filter {
+    height: 58px;
+    width: 100%;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-bottom-color: #ccc;
+    margin-bottom: 2px;
+}
+
+.permission-manager-filter .clear-selection a.clear-selection-link {
+    padding-right: 5px;
+    font-size: 13px;
+}
+
+.permission-manager-filter .clear-node-search {
+    position: absolute;
+    top: 22px;
+    font-size: 14px;
+    left: 46%;
+    width: 15px;
+}
+
+.permission-manager-item-list .card-tree-container {
+    margin-right: 0px;
+}
+
+.permission-manager .filter-bar {
+    display: flex;
+    flex-direction: row;
+    padding: 15px;
+}
+
+.permission-manager-item-list {
+    padding-left: 10px;
+}
+
+.permission-manager.header {
+    position: relative;
+    height: 100px;
+    padding-left: 10px;
+    color: #2b425b;
+    background: #fff;
+    border-bottom: 1px solid #eee;
+}
+
+.permission-manager .control-panel {
+    display: flex;
+    margin-left: 0px;
+}
+
+.permissions {
+    background: rgb(240, 240, 240);
+}
+
+.permissions:hover {
+    background: #fff;
+}
+
+.permissions.selected {
+    background: #fff;
+}
+
+.confirmation-permissions {
+    font-size: 12px;
+    color: #888;
+}
+
+.permission-selector {
+    margin: 20px 0px 30px 0px;
+}
+
+.permissions-readout {
+    float: right;
+    padding-right: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #454545;
+    padding-top: 10px;
+    margin-top: -10px;
+    margin-bottom: -10px;
+    padding-left: 10px;
+}
+
+.permissions-node {
+    font-size: 13px;
+    color: #555;
+}
+
+.no-cards-selected {
+    padding: 10px;
+    font-size: 13px;
+}
+
+.permissions-node-row {
+    display: inline-flex;
+    background: #fff;
+    border-bottom: 1px solid #D3E5F4;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    padding-left: 10px;
+    margin-right: 0px;
+    justify-content: space-between;
+}
+
+.permissions-node-row:nth-child(even) {
+    background: #F5FAFE;
+}
+
+.permissions-title {
+    font-size: 15px;
+}
+
+.permissions-title-panel {
+    position: absolute;
+    top: 3px;
+    left: 50px;
+}
+
+.library-icon-permissions {
+    position: absolute;
+    left: 30px;
+    top: 30px;
+    width: 100%;
+}
+
+.permissions-default {
+    height: 1px;
+    color: #555;
+    font-size: 16px;
+}
+
+.permissions-account-warning {
+    padding: 4px 10px;
+    background: #ffb54a;
+    color: #fff;
+    border: 1px solid #EF9A1F;
+}
+
+.permissions-list {
+    padding-top: 10px;
+    padding-bottom: 15px;
+    margin-bottom: 10px;
+    background: #fff;
+    width: 100%;
+}
+
+.permissions-selected {
+    display: flex;
+    flex-direction: column;
+    margin-top: 5px;
+    list-style: none;
+    color: #666;
+    line-height: 1.2;
+    padding-left: 0px;
+    font-size: 15px;
+    border: 1px solid #ddd;
+}
+
+
+/*------------------------------------------------*/
+
+.permission-grid {
+    display: grid;
+    grid-template-columns: 40px 450px auto 40px;
+    grid-template-rows: 25px auto auto auto;
+    grid-column-gap: 10px;
+    grid-row-gap: 10px;
+}
+
+.permission-grid .permission-header {
+    grid-column-start: 2;
+    grid-column-end: 4;
+    grid-row-start: 2;
+    grid-row-end: 2;
+}
+
+.permission-grid .permission-control {
+    grid-column-start: 2;
+    grid-column-end: 3;
+    grid-row-start: 3;
+    grid-row-end: 3;
+}
+
+.permission-grid .permission-list {
+    grid-column-start: 2;
+    grid-column-end: 4;
+    grid-row-start: 4;
+    grid-row-end: 4;
+    overflow-y: auto;
+}
+
+.permission-grid .permissions-options {
+    display: flex;
+    flex-direction: row;
+    margin-top: 5px;
+    padding: 10px 0px 15px;
+}
+
+.permission-filter {
+    display: inline-flex;
+    justify-content: space-between;
+    width: 250px;
+}
+
+.permissions-list-table {
+    height: 300px
+}
+
+.permissions-list-table-body {
+    height: 400px;
+    overflow-y: auto;
+    border: solid 1px #ddd;
+}
+
+.permissions-list-table-body::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 9px;
+    border-left: 1px solid #eee;
+}
+
+.permissions-list-table-body::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(0, 0, 0, .1);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
+
+.permissions-list-header {
+    background: #579ddb;
+    color: #fff;
+    width: 100%;
+    display: flex;
+    padding: 9px 5px;
+    border-bottom: 1px solid #D3E5F4;
+    font-weight: 600;
+}
+
+.permission-control .clear-filter {
+    align-self: center;
+    font-size: 14px;
+    margin-left: -20px;
+    padding-right: 15px;
+}
+
+.permissions-table-row {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 5px;
+    border-bottom: 1px solid #D3E5F4
+}
+
+.permissions-table-row:nth-child(odd) {
+    background: #F5FAFE;
+}
+
+.permissions-table-row.selected {
+    background-color: #F1F1FF;
+}
+
+.permissions-table-row.selected:hover {
+    background-color: #F1F1FF;
+    cursor: pointer;
+}
+
+.permissions-table-row:hover {
+    background-color: #B6DEFF;
+    cursor: pointer;
+}
+
+.permissions-table-row:first-child {
+    background-color: #f8f8f8;
+    color: #777;
+    font-weight: 600;
+}
+
+.permissions-table-row:first-child:hover {
+    cursor: default;
+}
+
+.permission-selection-panel {
+    display: inline-flex;
+    background: #fcfcfc;
+    border-top: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+    margin: 8px -5px -10px -5px;
+}
+
+.permission-selection-panel:hover {
+    cursor: default;
+}
+
+.permission-list-table .identities-column {
+    width: 35%;
+}
+
+.permission-list-table .permissions-column {
+    width: 65%;
+}
+
+.permission-grid .permissions-buttons {
+    grid-column-start: 2;
+    grid-column-end: 3;
+    grid-row-start: 5;
+    grid-row-end: 5;
+    height: 75px;
+    align-items: baseline;
+}
+
+.permission-grid .remove-permissions-btn {
+    grid-column-start: 3;
+    grid-column-end: 4;
+    grid-row-start: 5;
+    grid-row-end: 5;
+    height: 75px;
+    justify-self: end;
+}
+
+
+/*------------------------------------------------*/
+
+.library-search {
+    font-size: 11px;
+    height: 32px;
+    width: 100%;
+}
+
+.key-icon {
+    width: 50px;
+}
+
+#library .nav-tabs li:not(active) a {
+    opacity: 0.9;
+    border-radius: 0;
+    border: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+    background-color: #314151;
+    color: rgba(255, 255, 255, 0.5);
+    padding: 20px 0;
+}
+
+#library .nav-tabs .active a {
+    border-left: 1px solid rgba(0, 0, 0, 0.1);
+    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid transparent;
+    background-color: #37495b;
+    color: inherit!important;
+}
+
+.branch-preview {
+    height: 280px;
+    width: 280px;
+    background: #fff;
+    border: 1px solid #ddd;
+    color: #123;
+}
+
+.branch-icon {
+    border: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+.branch-icon:hover {
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    background: #5fa2dd;
+}
+
+.clear-selection {
+    width: 100%;
+    height: 21px;
+    padding-top: 4px;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+}
+
+.clear-selection-link {
+    cursor: pointer;
+    font-size: 9px;
+    float: right;
+    color: #555;
+}
+
+.clear-selection-link:hover {
+    color: #333;
+}
+
+.clear-selection a.clear-selection-link {
+    font-size: 11px;
+}
+
+.node circle {
+    fill: #fff;
+    stroke: #4682B4;
+    stroke-width: 1px;
+}
+
+.node {
+    font-size: 13px;
+    transition: all .40s ease;
+    stroke: #aaa;
+    stroke-width: 1px;
+}
+
+.node .node-selected {
+    fill: #3ACAA2;
+    stroke: #009E72;
+    stroke-width: 1px;
+}
+
+.node .node-filtered {
+    /*    fill: #f0f0f0;
+    stroke: #bbb;*/
+}
+
+.graph-node-text {
+    text-overflow: ellipsis;
+    stroke: steelblue;
+}
+
+.link {
+    fill: none;
+    stroke: #bbb;
+    stroke-width: 2px;
+}
+
+.node .node-over {
+    fill: #3ACAA2;
+    stroke: #009E72;
+    stroke-width: 1.5px;
+    cursor: pointer;
+    transition: all .40s ease;
+}
+
+.target-node circle {
+    opacity: 0.2;
+    fill: red;
+    stroke: red;
+    stroke-width: 25px;
+}
+
+.target-node circle.node-over {
+    opacity: 0.5;
+    fill: red;
+    stroke: red;
+    stroke-width: 32px;
+}
+
+#nodeCrud {
+    position: absolute;
+    width: 250px;
+    left: 300px;
+    top: 0;
+    bottom: 0;
+    color: #fff;
+    z-index: 200;
+    border-left: 1px solid #1E3143;
+    border-right: 1px solid #1E3143;
+    -webkit-border-radius: 12px;
+    -moz-border-radius: 2px;
+    border-radius: 0;
+    -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
+    -moz-box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.4);
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.4);
+    padding: 0 10px;
+}
+
+input[type="search"] {
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.round {
+    border-radius: 50%;
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    -webkit-transition: opacity .5s;
+    transition: opacity .5s;
+    -webkit-transition-timing-function: cubic-bezier(0.7, 0, 0.3, 1);
+    transition-timing-function: cubic-bezier(0.7, 0, 0.3, 1);
+}
+
+.arches-form {
+    background-color: #ebeef0;
+    padding: 20px 0 40px;
+}
+
+#aside-container #aside .nav-tabs li:not(active) a {
+    padding: 20px 0;
+}
+
+ul.nav.nav-tabs.nav-justified {
+    height: 59px;
+}
+
+.v-menu {
+    height: 100vh;
+    width: 300px;
+    background: #fff;
+    border-right: 1px solid #ddd;
+    padding: 0 0 0 12px;
+}
+
+.form-page {
+    background-color: #e7ebee;
+    width: 100%;
+    padding: 20px 20px 100px 5px;
+}
+
+.node-configuration {
+    background-color: #ffffff;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.settings-panel {
+    padding: 10px 20px 150px 25px;
+}
+
+.settings-panel-heading {
+    position: fixed;
+    top: 115px;
+    height: 50px;
+    width: 100%;
+    background: #25476a;
+    margin-top: -10px;
+    margin-bottom: 20px;
+    margin-left: -25px;
+    margin-right: -20px;
+    padding-left: 25px;
+    z-index: 10;
+}
+
+.card-settings-panel-heading {
+    position: fixed;
+    top: 115px;
+    height: 50px;
+    width: 100%;
+    background: #25476a;
+    margin-top: -10px;
+    margin-bottom: 20px;
+    margin-left: 0px;
+    margin-right: 0px;
+    padding-left: 25px;
+    padding-top: 10px;
+    color: #fff;
+    z-index: 100;
+}
+
+.settings-panel-heading+div {
+    /*margin-top: 13px;*/
+}
+
+.graph-crm-class {
+    font-size: 15px;
+    color: #ddd;
+    padding-left: 10px;
+}
+
+.graph-type {
+    font-size: 15px;
+    color: #777;
+    padding-left: 10px;
+}
+
+.graph-designer {
+    background: #fbfbfb;
+}
+
+.graph-designer-graph-content {
+    width: 100%;
+}
+
+.graph-designer-graph-content .graph-designer-title {
+    font-size: 17px;
+    font-weight: 500;
+    margin-top: 2px;
+    margin-bottom: 5px;
+    color: #fff;
+    padding: 10px 0 5px 0px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.graph-designer-title .name {
+    padding-left: 5px;
+    font-size: 17px;
+    margin-top: 2px;
+}
+
+.top-node-panel {
+    margin-top: 60px;
+}
+
+.graph-designer-header {
+    color: #888;
+    font-size: 16px;
+    padding-bottom: 5px;
+    border-bottom: solid 1px #ddd;
+}
+
+.columns label.form-checkbox.form-normal:before,
+.form-radio.form-normal::before {
+    left: 1px;
+}
+
+.pad-hor.columns {
+    background: #fff;
+    padding: 8px 5px 6px 10px;
+    /*border: 1px solid #ddd;*/
+}
+
+.form-radio.form-normal::before {
+    left: 0px;
+}
+
+.widget-container.graph-settings-switch {
+    padding-bottom: 0px;
+}
+
+.graph-settings-switch-label {
+    margin-left: 40px;
+    margin-top: -20px;
+    margin-bottom: 0px;
+}
+
+.graph-settings-switch-subtitle {
+    margin-left: 40px;
+    margin-top: -5px;
+    display: inline-block;
+    color: #5F7D9A;
+    position: relative;
+    top: -5px;
+    font-size: 13px;
+    font-weight: 400;
+}
+
+.exportable-field-name {
+    padding-left: 40px;
+}
+
+.graph-settings-panel-body {
+    padding: 5px 0px;
+}
+
+.graph-settings-panel-body .widgets .widget-container div div>input {
+    max-width: 500px;
+    min-width: 500px;
+}
+
+.graph-settings-panel-body .widgets .widget-container div .crm-selector div .chosen-drop .chosen-search>input {
+    max-width: 490px;
+    min-width: 490px;
+}
+
+.graph-settings-panel-body .widgets .widget-container div .colorpicker-component {
+    max-width: 250px;
+    min-width: 250px;
+    padding-left: 5px;
+    height: 32px;
+}
+
+.graph-settings-panel-body .widgets .widget-container div div div div div select .chosen-container {
+    width: 500px;
+}
+
+.graph-settings-panel-body .widgets .widget-container div div .domain-input {
+    max-width: 480px;
+    min-width: 480px;
+}
+
+.graph-settings-panel-body .widgets .widget-container div div .domain-input-item {
+    max-width: 468px;
+    min-width: 468px;
+}
+
+.function-node-alert {
+    display: inline-block;
+    background: #A2EAE2;
+    padding: 15px 30px;
+    margin-top: -10px;
+    margin-left: -5px;
+    margin-bottom: 15px;
+    font-size: 14px;
+    font-weight: 400;
+    color: #01766A;
+}
+
+.edtf-input {
+    padding-bottom: 15px;
+}
+
+.node-config-item {
+    padding: 5px 0px 12px 0px;
+}
+
+.node-config-item.pad-top {
+    padding: 15px 0px 12px 0px;
+}
+
+.concept-label {
+    padding-top: 0px;
+}
+
+.tree-container {
+    overflow-x: scroll;
+    padding: 0 0 10px 10px;
+}
+
+#container .table-hover>tbody>tr:hover {
+    background-color: #4682B4;
+    color: #fff;
+}
+
+.bg-primary:hover {
+    background-color: #3b8dd5;
+}
+
+div.dropdown-menu.open {
+    min-height: 250px;
+}
+
+.underline {
+    border-bottom: 1px solid #ddd;
+}
+
+.bg-green {
+    background: #139F78;
+}
+
+.og-grid {
+    list-style: none;
+    text-align: left;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2px 0;
+}
+
+.og-grid li {
+    display: inline-block;
+    vertical-align: top;
+    height: 200px;
+    min-width: 180px;
+    margin: 10px 5px 5px;
+}
+
+.og-grid li>a,
+.og-grid li>a img {
+    border: none;
+    outline: none;
+    display: block;
+    position: relative;
+}
+
+.nav-tabs>li.active>a,
+.nav-tabs>li.active>a:focus,
+.nav-tabs>li.active>a:hover {
+    border: 1px solid #fff;
+}
+
+.library-tools-icon {
+    font-size: 17px;
+    color: #999;
+    padding-right: 5px;
+}
+
+.nav-tabs.library-tools>li>a {
+    height: 40px;
+    border: none;
+    padding: 2px;
+}
+
+.nav-tabs.library-tools>li>a:hover {
+    background-color: inherit;
+}
+
+.nav-tabs.library-tools>li.active>a {
+    background-color: inherit;
+    border: none;
+}
+
+.chosen-container {
+    margin-bottom: 0px;
+    color: #8d8d8d;
+    line-height: 1.3333333;
+}
+
+.chosen-container-multi .chosen-choices li.search-field {
+    margin: 2px 3px 0 10px;
+}
+
+.chosen-container-single .chosen-single {
+    height: 36px;
+}
+
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close {
+    background-image: none !important;
+}
+
+.list-group-item.active:hover,
+.list-group-item.active:active,
+.list-group-item.active:focus {
+    background-color: #f9f9f9;
+    border-bottom: 1px solid #eee;
+    border-top: 1px solid #eee;
+    color: #5f5f5f;
+}
+
+.switchery>small,
+.switch>small {
+    background: #fff;
+    border-radius: 100%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    height: 30px;
+    position: absolute;
+    top: 0;
+    width: 30px;
+}
+
+.switch-small {
+    border-radius: 13px;
+    height: 13px;
+    width: 25px;
+}
+
+.switch-small>small {
+    height: 13px;
+    width: 13px;
+}
+
+.node .node-collected,
+.link.link-collected {
+    stroke-width: 3px;
+}
+
+.loading-mask {
+    position: fixed;
+    opacity: .75;
+    background-color: grey;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100000000;
+}
+
+.loading-mask:after {
+    position: fixed;
+    opacity: .5;
+    color: #454545;
+    content: '\f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 10vw;
+    margin-top: 42vh;
+    margin-left: 45vw;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.loading-mask-string {
+    font-size: 22px;
+    padding-top: 5%;
+    font-weight: 600;
+    width: 50%;
+    text-align: center;
+    top: 25%;
+    left: 25%;
+    height: 50%;
+    position: absolute;
+    color: #fff;
+    background-color: #000;
+    z-index: 8000;
+}
+
+.branch-list-loading-mask {
+    height: 100%;
+    position: relative;
+    margin: auto;
+    width: 50%;
+    padding: 36px;
+    text-align: center;
+    opacity: .5;
+    z-index: 100000001;
+}
+
+.branch-list-loading-mask:after {
+    position: relative;
+    content: '\f110';
+    animation: fa-spin 2s infinite linear;
+    -webkit-animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 30px;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.time-wheel-loading-mask {
+    height: 100%;
+    position: relative;
+    margin: auto;
+    width: 50%;
+    padding: 36px;
+    text-align: center;
+    opacity: .5;
+    z-index: 100000001;
+}
+
+.time-wheel-loading-mask:before {
+    position: relative;
+    content: '\f110';
+    animation: fa-spin 2s infinite linear;
+    -webkit-animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 30px;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.card-form-preview-container.loading-mask {
+    position: relative;
+    opacity: .5;
+    background-color: gray;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100000000;
+}
+
+.card-form-preview-container.loading-mask::before {
+    position: fixed;
+    opacity: .5;
+    color: #000;
+    content: '\f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: 14vw;
+    margin-top: 42vh;
+    margin-left: 32vw;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.ep-help-body.loading-mask::before {
+    position: fixed;
+    opacity: .5;
+    color: #000;
+    content: '\f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 10px/1 FontAwesome;
+    font-size: 10vw;
+    margin-top: 42vh;
+    margin-left: 18vw;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.ep-help-body.loading-mask:after {
+    display: none;
+}
+
+.ep-help-body.loading-mask {
+    position: relative;
+    opacity: .5;
+    background-color: gray;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100000000;
+}
+
+.ep-edits {
+    position: absolute;
+    top: 0px;
+    display: table;
+    right: 0;
+    width: 500px;
+    height: 100vh;
+    border-left: 1px solid #ddd;
+    z-index: 3900;
+    background: #fefefe;
+}
+
+.ep-edits-body.loading-mask::before {
+    position: fixed;
+    opacity: .5;
+    color: #000;
+    content: '\f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    display: inline-block;
+    font: normal normal normal 10px/1 FontAwesome;
+    font-size: 10vw;
+    margin-top: 42vh;
+    margin-left: 18vw;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transform: translate(0, 0);
+    z-index: 100000001;
+}
+
+.ep-edits-body.loading-mask:after {
+    display: none;
+}
+
+.ep-edits-body.loading-mask {
+    position: relative;
+    opacity: .5;
+    background-color: gray;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100000000;
+}
+
+.ep-help {
+    position: absolute;
+    top: 0px;
+    display: table;
+    right: 0;
+    width: 500px;
+    height: 100vh;
+    border-left: 1px solid #ddd;
+    z-index: 3900;
+    background: #fefefe;
+}
+
+.ep-notifs {
+    position: absolute;
+    top: 0px;
+    display: table;
+    right: 0;
+    width: 500px;
+    height: 100vh;
+    border-left: 1px solid #ddd;
+    z-index: 3900;
+    background: #fefefe;
+}
+
+.btn-notifs-download {
+    color: #6494cc;
+    background-color: transparent;
+    border: 1px solid #ddd;
+    margin-top: 5px;
+}
+
+.btn-notifs-dismiss-all {
+    width: 100%;
+    height: 50px;
+    color: #fff;
+    background-color: #579DDB;
+    border: 1px solid #2A24C2;
+}
+
+.btn-notifs-dismiss-all.disabled {
+    background-color: #B0D4F5;
+    color: #6D69D5;
+    border: 1px solid #6D69D5;
+}
+
+.btn-notifs-dismiss-all:hover {
+    cursor: pointer;
+    color: #fff;
+    background: #3685CB;
+}
+
+#circle {
+    width: 8px;
+    height: 8px;
+    background: #55AA55;
+    border-radius: 50%;
+    z-index: 10;
+    position: absolute;
+}
+
+#circle-outline {
+    width: 12px;
+    height: 12px;
+    background: #fff;
+    border: 1px solid #6E7F93;
+    border-radius: 50%;
+    z-index: 9;
+    position: absolute;
+    margin-left: -2px;
+    margin-top: -2px;
+}
+
+.ep-edits-header {
+    display: inline-flex;
+    width: 100%;
+    justify-content: space-between;
+    height: 50px;
+    background: #fafafa;
+    border-bottom: 1px solid #ddd;
+}
+
+.ep-edits-title {
+    float: left;
+    padding-left: 15px;
+    padding-top: 10px;
+}
+
+.ep-edits-title span {
+    font-size: 1.6em;
+}
+
+.ep-edits-close {
+    float: right;
+}
+
+.ep-edits-body {
+    height: calc(100vh - 50px);
+    width: 100%;
+    overflow-y: auto;
+    display: table-row;
+    float: left;
+    padding: 0px;
+}
+
+.ep-edits-body img {
+    max-width: 100%;
+}
+
+.ep-edits-body ul {
+    padding-left: 20px;
+}
+
+.ep-edits-body a {
+    color: #4765a0;
+}
+
+.ep-edits-toggle div .ion-help {
+    padding-left: 3px;
+}
+
+.list-divider-dark {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.4);
+}
+
+.nano>.nano-content {
+    font-size: 11px;
+    overflow-y: auto;
+}
+
+ul .collapse li {
+    height: 25px;
+}
+
+ul .collapse li:first-of-type {
+    margin-top: -10px;
+}
+
+ul .collapse li:last-of-type {
+    height: 35px;
+}
+
+.arches-panel-header {
+    font-size: 1.6em;
+    padding-left: 25px;
+    border-right: 1px solid #ddd;
+}
+
+.resource-grid-item {
+    float: left;
+    width: 100%;
+    border-bottom: 1px solid #ddd;
+    border-left: 1px solid #ebeef0;
+    border-right: 1px solid #ebeef0;
+    margin: 0;
+}
+
+.resource-grid-item:first-of-type {
+    border-top: 1px solid #ddd;
+}
+
+.resource-grid-main-container {
+    height: 90px;
+    background: #ebeef0;
+}
+
+.graph-btn {
+    display: none;
+}
+
+.resource-grid-item:hover .graph-btn {
+    display: block;
+}
+
+.report-image-grid .resource-grid-item:last-of-type .resource-grid-tools-container .btn-group ul {
+    margin-top: -331px;
+}
+
+.report-provisional-flag {
+    padding: 15px;
+    margin-top: 0px;
+    padding-left: 25px;
+    border-bottom-style: solid;
+    border-bottom-color: #DF2E6A;
+    border-bottom-width: 1px;
+    background-color: #F799B9;
+    color: #fff;
+}
+
+.resource-report .fullyprovisional {
+    display: none;
+}
+
+.dl-horizontal.provisional {
+    border-style: solid;
+    margin-right: 25px;
+    margin-left: -20px;
+    background: #fdfdfd;
+    padding: 10px;
+    border-color: #ddd;
+    border-width: 1px;
+}
+
+.report-card-provisional-flag {
+    background-color: #f8f8f8;
+    padding: 5px 10px;
+    margin-left: -20px;
+    margin-right: 25px;
+    border-top: solid 1px #ddd;
+    border-left: solid 1px #ddd;
+    border-right: solid 1px #ddd;
+}
+
+.resource-grid-main {
+    padding-top: 10px;
+    padding-left: 0;
+}
+
+.resource-grid-main-container.active {
+    background: #f6f6f6;
+}
+
+.resource-grid-icon {
+    height: 42px;
+    width: 42px;
+    padding-top: 12px;
+    color: #999;
+    transform: translate(0px, 7px);
+    background: #e2e2e2;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.resource-grid-icon-highlight {
+    background: #fbfbfb;
+    color: #777;
+    border-color: #bbb;
+}
+
+.resource-grid-item:hover {
+    cursor: pointer;
+    border-left: 1px solid #d5d5d5;
+    border-right: 1px solid #d5d5d5;
+    opacity: 1.0;
+    background: #f9f9f9;
+}
+
+.resource-grid-title {
+    font-weight: normal;
+    padding: 3px 20px 0 20px;
+    font-size: 1.416em;
+    line-height: 50px;
+    display: inline-block;
+}
+
+.resource-grid-subtitle {
+    padding-left: 69px;
+    margin-top: -20px;
+    color: #999;
+    font-size: 12px;
+    width: 500px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.resource-grid-tools-container {
+    position: absolute;
+    right: 20px;
+    top: 48px;
+}
+
+.resource-grid-item:hover .resource-grid-tools-container {
+    top: 20px;
+}
+
+.report-image-grid .resource-grid-item:last-of-type .resource-grid-tools-container .btn-group .manage-menu {
+    margin-top: 0px;
+}
+
+.resource-grid-tools-container a:last-of-type {
+    padding-right: 0;
+}
+
+.hightlight-tool {
+    color: #4F49DB;
+    font-weight: 600;
+}
+
+.eh-timeline-panel {
+    overflow-y: auto;
+    height: calc(100vh - 60px);
+    background: #ebeef0;
+}
+
+.eh-timeline-time {
+    max-width: 150px;
+    margin-top: 7px;
+}
+
+.eh-timeline-stat {
+    width: 140px;
+}
+
+.eh-timeline-label {
+    margin-left: 150px;
+}
+
+.panel .eh-timeline-label:after {
+    border-right-color: #fff;
+}
+
+.eh-timeline-header {
+    padding-left: 20px;
+}
+
+.eh-timeline {
+    margin-left: 20px;
+    padding-right: 25px;
+}
+
+.eh_resource_descriptors {
+    display: flex;
+    flex-direction: column;
+    margin-top: -6px;
+}
+
+.eh_resource_descriptors h4.report-toolbar-title {
+    margin-top: -10px;
+}
+
+.eh_description {
+    font-size: 11px;
+    color: #777;
+    padding-left: 25px;
+    margin-top: -15px;
+}
+
+.timeline:before {
+    left: 69px
+}
+
+.timeline:after {
+    left: 67px
+}
+
+.panel .timeline,
+.panel .timeline-time .eh-timeline-time {
+    background: #ebeef0;
+}
+
+.panel .eh-timeline-time {
+    background: #ebeef0;
+}
+
+.panel .eh-timeline-label {
+    box-shadow: none;
+    background-color: #fff;
+    border: 1px solid #e3e3e3;
+}
+
+.panel .eh-timeline-stat .timeline-icon {
+    box-shadow: 0 0 0 7px #ddd;
+}
+
+.eh-timeline:before {
+    margin-left: 20px;
+}
+
+.eh-timeline:after {
+    margin-left: 20px;
+}
+
+.eh-footer {
+    padding: 10px;
+    margin: 20px -10px -10px -10px;
+    background: #f8f8f8;
+    border-top: 1px solid #ddd;
+}
+
+.eh-edit-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #666;
+}
+
+.eh-node-group {
+    padding-left: 10px;
+}
+
+.tile-data-list {
+    list-style: none;
+    padding-left: 20px;
+}
+
+.tile-data-item {
+    font-weight: 600;
+    color: #777;
+}
+
+.tile-node-name {
+    width: 245px;
+    display: table-cell;
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.tile-node-value {
+    font-weight: 400;
+    padding-left: 10px;
+    display: table-cell;
+}
+
+.flex {
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+}
+
+.content-panel {
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: 100%;
+    height: calc(100vh - 50px);
+    position: relative;
+}
+
+.flexrow {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+}
+
+.resource-search-container {
+    /* display: flex; */
+}
+
+.resource-search-container .row.widget-wrapper {
+    padding: 0px;
+    min-width: 250px;
+    max-width: 550px;
+}
+
+.edit-panel {
+    position: absolute;
+    top: 0;
+    height: 100vh;
+    width: 100%;
+    background: #ebeef0;
+    z-index: 900;
+    opacity: 1.0;
+    transition: all .25s ease;
+}
+
+.edit-panel-search-bar {
+    position: absolute;
+    left: 40px;
+    padding-top: 10px;
+}
+
+.edit-panel-search-bar+.edit-panel-menu-bar {
+    left: 170px;
+}
+
+.edit-menu {
+    position: absolute;
+    top: 36px;
+    left: 220px;
+    height: 100vh;
+    width: 50px;
+}
+
+.edit-menu-item {
+    height: 60px;
+    border-left: 3px solid #ebeef0;
+    border-bottom: 1px solid #ddd;
+    background: #fff;
+    opacity: .99;
+    position: relative;
+}
+
+.edit-menu-item.disabled {
+    margin-left: 0.5px;
+}
+
+.edit-menu-item:hover {
+    background: #f8f8f8;
+    border-left: 3px solid #579ddb;
+    cursor: pointer;
+    opacity: 1.0;
+    color: #666;
+}
+
+.edit-menu-item a i {
+    margin-left: 15px;
+    margin-top: 13px;
+}
+
+.menu-item-title {
+    font-size: 14px;
+    color: #777;
+}
+
+.menu-item-subtitle {
+    font-size: 11px;
+    padding-left: 33px;
+    padding-right: 5px;
+    width: 220px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.edit-menu-item.selected {
+    background: #f4f4f4;
+    border-left: 3px solid #579ddb;
+    opacity: 1.0;
+}
+
+.edit-menu-item.disabled:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    background: rgba(255, 255, 255, 0.66);
+    bottom: 0;
+    left: -4px;
+    right: 0;
+    z-index: 1;
+    cursor: not-allowed;
+}
+
+.edit-menu-item.disable:hover {
+    border-left: 3px solid #ebeef0;
+    background: #fff;
+    opacity: .99;
+}
+
+.find-widget {
+    position: absolute;
+    left: 100px;
+    top: 10px;
+    width: 450px;
+    z-index: 10;
+}
+
+.graph-list-header {
+    position: sticky;
+    top: 0px;
+    z-index: 10;
+}
+
+.graph-list-header .find-widget {
+    z-index: 1;
+}
+
+.o-pane {
+    background: rgba(17, 17, 17, 0.5);
+    height: 690px;
+}
+
+.list-group-item:hover {
+    cursor: pointer;
+}
+
+.effect:hover {
+    cursor: default;
+}
+
+.bg-trans {
+    background: transparent;
+}
+
+.btn-flat {
+    height: 38px;
+    color: #fff;
+    background: #ddd;
+    font-size: 14px;
+    padding-top: 5px;
+}
+
+.btn-flat:active {
+    box-shadow: none;
+}
+
+.btn-flat:hover {
+    color: #fff;
+    background: #8ce196;
+}
+
+.demo-icon-font {
+    font-size: 14px;
+    margin-bottom: 6px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.demo-icon-font:hover {
+    cursor: pointer;
+    background: #eee;
+}
+
+.demo-icon-font .selected {
+    background: #eee;
+}
+
+.library-in {
+    position: absolute;
+    top: -10px;
+    height: 100vh;
+    left: 0;
+    width: 300px;
+    background: #fff;
+    border-left: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+    overflow-y: scroll;
+    transition: all .5s;
+}
+
+.library-item {
+    height: 103px;
+    background: #fdfdfd;
+    border-bottom: 1px solid #ddd;
+    margin-left: -10px;
+    padding: 0 10px 10px 20px;
+}
+
+.library-item-subtitle {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 12px;
+    color: #888;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: 89px;
+}
+
+.library-card-body {
+    height: 116px;
+    padding: 5px 20px 25px;
+    color: #888;
+    margin-top: -10px;
+    overflow-y: hidden;
+}
+
+.library-card-panel-title {
+    font-size: 1.2em;
+    margin-bottom: -10px;
+}
+
+.list-item-name {
+    font-size: 14px;
+    margin-top: -5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.list-item-model-name {
+    font-size: 12px;
+    font-size: 12px;
+    margin-top: 1px;
+    padding-left: 3px;
+}
+
+.node-list-details {
+    position: absolute;
+    font-size: 11px;
+    top: 70px;
+    width: 100%;
+    padding: 5px;
+    margin-left: -5px;
+    background: #fff;
+    overflow-y: hidden;
+    height: 108px;
+}
+
+.rr-fdg-description {
+    font-size: 12px;
+    line-height: 1.35;
+    color: #888;
+    background: #fff;
+    overflow: scroll;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    height: 70px;
+}
+
+.node-list-footer {
+    position: absolute;
+    font-size: 11px;
+    top: 70px;
+    width: 100%;
+    border-top: 1px solid #ddd;
+    padding-left: 5px;
+    padding-top: 10px;
+    padding-bottom: 11px;
+    margin-left: -5px;
+    background: #fafafa;
+}
+
+.resource-graph-node-icon {
+    display: block;
+    height: 20px;
+    width: 20px;
+    line-height: 20px;
+    border-radius: 50%;
+    color: white;
+    text-align: center;
+    font-size: 0.7em;
+}
+
+.related-node-details .graph-name {
+    display: flex;
+    flex-direction: row;
+    padding-top: 1px;
+}
+
+.node-list-footer a {
+    color: steelblue;
+    font-weight: 500;
+    padding-right: 10px;
+    height: 38px;
+}
+
+.node-list-footer a i {
+    padding-right: 2px;
+}
+
+.resource-list a.chosen-single {
+    background: transparent;
+    color: #333;
+    font-size: 22px;
+    height: 40px;
+    padding-top: 0;
+    border-color: transparent;
+}
+
+.resource-list a.chosen-single div b {
+    margin-top: -8px;
+}
+
+.resource-list .chosen-drop .chosen-results {
+    background: #fff;
+    color: #555;
+    border-width: 1px;
+}
+
+.resource-list .chosen-drop {
+    border-width: 1px;
+}
+
+.resource-list .chosen-container-active .chosen-with-drop {
+    border: 1px solid #ddd;
+}
+
+.form-toolbar {
+    position: absolute;
+    height: 60px;
+    right: 0;
+    left: 0;
+    border-left-width: 0;
+    border-bottom: 1px solid #ddd;
+    z-index: 2;
+    background: #f8f8f8;
+    transition: all .5s;
+}
+
+.form-container {
+    position: absolute;
+    left: 0;
+    top: 56px;
+    width: 100%;
+    padding-left: 10px;
+    padding-right: 10px;
+    border-right: 1px solid #ddd;
+    transition: all .5s;
+}
+
+.card-preview {
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    padding: 10px;
+}
+
+.ion-asterisk.widget-label-required {
+    padding-left: 3px;
+    font-size: 9px;
+    margin-top: 2px;
+    position: absolute;
+}
+
+#container.cls-container.arches-login {
+    background: rgb(236, 238, 241);
+}
+
+.arches-login>.cls-header {
+    background: rgb(236, 238, 241);
+}
+
+.arches-login div .cls-brand:after {
+    background: rgb(236, 238, 241);
+}
+
+.cls-content.arches-signin {
+    padding-top: 20px;
+}
+
+.login-panel-header.arches-signin {
+    font-size: 28px;
+}
+
+.arches-signin-subtext {
+    padding: 0px 5px 10px 5px;
+    color: #888;
+}
+
+.arches-signin .login-panel {
+    border: 1px solid #ddd;
+}
+
+.arches-signin .panel-footer {
+    color: #888;
+    padding: 15px 0px;
+}
+
+.arches-signin .panel-footer a {
+    color: steelblue;
+    font-weight: 600;
+}
+
+.arches-signin-btn {
+    padding-top: 0px;
+    padding-bottom: 10px;
+}
+
+.account-management {
+    margin-top: 10px;
+    margin-bottom: 20px;
+    border-top: 1px solid #ddd;
+}
+
+.cls-container .account-management a {
+    color: steelblue;
+}
+
+.account-link {
+    padding: 5px 0px;
+    display: block;
+}
+
+.account-link:first-child {
+    padding-top: 25px;
+}
+
+#login-form {
+    padding: 10px 5px;
+}
+
+.login-panel {
+    opacity: .9;
+}
+
+.login-panel-header {
+    font-size: 2.4em;
+    margin-top: 0;
+    padding-bottom: 5px;
+    font-weight: 300;
+}
+
+.change-password-form.popover {
+    display: block;
+    margin-top: 65px;
+    font-size: 14px;
+    width: 250px;
+    border: 1px solid rgba(0, 0, 0, .2);
+}
+
+.change-password-form .panel {
+    margin-bottom: 0px;
+}
+
+.profile-summary-page .password-success {
+    color: green;
+    position: absolute;
+    top: 50px;
+}
+
+.profile-toolbar {
+    top: 50px;
+    width: 100%;
+    height: 50px;
+    background: #f8f8f8;
+    border-bottom: 1px solid #ddd;
+}
+
+.change-password-form .error-message {
+    font-size: 11px;
+    color: #880000;
+    padding: 2px;
+}
+
+.change-password-form .error-message-container {
+    display: flex;
+    flex-direction: column;
+    align-content: center;
+}
+
+.change-password-form .panel-body {
+    padding: 20px 15px;
+}
+
+.change-password-form .panel-heading {
+    text-align: left;
+    position: relative;
+    padding-top: 10px;
+    height: 40px;
+    background-color: #f5f6f7;
+    color: #5c7174;
+    padding-left: 15px;
+    line-height: 1.1;
+    border-bottom: solid 0.5px #babebf;
+    font-weight: 300;
+}
+
+.change-password-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.img-login {
+    background-image: url(../img/backgrounds/easter_island_night.jpg);
+}
+
+.concept_tree {
+    padding: 13px;
+}
+
+ul.jqtree-tree div.jqtree_common {
+    display: block;
+    color: #333;
+    border: 1px solid #ccc;
+    text-decoration: none;
+    font-weight: 700;
+    background: linear-gradient(top, #fafafa0, #eee100);
+    -webkit-border-radius: 3px!important;
+    border-radius: 3px!important;
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    margin: 5px 0;
+    padding: 5px 10px;
+}
+
+ul.jqtree-tree li.jqtree-selected>.jqtree-element,
+ul.jqtree-tree li.jqtree-selected>.jqtree-element:hover {
+    background-color: #ddd;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+ul.jqtree-tree div.jqtree_common:hover {
+    color: #2ea8e5;
+    background: #fff;
+}
+
+ul.jqtree-tree .jqtree-toggler {
+    position: absolute;
+}
+
+.jqtree-tree li.jqtree-folder {
+    display: block;
+    position: relative;
+    font-size: 13px;
+    line-height: 20px;
+    margin: 0;
+    padding: 0;
+}
+
+.jqtree-tree .jqtree-title.jqtree-title-folder {
+    position: relative;
+    left: 1.5em;
+}
+
+.jqtree-tree .jqtree-title {
+    color: #1C4257;
+    vertical-align: middle;
+    margin-left: 0;
+}
+
+.jqtree-tree .jqtree-loading>div a {
+    content: url(../img/select2-spinner.gif);
+}
+
+ul.jqtree-tree li.jqtree-ghost {
+    margin: 0;
+}
+
+.jqtree-border {
+    border: dashed 1px #00f;
+    -webkit-border-radius: 3px!important;
+    border-radius: 3px!important;
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    padding: 0 5px;
+}
+
+ul.jqtree-tree li.jqtree-ghost span.jqtree-line {
+    background-color: #fff;
+    opacity: 0.6;
+    border: dashed 1px #00f;
+    height: 35px;
+    width: 100%;
+    position: relative;
+    left: 0;
+    top: 0;
+}
+
+.concept_result {
+    font-weight: 700;
+}
+
+.term-search-item {
+    font-weight: 400;
+}
+
+.term-search-group {
+    font-weight: 700;
+}
+
+.concept_result_schemaname {
+    font-size: 11px;
+    padding-left: 10px;
+}
+
+.layer-list .fdg-node-filter {
+    margin-right: 18px;
+    margin-left: 10px;
+    margin-top: -2px;
+    position: relative;
+}
+
+.layer-list.search {
+    background: #e4e4e4;
+    margin-left: -1px;
+    border: 1px solid #bbb;
+    border-top: transparent;
+    padding-top: 10px;
+    position: sticky;
+    top: 0px;
+    z-index: 10;
+}
+
+.node-current {
+    stroke: #454545;
+    stroke-width: 2px;
+    fill: #dcecfa;
+    opacity: 1;
+    cursor: pointer;
+}
+
+.node-current-selected {
+    fill: #dcecfa;
+    stroke: #454545;
+    stroke-width: 2px;
+}
+
+.node-current-neighbor {
+    fill: #dcecfa;
+    stroke: #454545;
+    stroke-width: 4px;
+}
+
+.node-current-label {
+    stroke: #999;
+    font-size: 21px;
+    font-weight: 900;
+    fill: #fcfcfc;
+    opacity: 1;
+    text-anchor: middle;
+    pointer-events: none;
+}
+
+.node-descendent {
+    stroke: #ededed;
+    fill: #fefefe;
+    opacity: 1;
+    stroke-width: 4px;
+    cursor: pointer;
+}
+
+.node-descendent-label {
+    font-size: 12px;
+    font-weight: 400;
+    fill: #c2c2c2;
+    opacity: 1;
+    text-anchor: middle;
+    pointer-events: none;
+}
+
+.node-ancestor {
+    /* Nodes that are unselected or not highlighted as neighbors during mousover */
+    stroke: #454545;
+    fill: #dcecfa;
+    opacity: 1;
+    stroke-width: 1px;
+    cursor: pointer;
+}
+
+.node-ancestor-neighbor {
+    stroke-width: 4px;
+    stroke: #454545;
+    fill: #dcecfa;
+}
+
+.node-ancestor-label {
+    font-size: 16px;
+    font-weight: 300;
+    fill: #a2a2a2;
+    opacity: 1;
+    text-anchor: middle;
+    pointer-events: none;
+}
+
+.node-ancestor-selected {
+    stroke: rgb(17, 95, 165);
+    stroke-width: 5px;
+    stroke-dasharray: 5, 1;
+    fill: rgb(220, 236, 250);
+    opacity: 1;
+    cursor: pointer;
+    z-index: 200000;
+}
+
+.relatedlink {
+    stroke: #4291d7;
+    stroke-width: 3px;
+    stroke-dasharray: 8, 5;
+}
+
+.linkMouseover {
+    /*Styles the link between selected/moused-over nodes*/
+    stroke: #063967;
+    stroke-opacity: .6;
+    stroke-width: 5px;
+}
+
+.nodeLabels {
+    font-size: 14px;
+    fill: #454545;
+    text-anchor: middle;
+    font-weight: 600;
+}
+
+.node_info {
+    width: 320px;
+    height: auto;
+    background-color: #FFF;
+    -webkit-border-radius: 12px;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+    -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
+    -moz-box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.4);
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.4);
+    padding: 15px;
+}
+
+.node-selected {
+    fill: #aacdec;
+    stroke: #115fa5;
+}
+
+.node-current-over,
+.node-ancestor-over {
+    /* The currently moused-over node */
+    stroke: #115fa5;
+    stroke-width: 5px;
+    fill: #dcecfa;
+    opacity: 1.0;
+    cursor: pointer;
+}
+
+.node-descendent-over {
+    stroke: #115fa5;
+    stroke-width: 8px;
+    fill: #dcecfa;
+    opacity: 1;
+    cursor: pointer;
+}
+
+#nodeCrud p,
+.node_info p {
+    font-family: sans-serif;
+    line-height: 20px;
+    margin: 0;
+}
+
+#nodeCrud.hidden,
+ul.jqtree-tree li.jqtree-ghost span.jqtree-circle,
+.node_info.hidden {
+    display: none;
+}
+
+.config-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 5px;
+    height: 100vh;
+    padding: 10px;
+}
+
+.item-selected {
+    background-color: #fafafa;
+}
+
+.card-item {
+    position: relative;
+    height: 24px;
+    width: 220px;
+    font-weight: 700;
+    font-size: 1.25px;
+    margin-left: -20px;
+    padding: 5px 5px 5px 10px;
+}
+
+.card-item:hover {
+    background-color: #fafafa;
+    cursor: pointer;
+}
+
+.primary-descriptors-card-container {
+    margin-top: -5px;
+    margin-left: 0px;
+    padding-left: 15px;
+    padding-right: 15px
+}
+
+.primary-descriptors-container {
+    border: 1px solid #ddd;
+    min-height: 450px;
+}
+
+.panel-padding-bottom {
+    padding-bottom: 20px;
+}
+
+.widget-container {
+    padding: 10px 15px 25px;
+}
+
+.widget-container.data-type {
+    padding-bottom: 5px;
+}
+
+.widget-container.data-type-config {
+    padding-bottom: 0px;
+}
+
+a.selected {
+    font-weight: 600;
+    font-size: 13px;
+    color: #123;
+}
+
+.tile-record {
+    display: inline-block;
+    font-size: 11px;
+}
+
+.dark-colored-text {
+    color: #25256b;
+}
+
+.panel-section-title {
+    font-size: 1.3em;
+    font-weight: 400;
+}
+
+.form-divider {
+    border-top: 1px solid #eee;
+    margin-top: 10px;
+}
+
+.cd-dark .panel-body .form-divider {
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.functions .chosen-choices {
+    height: 32px;
+    background: #314151;
+    border: 1px solid #314151;
+    color: #fff;
+}
+
+textarea:placeholder {
+    top: 0;
+}
+
+.design a.chosen-single {
+    height: 36px;
+    background: #fff;
+    border: 1px solid #ddd;
+    color: #999;
+}
+
+.design .chosen-drop .chosen-results {
+    background: #fff;
+    color: #123;
+    margin-bottom: 0;
+}
+
+.editable {
+    border: 1px solid #4682B4;
+    display: inline-block;
+    margin-bottom: 7px;
+    margin-top: 7px;
+    margin-left: 20px;
+}
+
+.editable-card {
+    margin-left: -10px;
+    margin-right: -10px;
+    padding: 5px 15px;
+}
+
+span.editable-card i.fa.fa-align-justify:hover {
+    cursor: move;
+}
+
+.widgets {
+    border-bottom-width: 1px;
+}
+
+.report li {
+    margin-left: -10px;
+    padding-left: 5px;
+}
+
+.report li:not(:first-child) {
+    margin-top: 20px;
+    padding-top: 10px;
+    padding-bottom: 20px;
+    border-top: 1px solid #ddd;
+}
+
+.report li:nth-child(2) {
+    background-color: #fafafa;
+    margin-left: -40px;
+    padding-left: 35px;
+}
+
+.report-image-grid {
+    width: 100%;
+    margin-bottom: 20px;
+}
+
+.navbar-top-links .dropdown-menu .recent-additions-container {
+    margin-top: 10px;
+    padding: 0 30px;
+}
+
+.recent-additions-container {
+    padding-left: 20px;
+}
+
+.dataTables_scrollBody {
+    max-height: 65vh !important;
+}
+
+.card-grid {
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+    margin: 5px
+}
+
+.r-grid-item {
+    float: left;
+    width: 275px;
+    height: 250px;
+    margin: 5px;
+    border: 1px solid #7847CE;
+}
+
+#resource-list .r-grid-item:hover {
+    cursor: default;
+    border: 1px solid #333;
+}
+
+.r-select-card {
+    background: #8BC3EB;
+    padding: 10px;
+    color: #440EA2;
+    font-weight: 500;
+    height: 200px;
+    opacity: .8;
+    text-align: center;
+}
+
+.r-grid-item:hover .r-select-card,
+.r-select-card:hover {
+    opacity: 1;
+}
+
+.r-select-card-footer {
+    height: 50px;
+    position: absolute;
+    bottom: 0px;
+    width: 100%;
+    background: #62A8DB;
+}
+
+.r-select-title {
+    font-size: 19px;
+    font-weight: 500;
+    color: #440EA2;
+    text-align: center;
+    overflow-wrap: break-word;
+}
+
+.r-desc-container {
+    position: absolute;
+    bottom: 55px;
+    left: 5px;
+    right: 5px;
+    padding: 0px 5px;
+}
+
+.r-select-desc {
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.r-select-circle {
+    position: absolute;
+    top: 67px;
+    left: 97px;
+    width: 70px;
+    height: 70px;
+    display: inline-block;
+    text-align: center;
+    padding: 18px;
+    border-radius: 50%;
+    background: #BFE0F7;
+    border: 1px solid #454545;
+}
+
+.r-select-circle.loader-button {
+    background: #C85FDA;
+    border: 1px solid #86039D;
+}
+
+.r-select-icon {
+    color: #fff;
+    font-size: 28px;
+    line-height: 32px;
+}
+
+.r-warning {
+    padding: 5px;
+    background: #FFE947;
+    color: #5E29BA;
+    height: 50px;
+    text-align: center;
+    border-top: 1px solid #5E29BA;
+}
+
+.r-warning .form-warning {
+    color: #5E29BA;
+}
+
+.btn-resource-select {
+    height: 50px;
+    width: 100%;
+    font-size: 14px;
+    font-weight: 600;
+    padding-top: 12px;
+    border-top: 1px solid #7847CE;
+}
+
+.btn-resource-select:hover {
+    border-top: 1px solid #0859A1;
+}
+
+.card-grid-item {
+    float: left;
+    width: 290px;
+    border: 1px solid #ddd;
+    background: #fff;
+    opacity: .9;
+    margin: 3px;
+}
+
+.card-grid-item:hover {
+    cursor: pointer;
+    opacity: 1.0;
+    border: 1px solid #aaa;
+}
+
+.card-grid-item.disabled {
+    float: left;
+    width: 290px;
+    border: 1px solid #ddd;
+    opacity: .79;
+    margin: 3px;
+}
+
+.card-grid-item.disabled:hover {
+    cursor: default;
+}
+
+div.card-grid-item.selected {
+    border: 1px solid #aaa;
+    opacity: 1.0;
+}
+
+.form-warning {
+    font-size: 12px;
+    color: #b20000;
+}
+
+.card-search {
+    margin-top: 3px;
+    height: 48px;
+    min-width: 300px;
+    max-width: 600px;
+}
+
+div.jqtree-element.jqtree_common:hover {
+    background-color: #49596A;
+}
+
+ul.jqtree-tree ul.jqtree_common {
+    list-style: none outside;
+    margin-left: 12px;
+    margin-right: 0;
+    margin-bottom: 2px;
+    display: block;
+}
+
+ul.jqtree-tree .jqtree-title {
+    color: #93a6b9;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    font-size: 13px;
+}
+
+ul.jqtree-tree li.jqtree-selected>.jqtree-element,
+ul.jqtree-tree li.jqtree-selected>.jqtree-element:hover {
+    background: none;
+    background-color: #49596A;
+    text-shadow: none;
+}
+
+div.jqtree-element.jqtree_common {
+    text-overflow: ellipsis;
+    padding: 2px 0;
+}
+
+ul.jqtree-tree .jqtree-element {
+    color: #93a6b9;
+}
+
+ul.jqtree_common li.jqtree-folder {
+    margin-bottom: 4px;
+}
+
+#container #profile-table td {
+    border-top: 1px solid rgba(0, 0, 0, 0.0);
+}
+
+.profile-summary-page {
+    width: 100%;
+    background: #fff;
+}
+
+.profile-summary-page .img-responsive {
+    max-height: 249px;
+}
+
+.profile-report {
+    height: 150px;
+    background: #102F4F;
+    width: 100%;
+    padding: 40px 150px 0px 150px;
+    border-bottom: 1px solid #520008;
+}
+
+.profile-list {
+    width: 100%;
+    padding: 40px 100px 50px 100px;
+    min-height: 170px;
+    border-bottom: 1px solid #ccc;
+}
+
+.profile-sections {
+    padding: 0px 0px;
+    min-height: 650px;
+}
+
+div.profile-notif-settings {
+    padding-top: 12px;
+}
+
+.notif-table {
+    width: 100%;
+    margin-top: -40px;
+}
+
+.notif-table th {
+    font-size: 1.05em;
+    font-weight: 600;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+    color: #4d627b;
+}
+
+th.notif-type {
+    width: 150px;
+}
+
+.widget-input-label-notif {
+    padding-left: 20px;
+    font-size: 12px;
+    margin-top: 2px;
+    font-weight: 500;
+    color: #666;
+}
+
+.widget-input-label-notif .arches-switch {
+    margin-right: 5px;
+}
+
+.profile-notif-settings td {
+    padding: 8px 10px;
+    color: #666;
+}
+
+.profile-notif-settings th {
+    padding: 4px 6px 4px 6px;
+}
+
+.profile-projects {
+    height: 100vh;
+}
+
+.btn-profile {
+    width: 65px;
+}
+
+.profile-full-name {
+    position: absolute;
+    color: #fff;
+    font-size: 2.6em;
+    top: 35px;
+    left: 100px;
+}
+
+.profile-e-mail {
+    position: absolute;
+    color: #fff;
+    font-size: 16px;
+    top: 80px;
+    left: 100px;
+    color: #ddd;
+    font-weight: 500;
+}
+
+.profile-header {
+    font-size: 21px;
+}
+
+.account-summary {
+    margin-top: -30px;
+    height: 200px;
+    background: #a1f1f1;
+}
+
+.profile-label-shim {
+    margin-top: -5px;
+    color: #777;
+}
+
+.btn-profile-password {
+    background: #fff;
+    border-width: 0px;
+    margin-top: -20px;
+    margin-left: -12px;
+    color: #579ddb;
+}
+
+.account-tips {
+    margin-top: 10px;
+    font-size: 13px;
+    color: #888;
+}
+
+.account-input {
+    max-width: 300px;
+}
+
+.account-label {
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.btn-profile-password:hover {
+    background: #fff;
+    color: #579ddb;
+}
+
+.btn-profile-password:focus {
+    background: #fff;
+    color: #579ddb;
+}
+
+.btn-profile-password.btn-default:active {
+    background-color: #fff;
+    border-width: 0px;
+    color: #579ddb;
+}
+
+.btn-profile-password.btn:not(.disabled):not(:disabled):active,
+.btn:not(.disabled):not(:disabled).active {
+    box-shadow: none;
+}
+
+.password-rules {
+    margin-top: -5px;
+    font-size: 12px;
+    color: #555;
+}
+
+.password-rule {
+    color: #888;
+    font-size: 13px;
+    padding-left: 5px;
+    padding-bottom: 3px;
+}
+
+.password-rule span {
+    padding-left: 3px;
+    font-size: 12px;
+}
+
+.password-rule i {
+    font-size: 11px;
+}
+
+.device-summary {
+    font-size: 13px;
+    margin-bottom: -5px;
+}
+
+.device-listing {
+    float: left;
+    margin-top: -20px;
+    padding-left: 0px;
+}
+
+.device-listing li:not(:first-child) {
+    margin-left: 20px;
+}
+
+.device-list-item {
+    display: inline-block;
+    padding: 10px;
+}
+
+.project-search-widget {
+    position: absolute;
+    top: -40px;
+    width: 250px;
+}
+
+.profile-default-message-panel {
+    text-align: center;
+    padding-top: 10px;
+    padding-bottom: 20px;
+    font-size: 17px;
+    color: #888;
+}
+
+.apple_app_store_icon {
+    height: 50px;
+    padding-top: 10px;
+}
+
+.android_app_store_icon {
+    height: 58px;
+    margin-top: 11px;
+}
+
+.library-tools {
+    padding-left: 15px;
+    margin-top: -3px;
+    border-bottom: none;
+}
+
+.library-tools-icon:hover {
+    cursor: pointer;
+    color: #123;
+}
+
+.graph-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: calc(100%-220px);
+}
+
+.no-icon {
+    left: 10px;
+    width: 300px;
+    font-size: 13px;
+    cursor: move;
+}
+
+.editable-help {
+    display: inline-block;
+    margin-right: 20px;
+    padding: 7px 12px;
+}
+
+.ep-toolbar {
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -ms-flex-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+    width: 100%;
+    height: 50px;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    z-index: 3000;
+}
+
+.ep-menu {
+    position: absolute;
+    top: 50px;
+    bottom: 0;
+    z-index: 4000;
+}
+
+.ep-menu-panel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 250px;
+    background: #fff;
+    border-right: 1px solid #ddd;
+    margin: 0;
+}
+
+.editor-tools {
+    width: 274px;
+}
+
+.ep-menu-list {
+    position: absolute;
+    top: 0;
+    left: 0;
+    list-style: none;
+    height: 100vh;
+    border-right: 1px solid #ddd;
+    background: #fcfcfc;
+}
+
+.ep-menu-footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 50px;
+}
+
+#menu-control {
+    background: #9490EE;
+    color: #eee;
+}
+
+#menu-control:hover {
+    color: #fff;
+    border-left: 1px solid #9490EE;
+    border-bottom: 1px solid #9490EE;
+}
+
+.ep-tools {
+    cursor: pointer;
+    border-right: 1px solid #514CCA;
+    border-bottom: 1px solid transparent;
+    height: 50px;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -ms-flex-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+    padding-left: 10px;
+    padding-right: 20px;
+}
+
+.ep-tools:hover {
+    background: #fafafa;
+    border-bottom: 1px solid #ddd;
+    border-left: 1px solid #ddd;
+}
+
+.navbar-top-links>li>a.navbar-button {
+    height: 49px;
+    width: 50px;
+    background: #fff;
+    text-align: center;
+    border-left: 1px solid #ddd;
+}
+
+.navbar-top-links>li>a.navbar-button:hover {
+    border-left: 1px solid #ddd;
+    background: #f8f8f8;
+}
+
+.navbar-top-links>li>a.navbar-button:active {
+    border-left: 1px solid #ddd;
+    background: #f8f8f8;
+}
+
+.navbar-top-links>li>a.navbar-button:focus {
+    border-left: 1px solid #ddd;
+    background: #f8f8f8;
+}
+
+.ep-tools-right {
+    border-right: none;
+    border-bottom: 1px solid #ddd;
+    border-left: 1px solid #ddd;
+    background: #fff;
+    font-size: 17px;
+    padding-left: 16px;
+    padding-right: 20px;
+    min-width: 50px;
+    max-width: 50px;
+}
+
+.ep-tools-right a:first-child {
+    margin: auto;
+}
+
+.ep-tools-login {
+    border: none;
+    padding-left: 16px;
+    padding-right: 20px;
+    vertical-align: middle;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    border-left: 1px solid #ddd;
+}
+
+.ep-tool-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #666;
+    border-left: 1px solid transparent;
+}
+
+.ep-tools-title {
+    height: 50px;
+    margin-right: auto;
+    overflow: hidden;
+}
+
+.ep-graph-title {
+    font-size: 1.6em;
+    padding-left: 5px;
+    padding-top: 5px;
+}
+
+.ep-graph-title-icon {
+    height: 40px;
+    width: 40px;
+    transform: translate(0px, 0px);
+    color: #666;
+    background: #f4f4f4;
+    border: 1px solid #ddd;
+}
+
+.ep-content {
+    color: #666;
+    transition: all .25s ease;
+}
+
+.ep-form-toolbar {
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    -ms-flex-align: center;
+    -webkit-align-items: center;
+    align-items: center;
+    width: 100%;
+    min-height: 55px;
+    background: #f6f6f6;
+    border-bottom: 1px solid #ddd;
+}
+
+.ep-form-toolbar div:nth-last-child(2) {
+    margin-right: auto;
+}
+
+.ep-form-toolbar-title {
+    font-size: 16px;
+    font-weight: 400;
+    color: #666;
+    padding-left: 15px;
+}
+
+.ep-form-toolbar-tools {
+    margin-right: 10px;
+    -ms-justify-content: flex-end;
+    -webkit-justify-content: flex-end;
+    justify-content: flex-end;
+}
+
+.ep-form-content {
+    z-index: 1;
+    padding: 12px;
+    transition: all .30s ease;
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+    overflow-y: scroll;
+}
+
+.alert-active .ep-form-content {
+    top: 140px;
+}
+
+.ep-card-search {
+    width: 400px;
+    padding: 5px 15px;
+}
+
+.resource-toolbar {
+    min-height: 60px;
+    background: #f6f6f6;
+    border-bottom: 1px solid #e4e4e4;
+}
+
+.resource-selector {
+    height: 60px;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    padding: 10px;
+}
+
+.ep-help {
+    position: absolute;
+    top: 0px;
+    display: table;
+    right: 0;
+    width: 500px;
+    height: 100vh;
+    border-left: 1px solid #ddd;
+    z-index: 3900;
+    background: #fefefe;
+}
+
+.ep-help-header {
+    border: none;
+    display: table-row;
+    height: 50px;
+}
+
+.ep-help-title {
+    float: left;
+    padding-left: 15px;
+    padding-top: 10px;
+}
+
+.ep-help-title span {
+    font-size: 1.6em;
+}
+
+.ep-help-close {
+    float: right;
+    background: #f8f8f8;
+    border-bottom: 1px solid #ddd !important;
+    border-left: 1px solid #ddd !important;
+}
+
+.ep-help-close:hover {
+    background: #f2f2f2;
+}
+
+.ep-help-body {
+    width: 100%;
+    overflow-y: auto;
+    padding: 0px 15px;
+    position: absolute;
+    bottom: 0;
+    top: 50px;
+}
+
+.ep-help-body img {
+    max-width: 100%;
+}
+
+.ep-help-body ul {
+    padding-left: 20px;
+}
+
+.ep-help-body a {
+    color: #4765a0;
+}
+
+.ep-help-topic-content {
+    display: none;
+}
+
+.ep-help-toggle div .ion-help {
+    padding-left: 3px;
+}
+
+.ep-help-table {
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 10px;
+}
+
+.ep-help-table tr th {
+    border-bottom: solid grey 1px;
+}
+
+.ep-help-table tr {
+    border-bottom: dashed grey 1px;
+}
+
+.ep-help-table tr td {
+    vertical-align: top;
+    color: grey;
+    padding: 5px 3px 5px 3px;
+}
+
+.ep-help-table tr td:first-of-type {
+    color: red;
+}
+
+.ep-help-table-header {
+    font-weight: 700;
+}
+
+.ep-help-topic-toggle>h4 {
+    display: inline-block;
+}
+
+.reloadable-img {
+    border: 2px solid #eee;
+}
+
+.ep-help-img-link {
+    float: right;
+    font-weight: 600;
+}
+
+.ep-card-tools-panel {
+    padding: 7px;
+    background: #fdfdfd;
+    border-right: 1px solid #e9e9e9;
+}
+
+.left-column-container.ep-card-tools-panel {
+    margin-bottom: 0px;
+}
+
+#node-listing .panel {
+    box-shadow: none;
+}
+
+.card-tree-container {
+    margin-right: -9px;
+    margin-left: -9px;
+}
+
+.card-tree-list {
+    list-style: none;
+    font-size: 12px;
+    color: #888;
+    padding-top: 0px;
+    margin-top: 1px;
+}
+
+ul.card-tree-list-item {
+    margin-left: -40px;
+}
+
+li.card-tree-list:last-of-type {
+    margin-bottom: 0px;
+}
+
+.card-tree-list a {
+    color: #777;
+}
+
+.card-tree-list.selected a {
+    color: #666;
+    font-weight: 600;
+}
+
+ul div .card-tree-list .cc-link {
+    margin-left: 0px;
+}
+
+ul div .card-tree-list span {
+    margin-left: 15px;
+}
+
+ul div .card-tree-list span .card-tree-list-item .card-tree-list-icon {
+    margin-left: 30px;
+}
+
+.report-tree-list {
+    margin-bottom: 0px;
+}
+
+.node-indent a {
+    padding-left: 30px;
+}
+
+.expando {
+    position: absolute;
+    font-size: 14px;
+    cursor: pointer;
+    display: none;
+    right: 13px;
+    top: 10px;
+}
+
+.card-tree-list a:hover .expando {
+    display: block;
+}
+
+.bg-card {
+    background: #46bbdc;
+    color: #fff;
+}
+
+.bg-report-card {
+    background: #9EE0F3;
+    color: #fff;
+    font-weight: 400;
+}
+
+.ep-card-crud {
+    position: absolute;
+    top: 100px;
+    bottom: 0;
+    left: 200px;
+    width: 250px;
+}
+
+.ep-card-crud-container {
+    margin: 10px;
+}
+
+.ep-card-crud-container>div.panel {
+    border: 1px solid #3b8dd5;
+}
+
+.dz-cancel {
+    border-radius: 50%;
+    background: #FFA08E;
+}
+
+.ep-card-crud-container:last-of-type {
+    margin-bottom: 200px;
+}
+
+.flex.relative {
+    max-width: calc(100% - 1px);
+}
+
+.left-column-crud-container {
+    -ms-flex: 0 0 275px;
+    -webkit-flex: 0 0 275px;
+    flex: 0 0 275px;
+    margin-top: -1px;
+    margin-bottom: 0px;
+    background-color: #fafafa;
+    width: 275px;
+    padding: 7px;
+    border-right: solid 1px #dddddd;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.left-column-container {
+    -ms-flex: 0 0 250px;
+    -webkit-flex: 0 0 250px;
+    flex: 0 0 250px;
+    margin-bottom: 0px;
+    background-color: #f0f0f0;
+    width: 200px;
+    padding: 0px 7px 7px 7px;
+    border-right: solid 1px #dddddd;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.left-column-container.graph-designer {
+    overflow-y: hidden;
+}
+
+.form-list {
+    padding-top: 0px;
+    background: #f0f0f0;
+    padding-bottom: 31px;
+}
+
+.form-list .grid {
+    border-top: none;
+}
+
+.provisional-edits {
+    pointer-events: none;
+    cursor: default;
+    padding: 3px 5px 5px 5px;
+    margin-right: 10px;
+    background: #FFB700;
+    color: #fff;
+}
+
+.has-provisional-edits {
+    color: #FFD15B;
+}
+
+.provisional-edits-list {
+    width: 0px;
+    background-color: #f0f0f0;
+    padding: 0px;
+    border-style: solid;
+    border-color: #ccc;
+    border-width: 1px;
+    margin-top: 0px;
+}
+
+.edit-message-container {
+    background: #FFD15B;
+    color: #fff;
+    font-weight: 700;
+    border-bottom: 1px solid #FFB700;
+    height: 50px;
+    margin-top: -15px;
+    margin-left: -25px;
+    margin-right: -25px;
+    padding: 15px 25px;
+}
+
+.edit-message-container.provisional-editor {
+    /* margin-right: -42px; */
+}
+
+.workbench-card-sidepanel.expanded .edit-message-container {
+    z-index: 5000;
+    width: 600px;
+    margin-top: 8px;
+    margin-left: -16px;
+}
+
+.edit-message-container .reset-authoritative {
+    float: right;
+    color: #fff;
+    font-weight: 600;
+    background: #db9a00;
+    padding: 5px;
+    margin-top: -3px;
+}
+
+.edit-message-container.approved {
+    background: #C8F89A;
+    border-bottom: 1px solid #9CEC4F;
+    border-top: 1px solid #9CEC4F;
+    color: #24B06D;
+}
+
+.edit-message-container-user {
+    font-weight: 700;
+}
+
+.new-provisional-edits-list {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    margin-right: -25px;
+    width: 250px;
+    padding: 5px 5px 0px 5px;
+    border-left: 1px solid #ddd;
+    height: 100vh;
+    background: #fafafa;
+}
+
+.workbench-card-sidepanel.expanded .new-provisional-edits-list {
+    margin-right: -16px;
+}
+
+.new-provisional-edit-card-container {
+    display: flex;
+    flex-direction: row-reverse;
+    /*    align-items: baseline;*/
+}
+
+.new-provisional-edit-card-container .card {
+    width: 100%;
+}
+
+.new-provisional-edit-entry {
+    border-bottom: 1px solid #ddd;
+    color: #777;
+    background: #fafafa;
+    padding: 5px;
+    margin-left: -5px;
+    width: 200px;
+    position: relative;
+}
+
+.new-provisional-edit-entry .title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.new-provisional-edits-title {
+    font-size: 14px;
+    margin-bottom: 5px;
+    font-weight: 400;
+    color: #2f527a;
+}
+
+.new-delete-provisional-edit {
+    position: absolute;
+    top: 10px;
+    right: -140px;
+    color: red;
+    font-size: 16px;
+}
+
+.new-provisional-edits-header {
+    background: #f9f9f9;
+    border-bottom: 1px solid #ddd;
+    height: 40px;
+    margin-left: -5px;
+    /*margin-right: -40px;*/
+    /* margin-top: -5px; */
+    padding: 10px 25px 10px 10px;
+    height: 80px;
+}
+
+.new-provisional-edit-entry:hover {
+    background-color: #fff;
+    color: #111;
+    cursor: pointer;
+}
+
+.new-provisional-edit-entry.selected {
+    background-color: #fff;
+    color: #111;
+}
+
+.new-provisional-edit-entry.selected:hover {
+    cursor: initial;
+}
+
+.new-provisional-edit-entry .field {
+    padding: 5px;
+    font-size: 13px;
+    font-weight: 500;
+    width: 170px;
+}
+
+.field.timestamp {
+    font-weight: 400;
+    font-size: 11px;
+    color: #777;
+    margin-top: -10px;
+}
+
+.notifications-container {
+    display: flex;
+    flex-direction: row;
+    border-bottom: solid #e4e4e4 1px;
+    padding: 8px 25px 15px 25px;
+    background-color: #fcfcfc;
+}
+
+.notification-message {
+    padding-bottom: 5px;
+    color: #777;
+}
+
+.notification-message span {
+    font-weight: 600;
+    color: #454545;
+}
+
+.entry .time-label {
+    font-weight: 600;
+}
+
+.ep-notifs-close {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    font-size: 17px;
+    background: #f8f8f8;
+    border-left: 1px solid #ddd;
+}
+
+.entry .ep-notifs-close {
+    right: -10px;
+}
+
+.ep-notifs-close:hover {
+    color: #1B3974;
+    border-left: 1px solid #ddd;
+    background: #f2f2f2;
+}
+
+.ep-edits-body.provisional-edit-history {
+    overflow: visible;
+}
+
+.new-provisional-edits-header .new-provisional-edits-delete-all {
+    width: 100%;
+    padding: 3px 0px;
+    margin: 3px;
+}
+
+.new-provisional-edit-history {
+    display: flex;
+    flex-direction: column;
+    border-bottom: solid #e4e4e4 1px;
+    padding: 8px 25px 15px 25px;
+    background-color: #fcfcfc;
+}
+
+.new-provisional-edit-history.selected-card,
+.notifications-container.selected-card {
+    color: #454545;
+    background-color: #f0f0f0;
+}
+
+.new-provisional-edit-history:hover,
+.notifications-container:hover {
+    background-color: #fff;
+}
+
+.new-provisional-edit-history .entry,
+.notifications-container .entry {
+    flex-direction: row;
+    display: flex;
+    color: #6494cc;
+    align-items: baseline;
+    justify-content: left;
+    width: 400px;
+}
+
+.new-provisional-edit-history .entry-label,
+.notifications-container .entry-label {
+    padding-right: 5px;
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.new-provisional-edit-history .entry-label-resource {
+    padding-right: 5px;
+    font-weight: 600;
+    font-size: 15px;
+    color: #454545;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.new-provisional-edit-history .entry .resource-edit-link {
+    font-size: 11px;
+    padding-right: 5px;
+}
+
+.provisional-edits-list-header {
+    display: inline-flex;
+    width: 100%;
+    align-items: center;
+    background-color: #f8f8f8;
+    height: 35px;
+    margin-top: 0px;
+    margin-bottom: 1px;
+}
+
+.grid-list.provisional-edit-history {
+    height: 100%;
+    position: absolute;
+    width: 100%;
+    overflow-y: scroll;
+}
+
+.provisional-edit-history-filter {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding-left: 5px;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ddd;
+}
+
+.provisional-edit-history-filter .calendar {
+    display: flex;
+    width: 220px;
+    padding-left: 10px;
+    align-items: baseline;
+    justify-content: space-between;
+}
+
+.provisional-edit-history-filter .toggle-container {
+    padding-bottom: 0px;
+}
+
+.provisional-edit-history-filter {
+    font-size: 12px;
+    color: inherit;
+    padding: 5px;
+}
+
+.provisional-review-pending {
+    padding: 2px 10px 3px 10px;
+    background: #F5BB25;
+    color: #fff;
+    font-size: 12px;
+}
+
+.provisional-review-declined {
+    padding: 2px 10px 3px 10px;
+    background: red;
+    color: #fff;
+    font-size: 12px;
+}
+
+.provisional-review-accepted {
+    padding: 2px 10px 3px 10px;
+    background: #64bd63;
+    color: #fff;
+    font-size: 12px;
+}
+
+.ep-edits-body.provisional-edit-history {
+    height: 100%;
+}
+
+.provisional-edits-list-header span {
+    padding-left: 4px;
+}
+
+.provisional-edit-qa-tool {
+    height: 28px;
+}
+
+.provisional-edit-qa-tool .toggle-container {
+    padding-left: 0px;
+}
+
+.provisional-edits-list.expanded {
+    width: 350px;
+    transition: all .30s ease;
+    padding: 0px;
+    border-top-width: 0px;
+}
+
+.provisional-edits-list.closed {
+    width: 0px;
+    transition: all .30s ease;
+    padding: 0px
+}
+
+.provisional-edit {
+    padding: 15px;
+    background-color: #fafafa;
+}
+
+.rp-report-tile.provisional-edit-cards {
+    padding-left: 0px;
+    padding-bottom: 0px;
+}
+
+.provisional-edit .content-title {
+    font-weight: 600;
+}
+
+.provisional-edit-cards dd {
+    position: relative;
+    padding-left: 15px;
+    word-wrap: break-word;
+}
+
+.layer-list {
+    height: 50px;
+    margin-right: -10px;
+    margin-bottom: 0px;
+    padding-top: 10px;
+    padding-bottom: 0px;
+    background: #f4f4f4;
+    border-top: solid 1px #ddd;
+}
+
+.middle-column-container {
+    -ms-flex: 0 0 300px;
+    -webkit-flex: 0 0 300px;
+    flex: 0 0 300px;
+    background: #fbfbfb;
+    padding: 4px 7px 44px 7px;
+    color: #666;
+    border-right: solid 1px #dddddd;
+    overflow-y: auto;
+}
+
+
+/*  Start card/widget manager Classes
+    used to manage placement and display of elements inside of the Card
+    and Widget Management forms
+*/
+
+.panel-config {
+    flex-direction: row-reverse;
+}
+
+.panel-config .middle-column-container {
+    border-right: transparent;
+    border-left: 1px solid #ddd;
+    background: #f4f4f4;
+    /*#2d3c4b*/
+    color: #2d3c4b;
+    /*#f1f1f1*/
+    height: 100%;
+}
+
+.panel-config .toggle-container {
+    padding-bottom: 5px;
+}
+
+.panel-config .form-divider {
+    border-top: 1px solid #ccc;
+}
+
+.panel-config .widget-config-container {
+    margin-left: 5px;
+    margin-right: 5px;
+}
+
+.panel-config .widget-config-container .control-label {
+    padding-top: 5px;
+    padding-left: 5px;
+}
+
+
+/* panel styling in widget manager for radio groups */
+
+.panel-config .widget-config-container .radio-panel {
+    background: #fff;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-top: 0px;
+    margin-left: -10px;
+    margin-right: -10px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+}
+
+
+/* panel styling in widget manager for checkbox groups */
+
+.panel-config .widget-config-container .checkbox-panel {
+    background: #fff;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-top: 0px;
+    margin-left: -10px;
+    margin-right: -10px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+}
+
+
+/* Color changes if you want to use a dark (#2d3c4b) background panel color
+    for the .panel-config .middle-column-container classes
+
+    .panel-config .panel-section-title {
+        color: #f1f1f1;
+    }
+
+    .panel-config .form-radio.form-normal:hover:after {
+        background: #fff;
+    }
+
+    .panel-config .form-radio.form-normal.active:after {
+        background: #fff;
+    }
+
+    .panel-config .tertiary-panel-content .control-label {
+        color: #2d3c4b;
+    }
+
+    .panel-config .accordion-body .control-label {
+        color: #2d3c4b;
+    }
+
+    .panel-config .accordion .panel-title a:focus {
+        color: #2d3c4b;
+    }
+
+    .panel-config .accordion .panel-title a:hover {
+        color: #2d3c4b;
+    }
+
+    .panel-config .input-group-addon {
+        color: #f1f1f1;
+    }
+
+    .panel-config .bootstrap-datetimepicker-widget {
+        color: #2d3c4b;
+    }
+
+    End color changes if you want to use a dark (#2d3c4b) background panel color */
+
+
+/*End card/widget manager Classes*/
+
+.card-form-preview-container {
+    -ms-flex: 1;
+    -webkit-flex: 1;
+    flex: 1;
+    background: #ebeef0;
+    overflow-y: scroll;
+    overflow-x: hidden;
+}
+
+.title-block-title {
+    font-size: 15px;
+    font-weight: 400;
+    margin-top: 0;
+    margin-bottom: 5px;
+    color: #222;
+    padding: 5px 0 5px 5px;
+    width: 210px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.crud-widget-container {
+    padding-bottom: 15px;
+}
+
+.sortable-placeholder {
+    border: dotted 2px #d4d4d4;
+}
+
+.data-widget-library {
+    width: 280px;
+    margin-bottom: 0px;
+}
+
+.resource-status {
+    font-size: 13px;
+    font-weight: 600;
+    color: #123;
+    margin-top: 3px;
+}
+
+.resource-status-label {
+    font-size: 11px;
+    float: right;
+    color: #555;
+    margin-top: 3px;
+}
+
+.menu-title-shim {
+    top: 40px;
+}
+
+.clear-node-search {
+    position: absolute;
+    top: 6px;
+    right: 10px;
+    font-size: 14px;
+}
+
+.node-list {
+    position: absolute;
+    top: 42px;
+    width: 200px;
+}
+
+.new-card.disabled {
+    background-color: #ccc;
+}
+
+.new-card.disabled #add-card {
+    cursor: default;
+}
+
+.card-library {
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+}
+
+.hide-card-library {
+    width: 0px;
+    transition: all .30s ease;
+}
+
+.show-card-library {
+    width: 282px;
+    transition: all .30s ease;
+}
+
+.data-widget-container {
+    padding-top: 10px;
+    padding-left: 10px;
+}
+
+.data-widget-grid-item {
+    float: left;
+    width: 250px;
+    border: 1px solid #ddd;
+    opacity: .9;
+    margin: 3px;
+}
+
+.data-widget-grid-item .disabled {
+    color: #999;
+}
+
+.data-widget-grid-item.disabled {
+    color: #999;
+}
+
+.data-widget-grid-item:hover {
+    cursor: move;
+    opacity: 1.0;
+}
+
+.dismiss-card-library {
+    position: absolute;
+    right: 15px;
+    top: 12px;
+    color: #123;
+    font-size: 17px;
+}
+
+.cc-link {
+    display: inline-block;
+    width: 100%;
+    height: 60px;
+    margin-top: -3px;
+    margin-bottom: -2px;
+    background: #f8f8f8;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 10px 0px 5px 10px;
+    border-bottom: 1px solid #ddd;
+}
+
+.cc-link:hover {
+    background: #fff;
+}
+
+.cc-link.active:hover {
+    cursor: default;
+}
+
+.card-tree-list a.cc-link.active:hover {
+    cursor: pointer;
+}
+
+.cc-link.active {
+    color: #666;
+    font-weight: 600;
+    background: #fff;
+}
+
+.node-name {
+    display: block;
+    margin-top: -40px;
+    font-size: 13px;
+    color: #1E6FB7;
+}
+
+.node-form.node-name {
+    font-size: 13px;
+    color: #777;
+    margin-top: 1px;
+    display: inline;
+    padding-right: 5px;
+}
+
+.node-form.ontology {
+    padding-right: 5px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.node-semantic-description {
+    display: flex;
+    height: 75px;
+    padding: 25px 20px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #ccc;
+    background-color: #f9f9f9;
+    min-width: 900px;
+}
+
+.node-subname {
+    font-size: 11px;
+    color: #888;
+}
+
+.node-permissions {
+    padding-right: 10px;
+    margin-top: 2px;
+}
+
+.node-permission-icon {
+    padding-right: 3px;
+}
+
+.expand-icon {
+    padding: 5px;
+    margin-right: -5px;
+}
+
+.card-tree-list a .node-name {
+    margin-left: 40px;
+    width: 180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-tree-list a .node-subname {
+    margin-left: 40px;
+}
+
+ul .card-tree-list a .node-name {
+    margin-left: 60px;
+    width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+ul .card-tree-list a .node-subname {
+    margin-left: 60px;
+}
+
+.tertiary-panel-content {
+    background: #f5f5f5;
+    height: 100%;
+    overflow-y: scroll;
+}
+
+.accordion-body {
+    padding-top: 0px;
+}
+
+.panel-group.accordion .panel-title a {
+    font-weight: 400;
+    color: #777;
+}
+
+#card-crud-advanced {
+    padding-top: 20px;
+}
+
+.toggle-container {
+    padding-bottom: 15px;
+    padding-right: 15px;
+    padding-top: 0px;
+    padding-left: 5px;
+}
+
+.arches-toggle-sm {
+    margin-left: 40px;
+    margin-top: -17px;
+    margin-bottom: 0;
+    font-size: 12px;
+}
+
+.arches-toggle-subtitle {
+    margin-left: 40px;
+    display: inline-block;
+    color: #5F7D9A;
+    font-size: 12px;
+    padding-right: 10px;
+}
+
+.note-editor .note-toolbar {
+    background: #fcfcfc;
+}
+
+.note-editor .note-editable {
+    background: #fff;
+    color: #666;
+}
+
+.cardinality-form {
+    padding: 7px;
+}
+
+.card-tree-list-icon {
+    padding-left: 3px;
+}
+
+li.search-field {
+    width: 190px;
+    font-size: 11px;
+}
+
+#graph {
+    background: #fdfdfd;
+}
+
+#graph-grid .library-card {
+    width: 300px;
+}
+
+.help-close:hover,
+.library-close-btn:hover,
+#aside .nav-tabs a i:hover,
+.btn-flat:focus,
+.help-close:hover,
+#aside .nav-tabs a i:hover,
+.jqtree-title.jqtree_common:hover,
+.btn-flat:focus,
+.help-close:hover,
+#aside .nav-tabs a i:hover,
+.jqtree-title.jqtree_common:hover,
+.btn-flat:focus,
+.help-close:hover {
+    color: #123;
+}
+
+.nav-tabs.library-tools>li.active>a>i {
+    color: #123;
+}
+
+.ltr,
+.ltr {
+    direction: ltr;
+}
+
+.resource-grid-tools-container a:hover,
+.card-tree-list a:hover {
+    color: #333;
+}
+
+.list-group-item .selected,
+.card-tree-list.selected {
+    background: #f8f8f8;
+}
+
+.library-card.relative.selected {
+    height: 180px;
+    -webkit-transition: height 0.25s;
+    /* Safari */
+    transition: height 0.25s;
+    background: #ffffff;
+    border-left: 5px solid steelblue;
+    overflow-y: hidden;
+}
+
+.library-card.relative.hovered {
+    background: #ffffff;
+    border-left: 5px solid #20CE05;
+}
+
+.library-card.relative {
+    -webkit-transition: height 0.25s;
+    /* Safari */
+    transition: height 0.25s;
+}
+
+.library-card.relative.selected.hovered {
+    background: #ffffff;
+    border-left: 5px solid steelBlue;
+}
+
+.bg-gray-dark,
+.bg-gray-dark a,
+.design a.chosen-single:hover,
+.design a.chosen-single:hover,
+.bg-gray-dark,
+.bg-gray-dark a {
+    color: #999;
+}
+
+.btn-shim,
+.control-label,
+.control-label,
+.btn-shim {
+    margin-bottom: 3px;
+}
+
+.grid:after,
+.report-image-grid:after,
+.report-image-grid:after,
+.grid:after {
+    content: '';
+    display: block;
+    clear: both;
+}
+
+#aside-container #aside .tab-content,
+#aside-container #aside .tab-content,
+#aside-container #aside .tab-content {
+    padding-top: 0;
+}
+
+a.list-group-item:not(.active):hover,
+div .switch label:hover,
+#demo-dt-selection tbody tr:hover,
+.highlight,
+div .switch label:hover,
+#demo-dt-selection tbody tr:hover,
+.highlight,
+div .switch label:hover,
+#demo-dt-selection tbody tr:hover,
+.highlight,
+.editable-card:hover,
+.clear-node-search:hover,
+.dismiss-card-library:hover {
+    cursor: pointer;
+}
+
+.columns .form-text.form-checkbox:not(.btn),
+.form-text.form-radio:not(.btn),
+.columns .form-text.form-checkbox:not(.btn),
+.form-text.form-radio:not(.btn),
+.columns .form-text.form-checkbox:not(.btn),
+.form-text.form-radio:not(.btn) {
+    width: 225px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.select2-search,
+.dropdown-shim,
+.dropdown-shim,
+.dropdown-shim {
+    margin-top: 10px;
+}
+
+.select2-drop.select2-drop-above .select2-search input {
+    margin-bottom: 10px;
+}
+
+.select2-results {
+    margin-top: 10px;
+}
+
+.relative,
+.slide,
+.relative,
+.slide,
+.relative,
+.slide,
+.relative {
+    position: relative;
+}
+
+.tile-record:hover,
+.note-editable,
+.note-editable,
+.tile-record:hover,
+.note-editable,
+.tile-record:hover,
+.note-editable,
+.tile-record:hover,
+.library-tools-icon.active,
+.library-close-btn:hover {
+    color: #123;
+}
+
+.resource-grid-tools-container a,
+.resource-grid-tools-container a,
+.resource-grid-tools-container a {
+    color: #777;
+}
+
+.selected,
+.selected,
+.selected {
+    background: #f4f4f4;
+}
+
+.btn-flat.selected {
+    background: #8ce196;
+    color: #fff;
+}
+
+.editable:hover,
+.editable.selected,
+.editable:hover,
+.editable.selected {
+    background: #C1F8E9;
+}
+
+.ep-form-alert {
+    position: absolute;
+    top: 0px;
+    z-index: 5000;
+    width: 100%;
+    height: 100px;
+    padding: 10px 25px;
+    color: #fff;
+    transition: all .40s ease;
+    overflow: hidden;
+}
+
+.alert-active .ep-form-alert {
+    display: block;
+    height: 90px;
+    top: 0px;
+}
+
+.ep-alert-red {
+    background: #f87359;
+    border: 1px solid #B72F16;
+    border-right-width: 0px;
+    border-left-width: 0px;
+    z-index: 5000;
+}
+
+.ep-alert-blue {
+    background: #57c1df;
+    border: 1px solid #1495B9;
+    border-right-width: 0px;
+    border-left-width: 0px;
+}
+
+.ep-form-alert-shim {
+    margin-top: 90px;
+    transition: all .40s ease;
+}
+
+.ep-form-alert-title {
+    font-size: 15px;
+    font-weight: 600;
+    margin-top: 0px;
+    margin-bottom: 3px;
+}
+
+.ep-form-alert-text {
+    font-size: 12px;
+    font-weight: 400;
+    overflow: hidden;
+}
+
+.ep-form-alert-default-dismiss {
+    position: absolute;
+    top: 10px;
+    right: 25px;
+    font-size: 16px;
+}
+
+.ep-form-alert-default-dismiss:hover {
+    cursor: pointer;
+    color: #f9f9f9;
+}
+
+.ep-form-alert-buttons {
+    position: absolute;
+    bottom: 10px;
+    right: 25px;
+}
+
+.graph-list-header .ep-form-alert {
+    position: relative;
+    top: 0px;
+}
+
+.file-upload {
+    position: relative;
+    overflow: hidden;
+}
+
+.file-select {
+    text-align: center;
+    padding: 70px 0;
+    background: #f9f9f9;
+}
+
+.file-upload input.upload {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0;
+    filter: alpha(opacity=0);
+}
+
+.dz-previews {
+    border: 1px solid #ddd;
+    overflow-y: scroll;
+    width: 100%;
+}
+
+.file-upload-filter {
+    /* margin-right: 5px; */
+    padding: 5px 10px;
+    width: 250px;
+}
+
+span.file-upload-clear-filter {
+    position: absolute;
+    left: 238px;
+    top: 37px;
+    z-index: 25;
+}
+
+.dz-previews .file-upload-card {
+    border-bottom: 1px solid #D3E5F4;
+    border-radius: 2px;
+    padding: 7px 8px 5px 15px;
+    background: #fff;
+    color: #666;
+    height: 50px;
+}
+
+.dz-previews .file-upload-card:nth-child(odd) {
+    background: #F5FAFE;
+}
+
+.file-upload-options {
+    padding-bottom: 8px;
+}
+
+.file-size-label {
+    float: right;
+    margin-top: 2px;
+}
+
+.btn-file-upload-reset {
+    color: #489EED;
+    font-size: 12px;
+    float: right;
+}
+
+.file-upload-card-detail-right {
+    min-width: 85px;
+    float: right;
+    margin-top: 6px;
+}
+
+.file-upload-card-detail a:hover {
+    cursor: pointer;
+}
+
+.btn-file-upload-limit {
+    color: #489EED;
+    font-size: 12px;
+    float: left;
+}
+
+.btn-file-cancel {
+    background: #01113c;
+    border-radius: 50%;
+    border: none;
+}
+
+.file-upload-footer {
+    background: #f1f1f1;
+    color: rgb(89, 56, 255);
+    ;
+    display: flex;
+    justify-content: left;
+    align-items: center;
+    border-top: 1px solid #ddd;
+    padding-left: 10px;
+    padding: 15px 15px;
+}
+
+.file-upload-footer .loader-selector {
+    max-height: 25px;
+}
+
+.file-select {
+    text-align: center;
+    padding: 70px 0;
+    background: #f6f6f6;
+}
+
+.file-select h2 {
+    font-weight: 400;
+}
+
+.loader-select {
+    text-align: center;
+    padding: 40px 0;
+    background: #f6f6f6;
+}
+
+.loader-select .r-select-title {
+    padding: 5px 10px;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.card-component-panel .loader-select h4 {
+    font-weight: 400;
+}
+
+.loader-error-message {
+    background: #E94484;
+    color: #fff ! important;
+    padding: 20px 0px;
+    margin-top: -46px;
+    margin-bottom: 45px;
+}
+
+.loader-error-message span {
+    font-weight: 800;
+}
+
+.file-chart-upload-panel {
+    height: inherit;
+}
+
+.file-select-window {
+    min-width: 350px;
+    border: 1px solid #c4c4c4;
+    border-radius: 2px;
+}
+
+.file-select-window h2 {
+    font-weight: 400;
+}
+
+.btn-file-select {
+    background: rgb(138, 115, 255);
+    color: #fff;
+    border: 1px solid rgb(89, 56, 255);
+    border-radius: 2px;
+    width: 240px;
+    margin: 30px 0;
+}
+
+.btn-file-select:hover {
+    color: #fff;
+}
+
+.btn-file-select:focus {
+    color: #fff;
+}
+
+div.hide-file-list>div>div>div>div>form>div>div:nth-child(3) {
+    visibility: hidden;
+}
+
+.resource-tools {
+    margin-left: 120px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+}
+
+.resource-grid-title {
+    font-weight: normal;
+    padding: 3px 20px 0 20px;
+    font-size: 1.416em;
+    line-height: 50px;
+    display: inline-block;
+}
+
+.resource-tools a.resource-grid-title.active {
+    color: #333;
+    background: #ddd;
+}
+
+.resource-tools a.resource-grid-title {
+    color: #999;
+    margin-top: 6px;
+    margin-left: 3px;
+    padding: 3px 20px 6px 20px;
+    line-height: 35px;
+}
+
+.resource-tools a.resource-grid-title:first-of-type {
+    margin-left: 10px;
+}
+
+.resource-tools a.resource-grid-title:not(.active):hover {
+    color: #666;
+    background: #ececec;
+}
+
+.resource-tools a.resource-grid-title.active:hover {
+    color: #333;
+    cursor: default;
+}
+
+.resource-grid-title:nth-child(2) {
+    padding-left: 0px;
+}
+
+.graph-find {
+    margin-top: 0px;
+    font-size: 19px;
+    color: #999;
+    padding-top: 5px;
+    padding-bottom: 3px;
+    padding-left: 25px;
+    width: 80px;
+    border-right: 1px solid #ccc;
+}
+
+.switch-panel {
+    padding: 5px
+}
+
+.switch-panel.disabled {
+    background: rgba(214, 214, 214, 0.3);
+}
+
+.wizard-card-tools {
+    float: right;
+    padding-left: 10px;
+    margin-top: 7px;
+    font-size: 19px;
+}
+
+div.row.widget-wrapper {
+    margin: 0;
+    margin-right: 10px;
+    padding: 10px 5px 25px 5px;
+    position: relative;
+}
+
+.map-filter-panel div.row.widget-wrapper {
+    padding: 5px 5px 25px 5px;
+}
+
+.input-group .form-control {
+    position: relative;
+    z-index: 0;
+    float: left;
+    width: 100%;
+    margin-bottom: 0;
+}
+
+.input-group.date {
+    max-width: 300px;
+}
+
+.select2-container.select2-allowclear .select2-choice abbr {
+    margin-top: 0px;
+    padding: 6px 7px 6px 6px;
+    border: 1px solid #ccc;
+}
+
+.widget-preview {
+    border: 1px solid transparent;
+}
+
+.widget-preview * {
+    cursor: pointer;
+}
+
+.widget-preview.active {
+    background: #fcfcfc;
+    border: 1px solid #ddd;
+    margin-left: -10px;
+    padding-left: 10px;
+    margin-right: -10px;
+    padding-right: 10px;
+}
+
+.widget-preview.hover {
+    background: #fafafa;
+    margin-left: -10px;
+    padding-left: 10px;
+    margin-right: -10px;
+    padding-right: 10px;
+}
+
+.panel-heading.note-toolbar {
+    height: auto;
+}
+
+.no-instructions-shim {
+    margin-top: -40px;
+}
+
+.arches-menu-icon {
+    font-size: 10px;
+    color: #abb1b7;
+    transform: translate(0, -2px);
+}
+
+.arches-menu-item-disabled:hover {
+    cursor: default;
+    margin-left: -3px;
+}
+
+.related-resources-container {
+    -ms-flex: 0 0 calc(100% - 400px);
+    -webkit-flex: 0 0 calc(100% - 400px);
+    flex: 0 0 calc(100% - 400px);
+    margin-bottom: 0px;
+    margin-left: -1px;
+    padding: 0px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    transition: all .5s;
+}
+
+.related-resources-container .pagination .active a {
+    z-index: 1;
+}
+
+.dataTables_info {
+    margin-top: 10px;
+}
+
+.dataTables_paginate {
+    margin-bottom: 140px;
+}
+
+.related-resources-nodes {
+    position: absolute;
+    width: 275px;
+    top: -50px;
+    right: 0px;
+    height: calc(100vh - 50px);
+    background: #fff;
+    z-index: 3;
+    opacity: 0.9;
+    border-left: 1px solid #ddd;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.relation-properties-buttons {
+    display: flex;
+    flex-direction: row;
+    position: absolute;
+    right: 15px;
+    align-content: flex-end;
+}
+
+.relation-properties-model-name {
+    padding-left: 5px;
+}
+
+a.mega-dropdown-toggle.disabled {
+    pointer-events: none;
+    cursor: default;
+    color: #aaa;
+}
+
+.relation-properties-button {
+    padding-left: 5px;
+}
+
+.related-resources-title-container {
+    display: flex;
+    flex-direction: row;
+}
+
+.search-candidate-link.unrelatable-search-result {
+    color: #999;
+}
+
+.dropdown-menu.mega-dropdown-menu.display-related-resource-properties {
+    display: block;
+    margin-top: 5px;
+}
+
+.rr-panel-note {
+    text-align: center;
+    font-size: 27px;
+    margin-top: 150px;
+}
+
+.rr-drag-panel-target {
+    border-bottom-width: 0px;
+    height: 100vh;
+    background: white;
+    border: 1px solid white;
+    border-radius: 2px;
+    padding: 0px 12px 0px 7px;
+    margin-top: -1px;
+    overflow-y: hidden;
+}
+
+#container .table-bordered td,
+#container .table-bordered th.rr-tab-field {
+    font-size: 13px;
+    font-weight: 400;
+    color: #666;
+}
+
+.settings-config-panel {
+    padding: 5px;
+}
+
+.data-table-selected {
+    text-align: center;
+}
+
+.data-table-selected.sorting_asc::after {
+    visibility: hidden;
+}
+
+.center-header {
+    text-align: center;
+}
+
+.shim {
+     margin-top: -25px;
+}
+
+.resource-relation-description {
+    color: #888;
+    padding: 10px;
+    font-size: 13px;
+    margin-top: 15px;
+    margin-right: 10px;
+    height: 145px;
+    border: 1px solid #ddd;
+}
+
+.settings-crud-panel {
+    margin-top: 10px;
+    margin-left: -20px;
+}
+
+.no-instructions-shim {
+    margin-top: -60px;
+}
+
+.report-image-grid {
+    width: 100%;
+    margin-bottom: 20px;
+}
+
+.search .grid .library-card {
+    background: #fafafa;
+}
+
+.search .grid .library-card.selected {
+    background: #fff;
+    font-weight: 600;
+}
+
+.search .grid .library-card:hover {
+    background: #fff;
+    border-left: 5px solid #20ce05;
+}
+
+#related-resources-drag-panel .card-header {
+    margin: -1px -30px 0px -30px;
+}
+
+#related-resources-drag-panel .card-header h2 {
+    margin-top: 5px;
+    color: #f1f1f1;
+    font-size: 17px;
+    font-weight: 400;
+}
+
+.rr-table {
+    max-height: 400px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    border: 1px solid #ddd;
+    max-width: 600px;
+}
+
+.rr-table.rr-summary-page {
+    max-height: 556px;
+    max-width: 100%;
+}
+
+.rr-table::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 9px;
+    border-left: 1px solid #ddd;
+}
+
+.rr-table::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(0, 0, 0, .1);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
+
+.rr-table-border {
+    border: solid 1px #e0e0e0;
+}
+
+.rr-table-row {
+    min-height: 36px;
+    display: flex;
+    border-bottom: solid 1px #ddd;
+    flex-direction: column;
+}
+
+.rr-table-row:hover {
+    background: #F6F6FE;
+    border-color: #B0AFE3;
+    cursor: pointer;
+}
+
+.rr-table-row:hover .rr-table-column {
+    border-color: #B0AFE3;
+    border-right: none;
+}
+
+.rr-table-row:nth-last-child(odd) {
+    background: #F5FAFE;
+}
+
+.rr-table-row:nth-last-child(odd):hover {
+    background: #F6F6FE;
+    border-color: #B0AFE3;
+    cursor: pointer;
+}
+
+.rr-table-row:nth-last-child {
+    border-bottom: none;
+}
+
+.rr-table-row:last-child {
+    border-bottom: none;
+}
+
+.rr-table-row-initial {
+    display: flex;
+    flex-direction: row;
+    height: 36px;
+}
+
+.rr-table-row-panel {
+    background: #fff;
+    border: none;
+    border-top: 1px solid #ddd;
+    padding: 20px 30px;
+}
+
+.rr-table-column {
+    padding-top: 8px;
+    padding-right: 10px;
+    border-left: solid 1px #ddd;
+}
+
+.rr-table-column:first-child {
+    border-left: none;
+}
+
+.rr-table-column:last-child {
+    border-right: none;
+}
+
+.rr-table-column button {
+    padding: 0px;
+    width: 36px;
+    color: #25476a;
+    border: none;
+    background: none;
+}
+
+.rr-table-column button i {
+    margin-left: 0px;
+    padding: 12px;
+}
+
+.rr-table-column.icon-column {
+    width: 36px;
+    padding: 0px;
+}
+
+.rr-table-column.icon-column:hover {
+    background: #D9D9F5;
+}
+
+.rr-table-column a {
+    color: steelblue;
+}
+
+.rr-relationship-icon {
+    font-size: 17px;
+    padding-left: 49%;
+}
+
+.rr-table-instance-label {
+    width: 430px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.create-resource-instance-card-component {
+    position: absolute;
+    background: #fcfcfc;
+    z-index: 11;
+    height: 95%;
+    overflow-y: auto;
+    top: 10px;
+    left: -100%;
+    width: calc(100% - 25px);
+    padding-bottom: 20px;
+}
+
+.create-resource-instance-card-component.rr-table-pop {
+    height: 100vh;
+    width: 100%;
+    padding: 0px;
+    background: #fff;
+    top: 0px;
+    left: 0%;
+    overflow-x: hidden;
+    /*-webkit-transform: translate3d(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);*/
+    transition: all 1s linear;
+}
+
+.create-resource-instance-card-component.rr-table-pop .rp-edit-buttons {
+    display: none;
+}
+
+.resource-instance-card-component-container {
+    display: flex;
+    overflow-x: hidden;
+}
+
+.resource-instance-card-component-container .card-component {
+    width: 100%;
+    position: absolute;
+    top: 50px;
+    padding-top: 0px !important;
+}
+
+.resource-instance-card-component-toc {
+    width: 300px;
+    border-right: 1px solid #ddd;
+    height: 100vh;
+    background: #fbfbfb;
+}
+
+.resource-instance-card-component-content {
+    flex: 2 0 0;
+}
+
+.resource-instance-card-menu-item {
+    height: 50px;
+    background: #f8f8f8;
+    padding: 15px;
+    border-bottom: 1px solid #ddd;
+    font-size: 13px;
+}
+
+.resource-instance-card-menu-item:not(.selected):hover {
+    cursor: pointer;
+    background: #fff;
+}
+
+.resource-instance-card-menu-item.selected {
+    background: #fff;
+    margin-right: -1px;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop {
+    top: 50px;
+    z-index: 30;
+    height: 100vh;
+    position: fixed;
+    left: 50px;
+    width: calc(100% - 50px);
+}
+
+.mainnav-lg .workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop {
+    left: 220px;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop .card-component {
+    margin-top: 15px;
+    margin-left: 0px;
+    margin-right: 0px;
+    border-radius: 0px;
+    height: 100vh;
+    overflow-y: auto;
+}
+
+.create-resource-instance-card-component.rr-table-pop .card-component {
+    margin-top: 15px;
+    margin-left: 0px;
+    margin-right: 0px;
+    border-radius: 0px;
+    padding: 20px;
+    width: 100%;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop .card-component .install-buttons {
+    right: 21px;
+    width: 357px;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop .create-instance-panel {
+    background: #fff;
+    min-height: 67%;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop .create-instance-panel .loading-mask {
+    left: 100%;
+    width: 450px;
+    display: none;
+}
+
+.create-resource-instance-card-component.rr-table-pop .create-instance-panel {
+    background: #fff;
+    min-height: 60%;
+}
+
+.new-provisional-edit-card-container .rr-table-instance-label {
+    width: 475px;
+}
+
+.workbench-card-sidepanel .rr-table-instance-label {
+    width: 220px;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop .install-buttons {
+    width: calc(100% - 350px) !important;
+    left: 350px;
+    text-align: left;
+}
+
+.mainnav-lg .workbench-card-sidepanel .create-resource-instance-card-component.rr-table-pop .install-buttons {
+    left: 520px;
+}
+
+.unselectable {
+    color: #ff0000;
+}
+
+#container .table-bordered .unselectable td {
+    color: #ddd;
+}
+
+.rr-text-notes {}
+
+.rr-result-grid-container {
+    position: relative;
+    margin-top: 15px;
+    width: 100%;
+    font-size: 16px;
+    padding-left: 0px;
+    padding-right: 0px;
+    font-weight: 300;
+    color: #999;
+}
+
+
+.rr-widget-filter-panel {
+    margin-top: -5px;
+    height: 40px;
+    background: #f2f2f2;
+    padding: 6px;
+    max-width: 600px;
+    border: 1px solid #ddd;
+    border-bottom: none;
+}
+
+.rr-widget-filter-panel .clear-node-search {
+    position: absolute;
+    left: 205px;
+    top: 5px;
+}
+
+.form-data-card-library {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-data-card-library .panel-heading,
+.form-data-card-library .menu-title-shim {
+    flex: 0 0 auto;
+}
+
+.form-data-card-library .report-image-grid {
+    margin: 0;
+    flex: 1 100%;
+}
+
+.rp-report-container {
+    color: #666;
+    padding-top: 100px;
+    padding-bottom: 50px;
+    transition: all .25s ease;
+}
+
+.graph-designer .rp-report-container-preview {
+    margin-top: 50px;
+    color: #666;
+    padding-bottom: 50px;
+    transition: all .25s ease;
+    background-color: white;
+}
+
+.card-component-panel .editor-report .rp-report-container-preview {
+    margin-top: 0px;
+}
+
+.rp-report-section.rp-report-section-root {
+    padding-top: 30px;
+    background-color: #fff;
+    display: flex;
+}
+
+.rp-report-section {
+    padding: 0px 0px 35px 0px;
+    background: #fff;
+    border-bottom: solid 1px lightgray;
+}
+
+.rp-report-section-title {
+    font-size: 14px;
+    font-weight: 400;
+    margin-top: -1px;
+    margin-bottom: 5px;
+    color: #666;
+    padding-bottom: 0px;
+    /* padding-left: 40px; */
+    background: #fff;
+    width: 100%
+}
+
+.rp-section-title {
+    font-size: 17px;
+    font-weight: 500;
+    margin-top: 2px;
+    margin-bottom: 5px;
+    padding: 14px 0 5px 0px;
+    color: #666;
+}
+
+.rp-card-section {
+    padding-bottom: 10px;
+    padding-top: 0px;
+    position: relative;
+    padding-left: 15px;
+}
+
+.rp-edit-buttons {
+    min-width: 34px;
+    display: inline-flex;
+    justify-content: space-between;
+    margin-right: 10%;
+    color: #597DBF;
+}
+
+.rp-edit-buttons i {
+    padding: 10px 12px;
+    border: 1px solid #ddd;
+    height: 36px;
+    width: 36px;
+    margin-right: 2px;
+    margin-left: 2px;
+    background: #D8FAF6;
+}
+
+.rp-edit-buttons i:hover {
+    cursor: pointer;
+    background: #fff;
+    color: #3A5FA4;
+}
+
+.rp-tile-separator {
+    border: 1px solid #ddd;
+    margin-right: 9%;
+}
+
+@media (min-width: 992px) {
+    .rp-card-section {
+        padding-left: 20px;
+    }
+}
+
+.rp-tile-title {
+    /* position: absolute; */
+    /* top: 0px; */
+    /* left: 45px; */
+    /* width: 250px; */
+    font-size: 15px;
+    font-weight: 500;
+    margin-top: 2px;
+    margin-bottom: 5px;
+    padding: 0px 0 5px 0px;
+    color: #666;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.rp-report-tile {
+    padding-bottom: 15px;
+    padding-left: 8px;
+    margin-top: 0px;
+}
+
+.rp-report-tile.related {
+    padding-bottom: 0px;
+}
+
+.rp-report-tile .reported-relationship {
+    padding-left: 5px;
+    color: #888;
+}
+
+.rp-no-data {
+    color: #888;
+    margin-top: 0px;
+}
+
+.rp-report-container-tile .rp-report-tile {
+    padding-bottom: 0;
+}
+
+.rp-report-container-tile {
+    padding-bottom: 15px;
+    padding-top: 15px;
+}
+
+.rp-report-tile dt {
+    font-weight: 600;
+}
+
+.rp-image-grid-item {
+    float: left;
+    margin: 3px;
+    max-width: 200px;
+}
+
+.dl-horizontal {
+    margin-bottom: 0px;
+}
+
+.report-print-date {
+    font-size: 11px;
+    color: #999;
+    margin: 7px;
+    padding-right: 20px;
+}
+
+.report-toolbar {
+    top: 50px;
+    width: calc(100% - 50px);
+    height: 50px;
+    background: #f8f8f8;
+    border-bottom: 1px solid #ddd;
+}
+
+.stamp {
+    position: absolute;
+    background: orange;
+    border: 4px dotted black;
+}
+
+.report-toolbar a {
+    width: 500px;
+}
+
+.report-toolbar-preview {
+    width: 100%;
+    height: 50px;
+    background: #f8f8f8;
+    border-bottom: 1px solid #ddd;
+    z-index: 10;
+}
+
+.report-toolbar-title {
+    font-size: 17px;
+    font-weight: 500;
+    margin-top: 0px;
+    width: 400px;
+    padding: 14px 0 5px 25px;
+    color: #555;
+}
+
+h4.report-toolbar-title {
+    width: 500px;
+}
+
+.dataTable tr:hover {
+    background-color: #dbf1f5 !important;
+    /*cursor: pointer;*/
+}
+
+#container .table td {
+    vertical-align: middle;
+}
+
+.disabled-link {
+    pointer-events: none;
+    cursor: default;
+    color: grey;
+}
+
+.map-widget-container {
+    position: absolute;
+    top: 6px;
+    right: 10px;
+    padding-top: 5px;
+    font-size: 17px;
+    color: #fff;
+    background: #706BE2;
+    opacity: 0.75;
+    width: 36px;
+    height: 36px;
+    border-radius: 2px;
+    border: 1px solid #332DC1;
+    transition: all .2s ease;
+    z-index: 10;
+    line-height: 1.5;
+}
+
+.panel-group.accordion .panel-heading.map-widget-config-accoridan-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding-right: 5px;
+}
+
+.panel-heading.map-widget-config-accoridan-item .panel-title {
+    width: 100%;
+}
+
+.map-widget-config-accoridan-item i {
+    float: right;
+    padding-top: 15px;
+}
+
+.map-disabled {
+    background-color: black;
+    height: 500px;
+    opacity: 0.2;
+    margin-bottom: -500px;
+    position: relative;
+    z-index: 100;
+}
+
+.map-widget-container a {
+    color: #fff;
+}
+
+div.row.widget-wrapper.report-header {
+    margin-right: 5px;
+    padding: 0px;
+    padding-bottom: 10px;
+    width: 100%;
+}
+
+div.row.widget-wrapper.report-header:hover {
+    background: #ebeef0;
+}
+
+.report-header .control-label.widget-input-label {
+    display: none;
+}
+
+.map-widget-container-expanded {
+    top: 6px;
+    right: 10px;
+    background: rgba(17, 17, 17, 0.21);
+    opacity: .9;
+    width: 300px;
+    height: calc(100vh - 35px);
+    border: 1px solid #999;
+    transition: all .2s ease;
+}
+
+.map-widget-container.hide-maptools {
+    display: none;
+}
+
+.overlay-selection-container {
+    position: absolute;
+    top: 6px;
+    left: 10px;
+    padding: 10px 25px;
+    width: calc(100% - 325px);
+    background: #fcfcfc;
+    /*height: calc(100vh - 35px);*/
+    border: 1px solid #bbb;
+    z-index: 1100;
+}
+
+#overlay-grid {
+    margin-left: 10px;
+    margin-right: 0px;
+    border-top-width: 0px;
+}
+
+#overlay-grid.grid {
+    height: 1600px;
+    overflow-y: scroll;
+}
+
+.overlay-selection-container.selector-closed {
+    visibility: hidden;
+}
+
+.overlay-close {
+    font-size: 19px;
+    color: #888;
+}
+
+.overlay-close:hover {
+    cursor: pointer;
+    color: #555;
+}
+
+.overlay-title {
+    font-size: 16px;
+    padding: 10px;
+}
+
+.overlay-filter-container {
+    position: relative;
+    padding-top: 5px;
+    padding-left: 10px;
+    padding-bottom: 10px;
+}
+
+.overlay-list-container {
+    padding-top: 0px;
+    padding-left: 0px;
+    padding-bottom: 5px;
+    height: 1000px;
+    overflow-y: scroll;
+}
+
+.overlay-filter {
+    height: 38px;
+}
+
+.overlay-card {
+    float: left;
+    width: 100%;
+    height: 50px;
+    margin-bottom: -2px;
+    position: relative;
+    padding: 0px;
+    border: 1px solid #ddd;
+    border-top-width: 1px;
+    background: #fcfcfc;
+}
+
+.overlay-card:hover {
+    background: #fff;
+    cursor: pointer;
+}
+
+.overlay-card:first-of-type {
+    border-top: 1px solid #ddd;
+}
+
+.overlay-card.selected {
+    background: #fff;
+}
+
+.overlay-card-item {
+    position: relative;
+}
+
+.overlay-card-main {
+    position: absolute;
+    left: 67px;
+    top: 15px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 14px;
+}
+
+.overlay-card-vis-toggle {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    text-align: center;
+    width: 50px;
+    height: 50px;
+    padding-top: 15px;
+    font-size: 17px;
+    border-right: 1px solid #ddd;
+    color: #ccc;
+    vertical-align: middle;
+    display: table-cell;
+}
+
+.overlay-card-main a {
+    color: #aaa;
+}
+
+.overlay-card.selected div div a {
+    color: #555;
+}
+
+.overlay-card.selected div div i {
+    color: #666;
+}
+
+.overlay-card:hover div div i not:selected {
+    color: rgb(102, 102, 102);
+}
+
+.overlay-card:hover div div {
+    color: rgb(102, 102, 102);
+}
+
+.overlay-filter {
+    height: 38px;
+}
+
+.resource-color-swatch {
+    font-size: 21px;
+}
+
+.geometry-tools-container {
+    position: absolute;
+    top: 50px;
+    left: 0px;
+    padding: 0px;
+}
+
+.map-search-container div.geometry-tools-container {
+    top: 0px;
+    left: 0px;
+}
+
+.geocode-container-shim {
+    margin-right: 265px;
+}
+
+.geocode-container {
+    position: absolute;
+    top: 6px;
+    right: 55px;
+    padding: 0px;
+    background: #fff;
+    opacity: .9;
+    width: 250px;
+    height: 36px;
+    border-radius: 2px;
+    transition: all .450s ease;
+    z-index: 10;
+    visibility: hidden;
+}
+
+.geocode-container input {
+    border-color: #aaa;
+}
+
+.geometry-editing-notifications {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    z-index: 2;
+    width: -webkit-calc(100% - 55px);
+    width: -moz-calc(100% - 55px);
+    width: 100%;
+    opacity: .85;
+}
+
+.notifications-minimized {
+    width: auto;
+}
+
+.geometry-editing-notifications span.arrow {
+    color: white;
+    position: absolute;
+    left: 10px;
+    top: 15px;
+}
+
+.geometry-editing-notifications span.arrow:hover {
+    cursor: pointer;
+}
+
+.alert-wrap>.alert>.media {
+    padding-left: 5px;
+}
+
+.geocode-container.hide-geocoder {
+    visibility: visible;
+}
+
+.relative {
+    position: relative;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.map-widget-panel {
+    position: absolute;
+    top: 56px;
+    width: 299px;
+    height: 450px;
+    overflow-y: auto;
+    right: 10px;
+    padding: 0px;
+    box-shadow: none;
+    background: transparent;
+    border-top: 1px solid #ddd;
+    /*transition: all .40s .15s ease;*/
+    z-index: 10;
+}
+
+#map-widget-basemaps.panel.map-widget-panel {
+    border-left: 1px solid #999;
+    right: 11px;
+}
+
+#overlays-panel.panel.map-widget-panel {
+    border-left: 1px solid #999;
+    right: 11px;
+}
+
+.map-search-container,
+.map-search-container div .map-widget-panel {
+    height: calc(100vh - 100px);
+}
+
+.map-widget-panel.map-panel-inactive {
+    visibility: hidden;
+}
+
+.map-widget-panel-title {
+    height: 50px;
+    width: 298px;
+    padding: 8px;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+}
+
+.map-widget-panel-title h4 {
+    font-weight: 400;
+    color: #444;
+}
+
+.map-crud-container {
+    top: 0px;
+    height: 500px;
+    background: #fbfbfb;
+    border: 1px solid #bbb;
+}
+
+.map-search-container {
+    background: #fbfbfb;
+}
+
+.map-report-header-container {
+    height: 500px;
+    background: #fbfbfb;
+}
+
+.plugin-main .map-report-header-container {
+    height: 100%;
+}
+
+.plugin-main .row.widget-wrapper.report-header {
+    padding: 0;
+    margin: 0;
+}
+
+.expanded-edit-map {
+    position: fixed;
+    border-width: 0px;
+    top: 0px;
+    left: 50px;
+    bottom: 0px;
+    right: 0px;
+    height: auto;
+}
+
+.map-search-container.expanded-edit-map {
+    top: 51px;
+}
+
+.expanded-buttons {
+    z-index: 1000;
+    position: absolute;
+    top: 5px;
+    right: 315px;
+    transition-duration: .3s;
+    background: #f2b251;
+    width: 213px;
+    height: 40px;
+}
+
+.effect>.install-buttons.expanded-buttons {
+    position: absolute;
+    top: -130px;
+    right: 250px;
+}
+
+.map-search-container.expanded-map {
+    margin-top: -25px;
+    margin-right: -15px;
+}
+
+.report-header .expanded-map {
+    margin-top: 0px;
+    margin-right: 0px;
+}
+
+.ui-sortable div div .expanded-map {
+    margin-top: 0px;
+    margin-left: 0px;
+    margin-right: 0px;
+}
+
+.map-widget-toolbar {
+    position: absolute;
+    background: #fff;
+    width: 298px;
+    height: 50px;
+    right: 11px;
+    top: 6px;
+    display: table-cell;
+    border-top: 1px solid #999;
+    z-index: 10;
+}
+
+#mainnav-container {
+    z-index: 15;
+}
+
+#navbar {
+    z-index: 16;
+}
+
+.map-widget-icon {
+    color: rgba(255, 255, 255, 1);
+    opacity: 1.0;
+}
+
+.map-widget-toolbar-list {
+    list-style: none;
+    padding-left: 0px;
+    display: inline-block;
+    width: 250px;
+}
+
+.map-widget-toolbar-item {
+    padding: 5px 10px 5px 10px;
+    font-size: 15px;
+    height: 50px;
+    color: #777;
+    vertical-align: middle;
+    text-align: left;
+    display: table-cell;
+}
+
+.map-widget-toolbar-item:hover {
+    cursor: pointer;
+    color: #444;
+}
+
+.map-widget-toolbar-item.active {
+    color: #444;
+}
+
+.map-widget-toolbar-item.active:focus {
+    color: #444;
+}
+
+.map-widget-toolbar-item.active:active {
+    color: #444;
+}
+
+.map-widget-icon {
+    color: #888;
+}
+
+li.active .map-widget-icon {
+    color: #444;
+}
+
+a#close-map-tools.map-widget-icon {
+    position: absolute;
+    right: 10px;
+    top: 17px;
+    font-size: 13px;
+    color: steelblue;
+}
+
+.basemap-unselected {
+    color: #ccc;
+}
+
+span.basemap-unselected {
+    color: #aaa;
+}
+
+.map-widget-overlay-item {
+    width: 298px;
+    height: 50px;
+    padding: 7px;
+    background: #fafafa;
+    border-bottom: 1px solid #ddd;
+}
+
+a#close-map-tools.map-widget-icon:hover {
+    color: #311557;
+}
+
+.map-widget-overlay-item.selected {
+    background: #fff;
+}
+
+.map-widget-overlay-item:hover {
+    background: #fff;
+    cursor: pointer;
+}
+
+.map-widget-overlay-item:hover div i {
+    color: #666;
+}
+
+.map-widget-overlay-item:hover div a span {
+    color: #454545;
+}
+
+.map-overlay-item-tools {
+    position: absolute;
+    top: 15px;
+    right: 10px;
+    padding: 0px 5px;
+}
+
+.overlay-toggle-icon {
+    font-size: 17px;
+}
+
+#overlays-panel div .map-widget-overlay-item {
+    background: #fff;
+}
+
+#overlays-panel div .overlay-invisible {
+    background: #fafafa;
+    border-bottom: 1px solid #ddd;
+}
+
+.show-tools {
+    height: 100px;
+    transition: all .40s ease;
+}
+
+.map-overlay-vis-toogle {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 50px;
+    height: 50px;
+    padding-top: 13px;
+    font-size: 19px;
+    border-right: 1px solid #ddd;
+    color: #666;
+    vertical-align: middle;
+    display: table-cell;
+}
+
+.map-overlay-item-tools-panel {
+    position: absolute;
+    top: 50px;
+    left: 0px;
+    height: 50px;
+    width: 290px;
+    padding: 12px 7px 7px 17px;
+    font-size: 17px;
+    color: #888;
+    border-top: 1px solid #f4f4f4;
+    border-bottom: 1px solid #ddd;
+    /*transition: all .40s ease;*/
+    display: none;
+}
+
+.overlay-tool-icon {
+    padding-right: 3px;
+}
+
+.overlay-tool-group {
+    float: right;
+}
+
+.map-overlay-name {
+    position: absolute;
+    top: 14px;
+    left: 60px;
+    width: 220px;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.leaflet-draw-toolbar .active {
+    background-color: #efefef;
+}
+
+.map-query-tool {
+    display: flex;
+    flex-direction: row;
+    justify-content: left;
+}
+
+.map-query-tool-input {
+    width: 140px;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.map-query-tool-input.buffer {
+    height: 40px;
+}
+
+.map-json-tool {
+    position: absolute;
+    height: 120px;
+    top: 10px;
+    left: 60px;
+    width: 180px;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.spatial-filter-container {
+    padding: 10px 5px 15px 5px;
+    margin-top: 45px;
+    border-bottom: 1px solid #ddd;
+}
+
+.buffer-control {
+    color: #4d627b;
+    border: none;
+    padding: 5px;
+    padding-left: 12px;
+    border-radius: 3px;
+    margin-bottom: 5px;
+}
+
+.buffer-control h5 {
+    font-size: 13px;
+}
+
+.buffer-input {
+    width: 75px;
+}
+
+.map-tool-container {
+    position: absolute;
+    top: 75px;
+    left: 30px;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.map-tool-container.buffer {
+    position: absolute;
+    top: 0px;
+    width: 220px;
+}
+
+.map-tool-container.buffer select {
+    height: 28px;
+    width: 75px;
+}
+
+.map-tool-item {
+    background: #aaa;
+}
+
+.map-tool-item.geojson {
+    padding: 1px;
+    background: #aaa;
+    color: #aaa;
+}
+
+.map-tool-item.xy {
+    background: #fff;
+    width: 220px;
+    top: 0px;
+}
+
+.map-tool-item.xy.buffer {
+    top: 44px;
+}
+
+.map-tool-item.xy .tool-header {
+    padding-bottom: 10px;
+    font-size: 15px;
+    color: #555;
+}
+
+.map-tool-item.xy select {
+    height: 24px;
+    min-width: 195px;
+    margin-bottom: 7px;
+}
+
+.map-tool-item.xy input {
+    height: 28px;
+    margin-bottom: 2px;
+    padding: 5px;
+}
+
+a.clear-geojson-button {
+    background-image: none;
+    position: absolute;
+    top: 7px;
+    right: 15px;
+    font-size: 12px;
+    color: steelblue;
+}
+
+.xy a.clear-geojson-button {
+    border-bottom: none;
+    top: 7px;
+    right: 15px;
+    color: steelblue;
+    font-size: 12px;
+}
+
+.xy a.clear-geojson-button:hover {
+    cursor: pointer;
+    color: #555;
+}
+
+a.clear-geojson-button.enabled {
+    color: steelblue;
+}
+
+a.clear-geojson-button:hover {
+    background-color: #fff;
+    cursor: pointer;
+}
+
+.form-control.map-json-tool-input {
+    width: 220px;
+    height: 120px;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: scroll;
+    text-overflow: ellipsis;
+}
+
+.mapboxgl-canvas:focus {
+    outline: none;
+}
+
+.map-widget-tool:nth-child(1) {
+    padding-left: 0px;
+    width: 50px;
+}
+
+.map-widget-tool.active {
+    background: steelblue;
+}
+
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl {
+    visibility: hidden;
+}
+
+.mapboxgl-ctrl-geocoder--input {
+    font-size: 13px;
+}
+
+.workbench-card-container .mapboxgl-ctrl-geocoder {
+    margin-right: 90px;
+}
+
+.workbench-card-wrapper .mapboxgl-ctrl-top-left .mapboxgl-ctrl {
+    visibility: visible;
+}
+
+.widget-wrapper .mapboxgl-map {
+    z-index: 10;
+    margin-bottom: -10px;
+}
+
+.map-overlay-item-tools-panel .noUi-base {
+    background: #489EED;
+    /*-webkit-transition: background 450ms;*/
+    /*transition: background 450ms;*/
+}
+
+.map-overlay-item-tools-panel .noUi-horizontal {
+    height: 10px;
+}
+
+.map-overlay-item-tools-panel .noUi-horizontal .noUi-handle {
+    width: 20px;
+    height: 20px;
+    left: -9px;
+    top: -6px;
+}
+
+.map-overlay-item-tools-panel .noUi-stacking .noUi-handle {
+    z-index: 10;
+}
+
+.map-overlay-item-tools-panel .noUi-handle {
+    border: 1px solid #e1e5ea;
+    border-radius: 2px;
+    background: #FFF;
+    cursor: default;
+    box-shadow: inset 0 0 1px #FFF, inset 0 1px 7px #EBEBEB, 0 3px 4px -3px #AAA;
+}
+
+.map-overlay-item-tools-panel .overlay-slider {
+    width: 150px;
+    margin-top: -5px;
+}
+
+.map-overlay-item-tools-panel .pips.noUi-horizontal {
+    margin-bottom: 70px;
+}
+
+.map-thumbnail {
+    padding-top: 5px;
+}
+
+.overlay-invisible .relative {
+    background-color: #f8f8f8;
+}
+
+.overlay-invisible a {
+    color: #999;
+}
+
+.overlay-invisible i {
+    color: #999;
+}
+
+#overlays-panel .map-widget-panel-title:hover {
+    cursor: pointer;
+}
+
+.noUi-target {
+    position: relative;
+    margin-top: 10px;
+    margin-bottom: -12px;
+}
+
+.new-option-field input {
+    display: inline;
+    width: 90%;
+}
+
+.new-option-field i {
+    padding-top: 10px;
+}
+
+.added-domain-option {
+    padding-bottom: 4px;
+}
+
+.domain-container {
+    width: 500px;
+}
+
+#widget-crud-settings div div .domain-container .domain-input {
+    width: 254px;
+}
+
+#widget-crud-settings div div .domain-container {
+    width: 270px;
+}
+
+.domain-input {
+    height: 32px;
+    margin-bottom: 5px;
+    padding-left: 5px;
+}
+
+.domain-input-item {
+    height: 32px;
+    padding-left: 5px;
+}
+
+.domain-drag-handle {
+    background: #f4f4f4;
+    padding-left: 4px;
+    padding-right: 1px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    border: 1px solid #ddd;
+    border-right-width: 0px;
+}
+
+.option-drag-handle {
+    color: #999;
+    cursor: move
+}
+
+.content-instructions {
+    font-size: 13px;
+    color: #8d8d8d;
+    margin-top: -30px;
+    line-height: 1.25;
+    margin-bottom: 20px;
+}
+
+
+/* Function Manager Page */
+
+.href-toolbar {
+    text-align: center;
+    margin-top: -10px;
+    padding-bottom: 10px;
+}
+
+.href-button {
+    color: #f4f4f4;
+    font-size: 11px;
+    padding: 5px 0px;
+    /*margin: -5px 0px 15px 0px;*/
+    background: #5393C8;
+    border: 1px solid #1561A1;
+    display: inline-block;
+    width: 100%;
+}
+
+.href-button:hover {
+    color: #fff;
+    background: #1266AB;
+}
+
+.href-button:focus {
+    color: #fff;
+    background: #1266AB;
+}
+
+
+/* Hide "Full Screen" button for map tools widget in card manager */
+
+
+/* End Disable "Full Screen" button for map tools widget in card manager */
+
+.left-column-message {
+    padding: 10px 15px;
+    color: #777;
+    font-size: 15px;
+}
+
+.library-container {
+    padding: 0px;
+    border-left: 1px solid #e8e8e8;
+}
+
+.library-header {
+    display: flex;
+    align-items: center;
+    height: 40px;
+    font-size: 15px;
+    background: #f4f4f4;
+    border-bottom: 1px solid #e4e4e4;
+}
+
+.library-find {
+    margin-right: 25px;
+    font-size: 15px;
+    color: #999;
+    width: 80px;
+    border-right: 1px solid #ccc;
+    display: block;
+    text-align: center;
+}
+
+.library-grid {
+    padding: 10px 15px;
+}
+
+.library-grid-title {
+    font-weight: normal;
+    font-size: 15px;
+    display: inline-block;
+}
+
+.msm-designer-panel {
+    width: 100%;
+    background-color: #fff;
+    overflow-y: auto;
+}
+
+.msm-locked-warning {
+    height: 60px;
+    background: #999;
+    font-size: 14px;
+    color: #fff;
+    padding-left: 10px;
+    position: relative;
+    padding-top: 20px;
+}
+
+.msm-list-filter {
+    display: flex;
+    padding: 12px 10px 13px 65px;
+}
+
+.msm-list-filter-input {
+    padding-left: 15px;
+    width: 350px;
+    height: 35px;
+    position: relative;
+}
+
+.msm-list-filter-input .clear-node-search {
+    top: 8px;
+    right: 10px;
+}
+
+.msm-summary-panel {
+    height: 100vh;
+    background: #fff;
+}
+
+.msm-summary-panel #cards {
+    background: #fafafa;
+}
+
+
+/* End Function Manager Page */
+
+.category-header {
+    display: flex;
+    align-items: center;
+    height: 50px;
+    padding-left: 10px;
+    font-size: 15px;
+    background: #f4f4f4;
+    border-bottom: 1px solid #e4e4e4;
+}
+
+.category-title {
+    font-weight: normal;
+    font-size: 15px;
+    padding: 9px 15px;
+    color: #999;
+    display: inline-block;
+}
+
+.category-title.active {
+    color: #123;
+    background: #ddd;
+    cursor: default;
+}
+
+.category-title:not(.active):hover {
+    cursor: pointer;
+    background: #ececec;
+}
+
+.carousel,
+.carousel .item {
+    height: 500px;
+    text-align: center;
+}
+
+.carousel-caption {
+    z-index: 10;
+}
+
+.carousel .container {
+    width: auto;
+}
+
+.carousel-inner>.item>img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    min-width: 100%;
+    height: inherit;
+    max-width: 100%;
+    object-fit: contain;
+}
+
+.dz-img {
+    object-fit: contain;
+}
+
+.dz-img-main {
+    width: 100%;
+    height: 100%;
+}
+
+.geocoder-results {
+    max-height: 410px;
+    width: 250px;
+    margin-left: 0px;
+    overflow-y: auto;
+}
+
+.geocoder-result-item {
+    min-height: 40px;
+    border: 1px solid #e2e2e2;
+    border-top-width: 0px;
+    background: #fbfbfb;
+    padding: 10px;
+    cursor: pointer;
+}
+
+.geocode-clear {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    cursor: pointer;
+}
+
+.focused-geocoder-result {
+    background-color: #dbf1f5;
+}
+
+.selected-geocoder-result {
+    font-weight: bold;
+    background: #dbf1f5;
+}
+
+.hover-panel-small {}
+
+.hover-feature-info {
+    position: absolute;
+    z-index: 1000;
+    left: 35px;
+    margin: 10px;
+    width: 400px;
+    padding: 0px;
+    border: solid 1px #999;
+    border-radius: 2px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+    background-color: rgb(249, 249, 249);
+    opacity: 0.9;
+}
+
+.hover-rr-node-info {
+    z-index: 999999;
+    margin: 10px;
+    width: 300px;
+    padding: 0px;
+    border: solid 1px #999;
+    border-radius: 2px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+    background-color: rgb(249, 249, 249);
+    display: flex;
+    flex-direction: column;
+}
+
+.rr-fdg-details {
+    display: flex;
+    flex-direction: column;
+}
+
+.rr-fdg-details span {
+    flex-direction: row;
+}
+
+.rr-number {
+    font-weight: bold;
+    padding-right: 5px
+}
+
+.rr-number.fdg {
+    font-weight: bold;
+    font-size: 22px;
+    text-shadow: 0px 0px 0.08em #fff;
+}
+
+.rr-fdg-name {
+    display: flex;
+    flex-direction: row;
+    padding: 5px;
+    background-color: #fff;
+    border-bottom-style: solid;
+    border-color: #ddd;
+    border-width: 1px;
+}
+
+.rr-fdg-model-name {
+    display: flex;
+    flex-direction: row;
+    padding-top: 3px;
+    background-color: #fff;
+}
+
+.rr-fdg-edge {
+    padding-left: 25px;
+    font-style: italic;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    border-bottom-style: solid;
+    border-color: #ddd;
+    border-width: 1px;
+}
+
+.related-node-details {
+    display: flex;
+    flex-direction: column;
+}
+
+#map-popup .hover-feature-title-bar {
+    height: 60px;
+    padding: 10px;
+    border-bottom: 1px solid #25476A;
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    max-width: 290px;
+}
+
+.hover-feature-title-bar {
+    height: 40px;
+    padding: 10px;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+    max-width: 311px;
+}
+
+.mapboxgl-popup-content .hover-feature-title-bar {
+    margin-bottom: 0px;
+}
+
+#map-popup .mapboxgl-popup-close-button {
+    height: 61px !important;
+    width: 61px;
+    top: -1px;
+    margin-right: -1px;
+    padding-top: 7px;
+    border-radius: 0px;
+    font-size: 27px;
+    background: #fafafa;
+    color: #454545;
+    border-left: 1px solid #ddd;
+    border-bottom: 1px solid #25476A;
+}
+
+#map-popup .mapboxgl-popup-close-button:hover {
+    background: #f4f4f4;
+}
+
+#map-popup .status-ok .mapboxgl-popup-close-button {
+    background: #C4F267;
+    border-left: 1px solid #7AB503;
+}
+
+#map-popup .status-ok .mapboxgl-popup-close-button:hover {
+    background: #B3ED3F;
+}
+
+#map-popup .status-warning .mapboxgl-popup-close-button {
+    background: #FFFF70;
+    border-left: 1px solid #B9B900;
+}
+
+#map-popup .status-warning .mapboxgl-popup-close-button:hover {
+    background: #D3D300;
+}
+
+#map-popup .status-late .mapboxgl-popup-close-button {
+    background: #DA55A0;
+    border-left: 1px solid #9F005A;
+    color: #fff;
+}
+
+#map-popup .status-late .mapboxgl-popup-close-button:hover {
+    background: #D02F8A;
+}
+
+.mapboxgl-popup-close-button {
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    height: 40px;
+    width: 40px;
+    border: 1px solid #ddd;
+    padding-bottom: 4px;
+    cursor: pointer;
+    background-color: #fafafa;
+    color: #676767;
+    font-size: 23px;
+    font-weight: 600;
+}
+
+.mapboxgl-popup-close-button:hover {
+    cursor: pointer;
+    background-color: #f4f4f4;
+    color: #454545;
+    font-size: 23px;
+    font-weight: 600;
+}
+
+#map-popup .hover-feature-title {
+    height: 40px;
+    text-align: center;
+    white-space: inherit;
+}
+
+.hover-feature-title {
+    font-size: 14px;
+    font-weight: 500;
+    max-width: 300px;
+    color: #25476A;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.hover-feature-nav-left {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    height: 40px;
+    background: #fafafa;
+    padding: 10px;
+    border: 1px solid #ddd;
+}
+
+.hover-feature-nav-left.disabled {
+    display: none;
+}
+
+.hover-feature-nav-right {
+    position: absolute;
+    right: 39px;
+    top: 0px;
+    height: 40px;
+    background: #fafafa;
+    padding: 10px;
+    border: 1px solid #ddd;
+}
+
+.hover-feature-nav-right.disabled {
+    display: none;
+}
+
+#map-popup .hover-feature-body {
+    padding: 0px;
+    border-left: none;
+    border-right: none;
+}
+
+#map-popup img {
+    width: 100%;
+    height: auto;
+    margin-top: -25px;
+}
+
+#map-popup .cons-stubs {
+    padding: 10px 0px;
+}
+
+.hover-feature-body {
+    padding: 10px 15px 15px 15px;
+    width: 350px;
+    border-left: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+}
+
+.hover-feature {
+    font-size: 13px;
+    color: #555;
+    margin-bottom: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    /* number of lines to show */
+    line-height: 1.2em;
+    /* fallback */
+    max-height: 12em;
+    min-height: 3em;
+    /* fallback */
+}
+
+.hover-panel-dismiss {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-size: 19px;
+}
+
+.hover-feature-metadata {
+    margin-bottom: -4px;
+    color: #888;
+}
+
+.hover-feature-metadata span {
+    color: steelblue;
+}
+
+.saved-search-container {
+    padding: 5px;
+    background: #fff;
+}
+
+.saved-search-grid {
+    height: calc(100vh - 105px);
+    width: 100%;
+    min-height: 400px;
+    overflow-y: scroll;
+}
+
+.ss-grid-item:last-child {
+    margin-bottom: 40px;
+}
+
+.ss-grid-item {
+    position: sticky;
+    border: 1px solid #ddd;
+    width: 224px;
+    height: 164px;
+    float: left;
+    -webkit-transition: .6s all ease;
+    -moz-transition: .6s all ease;
+    -o-transition: .6s all ease;
+    transition: .6s all ease;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    -o-background-size: cover;
+    background-size: cover;
+    background-color: white;
+}
+
+.search-caption-activeWrap {
+    position: absolute;
+    z-index: 2;
+    height: 100%;
+    width: 100%;
+}
+
+.search-caption-alignCenter {
+    display: table;
+    width: 100%;
+    height: 100%;
+}
+
+.search-caption-body {
+    display: table-cell;
+    vertical-align: middle;
+    text-align: center
+}
+
+.search-caption-activeWrap {
+    position: absolute;
+    z-index: 2;
+    height: 100%;
+    width: 100%;
+}
+
+.search-caption-alignCenter {
+    display: table;
+    width: 100%;
+    height: 100%;
+}
+
+.search-caption-body {
+    display: table-cell;
+    vertical-align: middle;
+    text-align: center
+}
+
+.search-query-link-captions {
+    padding-left: 0;
+    color: #123;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin: 0 0 20px;
+    list-style: none;
+    text-align: center;
+    cursor: pointer;
+}
+
+.search-query {
+    padding-top: 15px;
+    padding-bottom: 10px;
+    margin-top: -20px;
+    margin-left: 20px;
+    margin-right: 30px;
+    margin-bottom: 10px;
+    background: rgba(250, 250, 250, 0.66);
+}
+
+a.search-query-link-captions:hover {
+    font-weight: 600;
+    color: #25476A;
+}
+
+a.search-query-link-captions:active {
+    font-weight: 600;
+    color: #fff;
+}
+
+a.search-query-link-captions:focus {
+    font-weight: 600;
+    color: #fff;
+}
+
+.search-query-desc {
+    color: #444;
+    font-size: 13px;
+}
+
+.search-results {
+    -ms-flex: 0 0 400px;
+    -webkit-flex: 0 0 400px;
+    flex: 0 0 400px;
+}
+
+.search-inline-filters {
+    /*display: flex;
+        flex-direction: row;
+        justify-content: right;*/
+    margin-top: 10px;
+    margin-left: -5px;
+    margin-bottom: 5px;
+}
+
+.search-inline-filters div {
+    padding-left: 2px;
+    margin-bottom: 2px;
+}
+
+.qa-filter .resource-selector-button div .btn {
+    padding: 2px 47px;
+}
+
+.resource-filter .resource-selector-button div .btn {
+    padding: 2px 59px;
+}
+
+.search-control-container {
+    -ms-flex: 0 0 400px;
+    -webkit-flex: 0 0 400px;
+    flex: 1 0 400px;
+    margin-bottom: 0px;
+    background-color: #fafafa;
+    border-top: 1px solid #ddd;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    transition: all .5s;
+    margin-top: inherit;
+    z-index: 5;
+}
+
+.search-tools-container {
+    background: #f4f4f4;
+    border-bottom: 1px solid #ddd;
+    position: fixed;
+    height: 50px;
+    z-index: 3;
+    width: 399px;
+    padding: 4px 0px;
+    margin-top: -1px;
+    border-top: 1px solid #ddd;
+}
+
+.search-tools-container .clear-filter {
+    margin-right: 5px;
+}
+
+.search-count-container {
+    padding: 10px 5px 10px 10px;
+    text-align-last: justify;
+    height: 40px;
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.search-controls-container {
+    display: inline-flex;
+    float: right;
+    padding: 4px 10px;
+}
+
+.search-title {
+    font-size: 16px;
+    font-weight: 500;
+    margin-top: 0px;
+    display: inline-block;
+    margin-bottom: 0px;
+}
+
+.search-candidate-title,
+.search-candidate-link {
+    color: steelblue;
+    padding-right: 7px;
+}
+
+.search-listing-footer a {
+    margin-top: -5px;
+    padding: 5px 5px;
+}
+
+.search-listing-footer a:focus {
+    background: #d6d6d6;
+    border-radius: 1px;
+}
+
+.search-control-container.slide {
+    margin-left: -400px;
+    transition: all .5s;
+}
+
+.search-results-panel {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    max-width: 400px;
+    border-right: solid 1px #dcdcdc;
+}
+
+.clear-filter {
+    padding: 0px 9px !important;
+    margin-top: 1px;
+    height: 30px;
+    border-radius: 2px;
+    border: 1px solid #1ABA8E;
+}
+
+.search-listing-icon {
+    transform: translate(0, -2px);
+    font-size: 12px;
+}
+
+.search-footer {
+    position: fixed;
+    bottom: 0px;
+    background: #f4f4f4;
+    width: 449px;
+    left: 0px;
+    border-top: 1px solid #ddd;
+    height: 50px;
+}
+
+.mainnav-lg .search-footer {
+    left: 170px;
+}
+
+.search-footer .pagination {
+    margin-top: 10px;
+}
+
+.pagination>li>a.disabled {
+    cursor: default;
+    color: rgb(160, 160, 160);
+}
+
+.pagination>li>a.disabled:hover,
+.pagination>li>a.disabled:focus {
+    border-color: #dcdcdc;
+    box-shadow: none;
+    background-color: transparent;
+}
+
+ul.pagination {
+    font-size: 12px;
+}
+
+.map-filter-panel {
+    /*margin-left: 10px;*/
+    position: absolute;
+    left: -5px;
+    right: -15px;
+    top: -22px;
+    z-index: 1;
+}
+
+.arches-select2 .select2-choices .select2-search-field {
+    height: 34px;
+}
+
+.select2-container-multi .select2-choices {
+    min-height: 36px !important;
+    z-index: 10;
+}
+
+.select2-container-multi .select2-choices .select2-search-field input {
+    margin: 3px 10px;
+}
+
+.arches-select2 .select2-choices .select2-search-field input {
+    margin-top: 3px;
+}
+
+.select2-container.select2-container-multi.select2-container-disabled.select2-container-disabled .select2-search-choice {
+    color: #999;
+}
+
+.time-search-container {
+    padding: 20px;
+    background: #fff;
+}
+
+.time-search-container .calendar {
+    display: block;
+    width: inherit;
+    padding-left: 5px;
+    max-width: 152px;
+}
+
+.time-search-container #calendar {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.time-search-container #calendar .calendar .search-label {
+    margin-top: 10px;
+}
+
+.hide-datepicker-time-option .bootstrap-datetimepicker-widget table td span {
+    display: none;
+}
+
+.calendar.picker {
+    max-width: 175px;
+    min-width: 175px;
+}
+
+.dropdown-crud {
+    right: 0px;
+    padding-left: 15px;
+    min-height: 500px;
+    overflow-y: scroll;
+}
+
+.resource-selector-button {
+    padding-bottom: 0px;
+}
+
+.search-results-container {
+    padding: 60px 10px;
+    bottom: 50px;
+    overflow-y: scroll;
+    width: 400px;
+}
+
+.calendar {
+    display: table-cell;
+    width: 180px;
+    padding-left: 5px;
+}
+
+.calendar div .form-control[disabled] {
+    background: #f7f7f7;
+    border: 1px solid #ddd;
+    color: #777;
+}
+
+.datepicker-inline {
+    background: #fff;
+    border-width: 0px;
+}
+
+.search-label {
+    font-weight: 400;
+    font-size: 15px;
+    margin-bottom: 3px;
+}
+
+#calendar .chosen-container-single .chosen-single {
+    height: 35px;
+    padding-top: 8px;
+}
+
+#calendar .chosen-container-single .chosen-single div b:before {
+    vertical-align: -70%;
+}
+
+.rr-display-toggle {
+    width: 100px;
+}
+
+.rr-display-toggle>button {
+    border-radius: 10px;
+}
+
+.rr-display-toggle.open-graph {
+    right: 20px;
+}
+
+.related-resources-title {
+    font-size: 19px;
+    font-weight: 500;
+}
+
+.related-resources-relationship {}
+
+.related-resources-relationship .dropdown-menu {
+    left: auto;
+    width: 600px;
+}
+
+.related-resources-delete {
+    padding-right: 12px;
+}
+
+.selected-resource-list {
+    position: absolute;
+    top: 85px;
+    right: 25px;
+    left: 15px;
+    padding: 5px;
+    height: 100px;
+    background: #f8f8f8;
+    overflow-y: scroll;
+}
+
+.selected-resource {
+    margin-left: 5px;
+    margin-bottom: 3px;
+}
+
+.related-resources-crud-link {
+    background: #ddd;
+    border: 1px solid #ccc;
+    height: 33px;
+    padding: 5px 8px;
+    margin-left: 15px;
+}
+
+.search-filter {
+    transform: translate(0, -2px);
+    font-size: 21px;
+    padding: 6px;
+    margin-top: -10px;
+    color: #888;
+    border: 1px solid transparent;
+}
+
+.search-filter.active {
+    background: #f2f2f2;
+    color: #555;
+    border: 1px solid #ddd;
+}
+
+.search-filter:hover {
+    cursor: pointer;
+    background: #f2f2f2;
+    color: #555;
+    border: 1px solid #ddd;
+}
+
+.search-listing {
+    width: 370px;
+    background: #fff;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+}
+
+.search-listing:hover {
+    border: 1px solid steelblue;
+}
+
+.search-listing:active {
+    border: 1px solid steelblue;
+}
+
+.search-listing.selected {
+    border: 1px solid steelblue;
+}
+
+.search-listing-title {
+    font-size: 15px;
+    font-weight: 500;
+    background: #fff;
+    color: #666;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding: 10px 5px 0px 10px;
+}
+
+.search-listing-title.provisional-edits {
+    font-size: 12px;
+    color: #888;
+}
+
+.provisional-tile.qa-btn {
+    float: right;
+    margin-right: 30px;
+    margin-top: 3px;
+    font-weight: 500;
+}
+
+.provisional-tile.qa-btn:hover {
+    cursor: pointer;
+}
+
+.selected-provisional-tile {
+    border-color: #3B8DD5;
+    z-index: 1;
+    border-style: solid;
+    border-width: 1px;
+    padding-top: 5px;
+    padding-left: 5px;
+    padding-bottom: 3px;
+}
+
+.provisional-tile.icon {
+    padding-left: 7px;
+    font-size: 11px;
+    color: #f1b202;
+}
+
+.provisional-tile.icon.submitted {
+    color: green;
+}
+
+.provisional-tile.icon.authoritative {
+    padding-left: 7px;
+    font-size: 11px;
+    color: #ccc;
+}
+
+.search-listing-body {
+    height: 4.6em;
+    font-size: 12px;
+    line-height: 1.35;
+    color: #888;
+    background: #fff;
+    padding: 5px 10px;
+    margin-bottom: 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    /* number of lines to show */
+}
+
+.search-listing-footer {
+    height: 40px;
+    font-size: 11px;
+    padding: 10px 10px 0px 10px;
+    background: #f5f5f5;
+    border-top: 1px solid #ddd;
+}
+
+.time-wheel-wrap {
+    width: 100%;
+}
+
+.filter-title {
+    font-size: 17px;
+    margin-top: 30px;
+}
+
+.time-search-container .filter-title:first-child {
+    margin-top: 3px;
+    margin-bottom: 15px;
+}
+
+.filter-title .pull-right {
+    margin-top: -7px;
+}
+
+.title-underline {
+    margin: 3px 0px;
+    background: #ddd;
+}
+
+.time-wheel-title {
+    margin-top: 20px;
+    font-size: 17px;
+    font-weight: 400;
+}
+
+.time-wheel-instructions {
+    font-size: 12px;
+    color: #777;
+}
+
+.time-wheel-wrap .sequence {
+    font-size: 14px;
+    color: #25476A;
+    font-weight: 600;
+    position: absolute;
+}
+
+.time-wheel-wrap .sequence text {
+    font-weight: 600;
+    fill: #123;
+}
+
+.time-wheel-wrap .chart {
+    position: relative;
+    margin-top: 60px;
+    margin-left: 0px;
+}
+
+.time-wheel-wrap .chart path {
+    cursor: pointer;
+    stroke: #fff;
+    stroke-width: 0.5px;
+}
+
+.time-wheel-wrap .trail {
+    height: 30px;
+}
+
+.time-wheel-wrap .explanation {
+    position: absolute;
+    top: 260px;
+    left: 305px;
+    width: 140px;
+    text-align: center;
+    color: #666;
+    z-index: 1;
+}
+
+.time-wheel-wrap .percentage {
+    font-size: 2.5em;
+}
+
+table.table.dataTable {
+    margin-bottom: 0;
+}
+
+.arches-related-resource-panel {
+    position: absolute;
+    top: 50px;
+    right: 0;
+    left: 0;
+    z-index: 1;
+}
+
+.related-resource-management {
+    display: flex;
+    justify-content: space-between;
+}
+
+.related-resources-header {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    top: 0;
+    margin-top: 15px;
+    height: 40px;
+    margin-bottom: 35px;
+    width: 100%;
+    z-index: 2;
+}
+
+.tab-pane.active .related-resources-header {
+    display: none;
+}
+
+.related-resources-header .editor-elements {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    top: 0;
+    margin-top: 0px;
+    height: 35px;
+    width: 100%;
+    z-index: 2;
+}
+
+.related-resources-header .editor-elements h2 {
+    font-size: 16px;
+    margin-top: 0px;
+    margin-bottom: 5px;
+}
+
+.related-resources-header .editor-elements h3 {
+    font-size: 13px;
+    margin-top: 0px;
+    margin-bottom: 5px;
+}
+
+
+.related-resources-header .btn-group>.btn:hover {
+    z-index: 0;
+}
+
+.related-resources-header.open-graph {
+    width: calc(100% - 245px);
+}
+
+.root-node-label {
+    stroke: #999;
+    /*#3275b1;*/
+    font-size: 32px;
+    font-weight: 900;
+    fill: #fcfcfc;
+    /*#fdfdfd; */
+    opacity: 1;
+    text-anchor: middle;
+    pointer-events: none;
+}
+
+.map-preview-panel {
+    padding-top: 5px;
+}
+
+.service-buttons-heading {
+    position: absolute;
+    top: -3px;
+    right: 10px;
+}
+
+.basemap-preview-panel {
+    padding-top: 5px;
+    padding-left: 7.5px;
+}
+
+.map-service-container {
+    padding: 10px;
+}
+
+.map-service-manage-buttons {
+    position: absolute;
+    top: 10px;
+    right: 60px;
+}
+
+.basemap-preview-panel .map-service-manage-buttons {
+    right: 60px;
+}
+
+.resource-service-buttons-heading {
+    position: absolute;
+    top: -60px;
+    right: 10px;
+}
+
+.map-service-preview {
+    background: #f4f4f4;
+    border: 1px solid #ddd;
+    height: 250px;
+}
+
+.map-service-tab-content {
+    min-height: 250px;
+}
+
+.advanced-map-style-switch {
+    margin-top: -45px;
+    margin-right: 10px;
+    margin-bottom: 10px;
+}
+
+.service-url {
+    font-size: 12px;
+    color: #999;
+}
+
+.service-switch-shim {
+    margin-top: 8px;
+}
+
+.config-title {
+    font-weight: normal;
+    padding: 0 20px 0 0px;
+    margin-top: 10px;
+    font-size: 1.216em;
+    line-height: 40px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.config-title-tab {
+    font-weight: normal;
+    padding: 0 20px 0 0px;
+    margin-top: 10px;
+    font-size: 1.15em;
+    line-height: 40px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.advanced-style-panel {
+    margin-right: 0px;
+    margin-left: 0px;
+    margin-top: 5px;
+    margin-bottom: 10px;
+}
+
+.map-style-panel-body {
+    padding-bottom: 5px;
+}
+
+.simple-style-panel {
+    margin-top: -15px;
+}
+
+.map-service-nav-tabs {
+    background: #f6f6f6;
+}
+
+.service-widget-container {
+    padding: 0px 15px 10px 15px;
+    margin-top: -10px;
+}
+
+.dropdown-shim {
+    margin-top: 10px;
+}
+
+.style-title {
+    font-weight: 600;
+    color: #666;
+}
+
+.col-divider {
+    border-right: 1px solid #eee;
+}
+
+.map-server-instructions {
+    padding: 0px 10px 20px 10px;
+    color: #808080;
+}
+
+.map-server-basemap-button {
+    position: absolute;
+    z-index: 10;
+    right: 10px;
+    top: 5px;
+    background: rgba(255, 255, 255, 0.88);
+}
+
+.map-service-tabs {
+    border: 1px solid #ddd;
+    background: #f9f9f9;
+    margin-bottom: 0px;
+}
+
+.hover-feature-loading {
+    padding: 25px;
+    font-size: 16px;
+}
+
+
+/**********
+*  Axes
+*/
+
+.axis path {
+    fill: none;
+    stroke: #000;
+    stroke-opacity: .75;
+    shape-rendering: crispEdges;
+}
+
+.axis path.domain {
+    stroke-opacity: .75;
+}
+
+.axis line {
+    fill: none;
+    stroke: #000;
+    stroke-opacity: .25;
+    shape-rendering: crispEdges;
+}
+
+.axis line.zero {
+    stroke-opacity: .75;
+}
+
+
+/**********
+*  Line chart
+*/
+
+.point-paths path {
+    /*
+  fill: #eee;
+  stroke: #aaa;
+  */
+    stroke-opacity: 0;
+    fill-opacity: 0;
+}
+
+.lines path {
+    fill: none;
+    stroke-width: 1.5px;
+    stroke-linecap: round;
+    transition: stroke-width 250ms linear;
+    -moz-transition: stroke-width 250ms linear;
+    -webkit-transition: stroke-width 250ms linear;
+    transition-delay: 250ms;
+    -moz-transition-delay: 250ms;
+    -webkit-transition-delay: 250ms;
+}
+
+.line.hover path {
+    stroke-width: 6px;
+}
+
+.lines .point {
+    transition: stroke-width 250ms linear;
+    -moz-transition: stroke-width 250ms linear;
+    -webkit-transition: stroke-width 250ms linear;
+}
+
+.lines .point.hover {
+    stroke-width: 20px;
+    stroke-opacity: .5;
+}
+
+.hover-feature-body .row.widget-wrapper {
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.hover-feature-body .row.widget-wrapper .col-xs-12 {
+    padding: 0;
+}
+
+.hover-feature-body .row.widget-wrapper label {
+    display: none;
+}
+
+#map-popup .hover-feature-footer {
+    position: relative;
+    padding-left: 20px;
+    bottom: 15px;
+    left: 0px;
+    border-left: 0px solid transparent;
+    border-right: 0px solid transparent;
+    width: 350px;
+    background: #f4f4f4;
+    font-size: 14px;
+}
+
+.hover-feature-footer {
+    height: 50px;
+    border-top: 1px solid #ddd;
+    border-left: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+    background: #f8f8f8;
+    padding: 10px;
+    padding-top: 15px;
+}
+
+.hover-feature-footer a {
+    color: steelblue;
+    font-weight: 500;
+    padding-right: 10px;
+}
+
+.search-attribute-widget {
+    display: inline-block;
+    margin: 7px 8px;
+}
+
+.search-dropdown {
+    /*max-height: 36px;*/
+}
+
+.search-toolbar {
+    display: -webkit-flex;
+    display: flex;
+    width: 100%;
+    height: 51px;
+    background: #f4f4f4;
+    border-bottom: solid 1px #bbd1ea;
+}
+
+.search-type-btn-panel {
+    height: 50px;
+    background: #f2f2f2;
+    margin-left: 4px;
+}
+
+.search-type-btn.relative:hover {
+    background: #fff;
+    color: #25476A;
+}
+
+.search-type-btn.relative:active {
+    border-style: solid;
+    border-top: 0px solid #BBD1EA;
+    border-bottom: 0px solid transparent;
+}
+
+.search-type-btn.relative.active {
+    background: #fff;
+    color: #25476A;
+    border-bottom: 1px solid #fff;
+    cursor: default;
+}
+
+.search-type-btn {
+    height: 50px;
+    padding: 0px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #888;
+    min-width: 150px;
+    border-color: #BBD1EA;
+    border-top: none;
+    border-right: 1px solid;
+    background: #F7F9FB;
+    z-index: 1000;
+    margin-left: -5px;
+    border-width: 1px;
+    border-bottom: none;
+    border-right: 1px solid #BBD1EA;
+}
+
+.term-search-btn {
+    font-weight: 700;
+    font-size: 13px;
+    height: 30px;
+    padding-left: 0px;
+    border: none;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled {
+    background: #eee;
+    height: 35px;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled .group {
+    padding: 0px;
+    border-top: 1px solid #C1D4F3;
+    width: 383px;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled div span span button {
+    width: 195px;
+    height: 35px;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled div span span button.active {
+    background: #8EAFE3;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled div span span button.term-search-btn:not(.active) {
+    background: #BBD1EA;
+    color: #658CC9;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled div span span button:not(.active):hover {
+    background: #B9D0F4;
+    color: #4330A4;
+}
+
+.resource_search_widget_dropdown ul .select2-disabled div span span button:first-child {
+    border-right: 1px solid steelblue;
+}
+
+.resource_search_widget_dropdown .select2-results {
+    background: #fdfdfd;
+    z-index: 10;
+    margin-top: 0px;
+    border-top: 1px solid steelblue;
+}
+
+.resource_search_widget_dropdown.select2-drop-active {
+    border-color: steelblue;
+}
+
+.resource_search_widget_dropdown ul li:not(.select2-no-results) {
+    color: #0A449F;
+}
+
+.resource_search_widget_dropdown ul .select2-highlighted {
+    background: #E5EFFD;
+}
+
+.term-search-btn.active {
+    color: #4330A4;
+}
+
+.search-type-btn i {
+    font-size: 15px;
+}
+
+.search-type-btn p {
+    padding-top: 5px;
+}
+
+.search-type-btn-popup-panel {
+    margin-top: 0px;
+    display: inline-block;
+    flex-direction: row;
+    position: absolute;
+    right: 0px;
+}
+
+.popup-panel-row {
+    display: inline-flex;
+}
+
+.search-type-btn-popup {
+    height: 50px;
+    width: 50px;
+    padding: 0px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #888;
+    border-color: #BBD1EA;
+    border-top: none;
+    border-bottom: none;
+    border-right: none;
+    background: #F7F9FB;
+    border-width: 1px;
+    z-index: 1000;
+}
+
+.search-export {
+    padding: 5px 15px;
+}
+
+.search-export .parameters {
+    display: inline-flex;
+    justify-content: space-around;
+}
+
+.search-export .precision {
+    width: 75px;
+}
+
+.search-export .instruction {
+    font-size: 15px;
+}
+
+.search-export .instruction h2 {
+    font-size: 15px;
+    margin-top: 5px;
+}
+
+.search-export .instruction h4 {
+    font-size: 13px;
+    padding-left: 15px;
+    color: #888;
+    font-weight: 400;
+    margin-top: -5px;
+}
+
+.search-export .parameter {
+    padding: 0px 15px;
+    margin-bottom: 20px;
+}
+
+.search-export.download {
+    padding: 12px;
+}
+
+.download-message {
+    padding: 0px 15px;
+    font-size: 14px;
+}
+
+.search-type-btn-popup.relative:hover {
+    background: #fff;
+    color: #25476A;
+}
+
+.search-type-btn-popup.relative:active {
+    border-style: solid;
+    border-right: 0px solid #BBD1EA;
+    border-top: 0px solid #BBD1EA;
+    border-bottom: 0px solid #BBD1EA;
+}
+
+.search-type-btn-popup.relative.active {
+    background: #fff;
+    color: #25476A;
+    border-bottom: 1px solid #fff;
+    height: 51px;
+    line-height: 1;
+}
+
+.search-popup-panel {
+    position: fixed;
+    top: 101px;
+    right: 0px;
+    z-index: 900;
+    background-color: #fff;
+    width: 400px;
+    height: calc(100vh - 100px);
+    border-left: solid 1px #dcdcdc;
+}
+
+.rr-splash-img-container .fa {
+    font-size: 42px;
+    margin: 8px 5px;
+    color: steelblue;
+}
+
+.search-popup-panel .tab-pane.active div.saved-search-container div .rr-splash .rr-splash-img-container {
+    height: 50px;
+    width: 50px;
+}
+
+.search-popup-panel .tab-pane.active div.saved-search-container div .rr-splash .rr-splash-title {
+    font-size: 24px;
+    margin-bottom: 20px;
+}
+
+.search-popup-panel .tab-pane.active div.saved-search-container div .rr-splash .rr-splash-img-container .rr-splash-img {
+    height: 325%;
+    margin-top: -13px;
+    margin-left: -8px;
+}
+
+.facets-container {
+    position: absolute;
+    width: 275px;
+    right: 0px;
+    border-left: 1px solid #ddd;
+}
+
+.facets-search-container {
+    position: absolute;
+    width: calc(100% - 275px);
+    height: calc(100vh - 115px);
+    overflow-y: auto;
+    padding: 2px;
+    background: white;
+    border-right: 0.5px #e0e0e0 solid;
+}
+
+.faceted-search-card-container {
+    border: 1px solid #ddd;
+    padding: 20px;
+    margin: 15px;
+    background: #f9f9f9;
+}
+
+.search-facets {
+    height: calc(100vh - 115px);
+    overflow-y: auto;
+    background: #f8f8f8;
+    border-right: 1px solid #ddd;
+}
+
+.list-group.search-facets {
+    margin: 0;
+}
+
+.search-facet-item {
+    position: relative;
+    display: block;
+    padding: 10px 15px;
+    margin-bottom: -1px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-right-width: 0px;
+    border-left-width: 0px;
+}
+
+.search-facet-item:first-of-type {
+    border-top-width: 0px;
+}
+
+a.search-facet-item:not(.active):hover {
+    cursor: pointer;
+}
+
+a.search-facet-item:hover,
+a.search-facet-item:focus {
+    background-color: #f8f8f8;
+}
+
+.search-facet-item.header {
+    background: #e4e4e4;
+}
+
+div.search-facet-item.disabled {
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 1px;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+.search-facet-item-heading {
+    font-weight: 400;
+    font-size: 13px;
+}
+
+.search-facet-item.header input {
+    border-color: #bbb;
+}
+
+a.search-facet-item .search-facet-item-heading {
+    color: #666;
+}
+
+a.search-facet-item {
+    color: #777;
+}
+
+.search-facet-item.disabled {
+    background: #f6f6f6;
+    color: #666;
+    cursor: default;
+}
+
+a.search-facet-item.disabled {
+    cursor: default;
+}
+
+.facet-name {
+    font-size: 15px;
+    color: #333;
+}
+
+.facet-search-criteria {
+    position: relative;
+    padding: 10px 0px 0px 0px;
+}
+
+.facet-search-button {
+    padding: 10px;
+}
+
+.facet-btn-group {
+    display: block;
+    margin: 10px 15px 50px 15px;
+}
+
+.facet-btn {
+    width: 50%;
+    height: 40px;
+}
+
+.facet-btn:focus,
+.facet-btn.selected {
+    background: #ee9818;
+}
+
+.facet-label {
+    margin-left: 5px;
+    margin-bottom: 5px;
+}
+
+.facet-body {
+    padding-top: 5px;
+    padding-bottom: 45px;
+    margin-left: 10px;
+}
+
+.facet-body .col-md-4.col-lg-3 {
+    padding-right: 5px;
+
+}
+
+.facet-body div div .select2-container {
+    border: none;
+}
+
+.facet-body  .chosen-container-single .chosen-single {
+    height: 36px;
+}
+
+.related-resources-header .resource-instance-wrapper {
+    padding: 0;
+}
+
+#widget-crud-settings div.row.widget-wrapper {
+    padding-left: 0px;
+    padding-right: 0px;
+    margin-right: -5px;
+    margin-left: -5px;
+}
+
+#widget-crud-settings div.row.widget-wrapper div div .select2-container {
+    height: 32px;
+}
+
+.resource-instance-search .row.widget-wrapper {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.print-map {
+    display: none;
+}
+
+.hidden-map {
+    overflow: hidden;
+    height: 0;
+    width: 0;
+    position: fixed;
+}
+
+.print-map-container {
+    width: 576px;
+    height: 360px;
+}
+
+.default-message {
+    font-size: 13px;
+    padding-top: 5px;
+    color: #777;
+}
+
+.mobile-project-manager-editor div.title-block-title {
+    width: 255px;
+    height: 95px;
+}
+
+.mobile-project-manager-editor .library-card:first-child {
+    margin-top: -5px;
+}
+
+.mobile-project-manager-editor .library-card {
+    margin-left: -5px;
+    background: #fff;
+}
+
+.mobile-project-manager-editor .library-card:hover {
+    background: #fafafa;
+}
+
+.mobile-project-manager-editor .card-nav-container {
+    margin-bottom: 0;
+}
+
+.mobile-project-manager-editor .layer-list {
+    background: transparent;
+    border-top: 0px;
+    padding-top: 5px;
+}
+
+.mpm-project-card {
+    width: 200px;
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 14px;
+}
+
+.mpm-project-name {
+    width: 220px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 15px;
+}
+
+.mpm-card {
+    min-height: 550px;
+    background: #fff;
+}
+
+.mpm-card-content {
+    margin: 0px;
+    border-bottom: 1px solid #ddd;
+    padding: 50px 25px 50px 25px;
+    background: #f9f9f9;
+}
+
+.mpm-card-content.mpm-crud-section {
+    background: #fff;
+    padding-left: 40px;
+}
+
+.mpm-card-content.selection-page {
+    border-bottom: transparent;
+}
+
+.mpm-card-content.active-survey {
+    background: #fafafa;
+}
+
+.active-survey .msm-survey-message {
+    color: #888;
+}
+
+.msm-summary-panel .selection-page {
+    height: 100vh;
+}
+
+.mpm-group-panel-header {
+    padding: 10px 20px;
+    background: #fcfcfc;
+}
+
+.msm-group-label {
+    font-size: 15px;
+    color: #454545;
+    font-weight: 600;
+}
+
+.mpm-group-panel-header h4 {
+    margin-bottom: 5px;
+    margin-top: 0px;
+}
+
+.msm-filter-panel {
+    padding: 5px 0px;
+    width: 100%;
+    position: relative;
+}
+
+.mpm-group-panel-content {
+    padding: 0px 25px 20px 25px;
+}
+
+.mpm-user-panel-content {
+    padding: 0px 25px 20px 20px;
+    margin-top: -5px;
+}
+
+.mpm-group-panel-content .account-label {
+    font-weight: 600;
+}
+
+.mpm-group-panel-content.list {
+    border-top: solid 0px #ccc;
+    padding: 0px;
+}
+
+.mpm-card-content .userrow {
+    display: flex;
+    padding: 5px;
+    border-bottom: solid 1px #ccc;
+}
+
+.mpm-card-content .userrow:hover {
+    font-weight: 600;
+}
+
+.mpm-card-content .userrow.selected {
+    font-weight: 400;
+}
+
+.msm-user-account-item {
+    background: #fff;
+    height: 40px;
+    padding: 10px 15px;
+    border: transparent;
+    border-bottom: 1px solid #ddd;
+    border-left: 3px solid #fff;
+}
+
+.msm-user-account-item:nth-child(even) {
+    background: #fafafa;
+    border-left: 3px solid #fafafa;
+}
+
+.msm-user-account-item:hover {
+    cursor: pointer;
+    /*background: #F5FAFE;*/
+    border-left: 3px solid steelblue;
+}
+
+.msm-user-account-item.selected {
+    background: #F6F6FF;
+    border-left: 3px solid steelblue;
+    cursor: default;
+}
+
+.msm-user-account-item.checkbox {
+    margin: 0px;
+}
+
+.msm-filter-tools-panel {
+    margin-top: 10px;
+}
+
+.mpm-card-content.group-page {
+    padding: 0;
+}
+
+.mpm-card-content .title {
+    font-size: 22px;
+    font-weight: 525;
+    text-align: center;
+    padding: 10px;
+}
+
+.msm-identity-filter {
+    width: 100%;
+    flex: 1;
+}
+
+.msm-user-account-panel {
+    border-top: 1px solid #ddd;
+    height: 600px;
+    background: #fafafa;
+}
+
+.msm-account-listing-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    background: #fff;
+}
+
+.msm-account-summary-panel {
+    display: flex;
+    flex-direction: column;
+    background: #fcfcfc;
+    flex: 1;
+    border-left: solid 1px #ccc;
+}
+
+.msm-icon-wrap {
+    height: 60px;
+    width: 60px;
+    border-radius: 50%;
+    border: 1px solid #7080CB;
+    color: #7080CB;
+    background: #E1EAFC;
+    font-size: 28px;
+    padding-top: 14px;
+    padding-left: 2px;
+}
+
+.model-selection .msm-icon-wrap {
+    background: #fff;
+    color: steelblue;
+    padding-top: 15px;
+    border: 1px solid steelblue;
+}
+
+.active-survey .msm-icon-wrap {
+    background: #77DAD3;
+    color: #29b2a6;
+    padding-top: 15px;
+    padding-left: 2px;
+    border: 1px solid #26a69a;
+}
+
+.incomplete .msm-icon-wrap {
+    background: #FFD264;
+    color: #B88406;
+    padding-top: 13px;
+    padding-left: 2px;
+    border: 1px solid #B88406;
+}
+
+.incomplete.active-survey .msm-icon-wrap {
+    background: #F799B9;
+    color: #DF2E6A;
+    padding-top: 13px;
+    padding-left: 2px;
+    border: 1px solid #DF2E6A;
+}
+
+a.filter-tools {
+    margin-left: 0px;
+    padding: 3px 6px;
+    color: #888;
+    font-size: 12px;
+}
+
+a.filter-tools:hover {
+    cursor: pointer;
+    background: #ddd;
+    color: #454545;
+}
+
+.mpm-card-content .description {
+    font-size: 14px;
+    text-align: center;
+    margin: 15px 100px 15px 100px;
+}
+
+.mpm-resource-selection {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 15px;
+}
+
+.mpm-resource-selection .resource-dropdown {
+    width: 80%;
+}
+
+.account-wrapper {
+    padding-top: 0px;
+}
+
+.msm-data-selection .form-text.form-checkbox:not(.btn),
+.form-text.form-radio:not(.btn) {
+    margin-top: 1px;
+}
+
+.resource-grid-main.mpm-manager {
+    height: 100%;
+    padding-top: 20px;
+    padding-left: 20px;
+}
+
+.resource-grid-tools-container.mpm-manager {
+    display: flex;
+    flex-direction: column;
+}
+
+.resource-grid-main-container.mpm {
+    background: none;
+}
+
+.grid.mpm {
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+    max-width: none;
+}
+
+.list-filter.mpm {
+    background-color: #f4f4f4;
+    margin-bottom: 0;
+}
+
+.mpm-subtitle {
+    position: relative;
+    left: 55px;
+    top: -45px;
+    color: #999;
+    font-size: 12px;
+    width: 500px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.mpm-list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.mpm-summary-panel {
+    background: #fff;
+    padding: 0px 40px;
+    margin-top: -60px;
+    margin-left: 0px;
+    border-top: 1px solid #ddd;
+    margin-right: 0px;
+}
+
+.map-search-container div .map-widget-panel {
+    height: calc(100vh - 110px);
+}
+
+.resource-grid-item.mpm-manager:hover {
+    /*background-color: #f5f5f5;*/
+    border-radius: 3px;
+    color: #000;
+}
+
+.resource-grid-main.mpm-manager .mpm-title {
+    font-weight: 400;
+    color: #454545;
+    font-size: 1.416em;
+    position: relative;
+    left: 55px;
+    top: -45px;
+}
+
+.mpm-manager .resource-grid-icon {
+    margin-top: -2px;
+    font-size: 19px;
+}
+
+.report-image-grid.mpm {
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.nav-tabs li a.graph-designer-tab {
+    padding: 15px 10px 15px 10px;
+}
+
+.graph-selector-panel {
+    height: 60px;
+}
+
+.graph-selector {
+    width: 350px;
+    margin-right: 10px;
+}
+
+.graph-designer-tab-container {
+    background: #C9D4E1;
+    font-weight: 600;
+}
+
+.graph-designer-tab-container .nav-tabs>li.active>a {
+    background: #ecf0f5;
+    border: 1px solid #f4f4f4;
+}
+
+.graph-designer-tab-container .nav-tabs>li:not(.active)>a {
+    color: #777;
+}
+
+.graph-designer-tab-container .nav-tabs>li:not(.active)>a:hover {
+    cursor: pointer;
+    color: #666;
+    background: #ecf0f5;
+}
+
+.viewstate-btn {
+    width: 100px;
+    height: 30px;
+    padding-top: 3px;
+    background: #fcfcfc;
+}
+
+.btn-group-toggle .viewstate-btn {
+    border-radius: 2px 0px 0px 2px;
+}
+
+.btn-group-toggle .viewstate-btn:nth-child(2) {
+    margin-left: -1px;
+    border-radius: 0px 2px 2px 0px;
+}
+
+.viewstate-btn.active {
+    background-color: #9490EE;
+    color: #fff;
+    font-weight: 600;
+    cursor: default;
+}
+
+.viewstate-btn:not(.active):hover {
+    background: #f4f4f4;
+}
+
+#identities-card .library-card:not(.selected-card) {
+    border-left: 1px solid transparent;
+}
+
+.user-survey .project-status {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+}
+
+.mobile-project-manager-editor .tab-content {
+    padding: 1px;
+}
+
+.mobile-designer-title {
+    font-size: 1.6em;
+    padding-left: 15px;
+    padding-top: 12px;
+}
+
+.msm-edit-buttons.mobile-project-category-header {
+    left: 0;
+    top: 15px;
+    font-size: 17px;
+    margin-left: 0px;
+    padding-left: 15px;
+}
+
+.msm-tree {
+    height: 100%;
+}
+
+.msm-basemap-subtitle {
+    font-size: 13px;
+    color: #888;
+    padding-bottom: 10px;
+}
+
+.msm-location-card .row.widget-wrapper {
+    padding-right: 0px;
+    margin-left: 3px;
+}
+
+.msm-download-panel {
+    padding-top: 5px;
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+#custom-download-panel {
+    padding-top: 20px;
+    padding-left: 15px;
+}
+
+.number-widget-report {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 5px;
+}
+
+.number-prefix {
+    padding-right: 1px;
+}
+
+.number-suffix {
+    padding-left: 1px;
+}
+
+.report-title-bar {
+    display: block;
+}
+
+.editor-report {
+    background: white;
+    width: 100%;
+    overflow-y: auto;
+    height: 100%;
+}
+
+.editor-report .rp-report-section {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.report-related-resources {
+    padding: 0px 30px;
+}
+
+.report-related-resources .rp-card-section {
+    margin-left: -15px;
+}
+
+.report-related-resources .rp-card-section .rp-report-container-tile {
+    padding-top: 0px;
+    padding-bottom: 10px;
+    margin-top: -5px;
+}
+
+.editor-report .report-related-resources,
+.editor-report .report-title-bar {
+    display: none;
+}
+
+.mpm-selector-header {
+    height: 55px;
+    padding: 10px 5px;
+    border-style: solid;
+    border-width: 0.25px;
+    border-color: #eee;
+    background-color: #f4f4f4;
+}
+
+.mpm-selector-header-txt {
+    padding: 10px;
+    font-size: 13px;
+}
+
+.mpm-select-switch-label {
+    color: #999;
+    float: right;
+    padding-right: 5px;
+}
+
+.mpm-manager .btn-rr {
+    margin: -2px 0px 0px 0px;
+}
+
+.library-card.inactive {
+    background: #f7f7f7;
+}
+
+.mpm-item-listing-header {
+    font-size: 15px;
+    padding-left: 10px;
+    margin-top: 0px;
+    color: #454545;
+    font-weight: 500;
+}
+
+.mpm-survey-status-header {
+    padding-left: 10px;
+    margin-top: 0px;
+    color: #454545;
+    font-size: 24px;
+    font-weight: 500;
+    text-align: center;
+}
+
+.msm-survey-requirements-text {
+    margin-top: 20px;
+}
+
+.msm-survey-status-text {
+    margin-top: 0px;
+    padding: 20px 0px 10px 0px;
+}
+
+.msm-survey-requirements-text+.msm-survey-status-text {
+    padding-top: 0px;
+}
+
+.msm-survey-message {
+    margin-top: 20px;
+    font-size: 15px;
+    color: #888;
+}
+
+.msm-survey-status-instructions {
+    margin: 15px 20% 25px 20%;
+    padding: 20px 10px 20px 10px;
+    font-size: 15px;
+    background: #FFC741;
+    border: 1px solid #B88406;
+    color: #fff;
+    font-weight: 600;
+    text-align: center;
+    border-radius: 2px;
+}
+
+.msm-save-message {
+    padding-top: 20px;
+    font-size: 15px;
+    color: #2A096E;
+    text-align: center;
+}
+
+.msm-survey-status-instructions+.msm-save-message {
+    padding-top: 0px;
+}
+
+.msm-survey-issues {
+    padding-top: 5px;
+    font-size: 15px;
+    color: #888;
+    list-style-type: none;
+}
+
+.msm-survey-status-instructions+.text-center .msm-survey-issues {
+    padding-top: 0px;
+}
+
+.msm-report-section {
+    padding: 40px 30px;
+    background: #fefefe;
+    border-bottom: 1px solid #ddd;
+}
+
+.msm-crud-section {
+    padding: 40px 40px;
+    min-height: 150px;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+}
+
+.msm-crud-section:last-child {
+    border-bottom: transparent;
+}
+
+.msm-report-section.active {
+    background: #fff;
+}
+
+.mpm-item-listing-header.data-panel {
+    padding-left: 0px;
+}
+
+.msm-download-header {
+    font-size: 15px;
+    padding-left: 0px;
+    margin-top: 30px;
+    color: #454545;
+    font-weight: 500;
+}
+
+.project-search-widget.mpm-item-listing {
+    top: 0px;
+    right: 0px;
+}
+
+.mpm-model-detail-panel {
+    padding-left: 10px;
+}
+
+.mpm-node-detail-metadata {
+    list-style: none;
+    color: #777;
+}
+
+.mpm-activation-panel {
+    padding: 0px;
+}
+
+.msm-settings-summary {
+    height: 100%;
+}
+
+.msm-map-container {
+    padding: 0px;
+    height: 100vh;
+    margin-left: -13px;
+    margin-right: -20px;
+    margin-top: -10px;
+}
+
+.msm-map-container  .control-label {
+    display: none;
+}
+
+.msm-map-container .widget-wrapper .mapboxgl-map {
+    height: 100vh;
+}
+
+.msm-map-container .geometry-tools-container {
+    top: 60px;
+    left: 10px;
+}
+
+.msm-stats-panel {
+    padding: 10px 5px;
+    min-height: 80px;
+    margin-top: -15px;
+}
+
+.msm-stat {
+    color: #2d3c4b;
+    font-size: 36px;
+    margin-top: 2px;
+}
+
+.msm-stat-label {
+    color: #999;
+    font-size: 13px;
+    margin-top: -5px;
+}
+
+.msm-stat-user {
+    color: #2d3c4b;
+    font-size: 18px;
+    margin-top: 2px;
+}
+
+.msm-stat-user-panel {
+    margin-top: 10px;
+}
+
+.msm-stat-time {}
+
+.msm-stat-date {
+    font-size: 17px;
+    white-space: nowrap;
+}
+
+.profile-mpm-panel {
+    margin-left: 20px;
+    text-align: justify;
+    overflow: hidden;
+    font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    height: 0;
+    transition: height 600ms ease-out;
+}
+
+.profile-mpm-panel.show-details {
+    height: 400px;
+}
+
+.project-panel {
+    width: 100%;
+    border: 1px solid #3b8dd5;
+    margin-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    margin-top: 1px;
+}
+
+.project-panel.expired {
+    background: #fcfcfc;
+    border: 1px solid #ddd;
+}
+
+.project-panel-header {
+    position: relative;
+    height: 76px;
+    padding-left: 10px;
+    color: #2b425b;
+    background: #fff;
+    border-bottom: 1px solid #eee;
+}
+
+.project-panel.expired>.project-panel-header {
+    color: #888;
+}
+
+.project-panel-title {
+    font-size: 19px;
+    float: left;
+    font-weight: 500;
+    padding-left: 10px;
+    margin-top: 12px;
+    width: 500px;
+    height: 22px;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.project-status {
+    width: 70px;
+    height: 28px;
+    font-size: 13px;
+    color: #777;
+    padding: 3px;
+    font-style: italic;
+    text-align: center;
+    background: #ddd;
+}
+
+.library-card .project-status {
+    text-align: left;
+}
+
+.project-status.active {
+    background: #8bc34a;
+    color: #fff;
+}
+
+.project-metadata {
+    position: absolute;
+    top: 35px;
+    right: 0px;
+    list-style: none;
+    font-size: 14px;
+}
+
+.msm-edit-buttons {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    list-style: none;
+    font-size: 14px;
+}
+
+.project-metadata-item {
+    display: inline-block;
+    padding: 6px 10px 10px 10px;
+    color: #758697;
+}
+
+.project-details {
+    position: absolute;
+    display: flex;
+    flex-direction: row;
+    top: 40px;
+    font-size: 14px;
+    margin-left: 10px;
+}
+
+.card-panel-body {
+    /*height: 500px;
+    overflow-y: scroll;*/
+}
+
+.node-value-select-tile {
+    padding: 5px;
+    font-size: 0.9em;
+}
+
+.selected-node-value {
+    font-size: 1.3em;
+}
+
+.node-value-select-label {
+    font-weight: bold;
+}
+
+.node-value-widget-ontology {
+    padding: 15px 20px;
+    background: #fafafa;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+}
+
+.chosen-container-single .chosen-single {
+    background: #fff;
+    color: #4d627b;
+    border: 1px solid #ddd;
+    box-shadow: none;
+    border-radius: 3px;
+    display: block;
+    height: 32px;
+    line-height: 1.42857;
+    overflow: hidden;
+    padding: 6px 12px;
+    white-space: nowrap;
+}
+
+.chosen-container-single .chosen-single div b {
+    background-image: none !important;
+}
+
+.chosen-container-single .chosen-single .search-choice-close {
+    top: 10px;
+}
+
+.chosen-container-single .chosen-single div b:before {
+    border-bottom: 0 solid transparent;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-style: solid;
+    border-width: 5px 4px 0;
+    color: #4d627b;
+    content: "";
+    display: inline-block;
+    height: 0;
+    margin: 1em -2px;
+    vertical-align: middle;
+    width: 0;
+}
+
+.chosen-container .chosen-drop {
+    background: #fff;
+    border-color: currentcolor rgba(0, 0, 0, 0.09) rgba(0, 0, 0, 0.09);
+    border-style: none solid solid;
+    border-width: 0 1px 1px;
+    border-radius: 3px;
+}
+
+.chosen-container .chosen-search {
+    background: #fff;
+}
+
+.chosen-container-active.chosen-with-drop .chosen-single {
+    background: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.09);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.chosen-container .chosen-results li.highlighted {
+    background-color: #177bbb;
+    background-image: none;
+    color: #fff;
+}
+
+.chosen-container-multi .chosen-choices {
+    background: #fff;
+    color: #8f9ea6;
+    border: 1px solid rgba(0, 0, 0, 0.09);
+    box-shadow: none;
+    border-radius: 3px;
+    min-height: 32px;
+}
+
+.chosen-container-active .chosen-choices,
+.chosen-container-single .chosen-search input[type="text"] {
+    border: 1px solid rgba(0, 0, 0, 0.09);
+}
+
+.chosen-container-multi .chosen-choices li.search-choice {
+    background-color: #177bbb;
+    background-image: none;
+    color: #fff;
+    border: 0;
+    border-radius: 2px;
+    box-shadow: none;
+    line-height: 16px
+}
+
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close::after,
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close::before {
+    box-shadow: 0 0 0 1px inset;
+    content: "";
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close::after {
+    height: 0.8em;
+    width: 2px;
+}
+
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close::before {
+    height: 2px;
+    width: 0.8em;
+}
+
+.chosen-container-multi .chosen-choices li.search-choice .search-choice-close {
+    display: block;
+    height: 1.5em;
+    transform: rotate(45deg);
+    width: 1em;
+    color: #fff;
+    font-size: inherit;
+    top: 2px
+}
+
+.chosen-container .chosen-results li {
+    padding: 8px 6px
+}
+
+ul.select2-choices {
+    padding-right: 30px !important;
+}
+
+ul.select2-choices:after {
+    content: "";
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-top: 5px solid #333;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+}
+
+.sidepanel-draggable {
+    background-color: #f7f7f7;
+    border-left: solid 1px gainsboro;
+    border-right: solid 1px gainsboro;
+    height: 100%;
+    z-index: 3;
+    font-size: 10px;
+    display: flex;
+    align-items: center;
+}
+
+.sidepanel-draggable div {
+    cursor: col-resize;
+    margin: 2px;
+}
+
+.sidepanel-draggable div i {
+    display: block;
+    color: rgb(190, 190, 190);
+}
+
+.left-panel-inner-container {
+    min-width: 300px;
+    height: 100%;
+}
+
+.left-panel {
+    overflow: hidden;
+    z-index: 3;
+}
+
+.designer-tree {
+    height: calc(100vh - 225px);
+}
+
+.left-panel-overflow {
+    width: inherit;
+    background: #ecf0f5;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.left-panel-overflow > * {
+    background: inherit;
+}
+
+.main-panel {
+    background-color: #ffffff;
+    flex: 1
+}
+
+.rich-text {
+    padding: 20px;
+}
+
+.jstree .rich-text {
+    padding: 0px;
+    display: inline;
+}
+
+.graph-designer .card-component {
+    /*width: 100%;*/
+    background-color: #fff;
+}
+
+.graph-designer .card-component .install-buttons {
+    display: none;
+}
+
+.card-component {
+    padding: 15px 25px 25px 25px;
+    margin: 15px;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+}
+
+.card-component-panel {
+    width: 100%;
+    padding: 0px;
+    border-radius: 3px;
+    background-color: white;
+    z-index: 10;
+}
+
+.graph-designer .card-component-panel {
+    background: #fafafa;
+    margin-top: 50px;
+}
+
+.card-component-panel h3 {
+    color: #2f527a;
+    font-size: 1.2em;
+    font-weight: 400;
+}
+
+.card-component-panel h3.rr-splash-description {
+    font-size: 16px;
+    padding: 0px 20px;
+    color: #888;
+    margin: 0px;
+}
+
+.file-select .rr-splash-img {
+    margin-top: 0px;
+    margin-left: 2px;
+    height: 90%;
+}
+
+.card-component-panel h4 {
+    color: #2f527a;
+    font-size: 15px;
+    font-weight: 550;
+}
+
+.card-component-panel .card-component h4 {
+    margin-top: 5px;
+}
+
+.card-component-panel .card-component .is-function-node {
+    display: inline-block;
+    background: #A2EAE2;
+    color: #01766A;
+    padding: 10px 15px;
+    margin-bottom: 15px;
+    font-size: 13px;
+    font-weight: 600;
+    margin-top: 5px;
+    margin-bottom: 15px;
+    border-radius: 2px;
+}
+
+.card-component-panel hr {
+    border-color: #e9e9e9;
+}
+
+.card-component-panel h5 {
+    color: #999;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.card-component-wrapper-editor {
+    height: 100%;
+    padding-bottom: 50px;
+    overflow-y: auto;
+    background: #fafafa;
+}
+
+.card-header {
+    height: 50px;
+    padding: 10px 20px;
+    background: #25476a;
+}
+
+.card-header-title {
+    margin-top: -15px;
+}
+
+.card-breadcrumbs,
+.card-breadcrumbs a {
+    color: #f1f1f1;
+    margin-top: 17px;
+    font-size: 17px;
+}
+
+.card-breadcrumbs span.dropdown.open .dropdown-menu>li>a {
+    display: block;
+    padding: 5px 20px;
+    margin-top: 5px;
+    clear: both;
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 1.1;
+    color: #333;
+    white-space: nowrap;
+}
+
+.card-breadcrumbs span.dropdown.open .dropdown-menu>li>a:hover {
+    color: #fff;
+}
+
+.card-breadcrumbs a.toggle-tree {
+    font-size: 13px;
+}
+
+.current-crumb {
+    font-weight: 400;
+}
+
+.resource-editor-tree {
+    height: calc(100vh - 125px);
+    overflow-y: auto;
+    overflow-x: hidden;
+    background: #ecf0f5;
+    padding-bottom: 50px;
+}
+
+a.jstree-anchor strong {
+    font-weight: 500;
+}
+
+.expanded-nav {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.add-new-tile {
+    display: none;
+}
+
+.jstree-anchor:hover .add-new-tile,
+.add-new-tile.jstree-clicked {
+    display: inline;
+}
+
+a.jstree-anchor.disabled {
+    color: #ccc;
+}
+
+a.jstree-anchor.permissions-widget {
+    color: #bbb;
+    cursor: default;
+    pointer-events: none;
+}
+
+.jstree-default .card-designer-tree li {
+    background-image: url("tree/32px.png");
+    background-position: -292px -4px;
+    background-repeat: repeat-y;
+}
+
+.jstree-default .card-designer-tree li.jstree-last,
+.jstree-default .card-designer-tree .jstree-last>li {
+    background: transparent;
+}
+
+.card-summary-section li {
+    list-style: none;
+}
+
+.card-summary-section h4 {
+    font-size: 1.1em;
+}
+
+.card-summary-section .card-summary {
+    padding-bottom: 5px;
+}
+
+.card-summary-section.disabled h4 {
+    color: #7a7a7a;
+}
+
+.card-summary-section.disabled a {
+    cursor: default;
+}
+
+.card-summary-section .card-summary .card-summary-add {
+    margin-left: 2px;
+}
+
+.card-summary-section .card-summary {
+    margin-bottom: 10px;
+}
+
+.card-summary-section .tile-summary {
+    padding: 2px;
+}
+
+.card-summary-section .tile-summary a {
+    color: #6494cc;
+}
+
+.card-summary-section .tile-summary .tile-summary-label {
+    font-weight: 600;
+}
+
+.card-summary-name {
+    margin-bottom: 2px;
+}
+
+.tile-summary-item {
+    padding-left: 5px;
+}
+
+.card-summary-section {
+    padding: 20px 0 10px 0;
+}
+
+.btn-rr {
+    background: #9490EE;
+    color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.09);
+    margin: -10px 0px 30px 0px;
+}
+
+.btn-rr:hover {
+    color: #fff;
+}
+
+.rr-splash {
+    text-align: center;
+    margin: 48px 45px 20px 45px;
+    border: 1px solid #ddd;
+    padding: 40px 30px;
+    background: #f6f6f6;
+    border-radius: 4px;
+}
+
+.rr-splash-title {
+    color: #666;
+    font-size: 28px;
+    margin-bottom: 30px;
+    margin-top: 25px;
+}
+
+.rr-splash-img-container {
+    padding: 20px;
+    background: #fff;
+    border: 1px solid steelblue;
+    display: inline-block;
+}
+
+.rr-splash-img {
+    margin-top: 3px;
+    margin-left: 2px;
+    height: 90%;
+}
+
+.surveys {
+    height: 72px;
+    width: 72px;
+}
+
+.rr-splash-description {
+    font-size: 15px;
+    color: #999;
+}
+
+.rr-splash-description:last-child {
+    margin-bottom: 80px;
+}
+
+.rr-splash-help-link {
+    margin: 20px 0px 50px 0px;
+    font-size: 28px;
+    color: steelblue;
+}
+
+.rr-splash-help-link:hover {
+    cursor: pointer;
+}
+
+.report-expander {
+    cursor: pointer;
+    padding-left: 6px;
+    font-weight: bold;
+    font-size: 18px;
+}
+
+
+
+.create-resource-instance-card-component .card-component {
+    border: none;
+}
+
+.workbench-card-sidepanel .create-resource-instance-card-component {
+    top: 75px;
+}
+
+.new-instance-model-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: #004577;
+    width: 100%;
+}
+
+.create-instance-header {
+    height: 50px;
+    background: #f1f1f1;
+    position: relative;
+    border-bottom: 1px solid #ddd;
+    padding: 15px;
+    font-size: 15px;
+}
+
+.create-instance-menu-header {
+    height: 50px;
+    background: #ebebeb;
+    position: relative;
+    border-bottom: 1px solid #ddd;
+    padding: 15px;
+    font-size: 15px;
+}
+
+.create-instance-header .close-new-step {
+    position: absolute;
+    right: 10px;
+    top: 5px;
+}
+
+.create-instance-header .close-new-step:hover {
+    cursor: pointer;
+}
+
+.create-resource-instance-card-component .card-component {
+    padding-top: 10px;
+}
+
+.indent {
+    text-indent: 10px;
+    padding-left: 10px;
+}
+
+.mapboxgl-popup-content {
+    width: 350px;
+    padding: 0px;
+}
+
+.mapboxgl-popup-content .hover-feature-footer {
+    padding: 10px 15px;
+    height: auto;
+}
+
+.tabbed-report-header {
+    border-bottom: 1px solid #ddd;
+}
+
+.tabbed-report-header .workbench-card-wrapper {
+    height: 500px;
+}
+
+.tabbed-report-mainpanel {
+    top: 25px;
+    width: calc(100% - 50px);
+}
+
+.tabbed-report-mainpanel-content {
+    width: calc(100% - 50px);
+}
+
+.tabbed-report-mainpanel-title {
+    padding: 5px 15px;
+    font-size: 12px;
+    border-bottom: 1px solid #ddd;
+    background-color: rgb(237, 237, 237);
+}
+
+.tabbed-tile-value {
+    padding-left: 0px;
+}
+
+.tabbed-report-tile-title {
+    margin-bottom: 0;
+    padding: 12px 5px 0 0;
+}
+
+.tabbed-report-sidepanel {
+    width: 300px;
+    margin: 0 25px;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 25px;
+}
+
+.tabbed-report-sidepanel .tabbed-report-sidepanel-content {
+    border: 1px solid #ddd;
+}
+
+.tabbed-report-sidepanel-title {
+    padding: 5px 15px;
+    font-size: 12px;
+    border-bottom: 1px solid #ddd;
+    background-color: rgb(237, 237, 237);
+}
+
+.tabbed-report-sidepanel-title.consultation-status-title {
+    color: white;
+    font-size: 15px;
+    background-color: rgb(234, 141, 148);
+}
+
+.sidebar-section {
+    padding: 0px 10px 20px 10px;
+    border-bottom: 1px solid #ddd;
+}
+
+.sidebar-section:last-child {
+    border-bottom: none;
+}
+
+.sidebar-single-line-group {
+    margin-bottom: 0px;
+    font-size: 14px;
+}
+
+.sidebar-single-line-type {
+    color: #25476A;
+}
+
+.sidebar-single-line-value {
+    color: #777;
+}
+
+.sidebar-double-line-group {
+    margin-bottom: 6px;
+    font-size: 14px;
+}
+
+.sidebar-double-line-type {
+    color: #25476A;
+}
+
+.sidebar-double-line-value {
+    color: #777;
+}
+
+.tabbed-report-sidepanel-title.consultation-status-title.completed {
+    background-color: rgb(202, 247, 225);
+    color: rgb(84, 84, 84);
+}
+
+.tabbed-report-sidepanel-subtitle {
+    color: rgb(222, 222, 222);
+    font-size: 13px;
+    margin-top: -2px;
+    margin-bottom: 2px;
+}
+
+.completed .tabbed-report-sidepanel-subtitle {
+    color: rgb(167, 167, 167);
+}
+
+.tabbed-report-sidepanel-main {
+    padding: 5px 15px 15px;
+}
+
+.tabbed-report-sidepanel-main dt {
+    color: #2f527a;
+    font-weight: normal;
+    float: left;
+    width: 130px;
+    text-align: right;
+    padding-right: 10px;
+}
+
+.report-map-header-component {
+    height: 400px;
+}
+
+.search-result-details {
+    background: #fff;
+    height: 100%;
+}
+
+.search-result-details-splash {
+    padding-top: 50px;
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
+.search-result-details-splash .rr-splash {
+    margin-top: 0;
+}
+
+.iiif-viewer-gallery,
+.show-gallery-control {
+    color: rgb(45, 70, 103);
+    position: absolute;
+    bottom: 0;
+}
+
+.iiif-gallery-content,
+.show-gallery-control {
+    background-color: rgb(242, 242, 242);
+}
+
+.show-gallery-control {
+    left: 25px;
+    padding: 6px 12px;
+    border: solid 1px rgb(221, 221, 221);
+    border-bottom: transparent;
+    z-index: 10000;
+    color: #2f527a;
+}
+
+.show-gallery-control i {
+    cursor: pointer;
+    color: #2f527a;
+    font-size: 15px;
+}
+
+.show-gallery-control a {
+    cursor: pointer;
+    color: #2f527a;
+}
+
+.gallery-visible.show-gallery-control {
+    bottom: 159px;
+    z-index: 2000;
+}
+
+.show-gallery-control.gallery-expanded {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: auto;
+    border-bottom: solid 1px rgb(221, 221, 221);
+    z-index: 2000;
+    padding: 15px 0 15px 30px;
+}
+
+.workbench-card-container-sidepanel-active .show-gallery-control.gallery-expanded {
+    right: 400px;
+}
+
+.iiif-viewer-gallery {
+    right: 0;
+    left: 0;
+}
+
+.iiif-viewer-gallery.gallery-expanded {
+    top: 10px;
+    padding-top: 30px;
+    z-index: 1000;
+}
+
+.workbench-card-container-sidepanel-active .iiif-viewer-gallery {
+    right: 400px;
+}
+
+.workbench-card-container-sidepanel-active .workbench-card-container {
+    margin-right: 400px;
+}
+
+.hidden-file-input {
+    display: none;
+}
+
+.add-new-crumb {
+    float: right;
+    cursor: pointer;
+    padding: 4px 12px;
+    font-size: 13px;
+    background: #6984A0;
+    border: 1px solid #0A0737;
+    border-radius: 2px;
+    margin-top: -1px;
+}
+
+.map-data-drop-area {
+    padding: 25px 15px;
+    border: 1px dashed #bbb;
+    background: #f9f9f9;
+    text-align: center;
+    color: #808080;
+    margin: 5px 0px;
+    border-radius: 1px;
+    cursor: pointer;
+}
+
+.map-data-drop-area:hover,
+.map-data-drop-area.drag-hover {
+    border: 1px dashed black;
+    color: black;
+    background-color: #EEEEEE;
+}
+
+.iiif-gallery-content {
+    border-top: solid 1px rgb(221, 221, 221);
+    height: 160px;
+    width: 100%;
+    padding: 10px;
+    padding-bottom: 0px;
+    white-space: nowrap;
+    overflow-x: auto;
+    display: flex;
+}
+
+.show-gallery-control h3 {
+    display: inline-block;
+    margin: 0 2px;
+}
+
+.gallery-expanded .iiif-gallery-content {
+    height: 100%;
+    background-color: rgb(250, 250, 250);
+    padding: 5px 0px 20px 20px;
+}
+
+.workbench-card-wrapper .workbench-card-container-wrapper {
+    height: 100%;
+    width: calc(100% - 75px);
+    position: absolute;
+}
+
+.workbench-card-wrapper .workbench-card-container-wrapper.wide {
+    height: 100%;
+    width: 100%;
+}
+
+.workbench-card-wrapper .workbench-card-container-wrapper.workbench-card-container-sidepanel-active{
+    height: 100%;
+    width: calc(100% - 75px);
+    position: absolute;
+}
+
+.workbench-card-container.gallery-visible {
+    padding-bottom: 160px;
+}
+
+.iiif-leaflet {
+    height: 100%;
+    background: #fafafa;
+}
+
+.iiif-leaflet .leaflet-draw {
+    display: none;
+}
+
+.iiif-gallery-canvas,
+.iiif-gallery-sequence,
+.iiif-gallery-sequence-canvases {
+    padding-left: 0px;
+    display: inline-block;
+    white-space: nowrap;
+    vertical-align: top;
+}
+
+.iiif-viewer-gallery.gallery-expanded .iiif-gallery-canvas,
+.iiif-viewer-gallery.gallery-expanded .iiif-gallery-sequence,
+.iiif-viewer-gallery.gallery-expanded .iiif-gallery-sequence-canvases {
+    white-space: normal;
+}
+
+.iiif-gallery-sequence {
+    padding-right: 20px;
+}
+
+.iiif-viewer-gallery.gallery-expanded .iiif-gallery-sequence {
+    display: block;
+}
+
+.iiif-gallery-canvas-thumbnail img {
+    margin: 1px;
+    border: 1px solid rgb(162, 162, 162);
+    height: 55px;
+}
+
+.annotated .iiif-gallery-canvas-thumbnail img {
+    margin: 0px;
+    border: 2px solid rgb(28, 62, 95);
+}
+
+.iiif-viewer-gallery.gallery-expanded .iiif-gallery-canvas-thumbnail img {
+    height: 175px;
+}
+
+.iiif-gallery-sequence-label {
+    cursor: pointer;
+    color: rgb(91, 155, 215);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.iiif-gallery-panel {
+    display: flex;
+    flex-direction: column;
+    width: inherit;
+}
+
+
+.gallery-expanded .iiif-gallery-panel {
+    padding-left: 15px;
+    margin-left: 225px;
+}
+
+.iiif-gallery-header {
+    font-size: 1.2em;
+    padding-left: 10px;
+    position: sticky;
+    left: 0px;
+    display: inline-flex;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.gallery-expanded .iiif-gallery-header {
+    padding-left: 20px;
+    padding-top: 15px;
+    position: sticky;
+    top: 0px;
+    margin-left: -10px;
+    margin-top: 0px;
+    margin-bottom: 5px;
+    background: #fafafa;
+}
+
+.iiif-widget-report {
+    margin: 0 0 0 320px;
+}
+
+.iiif-widget-report .iiif-leaflet {
+    height: 300px;
+    margin: 0 20px 10px 0px;
+    border: solid 1px #808080;
+}
+
+.manifest-metadata-title {
+    margin-top: 8px;
+}
+
+.manifest-metadata-value {
+    line-height: 1.2;
+}
+
+.manifest-details {
+    white-space: normal;
+    width: 250px;
+    border-right: 1px solid #ddd;
+    background: #e9e9e9;
+    margin-top: -15px;
+    margin-left: -20px;
+    padding: 15px 10px 150px 10px;
+    height: 100%;
+    position: absolute;
+    overflow-y: scroll;
+}
+
+.manifest-details h3 {
+    width: 225px;
+}
+
+.manifest-details h4 {
+    padding-left: 0px;
+}
+
+.manifest-details-list,
+.manifest-logo {
+    padding-left: 0px;
+    margin-top: -5px;
+}
+
+.manifest-logo {
+    max-width: 150px;
+}
+
+.manifest-editor-label {
+    font-size: 1.2em;
+    padding: 3px;
+}
+
+.iiif-gallery-header .list-filter {
+    display: inline-block;
+}
+
+.iiif-gallery-canvas {
+    cursor: pointer;
+    margin-left: 10px;
+    padding: 6px;
+    border: 1px solid transparent;
+    min-width: 60px;
+    height: 100px;
+    margin-bottom: 10px;
+}
+
+.iiif-viewer-gallery.gallery-expanded .iiif-gallery-canvas {
+    height: 220px;
+    min-width: 120px;
+}
+
+.iiif-gallery-canvas:hover,
+.iiif-gallery-canvas.active {
+    border: 1px solid rgb(180, 180, 180);
+    background-color: rgb(230, 230, 230);
+}
+
+.iiif-gallery-canvas-label {
+    font-size: 0.9em;
+    font-weight: 650;
+    color: rgb(91, 155, 215);
+    width: 110px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    height: initial;
+}
+
+.gallery-expanded .iiif-gallery-canvas-label {
+    width: 100%;
+}
+
+.iiif-gallery-canvas-label .annotation-count {
+    font-size: 0.8em;
+    font-weight: normal;
+    color: rgb(142, 142, 142);
+    display: block;
+}
+
+.iiif-gallery-manifest-label {
+    max-width:300px;
+    display:inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: text-bottom;
+}
+
+.gallery-expanded .iiif-gallery-manifest-label {
+    display:none;
+}
+
+.iiif-image-tools {
+    margin-top: 55px;
+    padding: 10px;
+    color: rgb(30, 63, 94);
+    font-size: 1.1em;
+}
+
+.iiif-image-tool-slider {
+    padding-bottom: 20px;
+}
+
+.iiif-image-tool-slider-wrap {
+    margin: 0 20px;
+}
+
+.iiif-image-tool-value {
+    padding: 0 20px;
+    color: #777;
+}
+
+.iiif-image-tool-slider .toggle-container {
+    padding: 5px;
+}
+
+.iiif-image-tool-slider .arches-toggle-sm {
+    cursor: pointer;
+    margin-top: -19px;
+}
+
+.manifest-editor {
+    padding-bottom: 10px;
+    width: 100%;
+    padding-left: 20px;
+}
+
+.gallery-expanded .manifest-editor {
+    margin-left: -10px;
+    margin-top: 20px;
+}
+
+.manifest-details+.manifest-editor {
+    margin-left: 225px;
+}
+
+.manifest-editor-loading,
+.manifest-editor-error {
+    display: inline-block;
+    padding-left: 10px;
+}
+
+.gallery-expanded .manifest-editor-loading {
+    margin-top: 25px;
+}
+
+.manifest-editor-input {
+    margin-bottom: 10px;
+}
+
+.manifest-editor-error {
+    color: red;
+}
+
+.chart {
+    margin-right: 105px;
+    margin-left: 20px;
+    margin-top: 20px;
+}
+
+.style-tools-collapser {
+    cursor: pointer;
+    padding: 5px;
+    font-size: 0.9em;
+}
+
+.edtf-style-tools-collapser {
+    cursor: pointer;
+    padding: 5px;
+    font-size: 0.9em;
+    left: 510px;
+    position: absolute;
+    top: 6px;
+}
+
+.workbench-card-sidepanel .edtf-style-tools-collapser {
+    left: 250px;
+}
+
+.style-tools-panel {
+    background: #fbfbfb;
+    border: 1px solid #ddd;
+    padding: 15px 15px 5px 5px;
+    margin-bottom: 5px;
+    border-radius: 2px;
+}
+
+.edtf-style-tools-panel {
+    background: #fbfbfb;
+    border: 1px solid #ddd;
+    padding: 10px 15px 5px 5px;
+    margin-bottom: 5px;
+    border-radius: 2px;
+    height: 200px;
+    width: 600px;
+    overflow-y: scroll;
+}
+
+.edtf-style-tools-panel::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 9px;
+    border-left: 1px solid #ddd;
+}
+
+.edtf-style-tools-panel::-webkit-scrollbar-thumb {
+    border-radius: 1px;
+    background-color: rgba(0, 0, 0, .1);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
+
+.workbench-card-sidepanel .edtf-style-tools-panel {
+    width: 340px;
+}
+
+.widget-help-panel {
+    padding: 5px 10px;
+}
+
+.widget-help-panel h2 {
+    font-size: 1.0em;
+    margin-top: 0px;
+    margin-bottom: 5px;
+}
+
+.widget-help-panel a {
+    color: steelblue;
+    font-weight: 500;
+    text-decoration: underline;
+}
+
+.widget-help-panel h3 {
+    font-size: 1.0em;
+    margin-top: 0px;
+    color: #777;
+}
+
+.widget-help-panel .text-thin {
+    color: #666;
+    font-weight: 400;
+}
+
+.style-tools-color-visualizer {
+    border: 1px solid #000;
+}
+
+.lang-switch .chosen-single {
+    border: none;
+    font-size: 12px;
+    color: #454545;
+    padding-top: 8px;
+}
+
+.lang-switch .chosen-drop {
+    font-size: 12px;
+    color: #454545;
+}
+
+.leaflet-popup-content-wrapper {
+    border-radius: 3px;
+    padding: 0;
+}
+
+.leaflet-popup-content {
+    margin: 0;
+}
+
+.map-coordinate-editor {
+    margin-top: 15px;
+}
+
+.map-coordinate-editor-crs-selector {
+    position: fixed;
+    margin-top: 25px;
+    background: #fff;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #ddd;
+}
+
+.map-coordinate-editor-crs-selector dt,
+.map-coordinate-editor-crs-selector select {
+    display: block;
+    float: left;
+}
+.map-coordinate-editor-crs-selector dt {
+    width: 150px;
+    padding: 5px;
+    margin-top: 2px;
+    font-weight: 500;
+}
+.map-coordinate-editor-list {
+    padding: 0 5px;
+    margin-top: 70px;
+}
+
+.map-coordinate-editor-list a:focus i {
+    color: #579ddb;
+}
+.map-coordinate-editor-pair {
+    padding: 0px 0;
+}
+.map-coordinate-editor-pair input {
+    margin: 0 5px;
+    padding: 5px;
+    width: 130px;
+    display: inline-block;
+}
+.coordinate-entry-label {
+    display: inline-block;
+    color: #888;
+    width: 15px;
+    text-align: right;
+}
+.map-coordinate-editor hr {
+    margin: 10px 4px 5px;
+}
+.map-coordinate-editor .map-coordinate-editor-pair hr {
+    margin: 5px 0;
+}
+.map-coordinate-editor-drag-handler {
+    cursor: grab;
+    font-size: 16px;
+}
+.map-coordinate-editor-pair.ui-sortable-helper,
+.map-coordinate-editor-pair.ui-sortable-helper .map-coordinate-editor-drag-handler {
+    cursor: grabbing;
+}
+.map-coordinate-editor-header {
+    position: fixed;
+    background: #fff;
+    padding: 6px 0;
+    font-size: 1.2em;
+    width: 370px;
+    margin-top: -6px;
+}
+.map-coordinate-editor-pair.map-coordinate-editor-new-coordinates {
+    padding: 0 0px 10px 4px;
+}
+
+.map-coordinate-editor-button-container {
+    position: sticky;
+    bottom: -17px;
+    background: #fff;
+    width: 400px;
+    padding: 10px 5px;
+}
+
+.add-buffer-as-new-label {
+    display: inline-block;
+    position: relative;
+    top: -12px;
+    left: 5px;
+}
+
+.add-buffer-feature-header {
+    padding: 6px 0;
+    font-size: 1.2em;
+}
+
+.add-buffer-feature-input {
+    padding: 5px 0;
+}
+
+@keyframes loader {
+    0% {
+        background: #ddd;
+    }
+    33% {
+        background: #ccc;
+        box-shadow: 0 0 1px #ccc, 15px 30px 1px #ccc, -15px 30px 1px #ddd;
+    }
+    66% {
+        background: #ccc;
+        box-shadow: 0 0 1px #ccc, 15px 30px 1px #ddd, -15px 30px 1px #ccc;
+    }
+}
+
+@media (min-width: 992px) {
+    #page-content {
+        padding: 15px 15px 25px;
+    }
+
+    .rp-report-tile {
+        padding-left: 0px;
+    }
+    .dl-horizontal dd {
+        padding-right: 20px;
+        margin-left: 220px;
+    }
+    .dl-horizontal dt {
+        float: left;
+        overflow: hidden;
+        clear: left;
+        text-align: right;
+        text-overflow: ellipsis;
+        white-space: pre-wrap;
+        width: 200px;
+    }
+    .dl-horizontal dt a {
+        font-weight: 600;
+    }
+    .rp-no-data {
+        margin-left: 0px;
+        margin-top: 0px;
+        margin-bottom: 10px;
+    }
+}
+
+@media (min-width: 1366px) {
+
+    .dl-horizontal dt {
+        width: 300px;
+        margin-bottom: 0px;
+    }
+    .dl-horizontal dd {
+        padding-right: 20px;
+        margin-left: 320px;
+    }
+    .rp-report-section-title {
+        padding-left: 60px;
+    }
+    .rp-card-section.rp-card-section {
+        padding-left: 20px;
+    }
+    .rp-no-data {
+        margin-left: 0px;
+    }
+    .rp-no-data {
+        color: #888;
+        position: relative;
+        top: 0px;
+        left: 0px;
+    }
+    .report-related-resources .rp-card-section {
+        margin-left: 50px;
+    }
+    .report-related-resources .rp-card-section div div .dl-horizontal dt {
+        width: 500px;
+    }
+    .report-related-resources .rp-card-section div div .dl-horizontal dd {
+        padding-right: 20px;
+        margin-left: 520px;
+    }
+}
+
+@media (min-width: 768px) {
+    .dl-horizontal dt {
+        white-space: pre-wrap;
+        margin-bottom: 5px;
+        width: 200px;
+    }
+}
+
+@media screen and (max-width: 767px) {
+    .rp-no-data {
+        color: #888;
+        position: relative;
+        top: -30px;
+    }
+}
+
+@media screen and (max-width: 969px) {}
+
+@media screen and (min-width: 970px) {}
+
+@media screen and (max-width: 830px) {}
+
+@media screen and (max-width: 650px) {}
+
+@media screen and (max-width: 768px) {
+    #content-container {
+        padding-top: 50px !important;
+    }
+    #navbar {
+        width: 100%;
+    }
+    .resource-grid-main-container {
+        height: 130px;
+    }
+    .resource-grid-tools-container {
+        top: 70px;
+        left: 70px;
+    }
+    .rp-report-tile dd {
+        padding-left: 8px;
+    }
+
+}
+
+@media screen and (max-width: 500px) {
+    .resource-grid-subtitle {
+        width: 300px;
+    }
+
+}
+
+@media print {
+    header,
+    nav,
+    footer,
+    button,
+    aside,
+    .print-btn,
+    .ep-tools,
+    .geocode-container,
+    .geometry-tools-container,
+    .geometry-editing-notifications,
+    #map-widget-container>.map-widget-container {
+        display: none;
+    }
+    #content-container {
+        padding: 0 !important;
+    }
+    .scroll-y {
+        height: auto;
+    }
+    dt {
+        text-decoration: underline;
+        font-weight: bold;
+        color: #808080 !important;
+    }
+    dd {
+        margin-left: 2px;
+    }
+    a[href]:after {
+        content: none;
+    }
+    .dl-horizontal dd {
+        margin-left: 280px;
+        padding-right: 100px;
+    }
+    .dl-horizontal dt {
+        float: left;
+        width: 260px;
+        overflow: hidden;
+        clear: left;
+        text-align: right;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .rp-report-section {
+        border-bottom: 1px solid rgba(128, 128, 128, 0.5);
+    }
+    .mapboxgl-map {
+        display: none;
+    }
+
+    .print-map {
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
+    .print-hide {
+        display: none;
+        height: 0;
+    }
+}

--- a/arches/app/templates/base.htm
+++ b/arches/app/templates/base.htm
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 {% load staticfiles %}
 {% load i18n %}
+{% load compress %}
 
 <!DOCTYPE html>
 <!--[if IE 8]> <html lang="en" class="ie8"> <![endif]-->
@@ -39,7 +40,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <link rel="shortcut icon" href="{% static 'img/favicon.png' %}" />
 
     {% block css %}
-        <link href="{% static 'css/arches.css' %}" rel="stylesheet">
+    {% compress css %}
+        <link type="text/x-scss" href="{% static 'css/arches.scss' %}" rel="stylesheet" media="screen">
+    {% endcompress %}
         <link href="{% static 'css/package.css' %}" rel="stylesheet">
         <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock css%}

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -24,3 +24,5 @@ python-slugify==4.0.0
 pillow>=7.0.0
 arcgis2geojson==2.0.0
 openpyxl==3.0.7
+django_compressor==2.2
+django-libsass==0.7

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -263,6 +263,7 @@ STATICFILES_DIRS = (
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    "compressor.finders.CompressorFinder",
     #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
@@ -340,7 +341,8 @@ INSTALLED_APPS = (
     "revproxy",
     "corsheaders",
     "oauth2_provider",
-    "django_celery_results"
+    "django_celery_results",
+    "compressor",
     # 'debug_toolbar'
 )
 
@@ -613,6 +615,10 @@ GRAPH_MODEL_CACHE_TIMEOUT = None  # seconds * hours * days = ~1mo
 
 CANTALOUPE_DIR = os.path.join(ROOT_DIR, "cantaloupe")
 CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
+
+COMPRESS_PRECOMPILERS = (
+    ('text/x-scss', 'django_libsass.SassCompiler'),
+)
 
 RENDERERS = [
     {

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -616,9 +616,7 @@ GRAPH_MODEL_CACHE_TIMEOUT = None  # seconds * hours * days = ~1mo
 CANTALOUPE_DIR = os.path.join(ROOT_DIR, "cantaloupe")
 CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
-COMPRESS_PRECOMPILERS = (
-    ('text/x-scss', 'django_libsass.SassCompiler'),
-)
+COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
 
 RENDERERS = [
     {


### PR DESCRIPTION
re: #7395

This PR provides support for Sass preprocessing in Arches and converts the arches.css stylesheet to use Sass so that we can take advantage of the features it provides when improving these stylesheets. 

A couple of changes will need to be considered for projects taking on this change:
- there are two new python dependencies in requirements.txt that will need to be installed into your virtual environment
- the `compressor` application will need to be included in the `INSTALLED_APPS` setting (it is there in core arches settings, but may be overwritten in the project settings and therefore need to be updated)
- the `STATIC_ROOT` setting should point to the project root in development, so if this is configured for production in your project settings you will need to account for that
- with `STATIC_ROOT` pointing to the project root folder, `compressor` will create compiled files in a folder in the root called `CACHE`, which should be added to the project's .gitignore file to prevent committing these files

@aj-he @phudson-he - I couldn't help myself, so I took the liberty of implementing Sass preprocessing after our conversation this morning (or yesterday afternoon).  We can talk about how to integrate this into the work you are doing once it is reviewed and merged in.