### PR TITLE
8960 - Use settings.MEDIA_URL for generated URL when uploading media

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1360,7 +1360,7 @@ class FileListDataType(BaseDataType):
                     for file_json in current_tile_data[nodeid]:
                         if file_json["name"] == file_data.name and file_json["url"] is None:
                             file_json["file_id"] = str(file_model.pk)
-                            file_json["url"] = "/files/" + str(file_model.fileid)
+                            file_json["url"] = settings.MEDIA_URL + str(file_model.fileid)
                             file_json["status"] = "uploaded"
                             resave_tile = True
                         updated_file_records.append(file_json)
@@ -1436,7 +1436,7 @@ class FileListDataType(BaseDataType):
             else:
                 models.File.objects.get_or_create(fileid=tile_file["file_id"], path=file_path)
 
-            tile_file["url"] = "/files/" + tile_file["file_id"]
+            tile_file["url"] = settings.MEDIA_URL + tile_file["file_id"]
             tile_file["accepted"] = True
             compatible_renderers = self.get_compatible_renderers(tile_file)
             if len(compatible_renderers) == 1:
@@ -1450,7 +1450,7 @@ class FileListDataType(BaseDataType):
             for file in tile.data[nodeid]:
                 try:
                     if file["file_id"]:
-                        if file["url"] == "/files/{}".format(file["file_id"]):
+                        if file["url"] == f'{settings.MEDIA_URL}{file["file_id"]}':
                             val = uuid.UUID(file["file_id"])  # to test if file_id is uuid
                             file_path = "uploadedfiles/" + file["name"]
                             try:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Use settings.MEDIA_URL not hard coded /files/ prefix when generating URL during file upload

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8960 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
PR currently targeting dev/6.2.x branch but this should probably be merged into dev/7.0.x
