### PR TITLE
Cherrypick GeoJSON search endpoint fix from 6.1, re #8262 

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -370,7 +370,12 @@ class SearchResultsExporter(object):
 
     def to_geojson(self, instances, headers, name):  # a part of the code exists in datatypes.py, l.567
         if len(instances) > 0:
-            geometry_fields = self.get_geometry_fieldnames(instances[0])
+            geometry_fields = []
+            for instance in instances:
+                geometry_fields_in_instance = self.get_geometry_fieldnames(instance)
+                for geometry_field_value in geometry_fields_in_instance:
+                    if geometry_field_value not in geometry_fields:
+                        geometry_fields.append(geometry_field_value)
 
         features = []
         for geometry_field in geometry_fields:


### PR DESCRIPTION
Cherry picks 6.1 fix for GeoJSON search endpoint failing when first instance has no geom.