### PR TITLE
Pass permissions info to search components

### DIFF
--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -57,7 +57,7 @@ define([
             if (ko.unwrap(params.bounds)) {
                 map.fitBounds(ko.unwrap(params.bounds), boundingOptions);
             }
-        })
+        });
 
         this.bounds = ko.observable(ko.unwrap(params.bounds) || arches.hexBinBounds);
         this.bounds.subscribe(function(bounds) {

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -23,6 +23,8 @@ define([
         };
 
         this.activeTab = ko.observable(ko.unwrap(params.activeTab));
+        this.canEdit = params.userCanEditResources;
+        this.canRead = params.userCanReadResources;
 
         var boundingOptions = {
             padding: {
@@ -337,7 +339,7 @@ define([
         this.getPopupData = function(feature) {
             var data = feature.properties;
             var id = data.resourceinstanceid;
-            data.showEditButton = true;
+            data.showEditButton = self.canEdit;
             if (id) {
                 if (!self.resourceLookup[id]){
                     data = _.defaults(data, {

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -337,7 +337,7 @@ define([
         this.getPopupData = function(feature) {
             var data = feature.properties;
             var id = data.resourceinstanceid;
-            data.showEditButton = false;
+            data.showEditButton = true;
             if (id) {
                 if (!self.resourceLookup[id]){
                     data = _.defaults(data, {
@@ -352,8 +352,8 @@ define([
                         } catch (err) {
                             data.permissions = koMapping.toJS(ko.unwrap(data.permissions));
                         }
-                        if (data.permissions.users_without_edit_perm.indexOf(ko.unwrap(self.userid)) === -1) {
-                            data.showEditButton = true;
+                        if (data.permissions.users_without_edit_perm.indexOf(ko.unwrap(self.userid)) > 0) {
+                            data.showEditButton = false;
                         }
                     }
                     data = ko.mapping.fromJS(data);

--- a/arches/app/media/js/views/base-manager.js
+++ b/arches/app/media/js/views/base-manager.js
@@ -46,6 +46,8 @@ define([
                 });
             });
             options.viewModel.createableResources = ko.observableArray(data.createableResources);
+            options.viewModel.userCanReadResources = data.userCanReadResources;
+            options.viewModel.userCanEditResources = data.userCanEditResources;
 
             options.viewModel.setResourceOptionDisable = function(option, item) {
               if (item) {

--- a/arches/app/media/js/views/components/search/search-results.js
+++ b/arches/app/media/js/views/components/search/search-results.js
@@ -202,8 +202,8 @@ function($, _, BaseFilter, bootstrap, arches, select2, ko, koMapping, GraphModel
                             selected: ko.computed(function() {
                                 return result._source.resourceinstanceid === ko.unwrap(self.selectedResourceId);
                             }),
-                            canRead: result._source.permissions && result._source.permissions.users_without_read_perm.indexOf(this.userid) < 0,
-                            canEdit: result._source.permissions && result._source.permissions.users_without_edit_perm.indexOf(this.userid) < 0,
+                            canRead: result._source.permissions && result._source.permissions.users_without_read_perm.indexOf(this.userid) < 0 && self.userCanReadResources,
+                            canEdit: result._source.permissions && result._source.permissions.users_without_edit_perm.indexOf(this.userid) < 0 && self.userCanEditResources,
                             // can_delete: result._source.permissions.users_without_delete_perm.indexOf(this.userid) < 0,
                         });
                     }, this);

--- a/arches/app/media/js/views/search.js
+++ b/arches/app/media/js/views/search.js
@@ -118,6 +118,8 @@ define([
             _.extend(this, this.viewModel.sharedStateObject);
             this.viewModel.sharedStateObject.total = this.viewModel.total;
             this.viewModel.sharedStateObject.loading = this.viewModel.loading;
+            this.viewModel.sharedStateObject.userCanEditResources = this.viewModel.userCanEditResources;
+            this.viewModel.sharedStateObject.userCanReadResources = this.viewModel.userCanReadResources;
             this.queryString = ko.computed(function() {
                 return JSON.stringify(this.query());
             }, this);

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -477,6 +477,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 graphs: {{graphs}},
                 createableResources: {{createable_resources}},
                 help: "{{nav.help.template}}",
+                userCanEditResources: JSON.parse('{{ user_can_edit }}'.toLowerCase()),
+                userCanReadResources: JSON.parse('{{ user_can_read }}'.toLowerCase())
             };
         });
         {% endautoescape %}

--- a/arches/app/templates/views/components/map-popup.htm
+++ b/arches/app/templates/views/components/map-popup.htm
@@ -46,7 +46,6 @@
         {% trans "Report" %}
     </a>
     <!--/ko-->
-    {% if user_can_edit %}
     <!-- ko if: showEditButton -->
     <a data-bind="click: function () {
         window.open(editURL + resourceinstanceid());
@@ -55,7 +54,6 @@
         {% trans "Edit" %}
     </a>
     <!--/ko-->
-    {% endif %}
     {% endblock footer %}
 </div>
 <!--/ko-->

--- a/arches/app/templates/views/components/search/search-results.htm
+++ b/arches/app/templates/views/components/search/search-results.htm
@@ -23,22 +23,20 @@
             <a class="search-candidate-link" href="" data-bind="click: showDetails"><i class="fa fa-info-circle"></i> {% trans "Details" %} </a>
             <!-- /ko -->
 
-            {% if user_can_edit %}
             <!--ko if: canEdit -->
             <a class="search-candidate-link" href="" data-bind="click: $parent.editResource.bind($parent)"><i class="ion-ios-refresh-empty"></i> {% trans "Edit" %} </a>
             <!--/ko-->
-            {% endif %}
             
             <!-- ko if: !!$parent.mapFilter -->
             <a class="search-candidate-link" href="" data-bind="visible: point, click: mapLinkClicked"><i class="fa fa-map-marker"></i> {% trans "Map" %} </a>
             <!-- /ko -->
 
             <!--ko ifnot: $root.resourceEditorContext -->
-                {% if user_can_read %}
-                <!--ko if: !!$parent.relatedResourcesManager -->
+
+                <!--ko if: !!$parent.relatedResourcesManager && canRead -->
                 <a class="search-candidate-link pull-right" href="" data-bind="click: showrelated"><i class="fa fa-code-fork"></i> {% trans "Related Resources" %} </a>
                 <!--/ko-->
-                {% endif %}
+
                 <!--ko if: $root.resourceEditorContext -->
                     <!--ko if: relatable & $root.editingInstanceId != resourceinstanceid -->
                     <a class="search-candidate-link pull-right" href="" data-bind="click: function(val){relationshipcandidacy(val); showrelated()}"><i class="fa fa-code-fork"></i> {% trans "Relate Resource" %} </a>


### PR DESCRIPTION
Passes whether users can read and edit resources down to search components and fixes logic to display edit link in the map popup. re #7674, #7021