### PR TITLE
Properly assigns transaction id in tile delete

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -494,7 +494,7 @@ class Tile(models.TileModel):
         se = SearchEngineFactory().create()
         request = kwargs.pop("request", None)
         index = kwargs.pop("index", True)
-        transaction_id = kwargs.pop("index", None)
+        transaction_id = kwargs.pop("transaction_id", None)
         provisional_edit_log_details = kwargs.pop("provisional_edit_log_details", None)
         for tile in self.tiles:
             tile.delete(*args, request=request, **kwargs)


### PR DESCRIPTION
### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Properly assigns transaction id in tile delete

### Issues Solved
#8475

#### Ticket Background
*   Found by: @whatisgalen  <!--- This could be the person who files the bug, but not always. -->
