### PR TITLE
7963 multiprocessing option for ES commands

### DIFF
--- a/arches/app/search/search.py
+++ b/arches/app/search/search.py
@@ -21,8 +21,9 @@ import urllib.parse
 import urllib.error
 import uuid
 import logging
+import warnings
 from datetime import datetime
-from elasticsearch import Elasticsearch, helpers
+from elasticsearch import Elasticsearch, helpers, ElasticsearchWarning
 from elasticsearch.exceptions import RequestError
 from elasticsearch.helpers import BulkIndexError
 from arches.app.models.system_settings import settings
@@ -39,6 +40,8 @@ class SearchEngine(object):
         self.prefix = kwargs.pop("prefix", "").lower()
         self.es = Elasticsearch(serializer=serializer, **kwargs)
         self.logger = logging.getLogger(__name__)
+        warnings.filterwarnings("ignore", category=ElasticsearchWarning) 
+
 
     def _add_prefix(self, *args, **kwargs):
         if args:

--- a/arches/app/search/search.py
+++ b/arches/app/search/search.py
@@ -229,10 +229,10 @@ class SearchEngine(object):
             def __init__(self, **kwargs):
                 self.queue = []
                 self.batch_size = kwargs.pop("batch_size", 500)
-                kwargs.pop("maxsize","")
-                kwargs.pop("timeout","")
-                kwargs.pop("retry_on_timeout","")
-                kwargs.pop("max_retries","")
+                kwargs.pop("maxsize", "")
+                kwargs.pop("timeout", "")
+                kwargs.pop("retry_on_timeout", "")
+                kwargs.pop("max_retries", "")
                 self.kwargs = kwargs
 
             def add(self, op_type="index", index=None, id=None, data=None):

--- a/arches/app/search/search.py
+++ b/arches/app/search/search.py
@@ -40,8 +40,7 @@ class SearchEngine(object):
         self.prefix = kwargs.pop("prefix", "").lower()
         self.es = Elasticsearch(serializer=serializer, **kwargs)
         self.logger = logging.getLogger(__name__)
-        warnings.filterwarnings("ignore", category=ElasticsearchWarning) 
-
+        warnings.filterwarnings("ignore", category=ElasticsearchWarning)
 
     def _add_prefix(self, *args, **kwargs):
         if args:

--- a/arches/app/search/search.py
+++ b/arches/app/search/search.py
@@ -229,6 +229,10 @@ class SearchEngine(object):
             def __init__(self, **kwargs):
                 self.queue = []
                 self.batch_size = kwargs.pop("batch_size", 500)
+                kwargs.pop("maxsize","")
+                kwargs.pop("timeout","")
+                kwargs.pop("retry_on_timeout","")
+                kwargs.pop("max_retries","")
                 self.kwargs = kwargs
 
             def add(self, op_type="index", index=None, id=None, data=None):

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -1,4 +1,5 @@
 import django
+
 django.setup()
 import pyprind
 import sys
