### PR TITLE
Avoid node alias conflicts when appending a branch v6 #8878

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -536,7 +536,11 @@ class Graph(models.GraphModel):
             newEdge = models.Edge(domainnode=nodeToAppendTo, rangenode=branch_copy.root, ontologyproperty=property, graph=self)
             branch_copy.add_edge(newEdge)
 
+            aliases = [n.alias for n in self.nodes.values()]
+
             for node in branch_copy.nodes.values():
+                if node.alias in aliases:
+                    node.alias = self.make_name_unique(node.alias, aliases, "_n")
                 self.add_node(node)
             for card in branch_copy.get_cards():
                 self.add_card(card)

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -539,7 +539,7 @@ class Graph(models.GraphModel):
             aliases = [n.alias for n in self.nodes.values()]
 
             for node in branch_copy.nodes.values():
-                if node.alias in aliases:
+                if node.alias and node.alias in aliases:
                     node.alias = self.make_name_unique(node.alias, aliases, "_n")
                 self.add_node(node)
             for card in branch_copy.get_cards():

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -20,7 +20,7 @@ pyprind==2.11.3
 pycryptodome<4.0.0,>=3.3.1
 pyshp==2.1.2
 requests[security]>=2.18.1
-python-slugify==4.0.0
+python-slugify==7.0.0
 pillow>=7.0.0
 arcgis2geojson==2.0.0
 openpyxl==3.0.7


### PR DESCRIPTION
### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add a suffix to node aliases that violate the unique node alias constraint when appending a branch. 

Also upgrades python-slugify to support Python versions >= 3.7.

### Issues Solved
#8878 - v6