### PR TITLE
Fix grouping card in default report template.

### DIFF
--- a/arches/app/media/js/reports/image.js
+++ b/arches/app/media/js/reports/image.js
@@ -15,7 +15,7 @@ define([
 
             self.imgs = ko.computed(function() {
                 var imgs = [];
-                var nodes = self.nodes();
+                var nodes = ko.unwrap(self.nodes);
                 self.tiles().forEach(function(tile) {
                     _.each(tile.data, function(val, key) {
                         val = koMapping.toJS(val);

--- a/arches/app/templates/views/report-templates/default.htm
+++ b/arches/app/templates/views/report-templates/default.htm
@@ -51,7 +51,7 @@
                             state: 'report',
                             preview: $parent.report.preview,
                             card: card,
-                            pageVm: $root,
+                            pageVm: {...$root, report: $parent.report},
                             hideEmptyNodes: $parent.hideEmptyNodes
                         }
                     } --> <!-- /ko -->


### PR DESCRIPTION
Ensures that the report instance is passed to the card so that the grouping card has access to other cards in the report. re #7730.