### PR TITLE
Change key for dropzone text in manifest manager, re #1149

### DIFF
--- a/arches/app/templates/views/components/plugins/manifest-manager.htm
+++ b/arches/app/templates/views/components/plugins/manifest-manager.htm
@@ -178,9 +178,9 @@
     <div class="dropzone-photo-upload" data-bind="dropzone: dropzoneOptions">
         <div class="file-workbench-links">
             <a class="fileinput-button dz-clickable" data-bind="css: uniqueidClass">
-                <span data-bind="text: $root.translations.dropzoneDragDrop1"></span>
-                <span class="text-bold" data-bind="text: $root.translations.dropzoneDragDrop2"></span>
-                <span data-bind="text: $root.translations.dropzoneDragDrop3"></span>
+                <span data-bind="text: $root.translations.dropzoneDragOrDropDesc1"></span>
+                <span class="text-bold" data-bind="text: $root.translations.dropzoneDragOrDropDesc2"></span>
+                <span data-bind="text: $root.translations.dropzoneDragOrDropDesc3"></span>
             </a>
         </div>
         <div style="min-height: 100%;">


### PR DESCRIPTION
Fix missing text for dropzone element in manifest manager, re https://github.com/archesproject/arches-for-science-prj/issues/1149