### PR TITLE
Handle for file tiles with no file name in the file value object, re #7943

### DIFF
--- a/arches/app/media/js/views/components/cards/file-viewer.js
+++ b/arches/app/media/js/views/components/cards/file-viewer.js
@@ -136,7 +136,11 @@ define([
                 this.fileFormatRenderers.forEach(function(renderer){
                     var excludeExtensions = renderer.exclude ? renderer.exclude.split(",") : [];
                     var rawFileType = type;
-                    var rawExtension = file.name ? ko.unwrap(file.name).split('.').pop() : ko.unwrap(file).split('.').pop();
+                    try {
+                        rawExtension = ko.unwrap(file).split('.').pop();
+                    } catch (error) {
+                        var rawExtension = file.name ? ko.unwrap(file.name).split('.').pop() : undefined;
+                    }
                     if (renderer.type === rawFileType && renderer.ext === rawExtension)  {
                         defaultRenderers.push(renderer);
                     }


### PR DESCRIPTION
Handles for cases when a file tile is created from import or the api and for some reason the file object has no name and extension.