### PR TITLE
Reverse PR 8106 due to missing tiles in some resources, re #8089

### DIFF
--- a/arches/app/utils/label_based_graph.py
+++ b/arches/app/utils/label_based_graph.py
@@ -232,7 +232,7 @@ class LabelBasedGraph(object):
     def _build_graph(
         cls, input_node, input_tile, parent_tree, node_ids_to_tiles_reference, nodegroup_cardinality_reference, node_cache, datatype_factory
     ):
-        for associated_tile in node_ids_to_tiles_reference.get(str(input_node.pk), []):
+        for associated_tile in node_ids_to_tiles_reference.get(str(input_node.pk), [input_tile]):
             parent_tile = associated_tile.parenttile
 
             if associated_tile == input_tile or parent_tile == input_tile:

--- a/arches/app/utils/label_based_graph_v2.py
+++ b/arches/app/utils/label_based_graph_v2.py
@@ -242,7 +242,7 @@ class LabelBasedGraph(object):
     def _build_graph(
         cls, input_node, input_tile, parent_tree, node_ids_to_tiles_reference, nodegroup_cardinality_reference, node_cache, datatype_factory
     ):
-        for associated_tile in node_ids_to_tiles_reference.get(str(input_node.pk), []):
+        for associated_tile in node_ids_to_tiles_reference.get(str(input_node.pk), [input_tile]):
             parent_tile = associated_tile.parenttile
 
             if associated_tile == input_tile or parent_tile == input_tile:


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Reverses changes in PR #8089 because, although they fix #8106, they cause some tiles to not appear in the label based graph.

