### PR TITLE
Fixes edit log issue on resource creation through API

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -117,7 +117,24 @@ class Tile(models.TileModel):
         oldprovisionalvalue=None,
         provisional_edit_log_details=None,
         transaction_id=None,
+        new_resource_created=False
     ):
+        if(new_resource_created):
+            timestamp = datetime.datetime.now()
+            resource_edit = EditLog()
+            resource_edit.resourceclassid = self.resourceinstance.graph_id
+            resource_edit.resourceinstanceid = self.resourceinstance.resourceinstanceid
+            resource_edit.edittype = "create"
+            resource_edit.timestamp = timestamp
+            resource_edit.userid = getattr(user, "id", "")
+            resource_edit.user_email = getattr(user, "email", "")
+            resource_edit.user_firstname = getattr(user, "first_name", "")
+            resource_edit.user_lastname = getattr(user, "last_name", "")
+            resource_edit.user_username = getattr(user, "username", "") 
+            if transaction_id is not None:
+                resource_edit.transactionid = transaction_id
+            resource_edit.save()
+        
         timestamp = datetime.datetime.now()
         edit = EditLog()
         edit.resourceclassid = self.resourceinstance.graph_id
@@ -367,6 +384,7 @@ class Tile(models.TileModel):
         request = kwargs.pop("request", None)
         index = kwargs.pop("index", True)
         user = kwargs.pop("user", None)
+        new_resource_created = kwargs.pop("new_resource_created", False)
         log = kwargs.pop("log", True)
         transaction_id = kwargs.pop("transaction_id", None)
         provisional_edit_log_details = kwargs.pop("provisional_edit_log_details", None)
@@ -442,6 +460,7 @@ class Tile(models.TileModel):
                     newprovisionalvalue=newprovisionalvalue,
                     provisional_edit_log_details=provisional_edit_log_details,
                     transaction_id=transaction_id,
+                    new_resource_created=new_resource_created,
                 )
             else:
                 self.save_edit(
@@ -588,7 +607,6 @@ class Tile(models.TileModel):
         exist.
 
         """
-
         if tileid and models.TileModel.objects.filter(pk=tileid).exists():
             tile = Tile.objects.get(pk=tileid)
             tile.data[nodeid] = value
@@ -598,17 +616,19 @@ class Tile(models.TileModel):
             tile.data[nodeid] = value
             tile.save()
         else:
+            new_resource_created = False
             if not resourceinstanceid:
                 graph = models.Node.objects.get(pk=nodeid).graph
                 resource_instance = models.ResourceInstance(graph=graph)
                 resource_instance.save()
                 resourceinstanceid = str(resource_instance.resourceinstanceid)
+                new_resource_created = True
             tile = Tile.get_blank_tile(nodeid, resourceinstanceid)
             if nodeid in tile.data:
                 tile.data[nodeid] = value
-                tile.save()
+                tile.save(new_resource_created=new_resource_created)
             else:
-                tile.save()
+                tile.save(new_resource_created=new_resource_created)
                 if not nodegroupid:
                     nodegroupid = models.Node.objects.get(pk=nodeid).nodegroup_id
                 if nodegroupid and resourceinstanceid:

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -117,9 +117,9 @@ class Tile(models.TileModel):
         oldprovisionalvalue=None,
         provisional_edit_log_details=None,
         transaction_id=None,
-        new_resource_created=False
+        new_resource_created=False,
     ):
-        if(new_resource_created):
+        if new_resource_created:
             timestamp = datetime.datetime.now()
             resource_edit = EditLog()
             resource_edit.resourceclassid = self.resourceinstance.graph_id
@@ -130,11 +130,11 @@ class Tile(models.TileModel):
             resource_edit.user_email = getattr(user, "email", "")
             resource_edit.user_firstname = getattr(user, "first_name", "")
             resource_edit.user_lastname = getattr(user, "last_name", "")
-            resource_edit.user_username = getattr(user, "username", "") 
+            resource_edit.user_username = getattr(user, "username", "")
             if transaction_id is not None:
                 resource_edit.transactionid = transaction_id
             resource_edit.save()
-        
+
         timestamp = datetime.datetime.now()
         edit = EditLog()
         edit.resourceclassid = self.resourceinstance.graph_id


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
API is using the Tile proxy model to do a save; in some instances it does not create a log entry when new resource instance is created to support a new tile.  Adds functionality to save the new resource entry.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
closes #7611 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
