### PR TITLE
Allow card to override default popup, re #8389

### DIFF
--- a/arches/app/media/js/viewmodels/map-editor.js
+++ b/arches/app/media/js/viewmodels/map-editor.js
@@ -11,8 +11,7 @@ define([
     'proj4',
     'views/components/map',
     'views/components/cards/select-feature-layers',
-    'text!templates/views/components/cards/map-popup.htm'
-], function(arches, $, _, ko, koMapping, uuid, geojsonExtent, geojsonhint, toGeoJSON, proj4, MapComponentViewModel, selectFeatureLayersFactory, popupTemplate) {
+], function(arches, $, _, ko, koMapping, uuid, geojsonExtent, geojsonhint, toGeoJSON, proj4, MapComponentViewModel, selectFeatureLayersFactory) {
     var viewModel = function(params) {
         var self = this;
         var padding = 40;
@@ -536,8 +535,6 @@ define([
             if (tool && tool !== 'select_feature') return false;
             return feature.properties.resourceinstanceid || self.isSelectable(feature);
         };
-
-        this.popupTemplate = popupTemplate;
 
         self.isSelectable = function(feature) {
             var selectLayerIds = selectFeatureLayers.map(function(layer) {

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -428,7 +428,7 @@ define([
         };
 
         this.onFeatureClick = function(features, lngLat, MapboxGl) {
-            var popupTemplate = mapPopupProvider.getPopupTemplate(features);
+            const popupTemplate = this.popupTemplate ? this.popupTemplate : mapPopupProvider.getPopupTemplate(features);
             const map = self.map();
             const mapStyle = map.getStyle();
             self.popup = new MapboxGl.Popup()


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Allows a card to define its own primary descriptor template. If a card has this.popupTemplate object defined the map will use it instead of the popup defined in the map-popup-provider. 

Example of Related Resource Map card using its own popup:
https://github.com/archesproject/arches/blob/83c785d51c16071ba212eea4899db3c189a9f172/arches/app/media/js/views/components/cards/related-resources-map.js#L11-L12
https://github.com/archesproject/arches/blob/83c785d51c16071ba212eea4899db3c189a9f172/arches/app/media/js/views/components/cards/related-resources-map.js#L281

### Issues Solved
#8389
