### PR TITLE
Ensure loading spinner does not hang after saving some workflow steps. re #7968

### DIFF
--- a/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
+++ b/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
@@ -670,6 +670,7 @@ define([
         this.save = function(){};  /* overwritten by inherited components */
 
         this._saveComponent = function(componentBasedStepResolve) {
+            self.complete(false);
             var completeSubscription = self.complete.subscribe(function(complete) {
                 if (complete) {
 


### PR DESCRIPTION
Set complete to false to ensure complete subscription fires. re #7968