### PR TITLE
Remove z-index=0 from form group for langauge dropdown, re #8854

### DIFF
--- a/arches/app/templates/views/components/widgets/text.htm
+++ b/arches/app/templates/views/components/widgets/text.htm
@@ -4,7 +4,7 @@
 
 {% block form %}
 <div class="row widget-wrapper">
-    <div class="form-group" style="position: relative; z-index: 0">
+    <div class="form-group" style="position: relative;">
         <div style="max-width: 600px; position: relative">
             <div class="widget-inline-tools-collapser" data-bind=" click: function() {
                 showi18nOptions(!showi18nOptions());
@@ -89,7 +89,7 @@
         "
     >
 </div>
-<div class="form-group" style="position: relative; z-index: 0">
+<div class="form-group" style="position: relative;">
     <div style="max-width: 600px; position: relative">
     <div class="widget-inline-tools-collapser" data-bind=" click: function() {
         showi18nOptions(!showi18nOptions());


### PR DESCRIPTION
Remove z-index property that was causing language dropdown to appear behind other elements, re #8854
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
