### PR TITLE
Remove fabric from requirements_dev.txt

### DIFF
--- a/arches/install/requirements_dev.txt
+++ b/arches/install/requirements_dev.txt
@@ -1,4 +1,3 @@
-fabric
 livereload
 webtest
 django-webtest


### PR DESCRIPTION
Removes fabric because it is no longer used as a dev dependency, re #7852 
