### PR TITLE
Set the thumbnail image size for the small images

### DIFF
--- a/arches/app/views/manifest_manager.py
+++ b/arches/app/views/manifest_manager.py
@@ -81,6 +81,9 @@ class ManifestManagerView(View):
         def create_canvas(image_json, file_url, file_name, image_id):
             canvas_id = f"{self.cantaloupe_uri}/manifest/canvas/{image_id}.json"
             image_id = f"{self.cantaloupe_uri}/manifest/annotation/{image_id}.json"
+            thumbnail_width = 300 if image_json["width"] >= 300 else image_json["width"]
+            thumbnail_height = 300 if image_json["height"] >= 300 else image_json["height"]
+            thumbnail_id = f"{file_url}/full/!{thumbnail_width},{thumbnail_height}/0/default.jpg"
 
             return {
                 "@id": canvas_id,
@@ -110,7 +113,7 @@ class ManifestManagerView(View):
                 "label": f"{file_name}",
                 "license": "TBD",
                 "thumbnail": {
-                    "@id": file_url + "/full/!300,300/0/default.jpg",
+                    "@id": thumbnail_id,
                     "@type": "dctypes:Image",
                     "format": "image/jpeg",
                     "service": {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Set thumbnail image size to the image size if the image is smaller than the default thumbnail size (300 x 300), archesproject/arches-for-science#943

Fix the issue of the thumbnail image not loading when the image itself is small.
https://iiif.io/api/image/2.0/#size

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
archesproject/arches-for-science#943

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
