### PR TITLE
4936 cbyrd adds optional user signup settings

### DIFF
--- a/arches/app/templates/login.htm
+++ b/arches/app/templates/login.htm
@@ -70,7 +70,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 				<div class="row account-management">
 					<!-- <a href="arches_password_reminder.html" class="col-xs-5 btn btn-link mar-rgt" style="color:#515152;">{% trans "Forgot password ?" %}</a> -->
 					<a href="{% url 'password_reset' %}" class="btn btn-link account-link">{% trans "Forgot password?" %}</a>
-					<a href="{% url 'signup' %}" class="btn btn-link account-link" target="_blank">{% trans "Create a new account" %}</a>
+
+					{% if user_signup_enabled %}
+						<a href="{% url 'signup' %}" class="btn btn-link account-link" target="_blank">{% trans "Create a new account" %}</a>
+					{% endif %}
 				</div>
 			</div>
 

--- a/arches/app/views/auth.py
+++ b/arches/app/views/auth.py
@@ -117,11 +117,15 @@ class SignupView(View):
             userinfo = JSONSerializer().serialize(form.cleaned_data)
             encrypted_userinfo = AES.encrypt(userinfo)
             url_encrypted_userinfo = urlencode({"link": encrypted_userinfo})
+            confirmation_link = request.build_absolute_uri(reverse("confirm_signup") + "?" + url_encrypted_userinfo)
+
+            if not settings.FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION:  # bypasses email confirmation if setting is disabled
+                return redirect(confirmation_link)
 
             admin_email = settings.ADMINS[0][1] if settings.ADMINS else ""
             email_context = {
                 "button_text": _("Signup for Arches"),
-                "link": request.build_absolute_uri(reverse("confirm_signup") + "?" + url_encrypted_userinfo),
+                "link": confirmation_link,
                 "greeting": _(
                     "Thanks for your interest in Arches. Click on link below \
                     to confirm your email address! Use your email address to login."

--- a/arches/app/views/auth.py
+++ b/arches/app/views/auth.py
@@ -59,7 +59,7 @@ class LoginView(View):
             # need to redirect to 'auth' so that the user is set to anonymous via the middleware
             return redirect("auth")
         else:
-            return render(request, "login.htm", {"auth_failed": False, "next": next})
+            return render(request, "login.htm", {"auth_failed": False, "next": next, 'user_signup_enabled': settings.ENABLE_USER_SIGNUP})
 
     def post(self, request):
         # POST request is taken to mean user is logging in
@@ -75,7 +75,7 @@ class LoginView(View):
             auth_attempt_success = True
             return redirect(next)
 
-        return render(request, "login.htm", {"auth_failed": True, "next": next}, status=401)
+        return render(request, "login.htm", {"auth_failed": True, "next": next, 'user_signup_enabled': settings.ENABLE_USER_SIGNUP}, status=401)
 
 
 @method_decorator(never_cache, name="dispatch")
@@ -85,6 +85,9 @@ class SignupView(View):
         postdata = {"first_name": "", "last_name": "", "email": ""}
         showform = True
         confirmation_message = ""
+
+        if not settings.ENABLE_USER_SIGNUP:
+            raise(Exception(_("User signup has been disabled. Please contact your administrator.")))
 
         return render(
             request,
@@ -105,6 +108,9 @@ class SignupView(View):
         postdata = request.POST.copy()
         postdata["ts"] = int(time.time())
         form = ArchesUserCreationForm(postdata, enable_captcha=settings.ENABLE_CAPTCHA)
+
+        if not settings.ENABLE_USER_SIGNUP:
+            raise(Exception(_("User signup has been disabled. Please contact your administrator.")))
 
         if form.is_valid():
             AES = AESCipher(settings.SECRET_KEY)
@@ -156,6 +162,9 @@ class SignupView(View):
 @method_decorator(never_cache, name="dispatch")
 class ConfirmSignupView(View):
     def get(self, request):
+        if not settings.ENABLE_USER_SIGNUP:
+            raise(Exception(_("User signup has been disabled. Please contact your administrator.")))
+
         link = request.GET.get("link", None)
         AES = AESCipher(settings.SECRET_KEY)
         userinfo = JSONDeserializer().deserialize(AES.decrypt(link))

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -161,6 +161,9 @@ EMAIL_HOST_USER = "xxxx@xxx.com"
 
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
+ENABLE_USER_SIGNUP = True
+FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION = True
+
 POSTGIS_VERSION = (3, 0, 0)
 
 # If you set this to False, Django will make some optimizations so as not

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -161,7 +161,7 @@ EMAIL_HOST_USER = "xxxx@xxx.com"
 
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
-# If True, allows for user self creation via the signup view.
+# If True, allows for user self creation via the signup view. If False, users can only be created via the Django admin view.
 ENABLE_USER_SIGNUP = True
 
 # If True, users must authenticate their accout via email to complete the account creation process.

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -161,7 +161,9 @@ EMAIL_HOST_USER = "xxxx@xxx.com"
 
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
+# Allows for user self creation via the signup view.
 ENABLE_USER_SIGNUP = True
+# If True, user must authenticate their accout via email to complete the account creation process.
 FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION = True
 
 POSTGIS_VERSION = (3, 0, 0)

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -161,9 +161,10 @@ EMAIL_HOST_USER = "xxxx@xxx.com"
 
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
-# Allows for user self creation via the signup view.
+# If True, allows for user self creation via the signup view.
 ENABLE_USER_SIGNUP = True
-# If True, user must authenticate their accout via email to complete the account creation process.
+
+# If True, users must authenticate their accout via email to complete the account creation process.
 FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION = True
 
 POSTGIS_VERSION = (3, 0, 0)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Adds ENABLE_USER_SIGNUP and FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION settings.

To test ENABLE_USER_SIGNUP:
- set ENABLE_USER_SIGNUP to False
- notice the signup link in the login template is hidden
- access the signup page manually (http://localhost:8000/auth/signup)
- notice error thrown

To test FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION:
- set FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION to False
- create a new user
- notice how user is automatically redirected to auth
- ** should we attempt to add messaging when going from confirmation link to view? eg "Success! Your account has been registered. Please log in using your credentials."


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#4936 
