### PR TITLE
jquery loads twice fix

### DIFF
--- a/arches/app/frontend/webpack/webpack.common.js
+++ b/arches/app/frontend/webpack/webpack.common.js
@@ -137,7 +137,7 @@ module.exports = {
             'nifty': Path.resolve(__dirname, '../../media/plugins', 'nifty'),
             'async': Path.resolve(__dirname, '../../media/node_modules/requirejs-plugins/src/async'),
             'text': Path.resolve(__dirname, '../../media/node_modules/requirejs-text/text'),
-            // 'jquery-lib': Path.resolve(__dirname, '../../media/node_modules/jquery/dist/jquery.min'),
+            'jquery': Path.resolve(__dirname, '../../media/node_modules/jquery/dist/jquery.min'),
             // 'jquery': Path.resolve(__dirname, '../../media/node_modules/jquery-migrate/dist/jquery-migrate.min'),
             'js-cookie': Path.resolve(__dirname, '../../media/node_modules/js-cookie/src/js.cookie'),
             'select2': Path.resolve(__dirname, '../../media/node_modules/select2/select2'),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
fixes #8234 by stopping jquery from loading twice

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
fixes #8234 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
