### PR TITLE
Add db trigger on load_staging to get resourceid from legacyid, #8450

### DIFF
--- a/arches/app/models/migrations/8009_etlmodule.py
+++ b/arches/app/models/migrations/8009_etlmodule.py
@@ -316,7 +316,7 @@ add_get_resourceid_from_legacyid_trigger = """
     RETURNS trigger AS $$
     BEGIN
         IF NEW.legacyid IN (SELECT legacyid FROM resource_instances WHERE legacyid = NEW.legacyid) THEN
-            NEW.resourceid = (SELECT resourceinstanceid FROM resource_instances WHERE legacyid = NEW.legacyid);
+            SELECT resourceinstanceid FROM resource_instances INTO NEW.resourceid WHERE legacyid = NEW.legacyid;
         END IF;
         RETURN NEW;
     END;

--- a/arches/app/models/migrations/8009_etlmodule.py
+++ b/arches/app/models/migrations/8009_etlmodule.py
@@ -332,6 +332,8 @@ remove_get_resourceid_from_legacyid_trigger = """
     DROP TRIGGER IF EXISTS __arches_get_resourceid_from_legacyid_trigger ON load_staging;
     DROP FUNCTION IF EXISTS __arches_get_resourceid_from_legacyid_trigger_function();
     """
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -434,5 +436,5 @@ class Migration(migrations.Migration):
         migrations.RunSQL(add_validation_reporting_functions, remove_validation_reporting_functions),
         migrations.RunSQL(add_functions_to_get_nodegroup_tree, remove_functions_to_get_nodegroup_tree),
         migrations.RunSQL(add_staging_to_tile_function, remove_staging_to_tile_function),
-        migrations.RunSQL(add_get_resourceid_from_legacyid_trigger, remove_get_resourceid_from_legacyid_trigger),        
+        migrations.RunSQL(add_get_resourceid_from_legacyid_trigger, remove_get_resourceid_from_legacyid_trigger),
     ]

--- a/arches/app/models/migrations/8009_etlmodule.py
+++ b/arches/app/models/migrations/8009_etlmodule.py
@@ -311,7 +311,27 @@ remove_staging_to_tile_function = """
     DROP FUNCTION public.__arches_staging_to_tile(load_id uuid);
     """
 
+add_get_resourceid_from_legacyid_trigger = """
+    CREATE OR REPLACE FUNCTION __arches_get_resourceid_from_legacyid_trigger_function()
+    RETURNS trigger AS $$
+    BEGIN
+        IF NEW.legacyid IN (SELECT legacyid FROM resource_instances WHERE legacyid = NEW.legacyid) THEN
+            NEW.resourceid = (SELECT resourceinstanceid FROM resource_instances WHERE legacyid = NEW.legacyid);
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
 
+    CREATE TRIGGER __arches_get_resourceid_from_legacyid_trigger
+        BEFORE INSERT ON load_staging
+        FOR EACH ROW
+        EXECUTE PROCEDURE __arches_get_resourceid_from_legacyid_trigger_function();
+    """
+
+remove_get_resourceid_from_legacyid_trigger = """
+    DROP TRIGGER IF EXISTS __arches_get_resourceid_from_legacyid_trigger ON load_staging;
+    DROP FUNCTION IF EXISTS __arches_get_resourceid_from_legacyid_trigger_function();
+    """
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -414,4 +434,5 @@ class Migration(migrations.Migration):
         migrations.RunSQL(add_validation_reporting_functions, remove_validation_reporting_functions),
         migrations.RunSQL(add_functions_to_get_nodegroup_tree, remove_functions_to_get_nodegroup_tree),
         migrations.RunSQL(add_staging_to_tile_function, remove_staging_to_tile_function),
+        migrations.RunSQL(add_get_resourceid_from_legacyid_trigger, remove_get_resourceid_from_legacyid_trigger),        
     ]


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Add a database trigger to use the resource id if the resource id or legacy id is already in the system, #8450
This allows a user to append tiles to the existing resource if the resource id or legacy id is known during the etl process using db functions.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8450

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
