### PR TITLE
Ensure useriscreator is properly cast to boolean, re #8906

### DIFF
--- a/arches/app/media/js/views/resource/resource-editor-data.js
+++ b/arches/app/media/js/views/resource/resource-editor-data.js
@@ -15,7 +15,7 @@ define([], function() {
     parsedResourceEditorData["relationship_types"] = JSON.parse(forceDoubleQuotes(parsedResourceEditorData["relationship_types"]));
     parsedResourceEditorData["creator"] = JSON.parse(parsedResourceEditorData["creator"]);
     parsedResourceEditorData["userisreviewer"] = Boolean(parsedResourceEditorData["userisreviewer"] === "True");
-    parsedResourceEditorData["useriscreator"] = Boolean(parsedResourceEditorData["useriscreator"] === "True");
+    parsedResourceEditorData["useriscreator"] = ["true", "True"].includes(parsedResourceEditorData["useriscreator"]);
 
     return parsedResourceEditorData;
 });


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Allows manage permissions link to open permissions panel. This still requires a page refresh as described here: https://github.com/archesproject/arches/issues/8907

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8906
