### PR TITLE
Ensure all tiles save to the same resource instance. re #7748

### DIFF
--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -142,6 +142,7 @@ define([
         this.saveTile = function(callback) {
             self.loading(true);
             self.tile.transactionId = params.form?.workflowId || undefined;
+            self.tile.resourceinstance_id = self.tile.resourceinstance_id || ko.unwrap(self.form.resourceId);
             self.tile.save(function(response) {
                 self.loading(false);
                 params.pageVm.alert(

--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -142,7 +142,7 @@ define([
         this.saveTile = function(callback) {
             self.loading(true);
             self.tile.transactionId = params.form?.workflowId || undefined;
-            self.tile.resourceinstance_id = self.tile.resourceinstance_id || ko.unwrap(self.form.resourceId);
+            self.tile.resourceinstance_id = self.tile.resourceinstance_id || ko.unwrap(params.form?.resourceId);
             self.tile.save(function(response) {
                 self.loading(false);
                 params.pageVm.alert(

--- a/arches/app/media/js/views/components/cards/grouping.js
+++ b/arches/app/media/js/views/components/cards/grouping.js
@@ -211,10 +211,10 @@ define([
         }, this);
 
         this.saveTiles = function(){
-            // var self = this;
             var errors = ko.observableArray().extend({ rateLimit: 250 });
             var tiles = self.groupedTiles();
             var tile = self.groupedTiles()[0];
+            tile.resourceinstance_id = ko.unwrap(self.form.resourceId);
             self.saving = true;
 
             tile.save(function(response) {
@@ -222,10 +222,9 @@ define([
                 self.saving = false;
                 self.groupedCardIds.valueHasMutated();
                 self.selectGroupCard();
-            }, function(response){
-                var resourceInstanceId = response.resourceinstance_id;
+            }, function(){
                 var requests = _.map(_.rest(tiles), function(tile) {
-                    tile.resourceinstance_id = resourceInstanceId;
+                    tile.resourceinstance_id = ko.unwrap(self.form.resourceId);
                     return tile.save(function(response) {
                         errors.push(response);
                     });


### PR DESCRIPTION
The grouping card was using a different resourceinstanceid for each tile save. This fix ensures all tiles save to the same resource instance. re #7748