### PR TITLE
Fixes file viewer broken in 7.x

### DIFF
--- a/arches/app/templates/views/components/cards/file-viewer.htm
+++ b/arches/app/templates/views/components/cards/file-viewer.htm
@@ -35,8 +35,8 @@
             beforeMove: self.beforeMove,
             afterMove: card.reorderTiles
         }">
-            <li role="treeitem" class="jstree-node" style="user-select: none;" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0, 'hide-background': !showGrid()}, event: {'dragstart': function () { console.log('dragging...') }}, event: { auxclick: $parent.card.stageTile, contextmenu: function(a, e){e.preventDefault}}">
-                <i class="jstree-icon" role="presentation" data-bind="click: function(){expanded(!expanded())}, css: {'jstree-ocl': showGrid}"></i>
+            <li role="treeitem" class="jstree-node" style="user-select: none;" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0, 'hide-background': !self.showGrid()}, event: {'dragstart': function () { console.log('dragging...') }}, event: { auxclick: $parent.card.stageTile, contextmenu: function(a, e){e.preventDefault}}">
+                <i class="jstree-icon" role="presentation" data-bind="click: function(){expanded(!expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
                 <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.form.selection($data);}, css:{'staged': $parent.staging.indexOf($data.tileid) > -1, 'jstree-clicked': selected, 'child-selected': isChildSelected(), 'filtered-leaf': card.highlight(), 'unsaved-edit': !!$data.dirty()}">
                     <i class="fa " role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits(),'fa-pencil':$data.dirty()===true,'fa-file':!$data.dirty()}"></i>
                     <strong style="margin-right: 10px;">


### PR DESCRIPTION
Fixes #9239 by changing referencing the parent's showGrid method rather than the tile in fileviewer

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
