### PR TITLE
If the value of "disabled" changes, update the editor's readonly method

### DIFF
--- a/arches/app/media/js/bindings/ckeditor.js
+++ b/arches/app/media/js/bindings/ckeditor.js
@@ -30,7 +30,7 @@ define([
             $element.html(value);
             var editor = $element.ckeditor(options).editor;
 
-            allBindings()?.attr?.disabled?.subscribe(disabled => editor.setReadOnly(disabled));
+            allBindings()?.attr?.disabled?.subscribe(disabled => editor?.setReadOnly(disabled));
 
             // bind to change events and link it to the observable
             var onChange = function (e) {

--- a/arches/app/media/js/bindings/ckeditor.js
+++ b/arches/app/media/js/bindings/ckeditor.js
@@ -30,7 +30,11 @@ define([
             $element.html(value);
             var editor = $element.ckeditor(options).editor;
 
-            allBindings()?.attr?.disabled?.subscribe(disabled => editor?.setReadOnly(disabled));
+            allBindings()?.attr?.disabled?.subscribe(disabled => {
+                if(CKEDITOR.currentInstance && disabled === true || disabled === false) {
+                    editor?.setReadOnly(disabled);
+                }
+            });
 
             // bind to change events and link it to the observable
             var onChange = function (e) {

--- a/arches/app/media/js/bindings/ckeditor.js
+++ b/arches/app/media/js/bindings/ckeditor.js
@@ -30,6 +30,7 @@ define([
             $element.html(value);
             var editor = $element.ckeditor(options).editor;
 
+            allBindings()?.attr?.disabled?.subscribe(disabled => editor.setReadOnly(disabled));
 
             // bind to change events and link it to the observable
             var onChange = function (e) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Modifies CKeditor to respect changes to the widget's disabled observable.

Needed for [AFS PR #876](https://github.com/archesproject/arches-for-science-prj/pull/876)

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
fixes #8077 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
