### PR TITLE
8528 - Functions to  disable/enable tiles triggers for bulk load performance

### DIFF
--- a/arches/app/models/migrations/8502_loadevent_indexed_time.py
+++ b/arches/app/models/migrations/8502_loadevent_indexed_time.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "8009_etlmodule"),
+        ("models", "8449_filter_warning_etl_module"),
     ]
 
     operations = [

--- a/arches/app/models/migrations/8528_bulk_load_performance_functions.py
+++ b/arches/app/models/migrations/8528_bulk_load_performance_functions.py
@@ -59,15 +59,15 @@ class Migration(migrations.Migration):
     BEGIN
         return query SELECT t.resourceinstanceid,
                             t.nodegroupid,
-                            COALESCE(t.parenttileid::text, '')::uuid parent_tileid,
-                            count(*)                           tilecount
+                            t.parenttileid parent_tileid,
+                            count(*)       tilecount
                      FROM tiles t,
                           node_groups ng
                      WHERE t.nodegroupid = ng.nodegroupid
     --                                       AND ng.nodegroupid in (select n.nodegroupid from nodes n where n.graphid = (select graphid from graphs g where g.name = 'BC Fossil Site'))
                        AND ng.cardinality = '1'
                      group by t.resourceinstanceid, t.nodegroupid,
-                              COALESCE(t.parenttileid::text, '')
+                              t.parenttileid
                      having count(*) > 1
         order by nodegroupid, resourceinstanceid;
     END $$

--- a/arches/app/models/migrations/8528_bulk_load_performance_functions.py
+++ b/arches/app/models/migrations/8528_bulk_load_performance_functions.py
@@ -1,0 +1,86 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("models", "8502_loadevent_indexed_time"),
+    ]
+
+    sql_string = """
+    create procedure __arches_prepare_bulk_load() as
+    $$
+    DECLARE
+    BEGIN
+        alter table tiles disable trigger __arches_check_excess_tiles_trigger;
+        alter table tiles disable trigger __arches_trg_update_spatial_attributes;
+        Raise Notice 'tiles triggers disabled.';
+        Raise Notice ' run __arches_complete_bulk_load after loads complete to re-enable triggers and refresh spatial views';
+    END $$
+    language plpgsql;
+
+    create or replace procedure __arches_complete_bulk_load() as
+    $$
+    DECLARE
+        cardinality_violations bigint;
+    BEGIN
+        alter table tiles enable trigger __arches_check_excess_tiles_trigger;
+        alter table tiles enable trigger __arches_trg_update_spatial_attributes;
+
+        if (not __arches_refresh_spatial_views()) then
+            Raise EXCEPTION 'Unable to refresh spatial views';
+        end if;
+
+       with cardinality_violations as (SELECT t.resourceinstanceid,
+                                              t.nodegroupid,
+                                              COALESCE(t.parenttileid::text, '') parent_tileid,
+                                              count(*)
+                                       FROM tiles t,
+                                            node_groups ng
+                                       WHERE t.nodegroupid = ng.nodegroupid
+                                         AND ng.cardinality = '1'
+                                       group by t.resourceinstanceid, t.nodegroupid, parent_tileid
+                                       having count(*) > 1)
+       select count(*)
+       into cardinality_violations
+       from cardinality_violations;
+
+        if (cardinality_violations > 0) then
+            Raise Exception 'Cardinality violations found. Run `select * from __arches_get_tile_cardinality_violations()` to list violations';
+        else
+            Raise Notice 'No cardinality violations found';
+        end if;
+    END $$
+    language plpgsql;
+
+    create or replace function __arches_get_tile_cardinality_violations()
+        returns table(resourceinstanceid uuid, nodegroupid uuid, parenttileid uuid, tilecount bigint) as
+    $$
+    DECLARE
+    BEGIN
+        return query SELECT t.resourceinstanceid,
+                            t.nodegroupid,
+                            COALESCE(t.parenttileid::text, '')::uuid parent_tileid,
+                            count(*)                           tilecount
+                     FROM tiles t,
+                          node_groups ng
+                     WHERE t.nodegroupid = ng.nodegroupid
+    --                                       AND ng.nodegroupid in (select n.nodegroupid from nodes n where n.graphid = (select graphid from graphs g where g.name = 'BC Fossil Site'))
+                       AND ng.cardinality = '1'
+                     group by t.resourceinstanceid, t.nodegroupid,
+                              COALESCE(t.parenttileid::text, '')
+                     having count(*) > 1
+        order by nodegroupid, resourceinstanceid;
+    END $$
+        language plpgsql;
+
+    """
+
+    reverse_sql_string = """
+    drop procedure __arches_prepare_bulk_load;
+    drop procedure __arches_complete_bulk_load;
+    drop function __arches_get_tile_cardinality_violations;
+    """
+
+    operations = [
+        migrations.RunSQL(sql_string, reverse_sql_string),
+    ]

