### PR TITLE
9147 - fix i18n bug in __arches_get_tile_cardinality_violations

### DIFF
--- a/arches/app/models/migrations/9147_get_tile_cardinality_violations_i18n.py
+++ b/arches/app/models/migrations/9147_get_tile_cardinality_violations_i18n.py
@@ -1,0 +1,71 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("models", "8974_rr_load_performance_v2"),
+    ]
+
+    sql_string = """
+create or replace function __arches_get_tile_cardinality_violations()
+    returns table(graph_name text, node_names text[], resourceinstanceid uuid, nodegroupid uuid, parenttileid uuid, tilecount bigint) as
+$$
+DECLARE
+BEGIN
+    return query with tile_violations as ( SELECT t.resourceinstanceid,
+                        t.nodegroupid,
+                        t.parenttileid parent_tileid,
+                        count(*)       tilecount
+                 FROM tiles t,
+                      node_groups ng
+                 WHERE t.nodegroupid = ng.nodegroupid
+                   AND ng.cardinality = '1'
+                 group by t.resourceinstanceid, t.nodegroupid,
+                          t.parenttileid
+                 having count(*) > 1)
+        select g.name->>'en',
+               array_agg(n.name), tv.*
+            from tile_violations tv,
+                 nodes n,
+                 graphs g
+                where tv.nodegroupid = n.nodegroupid
+                  and n.graphid = g.graphid
+            group by g.name->>'en', tv.resourceinstanceid, tv.nodegroupid, tv.parent_tileid, tv.tilecount
+    order by nodegroupid, resourceinstanceid;
+END $$
+    language plpgsql;
+
+    """
+
+    reverse_sql_string = """
+create or replace function __arches_get_tile_cardinality_violations()
+    returns table(graph_name text, node_names text[], resourceinstanceid uuid, nodegroupid uuid, parenttileid uuid, tilecount bigint) as
+$$
+DECLARE
+BEGIN
+    return query with tile_violations as ( SELECT t.resourceinstanceid,
+                        t.nodegroupid,
+                        t.parenttileid parent_tileid,
+                        count(*)       tilecount
+                 FROM tiles t,
+                      node_groups ng
+                 WHERE t.nodegroupid = ng.nodegroupid
+                   AND ng.cardinality = '1'
+                 group by t.resourceinstanceid, t.nodegroupid,
+                          t.parenttileid
+                 having count(*) > 1)
+        select g.name, array_agg(n.name), tv.*
+            from tile_violations tv,
+                 nodes n,
+                 graphs g
+                where tv.nodegroupid = n.nodegroupid
+                  and n.graphid = g.graphid
+            group by g.name, tv.resourceinstanceid, tv.nodegroupid, tv.parent_tileid, tv.tilecount
+    order by nodegroupid, resourceinstanceid;
+END $$
+    language plpgsql;
+    """
+
+    operations = [
+        migrations.RunSQL(sql_string, reverse_sql_string),
+    ]


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fix i18n bug in __arches_get_tile_cardinality_violations - was referring to graphs.name as text, not i18n JSON string.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9147 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
I've added a diff here - copied the new function to the reverse migration section to show the diff.:
https://github.com/bcgov/arches/compare/9147_tile_cardinality_function_bug...bcgov:arches:9147_diff?expand=1

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
