### PR TITLE
Install Rust to satisfy dependencies for fabric.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,9 @@ RUN mv ${WHEELS}/entrypoint.sh entrypoint.sh
 
 RUN python3.8 -m venv ENV \
     && . ENV/bin/activate \
+    && pip install --upgrade pip \
+    && pip install rust \
+    && pip install setuptools_rust \
     && pip install requests \
     && pip install -f ${WHEELS} django-auth-ldap \
     && pip install -f ${WHEELS} gunicorn \


### PR DESCRIPTION
Building the image for getty/arches:5.0 fails in its current state. A dependency of fabric (cryptography) now requires Rust to be installed and available. Otherwise cryptography fails installation.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Dockerfile builds successfully
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)