### PR TITLE
Call graph endpoint only when graph list needed, re #8495

### DIFF
--- a/arches/app/media/js/views/components/etl_modules/branch-csv-importer.js
+++ b/arches/app/media/js/views/components/etl_modules/branch-csv-importer.js
@@ -25,6 +25,9 @@ define([
 
             this.toggleDownloadMode = () => {
                 this.downloadMode(!this.downloadMode());
+                if (this.downloadMode() && !ko.unwrap(this.templates).length) {
+                    getGraphs();
+                }
             };
 
             function getCookie(name) {
@@ -84,8 +87,6 @@ define([
                     self.templates(templates);
                 }
             };
-
-            getGraphs();
 
             this.addFile = async function(file){
                 self.loading(true);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Call graph endpoint only when a list of graphs is need to power the template dropdown.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8495
