### PR TITLE
Reduce queries in Tile.get_blank_tile method

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -579,12 +579,10 @@ class Tile(models.TileModel):
 
     @staticmethod
     def get_blank_tile(nodeid, resourceid=None):
-        node = models.Node.objects.filter(pk=nodeid).select_related('nodegroup')[0]
+        node = models.Node.objects.filter(pk=nodeid).select_related("nodegroup")[0]
         parentnodegroup_id = node.nodegroup.parentnodegroup_id
         if parentnodegroup_id is not None:
-            parent_tile = Tile.get_blank_tile_from_nodegroup_id(
-                nodegroup_id=parentnodegroup_id, resourceid=resourceid, parenttile=None
-            )
+            parent_tile = Tile.get_blank_tile_from_nodegroup_id(nodegroup_id=parentnodegroup_id, resourceid=resourceid, parenttile=None)
             parent_tile.tileid = None
             parent_tile.tiles = []
             for nodegroup in models.NodeGroup.objects.filter(parentnodegroup_id=parentnodegroup_id):

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -579,7 +579,7 @@ class Tile(models.TileModel):
 
     @staticmethod
     def get_blank_tile(nodeid, resourceid=None):
-        node = models.Node.objects.get(pk=nodeid)
+        node = models.Node.objects.filter(pk=nodeid).select_related('nodegroup')[0]
         parentnodegroup_id = node.nodegroup.parentnodegroup_id
         if parentnodegroup_id is not None:
             parent_tile = Tile.get_blank_tile_from_nodegroup_id(

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -579,16 +579,15 @@ class Tile(models.TileModel):
 
     @staticmethod
     def get_blank_tile(nodeid, resourceid=None):
-        parent_nodegroup = None
         node = models.Node.objects.get(pk=nodeid)
-        if node.nodegroup.parentnodegroup_id is not None:
-            parent_nodegroup = node.nodegroup.parentnodegroup
+        parentnodegroup_id = node.nodegroup.parentnodegroup_id
+        if parentnodegroup_id is not None:
             parent_tile = Tile.get_blank_tile_from_nodegroup_id(
-                nodegroup_id=node.nodegroup.parentnodegroup_id, resourceid=resourceid, parenttile=None
+                nodegroup_id=parentnodegroup_id, resourceid=resourceid, parenttile=None
             )
             parent_tile.tileid = None
             parent_tile.tiles = []
-            for nodegroup in models.NodeGroup.objects.filter(parentnodegroup_id=node.nodegroup.parentnodegroup_id):
+            for nodegroup in models.NodeGroup.objects.filter(parentnodegroup_id=parentnodegroup_id):
                 parent_tile.tiles.append(Tile.get_blank_tile_from_nodegroup_id(nodegroup.pk, resourceid=resourceid, parenttile=parent_tile))
             return parent_tile
         else:


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Refactors the get_blank_tile Tile proxy model method to reuse parentnodegroup_id reducing db queries

### Issues Solved
#7974
