### PR TITLE
fix broken reference issue with resource instance select widget, re #…

### DIFF
--- a/arches/app/media/js/views/components/datatypes/resource-instance.js
+++ b/arches/app/media/js/views/components/datatypes/resource-instance.js
@@ -66,40 +66,45 @@ define([
                     });
                     graph.ontologyProperty = ko.observable(ko.unwrap(graph.ontologyProperty));
                     graph.inverseOntologyProperty = ko.observable(ko.unwrap(graph.inverseOntologyProperty));
-                    // use this so that graph.name won't get saved back to the node config
-                    Object.defineProperty(graph, 'name', {
-                        value: model.name
-                    });
-                    window.fetch(arches.urls.graph_nodes(graph.graphid))
-                        .then(function(response){
-                            if(response.ok) {
-                                return response.json();
-                            }
-                            throw("error");
-                        })
-                        .then(function(json) {
-                            var node = _.find(json, function(node) {
-                                return node.istopnode;
-                            });
-                            // use this so that graph.ontologyclass won't get saved back to the node config
-                            Object.defineProperty(graph, 'ontologyClass', {
-                                value: node.ontologyclass
-                            });
-                        });
-
-                    // need to listen to these properties change so we can 
-                    // trigger a "dirty" state in the config
-                    var triggerDirtyState = function() {
-                        preventSetup = true;
-                        self.config.graphs(self.config.graphs());
-                        preventSetup = false;
-                    };
-                    graph.ontologyProperty.subscribe(triggerDirtyState);
-                    graph.inverseOntologyProperty.subscribe(triggerDirtyState);
-
                     graph.removeRelationship = function(graph){
                         self.config.graphs.remove(graph);
                     };
+                    if(!!model){
+                        // use this so that graph.name won't get saved back to the node config
+                        Object.defineProperty(graph, 'name', {
+                            value: model.name
+                        });
+                        window.fetch(arches.urls.graph_nodes(graph.graphid))
+                            .then(function(response){
+                                if(response.ok) {
+                                    return response.json();
+                                }
+                                throw("error");
+                            })
+                            .then(function(json) {
+                                var node = _.find(json, function(node) {
+                                    return node.istopnode;
+                                });
+                                // use this so that graph.ontologyclass won't get saved back to the node config
+                                Object.defineProperty(graph, 'ontologyClass', {
+                                    value: node.ontologyclass
+                                });
+                            });
+
+                        // need to listen to these properties change so we can 
+                        // trigger a "dirty" state in the config
+                        var triggerDirtyState = function() {
+                            preventSetup = true;
+                            self.config.graphs(self.config.graphs());
+                            preventSetup = false;
+                        };
+                        graph.ontologyProperty.subscribe(triggerDirtyState);
+                        graph.inverseOntologyProperty.subscribe(triggerDirtyState);
+                    }else{
+                        Object.defineProperty(graph, 'name', {
+                            value: arches.translations.modelDoesNotExist
+                        });
+                    }
                 };
 
                 this.config.graphs().forEach(function(graph) {

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -410,6 +410,7 @@
                 'mobileSurveyDesc': '{% trans "Summary of how this model participates in the survey" %}',
                 'groupingErrorTitle': '{% trans "Settings Conflict: Remove this card from grouped card?" %}',
                 'groupingErrorMessage': "{% trans 'The cardinality of this card can\'t be changed until you remove it from being grouped with the ${cardName} card.  Do you want to remove this card from being grouped with the ${cardName} card' %}",
+                'modelDoesNotExist': '{% trans "!! Referenced model does not exist -- Delete and select a new model !!" %}',
             },
             version: '{{ app_settings.VERSION }}'
         };


### PR DESCRIPTION
to test this create 2 models (A and B)
Model A has a resource instance node that references Model B
Then delete Model B
Go back to Model A and select the resource instance node. Notice that the UI is broken and can not be recovered from.
Apply the fix and notice that you can now reassign the graph reference.