### PR TITLE
Allow cache prevention in resource utils lookupResourceInstanceData

### DIFF
--- a/arches/app/media/js/utils/resource.js
+++ b/arches/app/media/js/utils/resource.js
@@ -7,8 +7,8 @@ define(['arches'], function(arches) {
          * @param  {resourceid} the id of the Resouce Instance
          * @return {object}
          */
-        lookupResourceInstanceData: function(resourceid) {
-            if (resourceLookup[resourceid]) {
+        lookupResourceInstanceData: function(resourceid, usecache=true) {
+            if (resourceLookup[resourceid] && usecache) {
                 return Promise.resolve(resourceLookup[resourceid]);
             } else {
                 return window.fetch(arches.urls.search_results + "?id=" + resourceid)


### PR DESCRIPTION
When managing resources in a workflow, a developer may need the latest version of the search document. This change just allows the developer to prevent lookupResourceInstanceData from using cached search results. re archesproject/arches-for-science#671