### PR TITLE
Remove related resource warning unless strict validation is used

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1892,35 +1892,33 @@ class ResourceInstanceDataType(BaseDataType):
                 resourceid = resourceXresourceId["resourceId"]
                 try:
                     uuid.UUID(resourceid)
-                    try:
-                        if not node:
-                            node = models.Node.objects.get(pk=nodeid)
-                        if node.config["searchString"] != "":
-                            dsl = node.config["searchDsl"]
-                            if dsl:
-                                query = Query(se)
-                                bool_query = Bool()
-                                ri_query = Dsl(dsl)
-                                bool_query.must(ri_query)
-                                ids_query = Dsl({"ids": {"values": [resourceid]}})
-                                bool_query.must(ids_query)
-                                query.add_query(bool_query)
-                                try:
-                                    results = query.search(index=RESOURCES_INDEX)
-                                    count = results["hits"]["total"]["value"]
-                                    assert count == 1
-                                except:
+                    if strict:
+                        try:
+                            if not node:
+                                node = models.Node.objects.get(pk=nodeid)
+                            if node.config["searchString"] != "":
+                                dsl = node.config["searchDsl"]
+                                if dsl:
+                                    query = Query(se)
+                                    bool_query = Bool()
+                                    ri_query = Dsl(dsl)
+                                    bool_query.must(ri_query)
+                                    ids_query = Dsl({"ids": {"values": [resourceid]}})
+                                    bool_query.must(ids_query)
+                                    query.add_query(bool_query)
+                                    try:
+                                        results = query.search(index=RESOURCES_INDEX)
+                                        count = results["hits"]["total"]["value"]
+                                        assert count == 1
+                                    except:                               
+                                        raise ObjectDoesNotExist()
+                            if len(node.config["graphs"]) > 0:
+                                graphids = map(lambda x: x["graphid"], node.config["graphs"])
+                                if not models.ResourceInstance.objects.filter(pk=resourceid, graph_id__in=graphids).exists():
                                     raise ObjectDoesNotExist()
-                        if len(node.config["graphs"]) > 0:
-                            graphids = map(lambda x: x["graphid"], node.config["graphs"])
-                            if not models.ResourceInstance.objects.filter(pk=resourceid, graph_id__in=graphids).exists():
-                                raise ObjectDoesNotExist()
-                    except ObjectDoesNotExist:
-                        message = _("The related resource with id '{0}' is not in the system.".format(resourceid))
-                        error_type = "WARNING"
-                        if strict:
-                            error_type = "ERROR"
-                        errors.append({"type": error_type, "message": message})
+                        except ObjectDoesNotExist:
+                            message = _("The related resource with id '{0}' is not in the system.".format(resourceid))
+                            errors.append({"type": "ERROR", "message": message})
                 except ValueError:
                     message = _("The related resource with id '{0}' is not a valid uuid.".format(resourceid))
                     error_type = "ERROR"

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1910,7 +1910,7 @@ class ResourceInstanceDataType(BaseDataType):
                                         results = query.search(index=RESOURCES_INDEX)
                                         count = results["hits"]["total"]["value"]
                                         assert count == 1
-                                    except:                               
+                                    except:
                                         raise ObjectDoesNotExist()
                             if len(node.config["graphs"]) > 0:
                                 graphids = map(lambda x: x["graphid"], node.config["graphs"])


### PR DESCRIPTION
…sed, re #8965

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Removes warning in the related resources validation if a resource instance's related resource does not already exist in the database. This validation bogs down data import with postgres and ES queries and can flood the terminal output with warnings that are not useful. In cases where this validation is needed, the 'strict' flag can be passed to the validation function.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#8965