### PR TITLE
update node-value-select to handle for edge cases #8763

### DIFF
--- a/arches/app/media/js/viewmodels/node-value-select.js
+++ b/arches/app/media/js/viewmodels/node-value-select.js
@@ -18,8 +18,16 @@ define([
         this.url = function(){
             var resourceId = ko.unwrap(self.resourceinstanceid);
             if (resourceId === '') {
-                resourceId = window.location.pathname.split('/');
-                resourceId = resourceId[resourceId.length-1];
+                const splitPath = window.location.pathname.split('/');
+
+                /** 
+                 * only assign a resourceId if it exists in the database, certain views have URL patterns that match
+                 * how this component handles Resource logic
+                */
+                const unsupportedViews = ['add-resource','graph_designer'];
+                if (!unsupportedViews.filter(value => splitPath.includes(value)).length) {  
+                    resourceId = splitPath[splitPath.length-1];
+                }
             }
             if (resourceId) {
                 return arches.urls.resource_tiles.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', resourceId);


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The previous logic uses a specific pattern to pull a `resourceId` from the URL, and fire a request that ultimately hits `permission_backend.check_resource_instance_permissions` . This function attempts to fetch the ResourceInstance from the database, and if that object doesn't exist it returns falsey. However the `add-resource` and `graph_designer` views do not yet have a `ResourceInstance` entry in the database, so the function incorrectly returns falsey and that results in an error.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8763 