### PR TITLE
8364 - Do not display map popup when in draw mode

### DIFF
--- a/arches/app/media/js/utils/map-popup-provider.js
+++ b/arches/app/media/js/utils/map-popup-provider.js
@@ -10,8 +10,10 @@ define(['arches',
          * @param feature Map feature to check
          * @returns <code>true</code> if the feature can be clicked, otherwise <code>false</code>
          */
-        isFeatureClickable: function(feature)
+        isFeatureClickable: function(feature, drawMode)
         {
+            if (typeof drawMode !== 'undefined' && drawMode !== null)
+                return false;
             return feature.properties.resourceinstanceid;
         },
 

--- a/arches/app/media/js/viewmodels/map-filter.js
+++ b/arches/app/media/js/viewmodels/map-filter.js
@@ -172,9 +172,9 @@ define(['underscore', 'knockout'], function(_, ko) {
             active: ko.observable(false)
         }];
 
-        this.drawMode = ko.observable();
+        this.selectedTool = ko.observable();
         this.drawModes = _.pluck(this.spatialFilterTypes, 'drawMode');
-        this.drawMode.subscribe(function(selectedDrawTool){
+        this.selectedTool.subscribe(function(selectedDrawTool){
             if(!!selectedDrawTool){
                 if(selectedDrawTool === 'extent'){
                     this.searchByExtent();
@@ -183,7 +183,7 @@ define(['underscore', 'knockout'], function(_, ko) {
                 }
             }
         }, this);
-        
+
         this.useMaxBuffer = function(unit, buffer, maxBuffer) {
             var res = false;
             if (unit === 'ft') {
@@ -224,7 +224,7 @@ define(['underscore', 'knockout'], function(_, ko) {
                         });
                         self.searchGeometries(e.features);
                         self.updateFilter();
-                        self.drawMode(undefined);
+                        self.selectedTool(undefined);
                     }
                 });
                 this.map().on('draw.update', function(e) {
@@ -234,7 +234,7 @@ define(['underscore', 'knockout'], function(_, ko) {
                     }
                 });
             });
-            
+
         };
 
         this.makeSearchFeature = function(feature) {
@@ -280,7 +280,7 @@ define(['underscore', 'knockout'], function(_, ko) {
             this.updateFilter();
         }, this);
         //----------------- End search buffer values from map-filter
-        
+
     };
     return MapFilterViewModel;
 });

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -478,7 +478,7 @@ define([
                         if (hoverFeature && hoverFeature.id && style) map.setFeatureState(hoverFeature, { hover: false });
                         hoverFeature = _.find(
                             map.queryRenderedFeatures(e.point),
-                            mapPopupProvider.isFeatureClickable
+                            feature => mapPopupProvider.isFeatureClickable(feature, self.selectedTool())
                         );
                         if (hoverFeature && hoverFeature.id && style) map.setFeatureState(hoverFeature, { hover: true });
 
@@ -499,7 +499,7 @@ define([
                     map.on('click', function(e) {
                         const popupFeatures = _.filter(
                             map.queryRenderedFeatures(e.point),
-                            mapPopupProvider.isFeatureClickable
+                            feature => mapPopupProvider.isFeatureClickable(feature, self.selectedTool())
                         );
                         if (popupFeatures.length) {
                             self.onFeatureClick(popupFeatures, e.lngLat, MapboxGl);

--- a/arches/app/media/js/views/components/search/map-filter.js
+++ b/arches/app/media/js/views/components/search/map-filter.js
@@ -107,7 +107,7 @@ define([
 
                 this.searchGeometries = ko.observableArray(null);
                 this.searchAggregations = ko.observable();
-                this.drawMode = ko.observable();
+                this.selectedTool = ko.observable();
                 this.geoJSONString = ko.observable(undefined);
                 this.geoJSONErrors = ko.observableArray();
                 this.pageLoaded = false;
@@ -249,7 +249,7 @@ define([
 
                 this.drawModes = _.pluck(this.spatialFilterTypes, 'drawMode');
 
-                this.drawMode.subscribe(function(selectedDrawTool){
+                this.selectedTool.subscribe(function(selectedDrawTool){
                     if(!!selectedDrawTool){
                         if(selectedDrawTool === 'extent'){
                             this.searchByExtent();
@@ -271,7 +271,7 @@ define([
                     var agg = ko.unwrap(self.searchAggregations);
                     var features = [];
                     var mouseoverInstanceId = self.mouseoverInstanceId();
-                    
+
                     if (agg) {
                         _.each(agg.results, function(result) {
                             _.each(result._source.points, function(point) {
@@ -384,7 +384,7 @@ define([
                     })
                     self.searchGeometries(e.features);
                     self.updateFilter();
-                    self.drawMode(undefined);
+                    self.selectedTool(undefined);
                 });
                 this.map().on('draw.update', function(e) {
                     self.searchGeometries(e.features);
@@ -396,7 +396,7 @@ define([
             },
 
             searchByExtent: function() {
-                if (_.contains(this.drawModes, this.drawMode())) {
+                if (_.contains(this.drawModes, this.selectedTool())) {
                     this.draw.deleteAll();
                 }
                 var bounds = this.map().getBounds();
@@ -420,7 +420,7 @@ define([
                 });
                 this.searchGeometries([boundsFeature]);
                 this.updateFilter();
-                this.drawMode(undefined);
+                this.selectedTool(undefined);
             },
 
             useMaxBuffer: function (unit, buffer, maxBuffer) {
@@ -481,7 +481,7 @@ define([
                             this.filter.inverted(feature.properties.inverted);
                         }
                     }, this);
-                    this.drawMode(undefined);
+                    this.selectedTool(undefined);
                     this.geoJSONString(undefined);
                 }
             },

--- a/arches/app/templates/views/components/search/map-filter.htm
+++ b/arches/app/templates/views/components/search/map-filter.htm
@@ -23,7 +23,7 @@
     <div class="workbench-card-sidepanel-body">
     <!-- ko if: geoJSONString() === undefined -->
     <div class="spatial-filter-container">
-        
+
         <!-- Buffer Definition -->
         <div class="buffer-control form-control">
             <h5 class="">{% trans "Buffer" %}</h5>
@@ -38,7 +38,7 @@
         <div class="add-new-feature buffer-control" style="">
             <h5 class="">{% trans "Select a filter" %}</h5>
             <select data-placeholder="{% trans "Draw a..." %}" data-bind="
-                value: drawMode,
+                value: selectedTool,
                 valueAllowUnset: true,
                 options: spatialFilterTypes,
                 optionsText: 'title',
@@ -50,7 +50,7 @@
                 }
             "></select>
         </div>
-        
+
     </div>
     <!-- /ko-->
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Modify the map popup provider so that map popups are not displayed when in a draw mode. Needed to align the name of the `drawMode` ko observable in `viewmodels/map-filter.js` and `views/components/search/map-filter.js` with the similar observable called `selectedTool` in the `viewmodels/map-editor.js` so that the tool context can be passed into the `utils/map-popup-provider.js` in both contexts.

### Issues Solved
#8364 Popup displayed when map in drawing mode

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
n/a
