### PR TITLE
Fixes request object not being passed to tile save from nodevalue api causing unexpected function behaviour

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -606,7 +606,7 @@ class Tile(models.TileModel):
         return tile
 
     @staticmethod
-    def update_node_value(nodeid, value, tileid=None, nodegroupid=None, resourceinstanceid=None, transaction_id=None):
+    def update_node_value(nodeid, value, tileid=None, nodegroupid=None, request=None, resourceinstanceid=None, transaction_id=None):
         """
         Updates the value of a node in a tile. Creates the tile and parent tiles if they do not yet
         exist.
@@ -615,11 +615,11 @@ class Tile(models.TileModel):
         if tileid and models.TileModel.objects.filter(pk=tileid).exists():
             tile = Tile.objects.get(pk=tileid)
             tile.data[nodeid] = value
-            tile.save(transaction_id=transaction_id)
+            tile.save(request=request, transaction_id=transaction_id)
         elif models.TileModel.objects.filter(Q(resourceinstance_id=resourceinstanceid), Q(nodegroup_id=nodegroupid)).count() == 1:
             tile = Tile.objects.filter(Q(resourceinstance_id=resourceinstanceid), Q(nodegroup_id=nodegroupid))[0]
             tile.data[nodeid] = value
-            tile.save(transaction_id=transaction_id)
+            tile.save(request=request, transaction_id=transaction_id)
         else:
             new_resource_created = False
             if not resourceinstanceid:
@@ -631,14 +631,14 @@ class Tile(models.TileModel):
             tile = Tile.get_blank_tile(nodeid, resourceinstanceid)
             if nodeid in tile.data:
                 tile.data[nodeid] = value
-                tile.save(new_resource_created=new_resource_created, transaction_id=transaction_id)
+                tile.save(request=request, new_resource_created=new_resource_created, transaction_id=transaction_id)
             else:
-                tile.save(new_resource_created=new_resource_created, transaction_id=transaction_id)
+                tile.save(request=request, new_resource_created=new_resource_created, transaction_id=transaction_id)
                 if not nodegroupid:
                     nodegroupid = models.Node.objects.get(pk=nodeid).nodegroup_id
                 if nodegroupid and resourceinstanceid:
                     tile = Tile.update_node_value(
-                        nodeid, value, nodegroupid=nodegroupid, resourceinstanceid=resourceinstanceid, transaction_id=transaction_id
+                        nodeid, value, nodegroupid=nodegroupid, request=request, resourceinstanceid=resourceinstanceid, transaction_id=transaction_id
                     )
 
         tile.after_update_all()
@@ -657,8 +657,9 @@ class Tile(models.TileModel):
                     function.save(self, request, context=context)
                 except NotImplementedError:
                     pass
-        except TypeError:
-            logger.info(_("No associated functions or other TypeError raised by a function"))
+        except TypeError as e:
+            logger.warning(_("No associated functions or other TypeError raised by a function"))
+            logger.warning(e)
 
     def __preDelete(self, request):
         try:
@@ -667,8 +668,9 @@ class Tile(models.TileModel):
                     function.delete(self, request)
                 except NotImplementedError:
                     pass
-        except TypeError:
-            logger.info(_("No associated functions or other TypeError raised by a function"))
+        except TypeError as e:
+            logger.warning(_("No associated functions or other TypeError raised by a function"))
+            logger.warning(e)
 
     def __postSave(self, request=None, context=None):
         """

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1606,7 +1606,7 @@ class NodeValue(APIBase):
                 data = datatype.update(tile, data, nodeid, action=operation)
 
             # update/create tile
-            new_tile = TileProxyModel.update_node_value(nodeid, data, tileid, resourceinstanceid=resourceid, transaction_id=transaction_id)
+            new_tile = TileProxyModel.update_node_value(nodeid, data, tileid, request=request, resourceinstanceid=resourceid, transaction_id=transaction_id)
 
             response = JSONResponse(new_tile, status=200)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Passes request object from nodevalue api call to the tile save so that functions expecting a request object, that is usually passed when using the web UI, doesn't error.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
fixes #8471 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
