### PR TITLE
Fix error preventing new users when resource instance permissions are used

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1294,8 +1294,11 @@ def create_permissions_for_new_users(sender, instance, created, **kwargs):
             resourceInstanceId = uuid.UUID(resourceInstanceId)
         resources = ResourceInstance.objects.filter(pk__in=resourceInstanceIds)
         assign_perm("no_access_to_resourceinstance", instance, resources)
-        for resource in resources:
-            Resource(resource.resourceinstanceid).index()
+        for resource_instance in resources:
+            resource = Resource(resource_instance.resourceinstanceid)
+            resource.graph_id = resource_instance.graph_id
+            resource.createdtime = resource_instance.createdtime
+            resource.index()
 
 
 class UserXTask(models.Model):

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -410,7 +410,9 @@ class ResourcePermissionDataView(View):
 
     def make_instance_public(self, resourceinstanceid, graphid=None):
         resource = Resource(resourceinstanceid)
-        resource.graph_id = graphid if graphid else str(models.ResourceInstance.objects.get(pk=resourceinstanceid).graph_id)
+        resource_instance = models.ResourceInstance.objects.get(pk=resourceinstanceid)
+        resource.graph_id = graphid if graphid else str(resource_instance.graph_id)
+        resource.createdtime = resource_instance.createdtime
         resource.remove_resource_instance_permissions()
         return self.get_instance_permissions(resource)
 

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -398,7 +398,9 @@ class ResourcePermissionDataView(View):
 
     def make_instance_private(self, resourceinstanceid, graphid=None):
         resource = Resource(resourceinstanceid)
-        resource.graph_id = graphid if graphid else str(models.ResourceInstance.objects.get(pk=resourceinstanceid).graph_id)
+        resource_instance = models.ResourceInstance.objects.get(pk=resourceinstanceid)
+        resource.graph_id = graphid if graphid else str(resource_instance.graph_id)
+        resource.createdtime = resource_instance.createdtime
         resource.add_permission_to_all("no_access_to_resourceinstance")
         instance_creator = get_instance_creator(resource)
         user = User.objects.get(pk=instance_creator["creatorid"])


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Ensure resource has all required properties before modifying permissions and indexing. Fixes error when instances are indexed upon the creation of a new user.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9251
