### PR TITLE
moves "required" flag closer to label

### DIFF
--- a/arches/app/templates/views/components/widgets/edtf.htm
+++ b/arches/app/templates/views/components/widgets/edtf.htm
@@ -4,6 +4,9 @@
 {% block form %}
 <div class="row widget-wrapper">
         <label class="control-label widget-input-label" for="" data-bind="text:label"></label>
+        <!-- ko if: node -->
+        <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>
+        <!-- /ko -->
         <div class="form-group">
           <div class="edtf-style-tools-collapser" data-bind=" click: function() {
               showEDTFFormats(!showEDTFFormats());
@@ -66,9 +69,6 @@
                   </div>
               </div>
           </div>
-        <!-- ko if: node -->
-        <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>
-        <!-- /ko -->
         <div class="col-xs-12">
             <input type="text" data-bind="textInput: value, attr: {placeholder: placeholder, disabled: disabled}" class="form-control input-lg widget-input">
         </div>


### PR DESCRIPTION
Fix issue with required asterisk missing in action for EDTF fields.  It was hiding behind the input field. 

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Move required asterisk closer to label so it won't get lost behind the input field.


### Issues Solved
* #6958 


### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
