### PR TITLE
Require the datatable binding only where used

### DIFF
--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -5,7 +5,6 @@ define([
     'backbone',
     'views/page-view',
     'view-data',
-    'bindings/datatable',
     'uuid',
     'core-js',
     'dom-4',

--- a/arches/app/media/js/views/edit-history.js
+++ b/arches/app/media/js/views/edit-history.js
@@ -1,5 +1,6 @@
 require([
-    'views/base-manager'
+    'views/base-manager',
+    'bindings/datatable'
 ], function(BaseManagerView) {
     /**
     * a BaseManagerView representing the recent edits pages


### PR DESCRIPTION
Requires the datatable binding only where it is used, re #7521