### PR TITLE
Hide inactive models in Resource Type filter

### DIFF
--- a/arches/app/media/js/views/components/search/resource-type-filter.js
+++ b/arches/app/media/js/views/components/search/resource-type-filter.js
@@ -21,7 +21,7 @@ define([
                         if (res.isactive === true) {
                             self.resourceModels.push(res);
                         }
-                    })
+                    });
                 } else {
                     // eslint-disable-next-line no-console
                     console.log('Failed to fetch resource instance list');

--- a/arches/app/media/js/views/components/search/resource-type-filter.js
+++ b/arches/app/media/js/views/components/search/resource-type-filter.js
@@ -17,7 +17,11 @@ define([
                 const response = await fetch(arches.urls.api_search_component_data + componentName);
                 if (response.ok) {
                     const data = await response.json();
-                    self.resourceModels(data.resources);
+                    data.resources.forEach(function(res) {
+                        if (res.isactive === true) {
+                            self.resourceModels.push(res);
+                        }
+                    })
                 } else {
                     // eslint-disable-next-line no-console
                     console.log('Failed to fetch resource instance list');


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Added a filter in the resource-type-filter.js to check for if model is active before adding it to array. Now only active models show in resource type filter.

<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
In version 6.0.0, only active models would show in the resource type filter, however, this feature broke upon the release of 6.1.0. Adding a filter to check if the resource model is active now shows only active models in resource type dropdown.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9435

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
