### PR TITLE
Fixes image paths with leading slashes in templates

### DIFF
--- a/arches/app/templates/views/mobile-survey-manager.htm
+++ b/arches/app/templates/views/mobile-survey-manager.htm
@@ -28,7 +28,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
             <!-- Image -->
             <div class="img-circle rr-splash-img-container surveys">
-                <img class="rr-splash-img" src="{% static "/img/multiple_inputs.png" %}" alt="Resource Editor">
+                <img class="rr-splash-img" src="{% static "img/multiple_inputs.png" %}" alt="Resource Editor">
             </div>
 
             <!-- Splash Title -->
@@ -95,7 +95,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                 </div>
                             </div>
                             <div class="resource-grid-tools-container mpm-manager">
-                                
+
                                 <button class="btn btn-shim btn-rr graph-btn btn-labeled btn-sm fa fa-trash" data-bind="click: function(val){$parent.deleteMobileSurvey(val)}, clickBubble: false, css: {'disabled': active()}" aria-expanded="true">{% trans 'delete' %}</button>
 
                                 <div>
@@ -103,7 +103,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                                     {% trans "Status" %}: <span class="resource-status" data-bind="text:active()?'{% trans "Active" %}':'{% trans "Inactive" %}'"></span>
                                     </p>
                                 </div>
-                                
+
                             </div>
                         </div>
                         <!-- /ko -->

--- a/arches/app/templates/views/resource/editor.htm
+++ b/arches/app/templates/views/resource/editor.htm
@@ -42,7 +42,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     <div class="header">
                         <div class="list-filter" data-bind="">
                             <input type="text" class="form-control" style="width: 100%;" placeholder="{% trans 'Find a card...' %}" data-bind="textInput: filter, event: {keypress: filterEnterKeyHandler}">
-    
+
                             <!-- Clear Search -->
                             <span class="clear-node-search" data-bind="visible: filter().length > 0, click: function() { filter(''); }"><i class="fa fa-times-circle"></i></span>
                         </div>
@@ -127,14 +127,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                         resourceId: resourceId,
                         creator: creator,
                         userIsCreator: userIsCreator,
-                        alert: alert, 
+                        alert: alert,
                         permissionLabelLookup: {
                             'view_resourceinstance':'{% trans 'Read' %}',
                             'change_resourceinstance':'{% trans 'Update' %}',
                             'no_access_to_resourceinstance':'{% trans 'No Access' %}',
                             'delete_resourceinstance':'{% trans 'Delete' %}',
                         },
-                        alertTitle: '{% trans 'You are about assign normal user access to this instance' %}', 
+                        alertTitle: '{% trans 'You are about assign normal user access to this instance' %}',
                         alertMessage: '{% trans 'Would you like to proceed?' %}'},
                 }"></div>
             </div>

--- a/arches/app/templates/views/resource/permissions/permissions-manager.htm
+++ b/arches/app/templates/views/resource/permissions/permissions-manager.htm
@@ -12,7 +12,6 @@
 
             <!-- Image -->
             <div class="img-lg img-circle rr-splash-img-container">
-                <!-- <img class="rr-splash-img" src="{% static "/img/Workflow.png" %}" alt="Resource Editor"> -->
                 <i class="fa fa-lock"></i>
             </div>
 
@@ -49,7 +48,7 @@
                     <div class="identities-column">{% trans 'Person/Group' %}</div><div class="permissions-column">{% trans 'Permissions' %}</div>
                 </div>
                 <div class="permissions-list-table-body">
-                     <!--ko foreach: filteredPermissions() --> 
+                     <!--ko foreach: filteredPermissions() -->
                         <!--ko if: $data.creatorOrSuperUser -->
                         <div class="permissions-table-row">
                             <div style="display: inline-flex">
@@ -105,6 +104,6 @@
         </div>
         </div>
 
-    
+
     <!--/ko-->
 </div>

--- a/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
+++ b/arches/app/templates/views/resource/related-resources/related-resources-manager.htm
@@ -6,7 +6,7 @@
 
     <!-- Image -->
     <div class="img-lg img-circle rr-splash-img-container">
-        <img class="rr-splash-img" src="{% static '/img/Workflow.png'%}" alt="Resource Editor">
+        <img class="rr-splash-img" src="{% static 'img/Workflow.png'%}" alt="Resource Editor">
     </div>
 
     <!-- Splash Title -->
@@ -308,7 +308,7 @@
         <div id="rr-splash" class="rr-splash" style="margin: 50px 310px 0px 40px;">
             <!-- Image -->
             <div class="img-lg img-circle rr-splash-img-container">
-                <img class="rr-splash-img" src="{% static '/img/Workflow.png' %}" alt="Saved Search">
+                <img class="rr-splash-img" src="{% static 'img/Workflow.png' %}" alt="Saved Search">
             </div>
 
             <!-- Splash Title -->


### PR DESCRIPTION
we were using the `static` template tag with image paths that included leading slashes, which was causing problems for applications with certain Django configurations.

@chiatt do you understand the conditions to recreate the original poster's issue?  I was able to confirm that the new paths work, but I was not able to reproduce the original issue just by changing my Django settings.

re: #7503 