--- a/arches/app/models/migrations/8528_bulk_load_performance_functions.py
+++ b/arches/app/models/migrations/8528_bulk_load_performance_functions.py
@@ -45,7 +45,8 @@ class Migration(migrations.Migration):
        from cardinality_violations;
 
         if (cardinality_violations > 0) then
-            Raise Exception 'Cardinality violations found. Run `select * from __arches_get_tile_cardinality_violations()` to list violations';
+            Raise Exception 'Cardinality violations found. Run `%` to list violations',
+                'select * from __arches_get_tile_cardinality_violations()';
         else
             Raise Notice 'No cardinality violations found';
         end if;
@@ -64,7 +65,6 @@ class Migration(migrations.Migration):
                      FROM tiles t,
                           node_groups ng
                      WHERE t.nodegroupid = ng.nodegroupid
-    --                                       AND ng.nodegroupid in (select n.nodegroupid from nodes n where n.graphid = (select graphid from graphs g where g.name = 'BC Fossil Site'))
                        AND ng.cardinality = '1'
                      group by t.resourceinstanceid, t.nodegroupid,
                               t.parenttileid

--- a/arches/app/models/migrations/8528_bulk_load_performance_functions.py
+++ b/arches/app/models/migrations/8528_bulk_load_performance_functions.py
@@ -53,25 +53,32 @@ class Migration(migrations.Migration):
     END $$
     language plpgsql;
 
-    create or replace function __arches_get_tile_cardinality_violations()
-        returns table(resourceinstanceid uuid, nodegroupid uuid, parenttileid uuid, tilecount bigint) as
-    $$
-    DECLARE
-    BEGIN
-        return query SELECT t.resourceinstanceid,
-                            t.nodegroupid,
-                            t.parenttileid parent_tileid,
-                            count(*)       tilecount
-                     FROM tiles t,
-                          node_groups ng
-                     WHERE t.nodegroupid = ng.nodegroupid
-                       AND ng.cardinality = '1'
-                     group by t.resourceinstanceid, t.nodegroupid,
-                              t.parenttileid
-                     having count(*) > 1
-        order by nodegroupid, resourceinstanceid;
-    END $$
-        language plpgsql;
+create or replace function __arches_get_tile_cardinality_violations()
+    returns table(graph_name text, node_names text[], resourceinstanceid uuid, nodegroupid uuid, parenttileid uuid, tilecount bigint) as
+$$
+DECLARE
+BEGIN
+    return query with tile_violations as ( SELECT t.resourceinstanceid,
+                        t.nodegroupid,
+                        t.parenttileid parent_tileid,
+                        count(*)       tilecount
+                 FROM tiles t,
+                      node_groups ng
+                 WHERE t.nodegroupid = ng.nodegroupid
+                   AND ng.cardinality = '1'
+                 group by t.resourceinstanceid, t.nodegroupid,
+                          t.parenttileid
+                 having count(*) > 1)
+        select g.name, array_agg(n.name), tv.*
+            from tile_violations tv,
+                 nodes n,
+                 graphs g
+                where tv.nodegroupid = n.nodegroupid
+                  and n.graphid = g.graphid
+            group by g.name, tv.resourceinstanceid, tv.nodegroupid, tv.parent_tileid, tv.tilecount
+    order by nodegroupid, resourceinstanceid;
+END $$
+    language plpgsql;
 
     """
 


### PR DESCRIPTION
Adds functionality to disable and re-enable triggers on the tiles table to increase bulk load performance.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds 3 procedures/functions to:
1. Disable triggers on the tiles table
2. Re-enable triggers on the tiles table, refresh spatial views, check for tiles cardinality violations
3. Retrieve a list of tiles cardinality violations

### Issues Solved
#8528 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
