### PR TITLE
Fix for [object object] error in subtitle for switch widget

### DIFF
--- a/arches/app/media/js/views/components/widgets/switch.js
+++ b/arches/app/media/js/views/components/widgets/switch.js
@@ -1,9 +1,10 @@
 define([
+    'arches',
     'knockout', 
     'underscore', 
     'viewmodels/widget',
     'templates/views/components/widgets/switch.htm',
-], function(ko, _, WidgetViewModel, switchWidgetTemplate) {
+], function(arches, ko, _, WidgetViewModel, switchWidgetTemplate) {
     /**
     * knockout components namespace used in arches
     * @external "ko.components"
@@ -26,9 +27,29 @@ define([
         params.configKeys = ['subtitle', 'defaultValue'];
          
         WidgetViewModel.apply(this, [params]);
+        const originalConfig = this.config();
         this.on = this.config().on || true;
+        this.activeLanguage = arches.activeLanguage;
         this.off = this.config().off || false;
         this.null = this.config().null || null;
+        this.localizedSubtitle = ko.observable(this.subtitle()[this.activeLanguage]);
+
+        // chained observable to avoid issues with ko.mapping
+        this.localizedSubtitle.subscribe((value) => {
+            const val = this.subtitle();
+
+            if(value != ""){
+                val[this.activeLanguage] = value;
+                this.subtitle(val);
+            } else {
+                delete val[this.activeLanguage];
+                this.config(originalConfig);
+            }
+
+            params.card.get('widgets').valueHasMutated();
+        });
+
+
         this.setvalue = this.config().setvalue || function(self, evt){
             if (ko.unwrap(self.disabled) === false) {
                 if(self.value() === self.on){

--- a/arches/app/models/migrations/7783_add_graph_publications.py
+++ b/arches/app/models/migrations/7783_add_graph_publications.py
@@ -6,6 +6,7 @@ from django.db import migrations, models
 import django.db.models.deletion
 from django.contrib.postgres.fields import JSONField
 
+
 class Migration(migrations.Migration):
 
     dependencies = [

--- a/arches/app/templates/views/components/widgets/switch.htm
+++ b/arches/app/templates/views/components/widgets/switch.htm
@@ -12,7 +12,7 @@
                 <!-- /ko -->
                 </div>
             </div>
-    <span class="arches-toggle-subtitle" data-bind="text: subtitle"></span>
+    <span class="arches-toggle-subtitle" data-bind="text: localizedSubtitle"></span>
 </div>
 {% endblock form %}
 
@@ -21,7 +21,7 @@
   <span data-bind="text: $root.translations.subtitle"></span>
 </div>
 <div class="col-xs-12 pad-no crud-widget-container">
-  <input type="" id="" class="form-control input-md widget-input" data-bind="value: subtitle, valueUpdate: 'keyup'">
+  <input type="" id="" class="form-control input-md widget-input" data-bind="value: localizedSubtitle, valueUpdate: 'keyup'">
 </div>
 <div class="control-label">
   <span data-bind="text: $root.translations.defaultValue"></span>
@@ -31,6 +31,6 @@
             <div style="display:flex; flex-direction:row;">
             <div class="arches-toggle-sm" data-bind="text:label"></div>
             </div>
-    <span class="arches-toggle-subtitle" data-bind="text: subtitle"></span>
+    <span class="arches-toggle-subtitle" data-bind="text: localizedSubtitle"></span>
 </div>
 {% endblock config_form %}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixes [object object] in the subtitle of the switch widget.  There are still some mysterious issues since the widget is instantiated twice (or more) in the graph designer and the config does not propagate correctly, but this change should make it functional.  

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8762 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
