### PR TITLE
Move 'Close' button into parent flex container so it's visible, re #8332

### DIFF
--- a/arches/app/templates/views/components/related-resources-map-editor.htm
+++ b/arches/app/templates/views/components/related-resources-map-editor.htm
@@ -173,12 +173,6 @@
                         <!-- /ko -->
                     <!-- /ko -->
                 </div>
-
-                <div class="display-in-workflow-step install-buttons">
-                    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: function () {
-                        showRelatedQuery(false);
-                    }">{% trans 'Close' %}</button>
-                </div>
             </div>
             <!-- /ko-->
 
@@ -362,7 +356,14 @@
             </div>
         </div>
     </div>
-    </div>
+</div>
+<!-- ko if: showRelatedQuery -->
+<div class="display-in-workflow-step">
+    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: function () {
+        showRelatedQuery(false);
+    }">{% trans 'Close' %}</button>
+</div>
+<!--/ko -->
 <!--/ko -->
 {{ block.super }}
 {% endblock sidepanel %}


### PR DESCRIPTION
### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Move 'Close' button into parent flex container so it's visible

### Issues Solved
#8332
