### PR TITLE
6638 api arches json put post

### DIFF
--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -45,6 +45,7 @@ from arches.app.utils.decorators import can_read_concept, group_required
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from arches.app.utils.data_management.resources.exporter import ResourceExporter
 from arches.app.utils.data_management.resources.formats.rdffile import JsonLdReader
+from arches.app.utils.data_management.resources.formats.archesfile import ArchesFileReader
 from arches.app.utils.permission_backend import (
     user_can_read_resource,
     user_can_edit_resource,
@@ -699,36 +700,70 @@ class Resources(APIBase):
         except Exception:
             indent = None
 
+        allowed_formats = ["arches-json", "json-ld"]
+        format = request.GET.get("format", "json-ld")
+        if format not in allowed_formats:
+            return JSONResponse(status=406, reason="incorrect format specified, only %s formats allowed" % allowed_formats)
+
+
         if not user_can_edit_resource(user=request.user, resourceid=resourceid):
             return JSONResponse(status=403)
         else:
             with transaction.atomic():
                 try:
-                    # DELETE
-                    resource_instance = Resource.objects.get(pk=resourceid)
-                    resource_instance.delete()
-                except models.ResourceInstance.DoesNotExist:
-                    pass
+                    if format == "json-ld":
+                        try:
+                            # DELETE
+                            resource_instance = Resource.objects.get(pk=resourceid)
+                            resource_instance.delete()
+                        except models.ResourceInstance.DoesNotExist:
+                            pass
 
-                try:
-                    # POST
-                    data = JSONDeserializer().deserialize(request.body)
-                    reader = JsonLdReader()
-                    if slug is not None:
-                        graphid = models.GraphModel.objects.get(slug=slug).pk
-                    reader.read_resource(data, resourceid=resourceid, graphid=graphid)
-                    if reader.errors:
-                        response = []
-                        for value in reader.errors.values():
-                            response.append(value.message)
-                        return JSONResponse({"error": response}, indent=indent, status=400)
-                    else:
-                        response = []
-                        for resource in reader.resources:
-                            with transaction.atomic():
-                                resource.save(request=request)
-                            response.append(JSONDeserializer().deserialize(self.get(request, resource.resourceinstanceid).content))
-                        return JSONResponse(response, indent=indent, status=201)
+                        # POST
+                        data = JSONDeserializer().deserialize(request.body)
+                        reader = JsonLdReader()
+                        if slug is not None:
+                            graphid = models.GraphModel.objects.get(slug=slug).pk
+                        reader.read_resource(data, resourceid=resourceid, graphid=graphid)
+                        if reader.errors:
+                            response = []
+                            for value in reader.errors.values():
+                                response.append(value.message)
+                            return JSONResponse({"error": response}, indent=indent, status=400)
+                        else:
+                            response = []
+                            for resource in reader.resources:
+                                with transaction.atomic():
+                                    resource.save(request=request)
+                                response.append(JSONDeserializer().deserialize(self.get(request, resource.resourceinstanceid).content))
+                            return JSONResponse(response, indent=indent, status=201)
+                            
+                    elif format == "arches-json":
+                        reader = ArchesFileReader()
+                        archesresource = JSONDeserializer().deserialize(request.body)
+
+                        resource = {
+                            "resourceinstance": {
+                                "graph_id": archesresource["graph_id"],
+                                "resourceinstanceid": archesresource["resourceinstanceid"],
+                                "legacyid": archesresource["legacyid"],
+                            },
+                            "tiles": archesresource["tiles"],
+                        }
+
+                        reader.import_business_data({"resources": [resource]})
+
+                        if reader.errors:
+                            response = []
+                            for value in reader.errors.values():
+                                response.append(value.message)
+                            return JSONResponse({"error": response}, indent=indent, status=400)
+                        else:
+                            response = []
+                            response.append(JSONDeserializer().deserialize(self.get(request, resourceid).content))
+                            return JSONResponse(response, indent=indent, status=201)
+
+
                 except models.ResourceInstance.DoesNotExist:
                     return JSONResponse(status=404)
                 except Exception as e:

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -144,7 +144,7 @@ class APITests(ArchesTestCase):
                                             payload, 
                                             content_type)
         #==Assert==========================================================================================
