### PR TITLE
9023 Fix for JSONL import multiprocessing flag

### DIFF
--- a/arches/app/utils/data_management/resources/importer.py
+++ b/arches/app/utils/data_management/resources/importer.py
@@ -185,7 +185,7 @@ class BusinessDataImporter(object):
                     lines = openf.readlines()
                     if use_multiprocessing is True:
                         pool = Pool(cpu_count())
-                        pool.map(import_one_resource, lines, prevent_indexing=prevent_indexing)
+                        pool.map(import_one_resource, lines)
                         connections.close_all()
                         reader = ArchesFileReader()
                     else:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Removing `prevent_indexing=prevent_indexing` from `pool.map(import_one_resource, lines, prevent_indexing=prevent_indexing)` in app/utils/data_management/resources/importer.py. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9023 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint
