### PR TITLE
Fixed the error explained in issue #8310, that is:

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/exporter.py
+++ b/arches/app/utils/data_management/resource_graphs/exporter.py
@@ -6,6 +6,7 @@ import uuid
 import csv
 import zipfile
 from io import StringIO
+from io import BytesIO
 
 from arches.app.models.graph import Graph
 from arches.app.models.concept import Concept
@@ -257,11 +258,11 @@ def create_mapping_configuration_file(graphid, include_concepts=True, data_dir=N
     files_for_export.append({"name": file_name, "outputfile": dest})
 
     if data_dir is not None:
-        with open(os.path.join(data_dir), "w") as config_file:
+        with open(os.path.join(data_dir, "temp.config"), "w") as config_file:
             json.dump(export_json, config_file, indent=4)
 
         file_name = Graph.objects.get(graphid=graphid).name
-        buffer = StringIO()
+        buffer = BytesIO()
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip:
             for f in files_for_export:
                 f["outputfile"].seek(0)
@@ -271,7 +272,7 @@ def create_mapping_configuration_file(graphid, include_concepts=True, data_dir=N
         buffer.flush()
         zip_stream = buffer.getvalue()
         buffer.close()
-        with open(os.path.join(data_dir), "w") as archive:
+        with open(os.path.join(data_dir, file_name + ".zip"), "wb") as archive:
             archive.write(zip_stream)
     else:
         return files_for_export

--- a/arches/app/utils/data_management/resource_graphs/exporter.py
+++ b/arches/app/utils/data_management/resource_graphs/exporter.py
@@ -258,9 +258,6 @@ def create_mapping_configuration_file(graphid, include_concepts=True, data_dir=N
     files_for_export.append({"name": file_name, "outputfile": dest})
 
     if data_dir is not None:
-        with open(os.path.join(data_dir, "temp.config"), "w") as config_file:
-            json.dump(export_json, config_file, indent=4)
-
         file_name = Graph.objects.get(graphid=graphid).name
         buffer = BytesIO()
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip:


### PR DESCRIPTION
exporting mapping files doesn't work as expected in command line. This changes enables export of single resource models in command line utility. fixed:
IsADirectoryError: [Errno 21] Is a directory: '<output_dir>'
TypeError: string argument expected, got 'bytes'

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Added temporary name to config file, that is a temporary workaround
Changed usage of StringIO to BytesIO in zip saving


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8310 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes (i get No module named 'tests.test_settings' error)
-   [x] I have added tests that prove my fix is effective or that my feature works (downloaded mapping files from my project)
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Warsaw University of Technology
*   Found by: @jakub-gorka
*   Tested by: @jakub-gorka
*   Designed by: @jakub-gorka

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
More changes are needed for this exporter script to work as described in readthedocs. first change should be at the beggining of 'def create_mapping_configuration_file', where 'graphid = uuid.UUID(graphid)' doesn't really do anything but throws an error with invalid UUID. Only then checks for multiple UUIDs or keywords (like 'all') can be made.