### PR TITLE
Restrict manifest-manager to jpeg, png, and tiff file types, re #7672

### DIFF
--- a/arches/app/media/js/views/components/plugins/manifest-manager.js
+++ b/arches/app/media/js/views/components/plugins/manifest-manager.js
@@ -242,6 +242,7 @@ define([
                 dictDefaultMessage: '',
                 autoProcessQueue: false,
                 uploadMultiple: true,
+                acceptedFiles: ["image/jpeg", "image/png", "image/tiff"].join(','),
                 autoQueue: false,
                 clickable: ".fileinput-create-button." + this.uniqueidClass(),
                 previewsContainer: '#hidden-dz-create-previews',


### PR DESCRIPTION
Add accepted files config to dropzone config in manifest manager. 


<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
