### PR TITLE
Update url pattern for password reset confirmation

### DIFF
--- a/arches/urls.py
+++ b/arches/urls.py
@@ -280,9 +280,9 @@ urlpatterns = [
     ),
     url(r"^password_reset/done/$", auth_views.PasswordResetDoneView.as_view(), name="password_reset_done"),
     path(
-        'reset/<uidb64>/<token>/',
+        "reset/<uidb64>/<token>/",
         PasswordResetConfirmView.as_view(),
-        name='password_reset_confirm',
+        name="password_reset_confirm",
     ),
     url(r"^reset/done/$", auth_views.PasswordResetCompleteView.as_view(), name="password_reset_complete"),
     url(r"^o/", include("oauth2_provider.urls", namespace="oauth2")),

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -75,7 +75,7 @@ from arches.app.views.auth import (
 )
 from arches.app.models.system_settings import settings
 from django.views.decorators.cache import cache_page
-from django.conf.urls.static import static
+from django.urls import path
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -279,10 +279,10 @@ urlpatterns = [
         name="password_reset",
     ),
     url(r"^password_reset/done/$", auth_views.PasswordResetDoneView.as_view(), name="password_reset_done"),
-    url(
-        r"^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
+    path(
+        'reset/<uidb64>/<token>/',
         PasswordResetConfirmView.as_view(),
-        name="password_reset_confirm",
+        name='password_reset_confirm',
     ),
     url(r"^reset/done/$", auth_views.PasswordResetCompleteView.as_view(), name="password_reset_complete"),
     url(r"^o/", include("oauth2_provider.urls", namespace="oauth2")),


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This updates the url pattern for password reset confirmations. It's an interesting rabbit hole that landed at an issue discovered as of Django 3.1:

https://code.djangoproject.com/ticket/31913
https://docs.djangoproject.com/en/3.1/ref/contrib/admin/#adding-a-password-reset-feature 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8716 