### PR TITLE
Allow custom class to define comp based step padding. re #7408

### DIFF
--- a/arches/app/media/css/arches.css
+++ b/arches/app/media/css/arches.css
@@ -1704,6 +1704,12 @@ div.workflow-panel {
     border: 1px solid black;
 }
 
+.workflow-component-based-step {
+    width: 100%;
+    height: 100%;
+    padding: 20px;
+}
+
 div.final-cons-step-splash {
     display: flex;
     flex-direction: column;

--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -594,6 +594,7 @@ define([
 
         this.complete = params.complete || ko.observable(false);
         this.alert = params.alert || ko.observable();
+        this.componentBasedStepClass = ko.unwrap(params.workflowstepclass);
 
         this.dataToPersist = ko.observable({});
         self.dataToPersist.subscribe(function(data) {

--- a/arches/app/templates/views/components/workflows/component-based-step.htm
+++ b/arches/app/templates/views/components/workflows/component-based-step.htm
@@ -1,10 +1,5 @@
 {% load i18n %}
-<div
-    style="
-        width: 100%;
-        height: 100%;
-    "
->
+<div data-bind="css: componentBasedStepClass || 'workflow-component-based-step'">
     <!-- ko foreach: { data: pageLayout(), as: 'layoutSection'} -->
     <div
         data-bind="style: { 'height': $parent.pageLayout().length === 1 && '100%' }"


### PR DESCRIPTION
Allows a workflow developer to assign a custom class to a component based step configuration (using the `workflowstepclass` property) so that they can control how much padding they want around their step. re #7408