### PR TITLE
Merges manifest images and files tables

### DIFF
--- a/arches/app/models/migrations/7442_delete_manifest_images_table.py
+++ b/arches/app/models/migrations/7442_delete_manifest_images_table.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("models", "7442_move_data_from_manifest_images_table_to_files_table"),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name="ManifestImage",
+        ),
+    ]

--- a/arches/app/models/migrations/7442_move_data_from_manifest_images_table_to_files_table.py
+++ b/arches/app/models/migrations/7442_move_data_from_manifest_images_table_to_files_table.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    def forward_migrate(apps, schema_editor, with_create_permissions=True):
+        manifest_image_model = apps.get_model("models", "ManifestImage")
+        file_model = apps.get_model("models", "File")
+
+        for manifest_image in manifest_image_model.objects.all():
+            file = file_model.objects.create(
+                fileid=manifest_image.imageid,
+                path=manifest_image.image,
+            )
+
+            file.save()
+
+    def reverse_migrate(apps, schema_editor, with_create_permissions=True):
+        manifest_image_model = apps.get_model("models", "ManifestImage")
+        file_model = apps.get_model("models", "File")
+        
+        for file in file_model.objects.all():
+            # not guaranteed accurate but should work for most cases,
+            # ManifestImage does not have tile data
+            if not file.tileid:
+                manifest_image = manifest_image_model.create(
+                    imageid=file.fileid,
+                    image=file.path,
+                )
+
+                manifest_image.save()
+
+    dependencies = [
+        ("models", "7262_report_template_data_fetch_bool"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward_migrate, reverse_migrate)
+    ]

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1361,7 +1361,7 @@ class IIIFManifest(models.Model):
 
 class ManifestImage(models.Model):
     imageid = models.UUIDField(primary_key=True, default=uuid.uuid1)
-    image = models.ImageField(upload_to="cantaloupe")
+    image = models.ImageField(upload_to="uploadedfiles")
 
     class Meta:
         managed = True

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1358,15 +1358,6 @@ class IIIFManifest(models.Model):
         managed = True
         db_table = "iiif_manifests"
 
-
-class ManifestImage(models.Model):
-    imageid = models.UUIDField(primary_key=True, default=uuid.uuid1)
-    image = models.ImageField(upload_to="uploadedfiles")
-
-    class Meta:
-        managed = True
-        db_table = "manifest_images"
-
 class GroupMapSettings(models.Model):
     group = models.OneToOneField(Group, on_delete=models.CASCADE)
     min_zoom = models.IntegerField(default=0)

--- a/arches/app/views/manifest_manager.py
+++ b/arches/app/views/manifest_manager.py
@@ -146,13 +146,14 @@ class ManifestManagerView(View):
 
         def create_image(file):
             new_image_id = uuid.uuid4()
-            new_image = models.ManifestImage.objects.create(imageid=new_image_id, image=file)
-            new_image.save()
+            new_image_file = models.File.objects.create(fileid=new_image_id, path=file)
+            new_image_file.save()
 
-            file_name = os.path.basename(new_image.image.name)
+            file_name = os.path.basename(new_image_file.path.name)
             file_url = f"{request.scheme}://{request.get_host()}/iiifserver/iiif/2/{file_name}"
             file_json_url = f"{self.cantaloupe_uri}/2/{file_name}/info.json"
             image_json = self.fetch(file_json_url)
+
             return image_json, new_image_id, file_url
 
         def get_image_count(manifest):
@@ -216,6 +217,7 @@ class ManifestManagerView(View):
                         image_json, image_id, file_url = create_image(f)
                     except:
                         return
+
                     canvas = create_canvas(image_json, file_url, os.path.splitext(f.name)[0], image_id)
                     canvases.append(canvas)
                 else:
@@ -287,6 +289,7 @@ class ManifestManagerView(View):
 
 class IIIFServerProxyView(ProxyView):
     upstream = settings.CANTALOUPE_HTTP_ENDPOINT
+
 
     def get_request_headers(self):
         headers = super(IIIFServerProxyView, self).get_request_headers()

--- a/arches/app/views/manifest_manager.py
+++ b/arches/app/views/manifest_manager.py
@@ -290,7 +290,6 @@ class ManifestManagerView(View):
 class IIIFServerProxyView(ProxyView):
     upstream = settings.CANTALOUPE_HTTP_ENDPOINT
 
-
     def get_request_headers(self):
         headers = super(IIIFServerProxyView, self).get_request_headers()
         if settings.CANTALOUPE_HTTP_ENDPOINT is None:

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -209,7 +209,7 @@ CELERY_BEAT_SCHEDULE = {
     "notification": {"task": "arches.app.tasks.message", "schedule": CELERY_SEARCH_EXPORT_CHECK, "args": ("Celery Beat is Running",),},
 }
 
-CANTALOUPE_DIR = os.path.join(ROOT_DIR, "cantaloupe")
+CANTALOUPE_DIR = os.path.join(ROOT_DIR, "uploadedfiles")
 CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
 # By setting RESTRICT_MEDIA_ACCESS to True, media file requests outside of Arches will checked against nodegroup permissions.

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -613,7 +613,7 @@ TILE_CACHE_TIMEOUT = 600  # seconds
 CLUSTER_DISTANCE_MAX = 5000  # meters
 GRAPH_MODEL_CACHE_TIMEOUT = None  # seconds * hours * days = ~1mo
 
-CANTALOUPE_DIR = os.path.join(ROOT_DIR, "cantaloupe")
+CANTALOUPE_DIR = os.path.join(ROOT_DIR, "uploadedfiles")
 CANTALOUPE_HTTP_ENDPOINT = "http://localhost:8182/"
 
 COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

This deletes the `ManifestImage` model and manifest_images table. It groups said functionality with `File`.

TO REPRODUCE:
1. Follow directions [here](https://arches.readthedocs.io/en/stable/managing-and-hosting-iiif/?highlight=cantaloupe#setting-up-cantaloupe) , but instead of `cantaloupe` folder use `uploadedfiles` folder
2. Navigate to project settings.py file, and change `CANTALOUPE_DIR = os.path.join(APP_ROOT, "uploadedfiles")`
3. Test as you normally would


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7442 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)