### PR TITLE
Get constraints directly off of params if available. re #7181

### DIFF
--- a/arches/app/media/js/viewmodels/card.js
+++ b/arches/app/media/js/viewmodels/card.js
@@ -84,6 +84,8 @@ define([
         let cardConstraints;
         if (params.card.constraints?.length) {
             cardConstraints = params.card.constraints;
+        } else if (params.constraints?.length) {
+            cardConstraints = params.constraints
         } else {
             cardConstraints = emptyConstraint;
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
In v6 constraints are not available on card.params. Instead, they are available directly off of params. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#7181
