### PR TITLE
fix reverse migration of 6458_language #8784

### DIFF
--- a/arches/app/models/migrations/6458_language.py
+++ b/arches/app/models/migrations/6458_language.py
@@ -121,7 +121,9 @@ class Migration(migrations.Migration):
                     return;
                 end;
                 $$
-            """.format(settings.LANGUAGE_CODE)
+            """.format(
+                        settings.LANGUAGE_CODE
+                    )
                 )
             ],
             reverse_sql=[
@@ -155,7 +157,9 @@ class Migration(migrations.Migration):
                     return;
                 end;
                 $$
-            """.format(settings.LANGUAGE_CODE)
+            """.format(
+                        settings.LANGUAGE_CODE
+                    )
                 )
             ],
         ),

--- a/arches/app/models/migrations/6458_language.py
+++ b/arches/app/models/migrations/6458_language.py
@@ -92,13 +92,13 @@ class Migration(migrations.Migration):
                     l record;
                     updated_count integer default -1;
                 begin
-                    select * into l from languages limit 1;
+                    select * into l from languages where code='{}' limit 1;
                     while updated_count != 0 loop
                         update tiles c
                             set tiledata =
                                 jsonb_set(
                                     tiledata,
-                                    ('{' || b.nodeid || '}')::text[],
+                                    ('{{' || b.nodeid || '}}')::text[],
                                     jsonb_build_object(
                                         l.code,
                                         jsonb_build_object(
@@ -121,7 +121,7 @@ class Migration(migrations.Migration):
                     return;
                 end;
                 $$
-            """
+            """.format(settings.LANGUAGE_CODE)
                 )
             ],
             reverse_sql=[
@@ -133,13 +133,13 @@ class Migration(migrations.Migration):
                     l record;
                     updated_count integer default -1;
                 begin
-                    select * into l from languages limit 1;
+                    select * into l from languages where code='{}' limit 1;
                     while updated_count != 0 loop
                         update tiles c
                         set tiledata =
                             jsonb_set(
                                 tiledata,
-                                ('{' || b.nodeid || '}')::text[],
+                                ('{{' || b.nodeid || '}}')::text[],
                                 to_jsonb(((((tiledata->>b.nodeid)::jsonb)->>l.code)::jsonb)->>'value'),
                                 false
                             )
@@ -155,7 +155,7 @@ class Migration(migrations.Migration):
                     return;
                 end;
                 $$
-            """
+            """.format(settings.LANGUAGE_CODE)
                 )
             ],
         ),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixes #8784 by using the system language for the migration.  The old code was using the first language in the languages table, which is not always a reliable system language - it's not necessarily the same as LANGUAGE_CODE in the django settings.  The important note here is that when a user migrates to a7 - settings.LANGUAGE_CODE is the language they're going to migrate their default strings to, and when they back out of the migration, they're going to lose everything but settings.LANGUAGE_CODE as that is what the string will revert to.  

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8784

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
