### PR TITLE
7959 - Accessibility - Resource text now scrollable if needed

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -5812,6 +5812,29 @@ span.editable-card i.fa.fa-align-justify:hover {
     color: #5E29BA;
 }
 
+#resource-list .r-select-card {
+    overflow-y: auto;
+}
+
+#resource-list .r-select-circle {
+    position: relative;
+    top: auto;
+    left: auto;
+    margin: 10px 0;
+}
+
+#resource-list .r-desc-container {
+    position: relative;
+    left: auto;
+    right: auto;
+    bottom: auto;
+}
+
+#resource-list .r-select-desc {
+    overflow: inherit;
+    display: block;
+}
+
 .btn-resource-select {
     height: 50px;
     width: 100%;

--- a/arches/app/templates/views/resource.htm
+++ b/arches/app/templates/views/resource.htm
@@ -30,7 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div class="graph-list-header" data-bind="css: {'alert-active': (alert() && alert().active())}">
 
         <!-- Toolbar -->
-        <div class="relative resource-toolbar" style="">
+        <div class="relative resource-toolbar">
 
             <!-- Search -->
             <div class="edit-panel-search-bar">
@@ -65,7 +65,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <!-- ko foreach: createableResources -->
             <div class="r-grid-item relative" data-bind="css: { 'disabled': disable_instance_creation}">
                 <div data-bind="attr: {href: '#', title: name, target: '_blank'}" href="#">
-                    <div class="r-select-card">
+                    <div class="r-select-card" tabindex="0">
                         <h4 class="r-select-title" data-bind="text: name"></h4>
                         <div class="r-select-circle" data-bind="attr:{style: ('background: ' + color)}">
                             <span>
@@ -73,7 +73,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             </span>
                         </div>
                         <div class="r-desc-container">
-                            <p data-bind="text: subtitle" class="r-select-desc"></p> 
+                            <p data-bind="text: subtitle" class="r-select-desc"></p>
                         </div>  
                     </div>
                 </div>
@@ -82,11 +82,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 <div class="r-select-card-footer">
                     <!-- ko if: disable_instance_creation -->
                     <div class="r-warning">
-                      <i class="fa fa-warning"></i> <span class="form-warning" style="" data-bind="text: disable_instance_creation"></span>
+                      <i class="fa fa-warning"></i> <span class="form-warning" data-bind="text: disable_instance_creation"></span>
                     </div>
                     <!-- /ko -->
                     <!-- ko if: !disable_instance_creation-->
-                    <div class="">
+                    <div>
                         <a href="#" class="btn btn-primary btn-resource-select" role="button" data-bind="
                         attr: { href: $parent.arches.urls.add_resource(graphid), 'data-arches-graphid': graphid},
                         css: { 'disabled': disable_instance_creation }">


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
In the Resource Manager, the text explaining what the resource models are for is cut off, depending on how large the subtitle text is. As per issue raised... #7959 

### Issues Solved
Ensures all text can be viewed if required, without impacting on the layout, even when tabbing to
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @rlwilliamss
*   Tested by: @rlwilliamss
*   Designed by: @phudson-he

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
