### PR TITLE
mutate domain options when domain values are changed

### DIFF
--- a/arches/app/media/js/views/components/datatypes/domain-value.js
+++ b/arches/app/media/js/views/components/datatypes/domain-value.js
@@ -34,7 +34,7 @@ define(['arches', 'knockout', 'uuid'], function (arches, ko, uuid) {
 
                 this.options = params.config.options;
                 params.config.options().map(option => { 
-                    option.text = ko.observable(option.text)
+                    option.text = ko.observable(option.text);
                     option.text.subscribe(value => {
                         if(value != option.text) {
                             self.options.valueHasMutated();

--- a/arches/app/media/js/views/components/datatypes/domain-value.js
+++ b/arches/app/media/js/views/components/datatypes/domain-value.js
@@ -34,7 +34,7 @@ define(['arches', 'knockout', 'uuid'], function (arches, ko, uuid) {
 
                 this.options = params.config.options;
                 params.config.options().map(option => { 
-                    option.text = ko.observable(option.text);
+                    option.text = ko.observable(ko.unwrap(option.text));
                     option.text.subscribe(value => {
                         if(value != option.text) {
                             self.options.valueHasMutated();

--- a/arches/app/media/js/views/components/datatypes/domain-value.js
+++ b/arches/app/media/js/views/components/datatypes/domain-value.js
@@ -33,6 +33,15 @@ define(['arches', 'knockout', 'uuid'], function (arches, ko, uuid) {
                 }
 
                 this.options = params.config.options;
+                params.config.options().map(option => { 
+                    option.text = ko.observable(option.text)
+                    option.text.subscribe(value => {
+                        if(value != option.text) {
+                            self.options.valueHasMutated();
+                        }
+                    });
+                    return option;
+                });
                 var setupOption = function(option) {
                     option.remove = function () {
                         self.options.remove(option);


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fix for domain options being modified after initial setup.  In initial setup, all the text values are observables - afterward, they're all text.  This fixes that and subscribes to changes in those values in order to mutate the options array and allow for dirty state.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
fixes #8168 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
