### PR TITLE
Resolve componentBasedStep after step component sets error to true

### DIFF
--- a/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
+++ b/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
@@ -552,6 +552,7 @@ define([
         this.value = ko.observable();
 
         this.complete = ko.observable(false);
+        this.error = ko.observable();
         this.dirty = ko.observable(); /* user can manually set dirty state */
 
         this.AlertViewModel = AlertViewModel;
@@ -677,8 +678,20 @@ define([
                             [self.componentData.uniqueInstanceName]: self.savedData(),
                         });
                     }
-
                     completeSubscription.dispose();  /* disposes after save */
+                    errorSubscription.dispose();  /* disposes after save */
+                }
+            });
+
+            var errorSubscription = self.error.subscribe(function(error) {
+                if (error) {
+
+                    if (componentBasedStepResolve) {
+                        componentBasedStepResolve();
+                        self.error(false);
+                    }
+                    completeSubscription.dispose();  /* disposes after save */
+                    errorSubscription.dispose();  /* disposes after save */
                 }
             });
 


### PR DESCRIPTION
Resolve componentBasedStep after step component indicates error is true, re #7813. Supports allowing alert messages to be displayed on outer save. QA using the instrument-info step in the upload dataset workflow on this PR: https://github.com/archesproject/arches-for-science-prj/pull/579/files