### PR TITLE
8803 - Fix ajax dataType setting in datatypes/concept.js 

### DIFF
--- a/arches/app/media/js/views/components/datatypes/concept.js
+++ b/arches/app/media/js/views/components/datatypes/concept.js
@@ -44,7 +44,7 @@ define(['arches', 'knockout', 'viewmodels/concept-select'], function (arches, ko
                     var self = this;
                     $.ajax({
                         url: arches.urls.get_concept_collections,
-                        type: 'json'
+                        dataType: 'json'
                     }).done(function(data){
                         arches.conceptCollections = data;
                         self.conceptCollections(data);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Correct ajax "type" setting to "dataType"


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8803

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
