### PR TITLE
runs after_update_all in Tile.update_node_value

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -640,6 +640,8 @@ class Tile(models.TileModel):
                     tile = Tile.update_node_value(
                         nodeid, value, nodegroupid=nodegroupid, resourceinstanceid=resourceinstanceid, transaction_id=transaction_id
                     )
+
+        tile.after_update_all()
         return tile
 
     def __preSave(self, request=None):


### PR DESCRIPTION
Ensures that the `Tile.update_node_value()` method executes `after_update_all()` on the target tile so that any functionality tied to that gets run.

addresses #8047 