### PR TITLE
updates displaydescription and displayname returns from methods leveraging the ES index #8682

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -593,10 +593,14 @@ class Resource(models.ResourceInstance):
 
                         # manually updates output to current language for `displaydescription` and `displayname`
                         current_language_display_description = [
-                            description_object['value'] for description_object in resource["_source"]["displaydescription"] if description_object.get('language') == current_language
+                            description_object["value"]
+                            for description_object in resource["_source"]["displaydescription"]
+                            if description_object.get("language") == current_language
                         ]
                         current_language_display_name = [
-                            name_object['value'] for name_object in resource["_source"]["displayname"] if name_object.get('language') == current_language
+                            name_object["value"]
+                            for name_object in resource["_source"]["displayname"]
+                            if name_object.get("language") == current_language
                         ]
 
                         if len(current_language_display_description):

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -39,6 +39,7 @@ from arches.app.search.mappings import TERMS_INDEX, RESOURCES_INDEX
 from arches.app.search.elasticsearch_dsl_builder import Query, Bool, Terms, Nested
 from arches.app.tasks import index_resource
 from arches.app.utils import import_class_from_string, task_management
+from arches.app.utils.i18n import get_localized_value
 from arches.app.utils.label_based_graph import LabelBasedGraph
 from arches.app.utils.label_based_graph_v2 import LabelBasedGraph as LabelBasedGraphV2
 from guardian.shortcuts import assign_perm, remove_perm
@@ -578,6 +579,9 @@ class Resource(models.ResourceInstance):
         if len(instanceids) > 0:
             related_resources = se.search(index=RESOURCES_INDEX, id=list(instanceids))
             if related_resources:
+
+                current_language = get_language()
+
                 for resource in related_resources["docs"]:
                     relations = get_relations(
                         resourceinstanceid=resource["_id"],
@@ -586,6 +590,20 @@ class Resource(models.ResourceInstance):
                     )
                     if resource["found"]:
                         resource["_source"]["total_relations"] = relations["total"]
+
+                        # manually updates output to current language for `displaydescription` and `displayname`
+                        current_language_display_description = [
+                            description_object['value'] for description_object in resource["_source"]["displaydescription"] if description_object.get('language') == current_language
+                        ]
+                        current_language_display_name = [
+                            name_object['value'] for name_object in resource["_source"]["displayname"] if name_object.get('language') == current_language
+                        ]
+
+                        if len(current_language_display_description):
+                            resource["_source"]["displaydescription"] = current_language_display_description[0]
+                        if len(current_language_display_name):
+                            resource["_source"]["displayname"] = current_language_display_name[0]
+
                         ret["related_resources"].append(resource["_source"])
 
         return ret

--- a/arches/app/search/search.py
+++ b/arches/app/search/search.py
@@ -128,7 +128,7 @@ class SearchEngine(object):
         id = kwargs.pop("id", None)
 
         if id:
-            kwargs = { # removes bad kwargs for get methods
+            kwargs = {  # removes bad kwargs for get methods
                 "index": kwargs["index"],
                 "source_includes": kwargs["source_includes"],
                 "source_excludes": kwargs["source_excludes"],

--- a/arches/app/search/search.py
+++ b/arches/app/search/search.py
@@ -128,7 +128,11 @@ class SearchEngine(object):
         id = kwargs.pop("id", None)
 
         if id:
-            kwargs.pop("query", None)  # remove query param
+            kwargs = { # removes bad kwargs for get methods
+                "index": kwargs["index"],
+                "source_includes": kwargs["source_includes"],
+                "source_excludes": kwargs["source_excludes"],
+            }
             if isinstance(id, str):
                 id = id.split(",")
                 if len(id) == 1:

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -366,13 +366,17 @@ def search_results(request, returnDsl=False):
 
         current_language = get_language()
 
-        for resource in results['hits']['hits']:
+        for resource in results["hits"]["hits"]:
             # manually updates output to current language for `displaydescription` and `displayname`
             current_language_display_description = [
-                description_object['value'] for description_object in resource["_source"]["displaydescription"] if description_object.get('language') == current_language
+                description_object["value"]
+                for description_object in resource["_source"]["displaydescription"]
+                if description_object.get("language") == current_language
             ]
             current_language_display_name = [
-                name_object['value'] for name_object in resource["_source"]["displayname"] if name_object.get('language') == current_language
+                name_object["value"]
+                for name_object in resource["_source"]["displayname"]
+                if name_object.get("language") == current_language
             ]
 
             if len(current_language_display_description):


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This updates the places in code where we're using the `displaydescription` and `displayname` objects retrieved from ElasticSearch. This does NOT update the `ResourceDescriptors` class as it's not being used anywhere that I can tell && having the raw ES return could be beneficial.

In a followup ticket, we should consider refactoring `Resource.get_documents_to_index` and the Resource database model to handle i18n in the application-standard way.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8682 #8691 