### PR TITLE
Allow resource to load in editor

### DIFF
--- a/arches/app/media/js/views/components/resource-report-abstract.js
+++ b/arches/app/media/js/views/components/resource-report-abstract.js
@@ -123,7 +123,10 @@ define([
             self.report(report);
         };
         
-        if (CardViewModel) {
+        if (ko.unwrap(this.template)?.preload_resource_data && CardViewModel) {
+            self.initialize();
+        } 
+        else if (!ko.unwrap(this.template)?.preload_resource_data) {
             self.initialize();
         }
     };


### PR DESCRIPTION
Allows a resource to load in editor by preventing it from hanging if CardViewModel is not available in the resource-report-abstract component, re #7697


