### PR TITLE
Add capability to flag lock in the workflow step, afs #368

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -254,10 +254,14 @@ define([
         var url = ko.observable(arches.urls.search_results);
         this.url = url;
         var resourceToAdd = ko.observable("");
+
+        this.disabled = ko.computed(function() {
+            return ko.unwrap(self.waitingForGraphToDownload) || ko.unwrap(params.disabled)
+        })
         this.select2Config = {
             value: self.renderContext === 'search' ? self.value : resourceToAdd,
             clickBubble: true,
-            disabled: this.waitingForGraphToDownload,
+            disabled: this.disabled,
             multiple: !self.displayOntologyTable ? params.multiple : false,
             placeholder: this.placeholder() || arches.translations.riSelectPlaceholder,
             closeOnSelect: true,

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -256,8 +256,8 @@ define([
         var resourceToAdd = ko.observable("");
 
         this.disabled = ko.computed(function() {
-            return ko.unwrap(self.waitingForGraphToDownload) || ko.unwrap(params.disabled)
-        })
+            return ko.unwrap(self.waitingForGraphToDownload) || ko.unwrap(params.disabled);
+        });
         this.select2Config = {
             value: self.renderContext === 'search' ? self.value : resourceToAdd,
             clickBubble: true,

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -37,6 +37,11 @@ define([
         this.postSaveCallback = ko.observable();
 
         this.externalStepData = {};
+        this.locked = ko.observable();
+
+        this.setLock = function(stepName, locked) {
+            config.workflow.setLock(stepName, locked);
+        };
 
         var externalStepSourceData = ko.unwrap(config.externalstepdata) || {};
         Object.keys(externalStepSourceData).forEach(function(key) {

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -237,7 +237,9 @@ define([
         }
 
         this.setSourceStepLock = function(locked) {
-            config.workflow.setLock(self.externalStepData.sourcesteptolock.stepName, locked);
+            self.lockableExternalSteps().forEach(function(step){
+                config.workflow.setLock(step, locked);
+            })
         };
 
         _.extend(this, config);

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -38,6 +38,7 @@ define([
 
         this.externalStepData = {};
         this.locked = ko.observable(false);
+        this.lockableExternalSteps = config.lockableExternalSteps || []
 
         var externalStepSourceData = ko.unwrap(config.externalstepdata) || {};
         Object.keys(externalStepSourceData).forEach(function(key) {
@@ -238,8 +239,12 @@ define([
         }
 
         this.lockExternalStep = function(step, locked) {
+            if (self.lockableExternalSteps.indexOf(step) > -1){
                 config.workflow.toggleStepLockedState(step, locked);
-        };
+            } else {
+                throw new Error("The step, " + step + ", cannot be locked")
+            }
+        }
 
         _.extend(this, config);
 

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -43,6 +43,10 @@ define([
             config.workflow.setLock(stepName, locked);
         };
 
+        this.locked.subscribe(function(val){
+            self.setToLocalStorage("locked", val);
+        });
+
         var externalStepSourceData = ko.unwrap(config.externalstepdata) || {};
         Object.keys(externalStepSourceData).forEach(function(key) {
             if (key !== '__ko_mapping__') {
@@ -120,6 +124,11 @@ define([
                 self.id(uuid.generate());
             }
 
+            var locked = self.getFromLocalStorage('locked');
+            if (locked) {
+                self.locked(locked);
+            }
+
             /* cached value logic */ 
             var cachedValue = self.getFromLocalStorage('value');
             if (cachedValue) {
@@ -187,7 +196,7 @@ define([
         this.getFromLocalStorage = function(key) {
             var allStepsLocalStorageData = JSON.parse(localStorage.getItem(STEPS_LABEL)) || {};
 
-            if (allStepsLocalStorageData[self.id()]) {
+            if (allStepsLocalStorageData[self.id()] && allStepsLocalStorageData[self.id()][key]) {
                 return JSON.parse(allStepsLocalStorageData[self.id()][key]);
             }
         };

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -191,7 +191,7 @@ define([
         this.getFromLocalStorage = function(key) {
             var allStepsLocalStorageData = JSON.parse(localStorage.getItem(STEPS_LABEL)) || {};
 
-            if (allStepsLocalStorageData[self.id()]) {
+            if (allStepsLocalStorageData[self.id()] && typeof allStepsLocalStorageData[self.id()][key] !== "undefined") {
                 return JSON.parse(allStepsLocalStorageData[self.id()][key]);
             }
         };

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -38,11 +38,6 @@ define([
 
         this.externalStepData = {};
         this.locked = ko.observable();
-
-        this.setLock = function(stepName, locked) {
-            config.workflow.setLock(stepName, locked);
-        };
-
         this.locked.subscribe(function(val){
             self.setToLocalStorage("locked", val);
         });
@@ -196,7 +191,7 @@ define([
         this.getFromLocalStorage = function(key) {
             var allStepsLocalStorageData = JSON.parse(localStorage.getItem(STEPS_LABEL)) || {};
 
-            if (allStepsLocalStorageData[self.id()] && allStepsLocalStorageData[self.id()][key]) {
+            if (allStepsLocalStorageData[self.id()]) {
                 return JSON.parse(allStepsLocalStorageData[self.id()][key]);
             }
         };
@@ -240,6 +235,10 @@ define([
                 })
             }
         }
+
+        this.setSourceStepLock = function(locked) {
+            config.workflow.setLock(self.externalStepData.sourcesteptolock.stepName, locked);
+        };
 
         _.extend(this, config);
 

--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -37,10 +37,7 @@ define([
         this.postSaveCallback = ko.observable();
 
         this.externalStepData = {};
-        this.locked = ko.observable();
-        this.locked.subscribe(function(val){
-            self.setToLocalStorage("locked", val);
-        });
+        this.locked = ko.observable(false);
 
         var externalStepSourceData = ko.unwrap(config.externalstepdata) || {};
         Object.keys(externalStepSourceData).forEach(function(key) {
@@ -136,6 +133,10 @@ define([
                 self.setToLocalStorage('value', value);
             });
 
+            self.locked.subscribe(function(value){
+                self.setToLocalStorage("locked", value);
+            });
+    
             /* cached informationBox logic */
             this.setupInformationBox();
         };
@@ -236,10 +237,8 @@ define([
             }
         }
 
-        this.setSourceStepLock = function(locked) {
-            self.lockableExternalSteps().forEach(function(step){
-                config.workflow.setLock(step, locked);
-            })
+        this.lockExternalStep = function(step, locked) {
+                config.workflow.toggleStepLockedState(step, locked);
         };
 
         _.extend(this, config);

--- a/arches/app/media/js/viewmodels/workflow.js
+++ b/arches/app/media/js/viewmodels/workflow.js
@@ -186,7 +186,7 @@ define([
             }
         };
 
-        this.setLock = function(stepName, locked) {
+        this.toggleStepLockedState = function(stepName, locked) {
             var step = self.steps.find(function(step) { return ko.unwrap(step.name) === ko.unwrap(stepName) });
             if (step) {
                 step.locked(locked);

--- a/arches/app/media/js/viewmodels/workflow.js
+++ b/arches/app/media/js/viewmodels/workflow.js
@@ -186,6 +186,13 @@ define([
             }
         };
 
+        this.setLock = function(stepName, locked) {
+            var step = self.steps.find(function(step) { return ko.unwrap(step.name) === ko.unwrap(stepName) });
+            if (step) {
+                step.locked(locked);
+            }
+        }
+
         this.getStepIdFromUrl = function() {
             var searchParams = new URLSearchParams(window.location.search);
             return searchParams.get(STEP_ID_LABEL);

--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -547,13 +547,15 @@ define([
     };
 
 
-    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving) {
+    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving, locked, setLock) {
         var self = this;
 
         this.saving = saving;
         this.complete = complete;
         this.resourceId = resourceId;
         this.componentData = componentData;
+        this.locked = locked;
+        this.setLock = setLock;
 
         this.previouslyPersistedComponentData = previouslyPersistedComponentData;
         this.externalStepData = externalStepData;
@@ -586,6 +588,9 @@ define([
     function viewModel(params) {
         var self = this;
 
+        this.locked = params.locked;
+        this.setLock = params.setLock;
+        
         this.resourceId = ko.observable();
         if (ko.unwrap(params.resourceid)) {
             self.resourceId(ko.unwrap(params.resourceid));
@@ -689,6 +694,8 @@ define([
                 params.title, 
                 self.complete,
                 self.saving,
+                self.locked,
+                self.setLock,
             );
 
             workflowComponentAbstract.savedData.subscribe(function() {

--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -547,7 +547,7 @@ define([
     };
 
 
-    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving, locked, setSourceStepLock) {
+    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving, locked, lockExternalStep, lockableExternalSteps) {
         var self = this;
 
         this.saving = saving;
@@ -555,7 +555,8 @@ define([
         this.resourceId = resourceId;
         this.componentData = componentData;
         this.locked = locked;
-        this.setSourceStepLock = setSourceStepLock;
+        this.lockExternalStep = lockExternalStep;
+        this.lockableExternalSteps = lockableExternalSteps;
 
         this.previouslyPersistedComponentData = previouslyPersistedComponentData;
         this.externalStepData = externalStepData;
@@ -600,8 +601,9 @@ define([
         this.complete = params.complete || ko.observable(false);
         this.alert = params.alert || ko.observable();
         this.componentBasedStepClass = ko.unwrap(params.workflowstepclass);
-        this.locked = params.locked || ko.observable(false);
-        this.setSourceStepLock = params.setSourceStepLock || ko.observable();
+        this.locked = params.locked;
+        this.lockExternalStep = params.lockExternalStep;
+        this.lockableExternalSteps = params.lockableExternalSteps;
 
         this.dataToPersist = ko.observable({});
         self.dataToPersist.subscribe(function(data) {
@@ -694,7 +696,8 @@ define([
                 self.complete,
                 self.saving,
                 self.locked,
-                self.setSourceStepLock,
+                self.lockExternalStep,
+                self.lockableExternalSteps
             );
 
             workflowComponentAbstract.savedData.subscribe(function() {

--- a/arches/app/media/js/views/components/workflows/component-based-step.js
+++ b/arches/app/media/js/views/components/workflows/component-based-step.js
@@ -547,7 +547,7 @@ define([
     };
 
 
-    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving, locked, setLock) {
+    function WorkflowComponentAbstract(componentData, previouslyPersistedComponentData, externalStepData, resourceId, title, complete, saving, locked, setSourceStepLock) {
         var self = this;
 
         this.saving = saving;
@@ -555,7 +555,7 @@ define([
         this.resourceId = resourceId;
         this.componentData = componentData;
         this.locked = locked;
-        this.setLock = setLock;
+        this.setSourceStepLock = setSourceStepLock;
 
         this.previouslyPersistedComponentData = previouslyPersistedComponentData;
         this.externalStepData = externalStepData;
@@ -587,9 +587,6 @@ define([
 
     function viewModel(params) {
         var self = this;
-
-        this.locked = params.locked;
-        this.setLock = params.setLock;
         
         this.resourceId = ko.observable();
         if (ko.unwrap(params.resourceid)) {
@@ -603,6 +600,8 @@ define([
         this.complete = params.complete || ko.observable(false);
         this.alert = params.alert || ko.observable();
         this.componentBasedStepClass = ko.unwrap(params.workflowstepclass);
+        this.locked = params.locked || ko.observable(false);
+        this.setSourceStepLock = params.setSourceStepLock || ko.observable();
 
         this.dataToPersist = ko.observable({});
         self.dataToPersist.subscribe(function(data) {
@@ -695,7 +694,7 @@ define([
                 self.complete,
                 self.saving,
                 self.locked,
-                self.setLock,
+                self.setSourceStepLock,
             );
 
             workflowComponentAbstract.savedData.subscribe(function() {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Add locked flag in the workflow step, re: archesproject/arches-for-science#368
When other steps needs to lock a previous step to prevent for a user to change it once the resource instance is created, the `locked` flag is added so that it can be used to disable selection widget, etc.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
archesproject/arches-for-science#368

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
