### PR TITLE
Ensure url and url_label are always props on url value, re #8451

### DIFF
--- a/arches/app/media/js/views/components/widgets/urldatatype.js
+++ b/arches/app/media/js/views/components/widgets/urldatatype.js
@@ -6,10 +6,22 @@ define(['knockout', 'viewmodels/widget'], function(ko, WidgetViewModel) {
             params.valueProperties = ['url', 'url_label'];
             WidgetViewModel.apply(this, [params]);
 
+            this.url.subscribe(val => {
+                if (val && !ko.unwrap(this.url_label)) {
+                    this.url_label("");
+                }
+            });
+
+            this.url_label.subscribe(val => {
+                if (val && !ko.unwrap(this.url)) {
+                    this.url("");
+                }
+            });
+
             this.urlPreviewText = ko.pureComputed(function() {
                 if (this.url()) {
-                    if (this.url_label && this.url_label()) {
-                        return this.url_label();
+                    if (ko.unwrap(this.url_label)) {
+                        return ko.unwrap(this.url_label);
                     } else if (this.url && this.url()) {
                         return this.url();
                     }

--- a/arches/app/media/js/views/components/widgets/urldatatype.js
+++ b/arches/app/media/js/views/components/widgets/urldatatype.js
@@ -22,7 +22,7 @@ define(['knockout', 'viewmodels/widget'], function(ko, WidgetViewModel) {
                 if (this.url()) {
                     if (ko.unwrap(this.url_label)) {
                         return ko.unwrap(this.url_label);
-                    } else if (this.url && this.url()) {
+                    } else {
                         return this.url();
                     }
                 }


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Ensures that both the url and url_label are saved to the url datatype value because if one of the properties is missing on the value, the widget will not work properly.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8451