### PR TITLE
fix issue with node-value node mis-configuration, re #8094

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2064,14 +2064,17 @@ class NodeValueDataType(BaseDataType):
 
     def get_display_value(self, tile, node):
         datatype_factory = DataTypeFactory()
-        value_node = models.Node.objects.get(nodeid=node.config["nodeid"])
-        data = self.get_tile_data(tile)
-        tileid = data[str(node.pk)]
-        if tileid:
-            value_tile = models.TileModel.objects.get(tileid=tileid)
-            datatype = datatype_factory.get_instance(value_node.datatype)
-            return datatype.get_display_value(value_tile, value_node)
-        return ""
+        try:
+            value_node = models.Node.objects.get(nodeid=node.config["nodeid"])
+            data = self.get_tile_data(tile)
+            tileid = data[str(node.pk)]
+            if tileid:
+                value_tile = models.TileModel.objects.get(tileid=tileid)
+                datatype = datatype_factory.get_instance(value_node.datatype)
+                return datatype.get_display_value(value_tile, value_node)
+            return ""
+        except:
+            raise Exception(f"Node with name \"{node.name}\" is not configured correctly.")
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
         pass

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2074,7 +2074,7 @@ class NodeValueDataType(BaseDataType):
                 return datatype.get_display_value(value_tile, value_node)
             return ""
         except:
-            raise Exception(f"Node with name \"{node.name}\" is not configured correctly.")
+            raise Exception(f'Node with name "{node.name}" is not configured correctly.')
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
         pass

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -150,6 +150,9 @@ class TileData(View):
                                     except ModelInactiveError as e:
                                         message = _("Unable to save. Please verify the model status is active")
                                         return JSONResponse({"status": "false", "message": [_(e.title), _(str(message))]}, status=500)
+                                    except Exception as e:
+                                        title = _("Unable to save.")
+                                        return self.handle_save_error(e, tile_id, title=title, message=str(e))
                                 else:
                                     if accepted_provisional is not None:
                                         provisional_editor = User.objects.get(pk=accepted_provisional_edit["user"])


### PR DESCRIPTION
To test this create a card with 2 string nodes and 1 node-value node.
The node-value node should reference one of the string nodes.
Configure the graph's resource descriptor function to utilize this card and the string node not being referenced by the node-value node.
After the graph is saved, delete the string node that is referenced by the node value node.
Create an instance of the resource and try and save the card by filling out the string value and saving.

Before the fix an unhelpful error message is displayed.
After the fix a much more helpful error message is displyed

re #8094