### PR TITLE
Fixes the error if local storage does not have stepId values yet, #7832

### DIFF
--- a/arches/app/media/js/viewmodels/workflow.js
+++ b/arches/app/media/js/viewmodels/workflow.js
@@ -142,7 +142,7 @@ define([
             var stepName = ko.unwrap(stepData.name);
             
             /* if stepIds exist for this workflow in localStorage, set correct value */ 
-            if (stepNameToIdLookup[stepName]) {
+            if (stepNameToIdLookup && stepNameToIdLookup[stepName]) {
                 stepData.id = stepNameToIdLookup[stepName];
             }
             


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
When the workflow is created to check if the array of stepIds from the local storage is defined. #7832 
It fixes the error when a user starts using a workflow for the first time or after cleaning up the browser history entirely.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7832

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
