### PR TITLE
Fixes circular import in advanced search #7881

### DIFF
--- a/arches/app/media/js/views/components/widgets/resource-instance-select.js
+++ b/arches/app/media/js/views/components/widgets/resource-instance-select.js
@@ -1,10 +1,10 @@
 define([
     'knockout',
-    'viewmodels/resource-instance-select',
     'bindings/select2-query'
-], function(ko, ResourceInstanceSelectViewModel) {
+], function(ko) {
     return ko.components.register('resource-instance-select-widget', {
         viewModel: function(params) {
+            const ResourceInstanceSelectViewModel = require('viewmodels/resource-instance-select');
             params.multiple = false;
             params.datatype = 'resource-instance';
             ResourceInstanceSelectViewModel.apply(this, [params]);


### PR DESCRIPTION
Fixes error in Adv Search caused by circular import with a synchronous import when loading facet with resource instance widget #7881



