### PR TITLE
resource instance list fix

### DIFF
--- a/arches/app/media/js/bindings/select2-query.js
+++ b/arches/app/media/js/bindings/select2-query.js
@@ -52,7 +52,7 @@ define([
             if (ko.unwrap(select2Config.disabled)) {
                 $(el).select2("disable");
                 select2Config.disabled.subscribe(function(val){
-                    if (val === false) {
+                    if (!val) {
                         $(el).select2("enable");
                     }
                 });

--- a/arches/app/media/js/bindings/select2-query.js
+++ b/arches/app/media/js/bindings/select2-query.js
@@ -52,7 +52,7 @@ define([
             if (ko.unwrap(select2Config.disabled)) {
                 $(el).select2("disable");
                 select2Config.disabled.subscribe(function(val){
-                    if (!val) {
+                    if (val === false) {
                         $(el).select2("enable");
                     }
                 });

--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -299,7 +299,7 @@ define([
         var resourceToAdd = ko.observable("");
 
         this.disabled = ko.computed(function() {
-            return ko.unwrap(self.waitingForGraphToDownload) || ko.unwrap(params.disabled) || ko.unwrap(params.form?.locked);
+            return ko.unwrap(self.waitingForGraphToDownload) || ko.unwrap(params.disabled) || !!ko.unwrap(params.form?.locked);
         });
         
         this.select2Config = {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
fixes issue where the first load of the resource instance select list wouldn't be enabled in the create new resource form.  The issue is that sometimes undefined, and false || undefined is undefined, which is invalid with the select2 binding's strict disabled comparison.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
resolves #7662 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
