### PR TITLE
translates descriptors in resource view re: #8866

### DIFF
--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -737,6 +737,17 @@ class ResourceCards(View):
 
 
 class ResourceDescriptors(View):
+    def get_localized_descriptor(self, document, descriptor_type):
+        language_codes = (translation.get_language(), settings.LANGUAGE_CODE)
+
+        descriptor = document["_source"][descriptor_type]
+        result = descriptor[0] if len(descriptor) > 0 else None
+        for language_code in language_codes:
+            for entry in descriptor:
+                if entry["language"] == language_code and entry["value"] != "":
+                    result = entry
+        return result["value"]
+
     def get(self, request, resourceid=None):
         if Resource.objects.filter(pk=resourceid).exclude(pk=settings.SYSTEM_SETTINGS_RESOURCE_ID).exists():
             try:
@@ -747,9 +758,9 @@ class ResourceDescriptors(View):
                     {
                         "graphid": document["_source"]["graph_id"],
                         "graph_name": resource.graph.name,
-                        "displaydescription": document["_source"]["displaydescription"],
-                        "map_popup": document["_source"]["map_popup"],
-                        "displayname": document["_source"]["displayname"],
+                        "displaydescription": self.get_localized_descriptor(document, "displaydescription"),
+                        "map_popup": self.get_localized_descriptor(document, "map_popup"),
+                        "displayname": self.get_localized_descriptor(document, "displayname"),
                         "geometries": document["_source"]["geometries"],
                         "permissions": document["_source"]["permissions"],
                         "userid": request.user.id,

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -741,7 +741,7 @@ class ResourceDescriptors(View):
         language_codes = (translation.get_language(), settings.LANGUAGE_CODE)
 
         descriptor = document["_source"][descriptor_type]
-        result = descriptor[0] if len(descriptor) > 0 else None
+        result = descriptor[0] if len(descriptor) > 0 else { "value": _("Undefined") }
         for language_code in language_codes:
             for entry in descriptor:
                 if entry["language"] == language_code and entry["value"] != "":

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -739,13 +739,12 @@ class ResourceCards(View):
 class ResourceDescriptors(View):
     def get_localized_descriptor(self, document, descriptor_type):
         language_codes = (translation.get_language(), settings.LANGUAGE_CODE)
-
         descriptor = document["_source"][descriptor_type]
         result = descriptor[0] if len(descriptor) > 0 else {"value": _("Undefined")}
         for language_code in language_codes:
             for entry in descriptor:
                 if entry["language"] == language_code and entry["value"] != "":
-                    return result["value"]
+                    return entry["value"]
         return result["value"]
 
     def get(self, request, resourceid=None):

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -741,7 +741,7 @@ class ResourceDescriptors(View):
         language_codes = (translation.get_language(), settings.LANGUAGE_CODE)
 
         descriptor = document["_source"][descriptor_type]
-        result = descriptor[0] if len(descriptor) > 0 else { "value": _("Undefined") }
+        result = descriptor[0] if len(descriptor) > 0 else {"value": _("Undefined")}
         for language_code in language_codes:
             for entry in descriptor:
                 if entry["language"] == language_code and entry["value"] != "":

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -745,7 +745,7 @@ class ResourceDescriptors(View):
         for language_code in language_codes:
             for entry in descriptor:
                 if entry["language"] == language_code and entry["value"] != "":
-                    result = entry
+                    return result["value"]
         return result["value"]
 
     def get(self, request, resourceid=None):


### PR DESCRIPTION
to fix issues with popups on map and iiif widgets, we should translate resource descriptors in the resource view.  the view now always returns a string for all descriptors, either: the only one available, the user's language translation, the system language translation, or the translated string "Undefined"

fixes: #8866