### PR TITLE
Use save rather than update to rollback tile edits, re #7779

### DIFF
--- a/arches/app/utils/transaction.py
+++ b/arches/app/utils/transaction.py
@@ -27,7 +27,6 @@ def reverse_edit_log_entries(transaction_id):
                         obj.data = edit_log.oldvalue
                         obj.save()
                         number_of_db_changes += 1
-
     except DatabaseError:
         logger.error("Error connecting to database")
 

--- a/arches/app/utils/transaction.py
+++ b/arches/app/utils/transaction.py
@@ -24,8 +24,10 @@ def reverse_edit_log_entries(transaction_id):
                         number_of_db_changes += 1
                 elif edit_log.edittype == "tile edit":
                     for obj in Tile.objects.filter(tileid=edit_log.tileinstanceid):
-                        obj.update(data=edit_log.oldvalue)
+                        obj.data = edit_log.oldvalue
+                        obj.save()
                         number_of_db_changes += 1
+
     except DatabaseError:
         logger.error("Error connecting to database")
 


### PR DESCRIPTION
Prevents error due to missing `update` method on the Tile proxy model. Also, `save` will reindex the resource after the tile is updated., re #7779