### PR TITLE
Add resourceid to responseJson in resource-report-abstract.js, re #8736

### DIFF
--- a/arches/app/media/js/views/components/resource-report-abstract.js
+++ b/arches/app/media/js/views/components/resource-report-abstract.js
@@ -58,8 +58,8 @@ define([
             } 
             else if (self.resourceid) {
                 url = arches.urls.api_resource_report(self.resourceid) + "?v=beta&uncompacted=true";
-
                 self.fetchResourceData(url).then(function(responseJson) {
+
                     var template = responseJson.template;
                     self.template(template);
                     if (template.preload_resource_data) {
@@ -69,6 +69,7 @@ define([
                         self.report({
                             'template': responseJson.template,
                             'report_json': responseJson.report_json,
+                            'resourceid': responseJson.resourceid
                         });
                     }
         


### PR DESCRIPTION
Add resourceid to resource-report-abstract.js so that a report can receive a resourceid even when reponseJson.report_json is empty coming back from api.ResourceReport, re #8736