### PR TITLE
Check for ontology id rather than ontology object, re #8671

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -207,7 +207,7 @@ class Graph(models.GraphModel):
 
         node.graph = self
 
-        if self.ontology is None:
+        if self.ontology_id is None:
             node.ontologyclass = None
         if node.pk is None:
             node.pk = uuid.uuid1()


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Checks for ontology_id rather than performing a database query to determine if a graph has an assigned ontology.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8671
