### PR TITLE
686 - Added target blank to link

### DIFF
--- a/arches/app/templates/views/components/widgets/file.htm
+++ b/arches/app/templates/views/components/widgets/file.htm
@@ -166,7 +166,7 @@
 
 <!-- ko foreach: reportFiles() -->
 <dd>
-    <a class="" data-bind="attr: {href: $parent.getFileUrl(url)}">
+    <a data-bind="attr: {href: $parent.getFileUrl(url)}" target="_blank">
         <i class="ion ion-forward"></i>
         <span data-bind="text: name"></span>
     </a>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
As per issue: https://github.com/archesproject/arches-her/issues/686 - Simply added `target="_blank"` to file link in report. Also removed an empty `class=""`.

### Issues Solved
Ensures that a user can continue to view the report page once a file has been downloaded.
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @rlwilliamss
*   Tested by: @rlwilliamss
*   Designed by: @phudson-he

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
