### PR TITLE
7796 es mapping integer outofbounds bug

### DIFF
--- a/arches/app/search/mappings.py
+++ b/arches/app/search/mappings.py
@@ -205,7 +205,7 @@ def prepare_search_index(create=False):
                     "dates": {
                         "type": "nested",
                         "properties": {
-                            "date": {"type": "integer"},
+                            "date": {"type": "long"},
                             "nodegroup_id": {"type": "keyword"},
                             "nodeid": {"type": "keyword"},
                             "provisional": {"type": "boolean"},
@@ -222,7 +222,7 @@ def prepare_search_index(create=False):
                     "date_ranges": {
                         "type": "nested",
                         "properties": {
-                            "date_range": {"type": "integer_range"},
+                            "date_range": {"type": "long_range"},
                             "nodegroup_id": {"type": "keyword"},
                             "provisional": {"type": "boolean"},
                         },
@@ -233,6 +233,7 @@ def prepare_search_index(create=False):
     }
     try:
         from arches.app.datatypes.datatypes import DataTypeFactory
+
         datatype_factory = DataTypeFactory()
         data = index_settings["mappings"]["_doc"]["properties"]["tiles"]["properties"]["data"]["properties"]
         for node in models.Node.objects.all():


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Changed Elasticsearch mappings for `dates` and `date_ranges` to use `long` and `long_range` types to handle prehistoric dates that exceed integer length.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7796 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @aj-he 
*   Tested by: @aj-he 
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
