### PR TITLE
adds functionality to create editable future graph on copy and delete

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -542,7 +542,7 @@ class Graph(models.GraphModel):
                     editable_future_graph = models.GraphModel.objects.get(source_identifier=self.graphid)
                     editable_future_graph.delete()
                 except models.GraphModel.DoesNotExist:
-                    pass # no editable future graph to delete
+                    pass  # no editable future graph to delete
 
                 for nodegroup in self.get_nodegroups():
                     nodegroup.delete()

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -538,6 +538,12 @@ class Graph(models.GraphModel):
     def delete(self):
         if self.is_editable() is True:
             with transaction.atomic():
+                try:
+                    editable_future_graph = models.GraphModel.objects.get(source_identifier=self.graphid)
+                    editable_future_graph.delete()
+                except models.GraphModel.DoesNotExist:
+                    pass # no editable future graph to delete
+
                 for nodegroup in self.get_nodegroups():
                     nodegroup.delete()
 

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -399,6 +399,7 @@ class GraphDataView(View):
                     ret = clone_data["copy"]
                     ret.slug = None
                     ret.save()
+                    ret.create_editable_future_graph()
                     ret.copy_functions(graph, [clone_data["nodes"], clone_data["nodegroups"]])
 
                 elif self.action == "reorder_nodes":


### PR DESCRIPTION
Add functionality to create editable future graphs on copy (clone) and remove on delete.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