-        self.assertTrue(resp_post.status_code == 201) # resource created.
+        self.assertEqual(resp_post.status_code, 201) # resource created.
         
 
         #==Act : GET confirmation that resource does now exist in database=================================
@@ -152,9 +152,9 @@ class APITests(ArchesTestCase):
                                     kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                     +"?format=arches-json")        
         #==Assert==========================================================================================
-        self.assertTrue(resp_get_confirm.status_code == 200) # Success, we got one.        
+        self.assertEqual(resp_get_confirm.status_code, 200) # Success, we got one.        
         data_get_confirm = JSONDeserializer().deserialize(resp_get_confirm.content)
-        self.assertTrue(data_get_confirm["legacyid"]=="ARCHES_api") # Success, we got the right one.
+        self.assertEqual(data_get_confirm["legacyid"], "ARCHES_api") # Success, we got the right one.
         
 
         #==Act : PUT resource changes to database==========================================================
@@ -164,7 +164,7 @@ class APITests(ArchesTestCase):
                                             payload_modified, 
                                             content_type)
         #==Assert==========================================================================================
-        self.assertTrue(resp_put.status_code == 201) # resource created.
+        self.assertEqual(resp_put.status_code, 201) # resource created.
 
 
         #==Act : GET confirmation that resource is now changed in database=================================
@@ -172,16 +172,16 @@ class APITests(ArchesTestCase):
                                     kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                     +"?format=arches-json")        
         #==Assert==========================================================================================
-        self.assertTrue(resp_get_confirm_mod.status_code == 200) # Success, we got one.     
+        self.assertEqual(resp_get_confirm_mod.status_code, 200) # Success, we got one.     
         data_get_confirm_mod = JSONDeserializer().deserialize(resp_get_confirm_mod.content)
