### PR TITLE
7830 usability adv search facet click area

### DIFF
--- a/arches/app/media/css/accessibility.css
+++ b/arches/app/media/css/accessibility.css
@@ -72,3 +72,8 @@
     color: #7AD02F;
     text-decoration: underline;
 }
+
+div.search-facet-item:focus {
+    box-shadow: inset 0 0 0 3px #000;
+    outline: none;
+}

--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -11346,7 +11346,6 @@ div.search-facet-item.disabled {
 .search-facet-item-heading {
     font-weight: 400;
     font-size: 13px;
-    cursor: pointer;
 }
 
 .search-facet-item.header input {
@@ -11364,7 +11363,7 @@ a.search-facet-item {
 .search-facet-item.disabled {
     background: #f6f6f6;
     color: #666;
-    cursor: default;
+    cursor: pointer;
 }
 
 a.search-facet-item.disabled {

--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -11346,6 +11346,7 @@ div.search-facet-item.disabled {
 .search-facet-item-heading {
     font-weight: 400;
     font-size: 13px;
+    cursor: pointer;
 }
 
 .search-facet-item.header input {

--- a/arches/app/templates/views/components/search/advanced-search.htm
+++ b/arches/app/templates/views/components/search/advanced-search.htm
@@ -18,7 +18,7 @@
             <!-- ko foreach: searchableGraphs -->
                 <!-- ko if: cards().length > 0  -->
                 <div class="search-facet-item disabled">
-                    <h4 class="search-facet-item-heading" data-bind="click: function () { collapsed(!collapsed()) }">
+                    <h4 tabindex="0" class="search-facet-item-heading" data-bind="click: function () { collapsed(!collapsed()) }">
                         <strong data-bind="text: name"></strong>
                         <span><i class="fa report-expander print-hide" data-bind="css: {'fa-angle-down': !collapsed(), 'fa-angle-right': collapsed()}"></i></span>
                     </h4>

--- a/arches/app/templates/views/components/search/advanced-search.htm
+++ b/arches/app/templates/views/components/search/advanced-search.htm
@@ -17,8 +17,8 @@
             </div>
             <!-- ko foreach: searchableGraphs -->
                 <!-- ko if: cards().length > 0  -->
-                <div class="search-facet-item disabled">
-                    <h4 tabindex="0" class="search-facet-item-heading" data-bind="click: function () { collapsed(!collapsed()) }">
+                <div tabindex="0" class="search-facet-item disabled" data-bind="click: function () { collapsed(!collapsed()) }">
+                    <h4 class="search-facet-item-heading">
                         <strong data-bind="text: name"></strong>
                         <span><i class="fa report-expander print-hide" data-bind="css: {'fa-angle-down': !collapsed(), 'fa-angle-right': collapsed()}"></i></span>
                     </h4>

--- a/arches/app/templates/views/components/search/advanced-search.htm
+++ b/arches/app/templates/views/components/search/advanced-search.htm
@@ -8,7 +8,7 @@
     <div class="facets-container" style="">
         <div class="list-group search-facets">
             <div class="search-facet-item header">
-                <h4 class="search-facet-item-heading">{% trans "Search Facets" %}</h4>
+                <h4 class=" ">{% trans "Search Facets" %}</h4>
                 <div class="list-filter relative">
                     <input type="text" class="form-control" style="" placeholder="{% trans "Find ..." %}" data-bind="value: facetFilterText, valueUpdate: 'keyup'">
                     <!-- Clear Filter -->
@@ -18,9 +18,9 @@
             <!-- ko foreach: searchableGraphs -->
                 <!-- ko if: cards().length > 0  -->
                 <div class="search-facet-item disabled">
-                    <h4 class="search-facet-item-heading">
+                    <h4 class="search-facet-item-heading" data-bind="click: function () { collapsed(!collapsed()) }">
                         <strong data-bind="text: name"></strong>
-                        <span><i class="fa report-expander print-hide" data-bind="css: {'fa-angle-down': !collapsed(), 'fa-angle-right': collapsed()}, click: function () { collapsed(!collapsed()) }"></i></span>
+                        <span><i class="fa report-expander print-hide" data-bind="css: {'fa-angle-down': !collapsed(), 'fa-angle-right': collapsed()}"></i></span>
                     </h4>
                 </div>
                 <div data-bind="visible: !collapsed()">

--- a/arches/app/templates/views/components/search/advanced-search.htm
+++ b/arches/app/templates/views/components/search/advanced-search.htm
@@ -8,7 +8,7 @@
     <div class="facets-container" style="">
         <div class="list-group search-facets">
             <div class="search-facet-item header">
-                <h4 class=" ">{% trans "Search Facets" %}</h4>
+                <h4 class="search-facet-item-heading">{% trans "Search Facets" %}</h4>
                 <div class="list-filter relative">
                     <input type="text" class="form-control" style="" placeholder="{% trans "Find ..." %}" data-bind="value: facetFilterText, valueUpdate: 'keyup'">
                     <!-- Clear Filter -->


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Advanced Search - make whole area of the facet header clickable. As per issue raised... #7830 

### Issues Solved
Entire facet header now clickable instead of just the expand/collapse icon.
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @rlwilliamss
*   Tested by: @rlwilliamss
*   Designed by: @phudson-he

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
