### PR TITLE
Save years before 1000 CE from csv import 

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -359,8 +359,8 @@ class DateDataType(BaseDataType):
         if value is not None:
             if type(value) == list:
                 value = value[0]
-            elif type(value) == str and len(value) < 4 and value.startswith('-') is False: #a year before 1000 but not BCE
-                value = value.zfill(4) 
+            elif type(value) == str and len(value) < 4 and value.startswith("-") is False:  # a year before 1000 but not BCE
+                value = value.zfill(4)
             valid_date_format, valid = self.get_valid_date_format(value)
             if valid:
                 v = datetime.strptime(value, valid_date_format)

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -355,19 +355,21 @@ class DateDataType(BaseDataType):
         return valid_date_format, valid
 
     def transform_value_for_tile(self, value, **kwargs):
-        if type(value) == list:
-            value = value[0]
-        valid_date_format, valid = self.get_valid_date_format(value)
-        if valid:
-            v = datetime.strptime(value, valid_date_format)
-        else:
-            v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
-        # The .astimezone() function throws an error on Windows for dates before 1970
-        try:
-            v = v.astimezone()
-        except:
-            v = self.backup_astimezone(v)
-        value = v.isoformat(timespec="milliseconds")
+        value = None if value == "" else value
+        if value is not None:
+            if type(value) == list:
+                value = value[0]
+            valid_date_format, valid = self.get_valid_date_format(value)
+            if valid:
+                v = datetime.strptime(value, valid_date_format)
+            else:
+                v = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
+            # The .astimezone() function throws an error on Windows for dates before 1970
+            try:
+                v = v.astimezone()
+            except:
+                v = self.backup_astimezone(v)
+            value = v.isoformat(timespec="milliseconds")
         return value
 
     def backup_astimezone(self, dt):

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -359,6 +359,8 @@ class DateDataType(BaseDataType):
         if value is not None:
             if type(value) == list:
                 value = value[0]
+            elif type(value) == str and len(value) < 4 and value.startswith('-') is False: #a year before 1000 but not BCE
+                value = value.zfill(4) 
             valid_date_format, valid = self.get_valid_date_format(value)
             if valid:
                 v = datetime.strptime(value, valid_date_format)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Save years before 1000 CE from csv import by padding year string with zeros to match Python's YYYY format (eg year 200 becomes 0200 and year 12 becomes 0012). This solution does not apply to years BCE. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7935


Model and data for QA:
[date_testing.zip](https://github.com/archesproject/arches/files/7435436/date_testing.zip)

Command for QA:
`python3 manage.py packages -o import_business_data -s 'date_testing/Robot.csv' -c 'date_testing/Robot.mapping' -ow 'overwrite' -g 93d791e8-3781-11ec-8ea7-0242ac1a0007`