-        self.assertTrue(data_get_confirm_mod["legacyid"]=="ARCHES_api_MOD") # Success, we got the right one.
+        self.assertEqual(data_get_confirm_mod["legacyid"], "ARCHES_api_MOD") # Success, we got the right one.
 
 
         #==Act : DELETE resource from database=============================================================
         resp_delete = self.client.delete(reverse("resources", 
                                     kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"}))        
         #==Assert==========================================================================================
-        self.assertTrue(resp_delete.status_code == 200) # Success, we got rid of one.     
+        self.assertEqual(resp_delete.status_code, 200) # Success, we got rid of one.     
 
 
         #==Act : GET confirmation that resource does not exist in database=================================

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -34,6 +34,8 @@ from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 
+from django.contrib.auth.models import User, Group, AnonymousUser
+
 # these tests can be run from the command line via
 # python manage.py test tests/views/api_tests.py --pattern="*.py" --settings="tests.test_settings"
 
@@ -49,20 +51,26 @@ class APITests(ArchesTestCase):
     def setUpClass(cls):
         geojson_nodeid = "3ebc6785-fa61-11e6-8c85-14109fd34195"
         cls.loadOntology()
-        with open(os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "rU") as f:
-            json = JSONDeserializer().deserialize(f)
-            cls.unique_graph = Graph(json["graph"][0])
-            cls.unique_graph.save()
+        # with open(os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "rU") as f:
+        #     json = JSONDeserializer().deserialize(f)
+        #     cls.unique_graph = Graph(json["graph"][0])
+        #     cls.unique_graph.save()
 
-        with open(os.path.join("tests/fixtures/resource_graphs/ambiguous_graph_shape.json"), "rU") as f:
-            json = JSONDeserializer().deserialize(f)
-            cls.ambiguous_graph = Graph(json["graph"][0])
-            cls.ambiguous_graph.save()
+        # with open(os.path.join("tests/fixtures/resource_graphs/ambiguous_graph_shape.json"), "rU") as f:
+        #     json = JSONDeserializer().deserialize(f)
+        #     cls.ambiguous_graph = Graph(json["graph"][0])
+        #     cls.ambiguous_graph.save()
 
-        with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "rU") as f:
-            json = JSONDeserializer().deserialize(f)
-            cls.phase_type_assignment_graph = Graph(json["graph"][0])
-            cls.phase_type_assignment_graph.save()
+        # with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "rU") as f:
+        #     json = JSONDeserializer().deserialize(f)
+        #     cls.phase_type_assignment_graph = Graph(json["graph"][0])
+        #     cls.phase_type_assignment_graph.save()
+        
+        cls.factory = RequestFactory()
+        cls.client = Client()
+        cls.user = User.objects.create_user("test", "test@archesproject.org", "password")
+        
+
 
     def test_api_base_view(self):
         """
@@ -82,3 +90,145 @@ class APITests(ArchesTestCase):
         request.user = None
         response = view(request)
         self.assertEqual(request.GET.get("ver"), "2.1")
+
+
+    def test_api_resources_put_archesjson(self):
+        """
+        Test that resources PUT accepts arches-json format data.
+
+        """
+
+        # test update a ResourceTestModel resource 
+        test_resource = {
+            "displaydescription": "undefined",
+            "displayname": "undefined",
+            "graph_id": "c9b37a14-17b3-11eb-a708-acde48001122",
+            "legacyid": "ARCHES",
+            "map_popup": "undefined",
+            "resourceinstanceid": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
+            "tiles": [
+                {
+                    "data": {
+                        "c9b37b7c-17b3-11eb-a708-acde48001122": "Foo ResourceTestModel"
+                    },
+                    "nodegroup_id": "c9b37b7c-17b3-11eb-a708-acde48001122",
+                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
+                    "sortorder": 0,
+                    "tileid": "9b7b8897-d4a0-4735-b1fe-9d82d9890740"
+                },
+                {
+                    "data": {
+                        "c9b37f96-17b3-11eb-a708-acde48001122": {
+                            "features": [
+                                {
+                                    "geometry": {
+                                        "coordinates": [
+                                            [
+                                                [
+                                                    -1.7933273753688184,
+                                                    51.56492920592859
+                                                ],
+                                                [
+                                                    -1.7932521887532005,
+                                                    51.564204760266338
+                                                ],
+                                                [
+                                                    -1.7899815709831444,
+                                                    51.563854217899379
+                                                ],
+                                                [
+                                                    -1.7899815709831444,
+                                                    51.564882467846988
+                                                ],
+                                                [
+                                                    -1.7933273753688184,
+                                                    51.56492920592859
+                                                ]
+                                            ]
+                                        ],
+                                        "type": "Polygon"
+                                    },
+                                    "id": "b11df9f801aa89ba1250ffc6843801e2",
+                                    "properties": {
+                                        "nodeId": "c9b37f96-17b3-11eb-a708-acde48001122"
+                                    },
+                                    "type": "Feature"
+                                }
+                            ],
+                            "type": "FeatureCollection"
+                        }
+                    },
+                    "nodegroup_id": "c9b37f96-17b3-11eb-a708-acde48001122",
+                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
+                    "sortorder": 0,
+                    "tileid": "16d2eb37-d5df-43d4-a930-937fcacd9db1"
+                },
+                {
+                    "data": {
+                        "c9b38568-17b3-11eb-a708-acde48001122": "2021-05-06"
+                    },
+                    "nodegroup_id": "c9b38568-17b3-11eb-a708-acde48001122",
+                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
+                    "sortorder": 0,
+                    "tileid": "b729b441-3240-420f-9a39-98244c8244e8"
+                },
+                {
+                    "data": {
+                        "c9b38aea-17b3-11eb-a708-acde48001122": "Foo ResourceTestModel Sensitive"
+                    },
+                    "nodegroup_id": "c9b38aea-17b3-11eb-a708-acde48001122",
+                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
+                    "sortorder": 0,
+                    "tileid": "e7f0a6db-045e-4aee-b490-c7d2f0d36b14"
+                },
+                {
+                    "data": {
+                        "c9b3828e-17b3-11eb-a708-acde48001122": "2021-05-06"
+                    },
+                    "nodegroup_id": "c9b3828e-17b3-11eb-a708-acde48001122",
+                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
+                    "sortorder": 0,
+                    "tileid": "71d169e7-bcf4-4354-ac90-0ea9f7fb3f4c"
+                }
+            ]
+        }
+        payload = JSONSerializer().serialize(test_resource)
+        content_type = "application/json"
+
+        factory = RequestFactory(HTTP_X_ARCHES_VER="2.1")
+        view = APIBase.as_view()
+
+
+
+
+
+
+        #==THIS CALLS YOUR FUNCTION CODE!!===="inspired by the elegant auth_tests"==================================================================================================
+
+        self.client.login(username="admin", password="admin")
+        resp = {"success": False}
+        raw_resp = self.client.put(reverse("resources", 
+                                            kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
+                                            +"?format=arches-json",
+                                            payload, 
+                                            content_type)
+        resp = JSONDeserializer().deserialize(raw_resp.content)
+
+        self.assertTrue(resp["success"])
+
+       
+        request.user = self.user
+        response = view(request)
+        
+        print("\n*************************************************************\n")
+        print(response)
+        print("\n*************************************************************\n")
+        
+        self.assertFalse(response.status_code == 405) # method not allowed
+
+        self.assertFalse(response.status_code == 404) # Not Found
+        self.assertFalse(response.status_code == 200) # Success
+        self.assertFalse(response.status_code == 401) # Unauthorised
+        self.assertFalse(response.status_code == 403) # Forbidden
+
+        self.assertFalse(response.status_code == 418) # I'm a Teapot

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -64,9 +64,7 @@ class APITests(ArchesTestCase):
         with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "rU") as f:
             json = JSONDeserializer().deserialize(f)
             cls.phase_type_assignment_graph = Graph(json["graph"][0])
-            cls.phase_type_assignment_graph.save()
-
-        cls.user = User.objects.create_user("test", "test@archesproject.org", "password")        
+            cls.phase_type_assignment_graph.save()   
 
         # Load the resource graph.
         test_pkg_path = os.path.join(test_settings.TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg")

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -27,13 +27,13 @@ import os
 from tests import test_settings
 from tests.base_test import ArchesTestCase
 from django.urls import reverse
+from django.core import management
 from django.test.client import RequestFactory, Client
 from arches.app.views.api import APIBase
 from arches.app.models.graph import Graph
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
-
 from django.contrib.auth.models import User, Group, AnonymousUser
 
 # these tests can be run from the command line via
@@ -50,29 +50,25 @@ class APITests(ArchesTestCase):
     @classmethod
     def setUpClass(cls):
         geojson_nodeid = "3ebc6785-fa61-11e6-8c85-14109fd34195"
-        cls.loadOntology()
-        # with open(os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "rU") as f:
-        #     json = JSONDeserializer().deserialize(f)
-        #     cls.unique_graph = Graph(json["graph"][0])
-        #     cls.unique_graph.save()
+        cls.loadOntology()        
+        with open(os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "rU") as f:
+            json = JSONDeserializer().deserialize(f)
+            cls.unique_graph = Graph(json["graph"][0])
+            cls.unique_graph.save()
 
-        # with open(os.path.join("tests/fixtures/resource_graphs/ambiguous_graph_shape.json"), "rU") as f:
-        #     json = JSONDeserializer().deserialize(f)
-        #     cls.ambiguous_graph = Graph(json["graph"][0])
-        #     cls.ambiguous_graph.save()
+        with open(os.path.join("tests/fixtures/resource_graphs/ambiguous_graph_shape.json"), "rU") as f:
+            json = JSONDeserializer().deserialize(f)
+            cls.ambiguous_graph = Graph(json["graph"][0])
+            cls.ambiguous_graph.save()
 
-        # with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "rU") as f:
-        #     json = JSONDeserializer().deserialize(f)
-        #     cls.phase_type_assignment_graph = Graph(json["graph"][0])
-        #     cls.phase_type_assignment_graph.save()
-        
-        # cls.factory = RequestFactory()
-        # cls.client = Client()
-        cls.user = User.objects.create_user("test", "test@archesproject.org", "password")
-        
+        with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "rU") as f:
+            json = JSONDeserializer().deserialize(f)
+            cls.phase_type_assignment_graph = Graph(json["graph"][0])
+            cls.phase_type_assignment_graph.save()
 
-        # # Looks like we need to load the resource graph.. this is from resource_tests.py
-        from django.core import management
+        cls.user = User.objects.create_user("test", "test@archesproject.org", "password")        
+
+        # Load the resource graph.
         test_pkg_path = os.path.join(test_settings.TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg")
         management.call_command("packages", operation="load_package", source=test_pkg_path, yes=True)
 
@@ -97,186 +93,89 @@ class APITests(ArchesTestCase):
         self.assertEqual(request.GET.get("ver"), "2.1")
 
 
-    def test_api_resources_post_archesjson(self):
+    def test_api_resources_archesjson(self):
         """
-        Test that resources POST accepts arches-json format data.
+        Test that resources POST and PUT accept arches-json format data.
 
         """
+        #==Arrange==================================================================================================
 
-        # test update a ResourceTestModel resource 
-        test_resource = {
-            "displaydescription": "undefined",
-            "displayname": "undefined",
-            "graph_id": "c9b37a14-17b3-11eb-a708-acde48001122",
-            "legacyid": "ARCHES",
-            "map_popup": "undefined",
-            "resourceinstanceid": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
-            "tiles": [
-                {
-                    "data": {
-                        "c9b37b7c-17b3-11eb-a708-acde48001122": "Foo ResourceTestModel"
-                    },
-                    "nodegroup_id": "c9b37b7c-17b3-11eb-a708-acde48001122",
-                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
-                    "sortorder": 0,
-                    "tileid": "9b7b8897-d4a0-4735-b1fe-9d82d9890740"
-                },
-                {
-                    "data": {
-                        "c9b37f96-17b3-11eb-a708-acde48001122": {
-                            "features": [
-                                {
-                                    "geometry": {
-                                        "coordinates": [
-                                            [
-                                                [
-                                                    -1.7933273753688184,
-                                                    51.56492920592859
-                                                ],
-                                                [
-                                                    -1.7932521887532005,
-                                                    51.564204760266338
-                                                ],
-                                                [
-                                                    -1.7899815709831444,
-                                                    51.563854217899379
-                                                ],
-                                                [
-                                                    -1.7899815709831444,
-                                                    51.564882467846988
-                                                ],
-                                                [
-                                                    -1.7933273753688184,
-                                                    51.56492920592859
-                                                ]
-                                            ]
-                                        ],
-                                        "type": "Polygon"
-                                    },
-                                    "id": "b11df9f801aa89ba1250ffc6843801e2",
-                                    "properties": {
-                                        "nodeId": "c9b37f96-17b3-11eb-a708-acde48001122"
-                                    },
-                                    "type": "Feature"
-                                }
-                            ],
-                            "type": "FeatureCollection"
-                        }
-                    },
-                    "nodegroup_id": "c9b37f96-17b3-11eb-a708-acde48001122",
-                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
-                    "sortorder": 0,
-                    "tileid": "16d2eb37-d5df-43d4-a930-937fcacd9db1"
-                },
-                {
-                    "data": {
-                        "c9b38568-17b3-11eb-a708-acde48001122": "2021-05-06"
-                    },
-                    "nodegroup_id": "c9b38568-17b3-11eb-a708-acde48001122",
-                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
-                    "sortorder": 0,
-                    "tileid": "b729b441-3240-420f-9a39-98244c8244e8"
-                },
-                {
-                    "data": {
-                        "c9b38aea-17b3-11eb-a708-acde48001122": "Foo ResourceTestModel Sensitive"
-                    },
-                    "nodegroup_id": "c9b38aea-17b3-11eb-a708-acde48001122",
-                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
-                    "sortorder": 0,
-                    "tileid": "e7f0a6db-045e-4aee-b490-c7d2f0d36b14"
-                },
-                {
-                    "data": {
-                        "c9b3828e-17b3-11eb-a708-acde48001122": "2021-05-06"
-                    },
-                    "nodegroup_id": "c9b3828e-17b3-11eb-a708-acde48001122",
-                    "resourceinstance_id": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae",
-                    "sortorder": 0,
-                    "tileid": "71d169e7-bcf4-4354-ac90-0ea9f7fb3f4c"
-                }
-            ]
-        }
         test_resource_simple = {
             "displaydescription": "Test Resource Desc",
             "displayname": "Test Resource dname",
             "graph_id": "c9b37a14-17b3-11eb-a708-acde48001122",
-            "legacyid": "ARCHES",
+            "legacyid": "ARCHES_api",
+            "map_popup": "undefined",
+            "resourceinstanceid": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae", 
+            "tiles": []          
+        }
+        test_resource_simple_modified = {
+            "displaydescription": "Test Resource Desc",
+            "displayname": "Test Resource dname",
+            "graph_id": "c9b37a14-17b3-11eb-a708-acde48001122",
+            "legacyid": "ARCHES_api_MOD",
             "map_popup": "undefined",
             "resourceinstanceid": "c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae", 
             "tiles": []          
         }
 
-        # KH - Try with simple payload? Try with complex payload?
-        #payload = JSONSerializer().serialize(test_resource)
         payload = JSONSerializer().serialize(test_resource_simple)
+        payload_modified = JSONSerializer().serialize(test_resource_simple_modified)
         
         content_type = "application/json"
 
-        # KH - What is this 'as_view'? I', not using it, should I be?
-        view = APIBase.as_view()
-
-
-
-        #==THIS CALLS YOUR FUNCTION CODE!!===="inspired by the elegant auth_tests"==================================================================================================
-
         self.client.login(username="admin", password="admin")
 
+        #==Act : GET confirmation that resource does not exist in database=========================================
         try:
-
-            # KH - We gonna GET to check it's not in there?
-            raw_resp0 = self.client.get(reverse("resources", 
+            resp_get = self.client.get(reverse("resources", 
                                         kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                         +"?format=arches-json")
-
-            print("\n**GET Response ON c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae***********************************************************\n")
-            print(raw_resp0)
-            print("\n*************************************************************\n")
-            # KH - can we trust this? Is it doing what we think it's doing?
-            # self.assertTrue(raw_resp0.status_code == 404) # Success, we not got one.
         except Exception as e: 
-            print("\n*************************************************************\n")
-            print("GET unable to find that which was absent " + str(e))
-            print(type(e))
-            print(e.args)
-            print("\n*************************************************************\n")
-            self.assertTrue(str(e) == "Resource matching query does not exist.")
+        #==Assert==================================================================================================
+            self.assertTrue(str(e) == "Resource matching query does not exist.") # Check exception message.
 
 
 
-
-
-
-
-        resp = {"success": False}
-        raw_resp = self.client.post(reverse("resources", 
+        #==Act : POST resource to database=========================================================================
+        resp_post = self.client.post(reverse("resources", 
                                             kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                             +"?format=arches-json",
                                             payload, 
                                             content_type)
-        print("\n**POST CALL ON c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae***********************************************************\n")
-        print(raw_resp)
-        print("\n*************************************************************\n")
+        #==Assert==================================================================================================
+        self.assertTrue(resp_post.status_code == 201) # resource created.
+
+
         
-        # KH - can we trust this? Is it doing what we think it's doing?
-        self.assertTrue(raw_resp.status_code == 201) # resource created.
 
-        # KH - What are you going to do with this now ya got it?
-        resp = JSONDeserializer().deserialize(raw_resp.content)
-        print("\n**Response ON c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae***********************************************************\n")
-        print(resp)
-        print("\n*************************************************************\n")
-
-        # KH - We gonna GET to check it's in there?
-        raw_resp2 = self.client.get(reverse("resources", 
+        #==Act : GET confirmation that resource does now exist in database=========================================
+        resp_get_confirm = self.client.get(reverse("resources", 
                                     kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
-                                    +"?format=arches-json")
+                                    +"?format=arches-json")        
+        #==Assert==================================================================================================
+        self.assertTrue(resp_get_confirm.status_code == 200) # Success, we got one.        
+        data_get_confirm = JSONDeserializer().deserialize(resp_get_confirm.content)
+        self.assertTrue(data_get_confirm["legacyid"]=="ARCHES_api") # Success, we got the right one.
+
         
-        # KH - can we trust this? Is it doing what we think it's doing?
-        self.assertTrue(raw_resp2.status_code == 200) # Success, we got one.
-        
-        print("\n**GET CALL ON c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae***********************************************************\n")
-        # KH - What are you going to do with this now ya got it?
-        resp2 = JSONDeserializer().deserialize(raw_resp2.content)
-        print(resp2)
-        print("\n*************************************************************\n")
+
+        #==Act : PUT resource changes to database==================================================================
+        resp_put = self.client.put(reverse("resources", 
+                                            kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
+                                            +"?format=arches-json",
+                                            payload_modified, 
+                                            content_type)
+        #==Assert==================================================================================================
+        self.assertTrue(resp_put.status_code == 201) # resource created.
+
+
+
+        #==Act : GET confirmation that resource is now changed in database=========================================
+        resp_get_confirm_mod = self.client.get(reverse("resources", 
+                                    kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
+                                    +"?format=arches-json")        
+        #==Assert==================================================================================================
+        self.assertTrue(resp_get_confirm_mod.status_code == 200) # Success, we got one.     
+        data_get_confirm_mod = JSONDeserializer().deserialize(resp_get_confirm_mod.content)
+        self.assertTrue(data_get_confirm_mod["legacyid"]=="ARCHES_api_MOD") # Success, we got the right one.

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -124,6 +124,8 @@ class APITests(ArchesTestCase):
 
         self.client.login(username="admin", password="admin")
 
+
+
         #==Act : GET confirmation that resource does not exist in database=========================================
         try:
             resp_get = self.client.get(reverse("resources", 
@@ -134,7 +136,6 @@ class APITests(ArchesTestCase):
             self.assertTrue(str(e) == "Resource matching query does not exist.") # Check exception message.
 
 
-
         #==Act : POST resource to database=========================================================================
         resp_post = self.client.post(reverse("resources", 
                                             kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
@@ -143,8 +144,6 @@ class APITests(ArchesTestCase):
                                             content_type)
         #==Assert==================================================================================================
         self.assertTrue(resp_post.status_code == 201) # resource created.
-
-
         
 
         #==Act : GET confirmation that resource does now exist in database=========================================
@@ -155,7 +154,6 @@ class APITests(ArchesTestCase):
         self.assertTrue(resp_get_confirm.status_code == 200) # Success, we got one.        
         data_get_confirm = JSONDeserializer().deserialize(resp_get_confirm.content)
         self.assertTrue(data_get_confirm["legacyid"]=="ARCHES_api") # Success, we got the right one.
-
         
 
         #==Act : PUT resource changes to database==================================================================
@@ -166,7 +164,6 @@ class APITests(ArchesTestCase):
                                             content_type)
         #==Assert==================================================================================================
         self.assertTrue(resp_put.status_code == 201) # resource created.
-
 
 
         #==Act : GET confirmation that resource is now changed in database=========================================

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -218,12 +218,36 @@ class APITests(ArchesTestCase):
 
 
 
-
-
-
         #==THIS CALLS YOUR FUNCTION CODE!!===="inspired by the elegant auth_tests"==================================================================================================
 
         self.client.login(username="admin", password="admin")
+
+        try:
+
+            # KH - We gonna GET to check it's not in there?
+            raw_resp0 = self.client.get(reverse("resources", 
+                                        kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
+                                        +"?format=arches-json")
+
+            print("\n**GET Response ON c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae***********************************************************\n")
+            print(raw_resp0)
+            print("\n*************************************************************\n")
+            # KH - can we trust this? Is it doing what we think it's doing?
+            # self.assertTrue(raw_resp0.status_code == 404) # Success, we not got one.
+        except Exception as e: 
+            print("\n*************************************************************\n")
+            print("GET unable to find that which was absent " + str(e))
+            print(type(e))
+            print(e.args)
+            print("\n*************************************************************\n")
+            self.assertTrue(str(e) == "Resource matching query does not exist.")
+
+
+
+
+
+
+
         resp = {"success": False}
         raw_resp = self.client.post(reverse("resources", 
                                             kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -126,51 +126,51 @@ class APITests(ArchesTestCase):
 
 
 
-        #==Act : GET confirmation that resource does not exist in database=========================================
+        #==Act : GET confirmation that resource does not exist in database=================================
         try:
             resp_get = self.client.get(reverse("resources", 
                                         kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                         +"?format=arches-json")
         except Exception as e: 
-        #==Assert==================================================================================================
+        #==Assert==========================================================================================
             self.assertTrue(str(e) == "Resource matching query does not exist.") # Check exception message.
 
 
-        #==Act : POST resource to database=========================================================================
+        #==Act : POST resource to database=================================================================
         resp_post = self.client.post(reverse("resources", 
                                             kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                             +"?format=arches-json",
                                             payload, 
                                             content_type)
-        #==Assert==================================================================================================
+        #==Assert==========================================================================================
         self.assertTrue(resp_post.status_code == 201) # resource created.
         
 
-        #==Act : GET confirmation that resource does now exist in database=========================================
+        #==Act : GET confirmation that resource does now exist in database=================================
         resp_get_confirm = self.client.get(reverse("resources", 
                                     kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                     +"?format=arches-json")        
-        #==Assert==================================================================================================
+        #==Assert==========================================================================================
         self.assertTrue(resp_get_confirm.status_code == 200) # Success, we got one.        
         data_get_confirm = JSONDeserializer().deserialize(resp_get_confirm.content)
         self.assertTrue(data_get_confirm["legacyid"]=="ARCHES_api") # Success, we got the right one.
         
 
-        #==Act : PUT resource changes to database==================================================================
+        #==Act : PUT resource changes to database==========================================================
         resp_put = self.client.put(reverse("resources", 
                                             kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                             +"?format=arches-json",
                                             payload_modified, 
                                             content_type)
-        #==Assert==================================================================================================
+        #==Assert==========================================================================================
         self.assertTrue(resp_put.status_code == 201) # resource created.
 
 
-        #==Act : GET confirmation that resource is now changed in database=========================================
+        #==Act : GET confirmation that resource is now changed in database=================================
         resp_get_confirm_mod = self.client.get(reverse("resources", 
                                     kwargs={"resourceid":"c29e5caf-6c8d-422b-a2ac-f5f5d99e4dae"})
                                     +"?format=arches-json")        
-        #==Assert==================================================================================================
+        #==Assert==========================================================================================
         self.assertTrue(resp_get_confirm_mod.status_code == 200) # Success, we got one.     
         data_get_confirm_mod = JSONDeserializer().deserialize(resp_get_confirm_mod.content)
         self.assertTrue(data_get_confirm_mod["legacyid"]=="ARCHES_api_MOD") # Success, we got the right one.


### PR DESCRIPTION
## Description

**Enhancement related to #6638**

Resources API put and post methods now supports arches json format as well as arches json-ld format. 

GET and DELETE already handle all formats

This supersedes PR #6676 submitted previously.

## Checks
- [x] Run unit tests
- [x] Documentation already suggests json format is supported.
- [x] Tested on internal application at v5.2.x