### PR TITLE
corrects migration order #8557

### DIFF
--- a/arches/app/models/migrations/7783_add_graph_publications.py
+++ b/arches/app/models/migrations/7783_add_graph_publications.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.fields import JSONField
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "7783_make_settings_active"),
+        ("models", "8528_bulk_load_performance_functions"),
     ]
 
     def forwards_add_graph_column_data(apps, schema_editor):

--- a/arches/app/models/migrations/7874_node_alias.py
+++ b/arches/app/models/migrations/7874_node_alias.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "7783_add_graph_publications"),
+        ("models", "8085_relational_data_model_handle_dates"),
     ]
 
     operations = [


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Corrects migration order discrepancy between 6.1.x and 7.0.x


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8557 


### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

To test, cut a branch off of 6.1.x and run `arches create-project $PROJECT_NAME`. Navigate to the project and run `setup_db`. Then pull in dev/7.0.x and run `python manage.py migrate`. It should run successfully
