### PR TITLE
Use synchronous require import to prevent Advanced Search error

### DIFF
--- a/arches/app/media/js/views/components/resource-report-abstract.js
+++ b/arches/app/media/js/views/components/resource-report-abstract.js
@@ -6,10 +6,10 @@ define([
     'report-templates',
     'models/report',
     'models/graph',
-    'viewmodels/card',
-], function(arches, $, _, ko, reportLookup, ReportModel, GraphModel, CardViewModel) {
+], function(arches, $, _, ko, reportLookup, ReportModel, GraphModel) {
     var ResourceReportAbstract = function(params) {
         var self = this;
+        var CardViewModel = require('viewmodels/card');
 
         this.loading = ko.observable(true);
 
@@ -58,7 +58,6 @@ define([
                 self.fetchResourceData(url).then(function(responseJson) {
                     var template = responseJson.template;
                     self.template(template);
-                    
                     if (template.preload_resource_data) {
                         self.preloadResourceData(responseJson);
                     }
@@ -130,16 +129,7 @@ define([
             self.report(report);
         };
 
-        if (!CardViewModel) {
-            require(['viewmodels/card'], function(cardViewModel) { 
-                CardViewModel = cardViewModel; 
-                
-                self.initialize();
-            });
-        }
-        else {
-            self.initialize();
-        }
+        self.initialize();
     };
     ko.components.register('resource-report-abstract', {
         viewModel: ResourceReportAbstract,


### PR DESCRIPTION
Use a synchronous require import to avoid error related to a circular import in the related-instance-select viewmodel. re #7717

For docs on synchronous require:
https://github.com/requirejs/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#notes-about-synchronous-require