### PR TITLE
jquery dependencies not installed in new projects re #8885

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "font-awesome": "~4.6.3",
         "ionicons": "~2.0.1",
         "jqtree": "1.3.4",
-        "jquery": "3.6.0",
+        "jquery": "3.6.1",
         "jquery-migrate": "3.4.0",
         "jquery-validation": "1.19.5",
         "jqueryui": "1.11.1",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
`jquery@3.6.0` was not compatible with some of its downstream dependencies. Upgrading to `jquery@3.6.1` solved the issue.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8885 