@@ -23,6 +24,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 os.environ.setdefault("PYTHONWARNINGS", "ignore")
+
 
 def index_db(clear_index=True, batch_size=settings.BULK_IMPORT_BATCH_SIZE, quiet=False, use_multiprocessing=False, max_subprocesses=0):
     """
@@ -120,7 +122,7 @@ def index_resources_by_type(
             q.delete(index=RESOURCES_INDEX, refresh=True)
 
         if use_multiprocessing:
-            #force spawn to mirror 3.8 windows and mac settings
+            # force spawn to mirror 3.8 windows and mac settings
             multiprocessing.set_start_method("spawn")
             logger.debug(f"... multiprocessing method: {multiprocessing.get_start_method()}")
             resources = [
@@ -206,6 +208,7 @@ def index_resources_by_type(
 
 def _index_resource_batch(resourceids):
     from arches.app.search.search_engine_factory import SearchEngineInstance as _se
+
     resources = Resource.objects.filter(resourceinstanceid__in=resourceids)
     batch_size = len(resources)
     datatype_factory = DataTypeFactory()

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -221,12 +221,12 @@ def _index_resource_batch(resourceids):
     from arches.app.search.search_engine_factory import SearchEngineInstance as _se
 
     resources = Resource.objects.filter(resourceinstanceid__in=resourceids)
-    batch_size = len(resources)
+    batch_size = int(len(resourceids) / 2)
     datatype_factory = DataTypeFactory()
     node_datatypes = {str(nodeid): datatype for nodeid, datatype in models.Node.objects.values_list("nodeid", "datatype")}
 
     with _se.BulkIndexer(batch_size=batch_size, refresh=True, timeout=30, max_retries=10, retry_on_timeout=True) as doc_indexer:
-        with _se.BulkIndexer(batch_size=batch_size * 2, refresh=True, timeout=30, max_retries=10, retry_on_timeout=True) as term_indexer:
+        with _se.BulkIndexer(batch_size=batch_size, refresh=True, timeout=30, max_retries=10, retry_on_timeout=True) as term_indexer:
             for resource in resources:
                 document, terms = resource.get_documents_to_index(
                     fetchTiles=True, datatype_factory=datatype_factory, node_datatypes=node_datatypes

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -172,9 +172,9 @@ def index_resources_by_type(
                 finally:
                     logger.error(f"Error indexing resource batch, type {type(err)}, message: {err}, \n>>>>>>>>>>>>>> TRACEBACK: {tb}")
 
-            process_count = math.ceil(multiprocessing.cpu_count() / 2 ) if max_subprocesses == 0 else max_subprocesses
+            process_count = math.ceil(multiprocessing.cpu_count() / 2) if max_subprocesses == 0 else max_subprocesses
             logger.debug(f"... multiprocessing process count: {process_count}")
-            logger.debug(f"... resource type batch count (batch size={batch_size}): {batch_number}")
+            logger.debug(f"... resource type batch count (batch size={batch_size}): {len(resource_batches)}")
             with multiprocessing.Pool(processes=process_count) as pool:
                 for resource_batch in resource_batches:
                     pool.apply_async(

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -226,8 +226,8 @@ def _index_resource_batch(resourceids):
     datatype_factory = DataTypeFactory()
     node_datatypes = {str(nodeid): datatype for nodeid, datatype in models.Node.objects.values_list("nodeid", "datatype")}
 
-    with _se.BulkIndexer(batch_size=batch_size, refresh=True) as doc_indexer:
-        with _se.BulkIndexer(batch_size=batch_size * 2, refresh=True) as term_indexer:
+    with _se.BulkIndexer(batch_size=batch_size, refresh=True, timeout=30, max_retries=10, retry_on_timeout=True) as doc_indexer:
+        with _se.BulkIndexer(batch_size=batch_size * 2, refresh=True, timeout=30, max_retries=10, retry_on_timeout=True) as term_indexer:
             for resource in resources:
                 document, terms = resource.get_documents_to_index(
                     fetchTiles=True, datatype_factory=datatype_factory, node_datatypes=node_datatypes

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -63,7 +63,7 @@ def index_resources(
     batch_size -- the number of records to index as a group, the larger the number to more memory required
     quiet -- Silences the status bar output during certain operations, use in celery operations for example
     use_multiprocessing (default False) -- runs the reindexing in multiple subprocesses to take advantage of parallel indexing
-    max_subprocesses (default 0) -- by default (0) the use_multiprocessing function will create a subprocess per core. This overrides that setting.
+    max_subprocesses -- explicitly sets the size of process pool. Auto limits to cpu count if more than this.
 
     """
 

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -67,7 +67,7 @@ def index_resources(
     """
 
     resource_types = (
-        models.CardProxyModel.objects.filter(isresource=True)
+        models.GraphModel.objects.filter(isresource=True)
         .exclude(graphid=settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID)
         .values_list("graphid", flat=True)
     )

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -1,6 +1,4 @@
 import pyprind
-import django
-django.setup()
 from django.db import connection, connections
 from django.db.models import Q
 from arches.app.models import models
@@ -206,6 +204,8 @@ def index_resources_by_type(
 
 
 def _index_resource_batch(resourceids):
+    import django
+    django.setup()
     from arches.app.search.search_engine_factory import SearchEngineInstance as _se #<<<<<<<<<<<<<<<<<<<<<<<<<<<< multiprocess client needed?
     os.environ.setdefault("PYTHONWARNINGS", "ignore")
     resources = Resource.objects.filter(resourceinstanceid__in=resourceids)

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -21,6 +21,7 @@ from datetime import datetime
 
 import multiprocessing
 import os
+import math
 import logging
 
 logger = logging.getLogger(__name__)
@@ -103,10 +104,10 @@ def index_resources_by_type(
 
     if isinstance(resource_types, str):
         try:
-            resource_types = resource_types.split(',')
+            resource_types = resource_types.split(",")
         except:
             pass
-        #resource_types = [resource_types]
+        # resource_types = [resource_types]
 
     for resource_type in resource_types:
         start = datetime.now()
@@ -142,9 +143,6 @@ def index_resources_by_type(
             batch_number = 0
             resource_batches.append([])
 
-            # batch_size needs to be >= 200 as read timeouts start occuring (at least on 16 thread i9)
-            batch_size = 200 if batch_size < 200 else batch_size
-
             for resource in resources:
                 resource_count += 1
                 resource_batches[batch_number].append(resource)
@@ -174,7 +172,8 @@ def index_resources_by_type(
                 finally:
                     logger.error(f"Error indexing resource batch, type {type(err)}, message: {err}, \n>>>>>>>>>>>>>> TRACEBACK: {tb}")
 
-            process_count = multiprocessing.cpu_count() if max_subprocesses == 0 else max_subprocesses
+            process_count = math.ceil(multiprocessing.cpu_count() / 2 ) if max_subprocesses == 0 else max_subprocesses
+            logger.debug(f"... multiprocessing process count: {process_count}")
             logger.debug(f"... resource type batch count (batch size={batch_size}): {batch_number}")
             with multiprocessing.Pool(processes=process_count) as pool:
                 for resource_batch in resource_batches:

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -1,6 +1,7 @@
 import django
 
 django.setup()
+
 import pyprind
 import sys
 from django.db import connection, connections
@@ -23,7 +24,6 @@ import os
 import logging
 
 logger = logging.getLogger(__name__)
-os.environ.setdefault("PYTHONWARNINGS", "ignore")
 
 
 def index_db(clear_index=True, batch_size=settings.BULK_IMPORT_BATCH_SIZE, quiet=False, use_multiprocessing=False, max_subprocesses=0):

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -1,4 +1,6 @@
 import pyprind
+import django
+django.setup()
 from django.db import connection, connections
 from django.db.models import Q
 from arches.app.models import models

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,6 +1,6 @@
 Django==2.2.24
 psycopg2-binary==2.8.4
-elasticsearch>=7.0.0,<8.0.0
+elasticsearch>=7.11.0,<8.0.0
 rdflib==4.2.2
 django-guardian==2.3.0
 python-memcached==1.59

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -118,24 +118,23 @@ class Command(BaseCommand):
         parser.add_argument("-n", "--name ", action="store", dest="name", default=None, help="Name of the custom index")
 
         parser.add_argument(
-            "-sp",
-            "--use_subprocess",
+            "-mp",
+            "--use_multiprocessing",
             action="store_true",
-            dest="use_subprocess",
+            dest="use_multiprocessing",
             default=False,
             help="indexes the batches in parallel processes",
         )
 
         parser.add_argument(
-            "-mp",
+            "-mxp",
             "--max-subprocesses",
             action="store",
             type=int,
             dest="max_subprocesses",
             default=0,
-            help="changes the pool size when using use_subprocess. default = cpu count",
+            help="changes the pool size when using use_multiprocessing. default = cpu count",
         )
-
 
     def handle(self, *args, **options):
         if options["operation"] == "setup_indexes":
@@ -152,11 +151,21 @@ class Command(BaseCommand):
 
         if options["operation"] == "index_database":
             self.index_database(
-                batch_size=options["batch_size"], clear_index=options["clear_index"], name=options["name"], quiet=options["quiet"], use_subprocess=options["use_subprocess"], max_subprocesses=options["max_subprocesses"],
+                batch_size=options["batch_size"],
+                clear_index=options["clear_index"],
+                name=options["name"],
+                quiet=options["quiet"],
+                use_multiprocessing=options["use_multiprocessing"],
+                max_subprocesses=options["max_subprocesses"],
             )
 
         if options["operation"] == "reindex_database":
-            self.reindex_database(batch_size=options["batch_size"], name=options["name"], quiet=options["quiet"],use_subprocess=options["use_subprocess"], max_subprocesses=options["max_subprocesses"],
+            self.reindex_database(
+                batch_size=options["batch_size"],
+                name=options["name"],
+                quiet=options["quiet"],
+                use_multiprocessing=options["use_multiprocessing"],
+                max_subprocesses=options["max_subprocesses"],
             )
 
         if options["operation"] == "index_concepts":
@@ -164,7 +173,11 @@ class Command(BaseCommand):
 
         if options["operation"] == "index_resources":
             index_database_util.index_resources(
-                clear_index=options["clear_index"], batch_size=options["batch_size"], quiet=options["quiet"],use_subprocess=options["use_subprocess"], max_subprocesses=options["max_subprocesses"]
+                clear_index=options["clear_index"],
+                batch_size=options["batch_size"],
+                quiet=options["quiet"],
+                use_multiprocessing=options["use_multiprocessing"],
+                max_subprocesses=options["max_subprocesses"],
             )
 
         if options["operation"] == "index_resources_by_type":
@@ -173,8 +186,8 @@ class Command(BaseCommand):
                 clear_index=options["clear_index"],
                 batch_size=options["batch_size"],
                 quiet=options["quiet"],
-                use_subprocess=options["use_subprocess"],
-                max_subprocesses=options["max_subprocesses"]
+                use_multiprocessing=options["use_multiprocessing"],
+                max_subprocesses=options["max_subprocesses"],
             )
 
         if options["operation"] == "index_resource_relations":
@@ -188,16 +201,43 @@ class Command(BaseCommand):
         es_index = get_index(name)
         es_index.delete_index()
 
-    def index_database(self, batch_size, clear_index=True, name=None, quiet=False, use_subprocess=False, max_subprocesses=0):
+    def index_database(self, batch_size, clear_index=True, name=None, quiet=False, use_multiprocessing=False, max_subprocesses=0):
         if name is not None:
-            index_database_util.index_custom_indexes(index_name=name, clear_index=clear_index, batch_size=batch_size, quiet=quiet,use_subprocess=use_subprocess, max_subprocesses=max_subprocesses)
+            index_database_util.index_custom_indexes(
+                index_name=name,
+                clear_index=clear_index,
+                batch_size=batch_size,
+                quiet=quiet,
+                use_multiprocessing=use_multiprocessing,
+                max_subprocesses=max_subprocesses,
+            )
         else:
-            index_database_util.index_db(clear_index=clear_index, batch_size=batch_size, quiet=quiet, use_subprocess=use_subprocess, max_subprocesses=max_subprocesses)
+            index_database_util.index_db(
+                clear_index=clear_index,
+                batch_size=batch_size,
+                quiet=quiet,
+                use_multiprocessing=use_multiprocessing,
+                max_subprocesses=max_subprocesses,
+            )
 
-    def reindex_database(self, batch_size, name=None, quiet=False, use_subprocess=False, max_subprocesses=0,):
+    def reindex_database(
+        self,
+        batch_size,
+        name=None,
+        quiet=False,
+        use_multiprocessing=False,
+        max_subprocesses=0,
+    ):
         self.delete_indexes(name=name)
         self.setup_indexes(name=name)
-        self.index_database(batch_size=batch_size, clear_index=False, name=name, quiet=quiet, use_subprocess=use_subprocess, max_subprocesses=max_subprocesses)
+        self.index_database(
+            batch_size=batch_size,
+            clear_index=False,
+            name=name,
+            quiet=quiet,
+            use_multiprocessing=use_multiprocessing,
+            max_subprocesses=max_subprocesses,
+        )
 
     def setup_indexes(self, name=None):
         if name is None:

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -133,7 +133,7 @@ class Command(BaseCommand):
             type=int,
             dest="max_subprocesses",
             default=0,
-            help="changes the pool size when using use_multiprocessing. default = cpu count",
+            help="Changes the process pool size when using use_multiprocessing. Default is ceil(cpu_count()/2)",
         )
 
     def handle(self, *args, **options):

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -128,7 +128,7 @@ class Command(BaseCommand):
 
         parser.add_argument(
             "-mxp",
-            "--max-subprocesses",
+            "--max_subprocesses",
             action="store",
             type=int,
             dest="max_subprocesses",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Provided the capability to index resources using multiprocessing via the `es` management command. 

<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Provided the capability to index resources using multiprocessing via the `es` management command. This is enabled by using the two new command parameters:

- `-mp` / `--use_multiprocessing`  flag to enable multiprocessing
-  `-mxp` / `--max_subprocesses`  (optional) - explicitly sets the maximum number of processes created by the process pool. Default = ceil(cpu_count / 2)

These parameters are available on the following es management module operations:

- `index_database`
- `reindex_database`
- `index_resources`

Default behaviour of these operations are unchanged. Using `--use_multiprocessing` enables the functionality.

**example usage**:
`$ python manage.py es index_database --use_multiprocessing`
`$ python manage.py es index_database -mp -mxp 6` where you want the process pool to explicitly make 6 processes available.

**Limitations**
A combination of batch size, and the number of processes being used can have adverse effects if the configuration of ElasticSearch means there are not enough resources to accept the load. Large batch sizes coupled with a lot of processes may cause ES to reject some index calls if it does not have enough memory.

As such, the use of `-mp` should remain an optional flag for developers/technical users.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7963 #4858

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Tested by: @aj-he @csmith-he 
*   Designed by: @aj-he

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I will add the new options to arches-docs once the functionality has been reviewed and merged.