### PR TITLE
Convert json to dict regardless of single or double quotes

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2080,8 +2080,18 @@ class AnnotationDataType(BaseDataType):
             return self.compile_json(tile, node, geojson=data.get(str(node.nodeid)))
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
-        # document["strings"].append({"string": nodevalue["address"], "nodegroup_id": tile.nodegroup_id})
         return
+
+    def transform_value_for_tile(self, value, **kwargs):
+        try:
+            return json.loads(value)
+        except ValueError:
+            # do this if json (invalid) is formatted with single quotes, re #6390
+            return ast.literal_eval(value)
+        except TypeError:
+            # data should come in as json but python list is accepted as well
+            if isinstance(value, list):
+                return value
 
     def get_search_terms(self, nodevalue, nodeid=None):
         # return [nodevalue["address"]]

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2070,7 +2070,7 @@ class NodeValueDataType(BaseDataType):
 
 
 class AnnotationDataType(BaseDataType):
-    def validate(self, value, source=None, node=None, strict=False):
+    def validate(self, value, row_number=None, source=None, node=None, nodeid=None, strict=False):
         errors = []
         return errors
 


### PR DESCRIPTION
Fixes error when annotation json in a csv import file is written with single rather than double quotes re #7854

This can be tested on AfS with this csv and mapping file and the following command:
[Phys_thing_test.zip](https://github.com/archesproject/arches/files/7280462/Phys_thing_test.zip)

```
python3 manage.py packages -o import_business_data -s 'Physical Thing_test.csv' -c 'Physical Thing_test.mapping' -ow 'overwrite'
```


