### PR TITLE
parameter for uncompacted resource json

### DIFF
--- a/arches/app/media/js/views/components/resource-report-abstract.js
+++ b/arches/app/media/js/views/components/resource-report-abstract.js
@@ -29,7 +29,10 @@ define([
             if (params.report) {
                 if (!params.report.report_json && params.report.attributes.resourceid) {
                     url = arches.urls.api_bulk_disambiguated_resource_instance + `?resource_ids=${params.report.attributes.resourceid}`;
-    
+                    if(params.report.defaultConfig?.uncompacted_reporting) {
+                        url += '&uncompacted=true';
+                    }
+
                     $.getJSON(url, function(resp) {
                         params.report.report_json = resp[params.report.attributes.resourceid];
     

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1327,7 +1327,7 @@ class BulkDisambiguatedResourceInstance(APIBase):
     def get(self, request):
         resource_ids = request.GET.get("resource_ids").split(",")
         uncompacted_value = request.GET.get("uncompacted")
-        compact = False
+        compact = True
         if uncompacted_value == "true":
             compact = False
         return JSONResponse({resource.pk: resource.to_json(compact=compact) for resource in Resource.objects.filter(pk__in=resource_ids)})

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1326,7 +1326,11 @@ class BulkResourceReport(APIBase):
 class BulkDisambiguatedResourceInstance(APIBase):
     def get(self, request):
         resource_ids = request.GET.get("resource_ids").split(",")
-        return JSONResponse({resource.pk: resource.to_json() for resource in Resource.objects.filter(pk__in=resource_ids)})
+        uncompacted_value = request.GET.get("uncompacted")
+        compact = False
+        if uncompacted_value == "true":
+            compact = False
+        return JSONResponse({resource.pk: resource.to_json(compact=compact) for resource in Resource.objects.filter(pk__in=resource_ids)})
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Adds a parameter for the bulk resource API to allow for uncompacted output, which is needed for reporting in some cases.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
resolves #7700

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
