### PR TITLE
Filter instances when all nodegroups are restricted, re #8438 

### DIFF
--- a/arches/app/media/js/views/components/search/resource-type-filter.js
+++ b/arches/app/media/js/views/components/search/resource-type-filter.js
@@ -1,15 +1,30 @@
 define([
     'knockout',
+    'arches',
     'views/components/search/base-filter'
-], function(ko, BaseFilter) {
+], function(ko, arches, BaseFilter) {
     var componentName = 'resource-type-filter';
     return ko.components.register(componentName, {
         viewModel: BaseFilter.extend({
-            initialize: function(options) {
+            initialize: async function(options) {
                 options.name = 'Resource Type Filter';
                 this.requiredFilters = ['term-filter'];
                 BaseFilter.prototype.initialize.call(this, options);
+                this.resourceModels = ko.observableArray();
+                const self = this;
+
+                const getData = async function() {
+                    const response = await fetch(arches.urls.api_search_component_data + componentName);
+                    if (response.ok) {
+                        const data = await response.json();
+                        self.resourceModels(data.resources);
+                    } else {
+                        // eslint-disable-next-line no-console
+                        console.log('Failed to fetch resource instance list');
+                    }
+                };
                 
+                await getData();
                 this.filter = ko.observableArray();
 
                 var filterUpdated = ko.computed(function() {
@@ -64,8 +79,8 @@ define([
                 }, this);
                 if(!!item){
                     var inverted = ko.observable(false);
-                    this.getFilter('term-filter').addTag(item.name(), this.name, inverted);
-                    this.filter([{graphid:item.graphid, name: item.name(), inverted: inverted}]);
+                    this.getFilter('term-filter').addTag(item.name, this.name, inverted);
+                    this.filter([{graphid:item.graphid, name: item.name, inverted: inverted}]);
                 }else{
                     this.clear();
                 }

--- a/arches/app/media/js/views/components/search/resource-type-filter.js
+++ b/arches/app/media/js/views/components/search/resource-type-filter.js
@@ -11,21 +11,17 @@ define([
                 this.requiredFilters = ['term-filter'];
                 BaseFilter.prototype.initialize.call(this, options);
                 this.resourceModels = ko.observableArray();
+                this.filter = ko.observableArray();
                 const self = this;
 
-                const getData = async function() {
-                    const response = await fetch(arches.urls.api_search_component_data + componentName);
-                    if (response.ok) {
-                        const data = await response.json();
-                        self.resourceModels(data.resources);
-                    } else {
-                        // eslint-disable-next-line no-console
-                        console.log('Failed to fetch resource instance list');
-                    }
-                };
-                
-                await getData();
-                this.filter = ko.observableArray();
+                const response = await fetch(arches.urls.api_search_component_data + componentName);
+                if (response.ok) {
+                    const data = await response.json();
+                    self.resourceModels(data.resources);
+                } else {
+                    // eslint-disable-next-line no-console
+                    console.log('Failed to fetch resource instance list');
+                }
 
                 var filterUpdated = ko.computed(function() {
                     return JSON.stringify(ko.toJS(this.filter()));

--- a/arches/app/search/components/resource_type_filter.py
+++ b/arches/app/search/components/resource_type_filter.py
@@ -1,6 +1,8 @@
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.search.elasticsearch_dsl_builder import Bool, Terms
 from arches.app.search.components.base import BaseSearchFilter
+from arches.app.models.models import GraphModel
+from arches.app.utils.permission_backend import get_resource_types_by_perm
 
 details = {
     "searchcomponentid": "",
@@ -20,10 +22,13 @@ class ResourceTypeFilter(BaseSearchFilter):
     def append_dsl(self, search_results_object, permitted_nodegroups, include_provisional):
         search_query = Bool()
         querystring_params = self.request.GET.get(details["componentname"], "")
-
         graph_ids = []
         for resourceTypeFilter in JSONDeserializer().deserialize(querystring_params):
-            graph_ids.append(str(resourceTypeFilter["graphid"]))
+            graphid = str(resourceTypeFilter["graphid"])
+            graph = GraphModel.objects.get(pk=graphid)
+            graph_nodegroups = {str(val[0]) for val in graph.cardmodel_set.values_list('nodegroup_id')}
+            if len(set(permitted_nodegroups).intersection(graph_nodegroups)) > 0:
+                graph_ids.append(graphid)
 
         terms = Terms(field="graph_id", terms=graph_ids)
         if resourceTypeFilter["inverted"] is True:
@@ -32,3 +37,7 @@ class ResourceTypeFilter(BaseSearchFilter):
             search_query.filter(terms)
 
         search_results_object["query"].add_query(search_query)
+
+
+    def view_data(self):
+        return  {"resources": get_resource_types_by_perm(self.request.user, 'read_nodegroup')}

--- a/arches/app/search/components/resource_type_filter.py
+++ b/arches/app/search/components/resource_type_filter.py
@@ -43,11 +43,10 @@ class ResourceTypeFilter(BaseSearchFilter):
             terms = Terms(field="graph_id", terms=list(permitted_graphids))
         else:
             terms = Terms(field="graph_id", terms=graph_ids)
-        
+
         search_query.filter(terms)
 
         search_results_object["query"].add_query(search_query)
 
-
     def view_data(self):
-        return  {"resources": get_resource_types_by_perm(self.request.user, 'read_nodegroup')}
+        return {"resources": get_resource_types_by_perm(self.request.user, "read_nodegroup")}

--- a/arches/app/search/components/resource_type_filter.py
+++ b/arches/app/search/components/resource_type_filter.py
@@ -17,16 +17,18 @@ details = {
     "enabled": True,
 }
 
+def get_permitted_graphids(permitted_nodegroups):
+    permitted_graphids = set()
+    for node in Node.objects.filter(nodegroup__in=permitted_nodegroups):
+        permitted_graphids.add(str(node.graph_id))
+    return permitted_graphids
 
 class ResourceTypeFilter(BaseSearchFilter):
     def append_dsl(self, search_results_object, permitted_nodegroups, include_provisional):
         search_query = Bool()
         querystring_params = self.request.GET.get(details["componentname"], "")
         graph_ids = []
-        permitted_graphids = set()
-
-        for node in Node.objects.filter(nodegroup__in=permitted_nodegroups).select_related("graph"):
-            permitted_graphids.add(str(node.graph_id))
+        permitted_graphids = get_permitted_graphids(permitted_nodegroups)
 
         for resourceTypeFilter in JSONDeserializer().deserialize(querystring_params):
             graphid = str(resourceTypeFilter["graphid"])

--- a/arches/app/search/components/search_results.py
+++ b/arches/app/search/components/search_results.py
@@ -26,7 +26,9 @@ class SearchResultsFilter(BaseSearchFilter):
         geo_agg_filter = Bool()
 
         try:
-            search_results_object["query"].dsl["query"]["bool"]["filter"][0]["terms"]["graph_id"] # check if resource_type filter is already applied
+            search_results_object["query"].dsl["query"]["bool"]["filter"][0]["terms"][
+                "graph_id"
+            ]  # check if resource_type filter is already applied
         except (KeyError, IndexError):
             resource_model_filter = Bool()
             permitted_graphids = get_permitted_graphids(permitted_nodegroups)

--- a/arches/app/search/components/search_results.py
+++ b/arches/app/search/components/search_results.py
@@ -26,7 +26,7 @@ class SearchResultsFilter(BaseSearchFilter):
         geo_agg_filter = Bool()
 
         try:
-            search_results_object["query"].dsl["query"]["bool"]["filter"][0]["terms"]["graph_id"]
+            search_results_object["query"].dsl["query"]["bool"]["filter"][0]["terms"]["graph_id"] # check if resource_type filter is already applied
         except (KeyError, IndexError):
             resource_model_filter = Bool()
             permitted_graphids = get_permitted_graphids(permitted_nodegroups)

--- a/arches/app/templates/views/components/search/resource-type-filter.htm
+++ b/arches/app/templates/views/components/search/resource-type-filter.htm
@@ -1,13 +1,14 @@
 {% load i18n %}
 
 <div class="resource-selector-button pull-right">
+    <div data-bind="value: resourceModels"></div>
     <div class="btn-group btn-group-xs">
         <button class="btn btn-primary btn-active-primary dropdown-toggle" data-toggle="dropdown" type="button" aria-expanded="true"> {% trans "Resource Type" %} <i class="dropdown-caret fa fa-caret-down"></i>
         </button>
         <ul class="dropdown-menu dropdown-menu-right">
             <li><a href="#" data-bind="click: selectModelType.bind($data, null)">{% trans "All resources" %}</a></li>
-            <!-- ko foreach: $root.resources -->
-            <li><a href="#" data-bind="text: name().length > 55 ? name().substring(55, length) + '...' : name(), click: $parent.selectModelType.bind($parent)"></a></li>
+            <!-- ko foreach: resourceModels -->
+            <li><a href="#" data-bind="text: name.length > 55 ? name.substring(55, length) + '...' : name, click: $parent.selectModelType.bind($parent)"></a></li>
             <!-- /ko -->
         </ul>
     </div>

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -233,7 +233,7 @@ def get_createable_resource_types(user):
 
 def get_resource_types_by_perm(user, perms):
     """
-    returns a list of graphs for which a user has specific node permissions
+    returns a list of graphs for which a user has specific nodegroup permissions
 
     Arguments:
     user -- the user to check


### PR DESCRIPTION
### Description of Change
Filters out resource instances from search results of resource models for which all nodegroups are restricted.

### Issues Solved
#8438
This also solves most of #2491 with the exception of concealing displaynames/terms from restricted instances in the search suggestions. However, applying permissions to terms should probably be treated in a different PR because it involves resource instance permissions as well as nodegroup permissions, so we can close #8438 and #2491 when this PR is approved, and address term permissions under #7316