### PR TITLE
Enforces workflow asynchronousity on getExternalStepData

### DIFF
--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -171,7 +171,7 @@ define([
                 allStepsLocalStorageData[self.id()] = {};
             }
             
-            allStepsLocalStorageData[self.id()][key] = koMapping.toJSON(value);
+            allStepsLocalStorageData[self.id()][key] = value ? koMapping.toJSON(value) : value;
 
             localStorage.setItem(
                 STEPS_LABEL, 

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -27,6 +27,8 @@ define([
 
         this.hasDirtyTile = ko.observable(false);
 
+        this.saving = ko.observable(false);
+
         this.complete = ko.observable(false);
         this.required = ko.observable(ko.unwrap(config.required));
         this.autoAdvance = ko.observable(true);
@@ -39,10 +41,12 @@ define([
         var externalStepSourceData = ko.unwrap(config.externalstepdata) || {};
         Object.keys(externalStepSourceData).forEach(function(key) {
             if (key !== '__ko_mapping__') {
-                self.externalStepData[key] = {
-                    stepName: externalStepSourceData[key],
-                    data: config.workflow.getStepData(externalStepSourceData[key]),
-                };
+                config.workflow.getStepData(externalStepSourceData[key]).then(function(data) {
+                    self.externalStepData[key] = {
+                        stepName: externalStepSourceData[key],
+                        data: data,
+                    };
+                });
             }
         });
         delete config.externalstepdata;
@@ -193,7 +197,9 @@ define([
 
         this.getExternalStepData = function() {
             Object.keys(self.externalStepData).forEach(function(key) {
-                self.externalStepData[key]['data'] = config.workflow.getStepData(externalStepSourceData[key]);
+                config.workflow.getStepData(externalStepSourceData[key]).then(function(data) {
+                    self.externalStepData[key]['data'] = data;
+                });
             });
         };
 

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -171,7 +171,7 @@ define([
                 allStepsLocalStorageData[self.id()] = {};
             }
             
-            allStepsLocalStorageData[self.id()][key] = value;
+            allStepsLocalStorageData[self.id()][key] = koMapping.toJSON(value);
 
             localStorage.setItem(
                 STEPS_LABEL, 
@@ -183,7 +183,7 @@ define([
             var allStepsLocalStorageData = JSON.parse(localStorage.getItem(STEPS_LABEL)) || {};
 
             if (allStepsLocalStorageData[self.id()]) {
-                return allStepsLocalStorageData[self.id()][key];
+                return JSON.parse(allStepsLocalStorageData[self.id()][key]);
             }
         };
 

--- a/arches/app/media/js/viewmodels/workflow.js
+++ b/arches/app/media/js/viewmodels/workflow.js
@@ -168,7 +168,22 @@ define([
         this.getStepData = function(stepName) {
             /* ONLY to be used as intermediary for when a step needs data from a different step in the workflow */
             var step = self.steps.find(function(step) { return ko.unwrap(step.name) === ko.unwrap(stepName) });
-            if (step) { return step.value(); }
+
+            if (step) { 
+                return new Promise(function(resolve) {
+                    if (step.saving()) {
+                        var savingSubscription = step.saving.subscribe(function(saving) {
+                            if (!saving) {
+                                savingSubscription.dispose(); /* self-disposing subscription */
+                                resolve(step.value()); 
+                            }
+                        });
+                    }
+                    else {
+                        resolve(step.value());
+                    }
+                });
+            }
         };
 
         this.getStepIdFromUrl = function() {

--- a/arches/app/media/js/views/components/plugins/manifest-manager.js
+++ b/arches/app/media/js/views/components/plugins/manifest-manager.js
@@ -20,7 +20,7 @@ define([
             this.editService = ko.observable(false);
             this.createService = ko.observable(true);
             this.remoteManifest = ko.observable(true);
-            this.alert = params.alert;
+            this.alert = params.alert || ko.observable(); 
             this.addCanvas = function(canvas) { //the function name needs to be better
                 self.canvasesForDeletion.push(canvas);
                 self.canvas(canvas.images[0].resource.service['@id']);
@@ -214,6 +214,12 @@ define([
             this.manifest.subscribe(function(val){
                 self.getManifestData(val);
                 self.mainMenu(false);
+            });
+
+            this.manifestData.subscribe(function(manifestData) {
+                if (params.manifestData && ko.isObservable(params.manifestData)) {
+                    params.manifestData(manifestData);
+                }
             });
 
             this.manifest.subscribe(function(){

--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -32,6 +32,8 @@ define([
         };
 
         this.save = function() {
+            self.saving(true);
+
             self.complete(true);
             self.savedData(self.addedData());
         };
@@ -545,9 +547,10 @@ define([
     };
 
 
-    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete) {
+    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving) {
         var self = this;
 
+        this.saving = saving;
         this.complete = complete;
         this.resourceId = resourceId;
         this.componentData = componentData;
@@ -559,7 +562,6 @@ define([
         this.hasUnsavedData = ko.observable();
 
         this.loading = ko.observable(true);
-        this.saving = ko.observable();
 
         this.initialize = function() {
             if (!componentData.tilesManaged || componentData.tilesManaged === "none") {
@@ -592,6 +594,7 @@ define([
             self.resourceId(ko.unwrap(params.workflow.resourceId));
         } 
 
+        this.saving = params.saving || ko.observable(false);
         this.complete = params.complete || ko.observable(false);
         this.alert = params.alert || ko.observable();
         this.componentBasedStepClass = ko.unwrap(params.workflowstepclass);
@@ -650,6 +653,7 @@ define([
     
             params.postSaveCallback(function() {
                 self.hasUnsavedData(false);
+                self.saving(false);
             });
 
             ko.toJS(params.layoutSections).forEach(function(layoutSection) {
@@ -683,7 +687,8 @@ define([
                 params.externalStepData,
                 self.resourceId,
                 params.title, 
-                self.complete
+                self.complete,
+                self.saving,
             );
 
             workflowComponentAbstract.savedData.subscribe(function() {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

moves saving observable to workflow-step.
workflow.getStepData now uses Promises.

THIS WILL BREAK the `getStepData` logic in arches-HER


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7421 

