### PR TITLE
Fixes completed workflows steps that hang with loading spinners

### DIFF
--- a/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
+++ b/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
@@ -670,14 +670,19 @@ define([
         this.save = function(){};  /* overwritten by inherited components */
 
         this._saveComponent = function(componentBasedStepResolve) {
+
+            const assignSavedData = function() {
+                if (componentBasedStepResolve) {
+                    componentBasedStepResolve({
+                        [self.componentData.uniqueInstanceName]: self.savedData(),
+                    });
+                }
+            };
+
             var completeSubscription = self.complete.subscribe(function(complete) {
                 if (complete) {
 
-                    if (componentBasedStepResolve) {
-                        componentBasedStepResolve({
-                            [self.componentData.uniqueInstanceName]: self.savedData(),
-                        });
-                    }
+                    assignSavedData();
                     completeSubscription.dispose();  /* disposes after save */
                     errorSubscription.dispose();  /* disposes after save */
                 }
@@ -696,6 +701,11 @@ define([
             });
 
             self.save();
+
+            if (!self.saving() && self.complete()) {
+                assignSavedData();
+            }
+            
         };
 
         this._resetComponent = function(componentBasedStepResolve) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Some workflow steps set self.completed to true and self.saving to false before _saveComponent is actually called. That prevents the subscriptions in _saveComponent from firing, so the loading spinner is never removed. This fix ensures _saveComponent resolves as expected in either case.

### Issues Solved
#7968
