### PR TITLE
Revproxy dependency replacement and django patch upgrade, re #8941, #8882

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.14
+Django==3.2.15
 psycopg2-binary==2.8.4
 elasticsearch>=7.11.0,<8.0.0
 rdflib==4.2.2

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -11,7 +11,7 @@ SPARQLWrapper==1.8.5
 django-recaptcha==2.0.6
 edtf==4.0.1
 couchdb==1.2
-django-revproxy @ git+https://github.com/jazzband/django-revproxy@d2234005135dc0771b7c4e0bb0465664ccfa5787
+arches-django-revproxy==0.10.0
 django-cors-headers==3.1.1
 django-oauth-toolkit==1.2.0
 python-docx==0.8.10

--- a/releases/6.2.0.md
+++ b/releases/6.2.0.md
@@ -14,7 +14,7 @@ Arches 6.2.0 release notes (draft)
 ```
 Python:
     Upgraded:
-        Django 3.2.14 -> 3.2.15
+        Django 2.2.24 -> 3.2.15
         celery 4.4.4  -> 5.2.7
         django-celery-results 1.2.1 -> 2.4.0
         django-compressor 2.2 -> 3.1

--- a/releases/6.2.0.md
+++ b/releases/6.2.0.md
@@ -54,15 +54,17 @@ Javascript:
 
 2. Be sure to backup your database before proceeding
 
-3. Upgrade to Arches 6.1.0
+3. Remove django-revproxy `pip uninstall django-revproxy` 
+
+4. Upgrade to Arches 6.1.0
 
         pip install --upgrade arches
 
-4. Within your project with your Python 3 virtual environment activated:
+5. Within your project with your Python 3 virtual environment activated:
 
         python manage.py migrate
 
-5. **Important:** If you are maintaining an Arches package, be sure to export your graphs and resource instance data before re-importing or reloading your package. 
+6. **Important:** If you are maintaining an Arches package, be sure to export your graphs and resource instance data before re-importing or reloading your package. 
 
 ### Upgrading an Arches project
 

--- a/releases/6.2.0.md
+++ b/releases/6.2.0.md
@@ -14,15 +14,17 @@ Arches 6.2.0 release notes (draft)
 ```
 Python:
     Upgraded:
-        Django 2.2.24 -> 3.2.14
-        Celery 4.4.4  -> 5.2.7
-        Django Celery Results 1.2.1 -> 2.4.0
-        Django Revproxy 0.9.15 -> 0.10.x
-        Django Compressor 2.2 -> 3.1
-        Django Libsass 0.7 -> 0.9
+        Django 3.2.14 -> 3.2.15
+        celery 4.4.4  -> 5.2.7
+        django-celery-results 1.2.1 -> 2.4.0
+        django-compressor 2.2 -> 3.1
+        django-libsass 0.7 -> 0.9
 
     Added:
-        none
+        arches-django-revproxy==1.10.0
+    
+    Removed:
+        django-revproxy==0.9.15
 
 Javascript:
     Upgraded:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Use arches-django-revproxy, pypi will reject github install of django-revproxy.

### Issues Solved
#8941, #8882