### PR TITLE
exclude parts of graph api

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -75,7 +75,7 @@ define([
             if (graphid in self.graphLookup){
                 return Promise.resolve(self.graphLookup[graphid]);
             } else {
-                return window.fetch(`${arches.urls.graphs_api}${graphid}?cards=false`)
+                return window.fetch(`${arches.urls.graphs_api}${graphid}?cards=false&exclude=cards,domain_connections,edges,nodegroups,nodes,widgets`)
                     .then(function(response){
                         if (!response.ok) {
                             throw new Error(arches.translations.reNetworkReponseError);

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -485,11 +485,16 @@ class MVT(APIBase):
 class Graphs(APIBase):
     def get(self, request, graph_id=None):
         cards_querystring = request.GET.get("cards", None)
-
+        exclusions_querystring = request.GET.get("exclude", None)
         if cards_querystring == "false":
             get_cards = False
         else:
             get_cards = True
+
+        if exclusions_querystring is not None:
+            exclusions = list(map(str.strip, exclusions_querystring.split(",")))
+        else:
+            exclusions = []
 
         perm = "read_nodegroup"
         graph = cache.get(f"graph_{graph_id}")
@@ -497,7 +502,7 @@ class Graphs(APIBase):
 
         if graph is None:
             graph = Graph.objects.get(graphid=graph_id)
-        graph = JSONSerializer().serializeToPython(graph, sort_keys=False, exclude=["is_editable", "functions"])
+        graph = JSONSerializer().serializeToPython(graph, sort_keys=False, exclude=["is_editable", "functions"] + exclusions)
 
         if get_cards:
             datatypes = models.DDataType.objects.all()


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Allows for the graph API caller to exclude parts of the API return - and then uses that change to exclude most of the return for the resource instance select widget in an attempt to improve performance.  Performance is noticeably better, though perhaps still not as good as it could be.  In testing, I found that most of the performance issues lie within the graph model build process

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
closes #7635 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
