### PR TITLE
9477 edtf and table alias fix for spatial views

### DIFF
--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
@@ -77,7 +77,12 @@ class Migration(migrations.Migration):
         """
 
     reverse_sql_string = """
-            create or replace function __arches_get_node_display_value(in_tiledata jsonb, in_nodeid uuid) returns text language plpgsql as $$
+            create or replace function __arches_get_node_display_value(
+                in_tiledata jsonb,
+                in_nodeid uuid)
+                returns text
+                language plpgsql
+            as $$
                 declare
                     display_value   text := '';
                     in_node_type    text;
@@ -91,14 +96,14 @@ class Migration(migrations.Migration):
                         return '';
                     end if;
 
-                    select n.datatype, n.config 
-                    into in_node_type, in_node_config 
+                    select n.datatype, n.config
+                    into in_node_type, in_node_config
                     from nodes n where nodeid = in_nodeid::uuid;
-                        
+
                     if in_node_type = 'semantic' then
                         return '<semantic>';
                     end if;
-                    
+
                     if in_node_type is null then
                         return '';
                     end if;
@@ -133,8 +138,8 @@ class Migration(migrations.Migration):
 
                     return display_value;
                 end;
-                $$;
-                SELECT public.__arches_refresh_spatial_views();
+            $$;
+            SELECT public.__arches_refresh_spatial_views();
         """
 
     operations = [

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
@@ -1,0 +1,92 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("models", "9436_relational_view_null_geom_support"),
+    ]
+
+    sql_string = """
+            CREATE OR REPLACE FUNCTION public.__arches_get_node_display_value(
+                in_tiledata jsonb,
+                in_nodeid uuid)
+                RETURNS text
+                LANGUAGE 'plpgsql'
+                COST 100
+                VOLATILE PARALLEL UNSAFE
+            AS $BODY$
+                            declare
+                                display_value   text := '';
+                                in_node_type    text;
+                                in_node_config  json;
+                            begin
+                                if in_nodeid is null or in_nodeid is null then
+                                    return '<invalid_nodeid>';
+                                end if;
+                                
+                                if in_tiledata is null then
+                                    return '';
+                                end if;
+
+                                select n.datatype, n.config 
+                                into in_node_type, in_node_config 
+                                from nodes n where nodeid = in_nodeid::uuid;
+                                    
+                                if in_node_type = 'semantic' then
+                                    return '<semantic>';
+                                end if;
+                                
+                                if in_node_type is null then
+                                    return '';
+                                end if;
+                                
+                                case in_node_type
+                                    when 'concept' then
+                                        display_value := __arches_get_concept_label((in_tiledata ->> in_nodeid::text)::uuid);
+                                    when 'concept-list' then
+                                        display_value := __arches_get_concept_list_label(in_tiledata -> in_nodeid::text);
+                                    when 'edtf' then
+                                        display_value := (in_tiledata ->> in_nodeid::text);
+                                    when 'file-list' then
+                                        select string_agg(f.url,' | ') from (select (jsonb_array_elements(in_tiledata -> in_nodeid::text) -> 'name')::text as url) f into display_value;
+                                    when 'domain-value' then
+                                        display_value := __arches_get_domain_label((in_tiledata ->> in_nodeid::text)::uuid, in_nodeid);
+                                    when 'domain-value-list' then
+                                        display_value := __arches_get_domain_list_label(in_tiledata -> in_nodeid, in_nodeid);
+                                    when 'url' then
+                                        display_value := (in_tiledata -> in_nodeid::text ->> 'url');
+                                    when 'node-value' then
+                                        display_value := __arches_get_nodevalue_label(in_tiledata -> in_nodeid::text, in_nodeid);
+                                    when 'resource-instance' then
+                                        display_value := __arches_get_resourceinstance_label(in_tiledata -> in_nodeid::text, 'name');
+                                    when 'resource-instance-list' then
+                                        display_value := __arches_get_resourceinstance_list_label(in_tiledata -> in_nodeid::text, 'name');
+                                    else
+                                        -- print the content of the json
+                                        -- 'string'
+                                        -- 'number'
+                                        -- 'date' -----------------might need to look at date formatting?
+                                        -- 'boolean
+                                        -- 'geojson-feature-collection'
+                                        -- 'annotation'
+                                        -- 'any other custom datatype - will need a pattern to handle this'
+                                        display_value := (in_tiledata ->> in_nodeid::text)::text;
+                                    
+                                    end case;
+                                        
+                                return display_value;
+                            end;
+                            
+            $BODY$;
+
+            SELECT public.__arches_refresh_spatial_views();
+        """
+
+    reverse_sql_string = """
+            drop function if exists public.__arches_get_node_display_value;
+        """
+
+    operations = [
+        migrations.RunSQL(sql_string, reverse_sql_string),
+    ]

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
@@ -4,7 +4,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "9055_add_branch_publication_to_node"),
+        ("models", "9477_fix_for_spatial_view_dbf_function_table_alias_error"),
     ]
 
     sql_string = """

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
@@ -4,7 +4,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "9436_relational_view_null_geom_support"),
+        ("models", "9055_add_branch_publication_to_node"),
     ]
 
     sql_string = """

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
@@ -24,23 +24,23 @@ class Migration(migrations.Migration):
                                 if in_nodeid is null or in_nodeid is null then
                                     return '<invalid_nodeid>';
                                 end if;
-                                
+
                                 if in_tiledata is null then
                                     return '';
                                 end if;
 
-                                select n.datatype, n.config 
-                                into in_node_type, in_node_config 
+                                select n.datatype, n.config
+                                into in_node_type, in_node_config
                                 from nodes n where nodeid = in_nodeid::uuid;
-                                    
+
                                 if in_node_type = 'semantic' then
                                     return '<semantic>';
                                 end if;
-                                
+
                                 if in_node_type is null then
                                     return '';
                                 end if;
-                                
+
                                 case in_node_type
                                     when 'concept' then
                                         display_value := __arches_get_concept_label((in_tiledata ->> in_nodeid::text)::uuid);
@@ -49,7 +49,9 @@ class Migration(migrations.Migration):
                                     when 'edtf' then
                                         display_value := (in_tiledata ->> in_nodeid::text);
                                     when 'file-list' then
-                                        select string_agg(f.url,' | ') from (select (jsonb_array_elements(in_tiledata -> in_nodeid::text) -> 'name')::text as url) f into display_value;
+                                        select string_agg(f.url,' | ')
+                                          from (select (jsonb_array_elements(in_tiledata -> in_nodeid::text) -> 'name')::text as url) f
+                                          into display_value;
                                     when 'domain-value' then
                                         display_value := __arches_get_domain_label((in_tiledata ->> in_nodeid::text)::uuid, in_nodeid);
                                     when 'domain-value-list' then
@@ -72,12 +74,12 @@ class Migration(migrations.Migration):
                                         -- 'annotation'
                                         -- 'any other custom datatype - will need a pattern to handle this'
                                         display_value := (in_tiledata ->> in_nodeid::text)::text;
-                                    
+
                                     end case;
-                                        
+
                                 return display_value;
                             end;
-                            
+
             $BODY$;
 
             SELECT public.__arches_refresh_spatial_views();

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_edtf_displaying_null.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("models", "9477_fix_for_spatial_view_dbf_function_table_alias_error"),
     ]
@@ -65,14 +64,6 @@ class Migration(migrations.Migration):
                                     when 'resource-instance-list' then
                                         display_value := __arches_get_resourceinstance_list_label(in_tiledata -> in_nodeid::text, 'name');
                                     else
-                                        -- print the content of the json
-                                        -- 'string'
-                                        -- 'number'
-                                        -- 'date' -----------------might need to look at date formatting?
-                                        -- 'boolean
-                                        -- 'geojson-feature-collection'
-                                        -- 'annotation'
-                                        -- 'any other custom datatype - will need a pattern to handle this'
                                         display_value := (in_tiledata ->> in_nodeid::text)::text;
 
                                     end case;
@@ -86,7 +77,64 @@ class Migration(migrations.Migration):
         """
 
     reverse_sql_string = """
-            drop function if exists public.__arches_get_node_display_value;
+            create or replace function __arches_get_node_display_value(in_tiledata jsonb, in_nodeid uuid) returns text language plpgsql as $$
+                declare
+                    display_value   text := '';
+                    in_node_type    text;
+                    in_node_config  json;
+                begin
+                    if in_nodeid is null or in_nodeid is null then
+                        return '<invalid_nodeid>';
+                    end if;
+
+                    if in_tiledata is null then
+                        return '';
+                    end if;
+
+                    select n.datatype, n.config 
+                    into in_node_type, in_node_config 
+                    from nodes n where nodeid = in_nodeid::uuid;
+                        
+                    if in_node_type = 'semantic' then
+                        return '<semantic>';
+                    end if;
+                    
+                    if in_node_type is null then
+                        return '';
+                    end if;
+
+                    case in_node_type
+                        when 'concept' then
+                            display_value := __arches_get_concept_label((in_tiledata ->> in_nodeid::text)::uuid);
+                        when 'concept-list' then
+                            display_value := __arches_get_concept_list_label(in_tiledata -> in_nodeid::text);
+                        when 'edtf' then
+                            display_value := ((in_tiledata -> in_nodeid::text) ->> 'value');
+                        when 'file-list' then
+                            select string_agg(f.url,' | ')
+                              from (select (jsonb_array_elements(in_tiledata -> in_nodeid::text) -> 'name')::text as url) f
+                              into display_value;
+                        when 'domain-value' then
+                            display_value := __arches_get_domain_label((in_tiledata ->> in_nodeid::text)::uuid, in_nodeid);
+                        when 'domain-value-list' then
+                            display_value := __arches_get_domain_list_label(in_tiledata -> in_nodeid, in_nodeid);
+                        when 'url' then
+                            display_value := (in_tiledata -> in_nodeid::text ->> 'url');
+                        when 'node-value' then
+                            display_value := __arches_get_nodevalue_label(in_tiledata -> in_nodeid::text, in_nodeid);
+                        when 'resource-instance' then
+                            display_value := __arches_get_resourceinstance_label(in_tiledata -> in_nodeid::text, 'name');
+                        when 'resource-instance-list' then
+                            display_value := __arches_get_resourceinstance_list_label(in_tiledata -> in_nodeid::text, 'name');
+                        else
+                            display_value := (in_tiledata ->> in_nodeid::text)::text;
+
+                        end case;
+
+                    return display_value;
+                end;
+                $$;
+                SELECT public.__arches_refresh_spatial_views();
         """
 
     operations = [

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
@@ -3,7 +3,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("models", "9055_add_branch_publication_to_node"),
+        ("models", "9558_add_plugin_help"),
     ]
 
     sql_string = """

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
@@ -1,0 +1,258 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("models", "9436_relational_view_null_geom_support"),
+    ]
+
+    sql_string = """
+            -- FUNCTION: public.__arches_create_spatial_view_attribute_table(text, uuid, jsonb, text)
+
+            -- DROP FUNCTION IF EXISTS public.__arches_create_spatial_view_attribute_table(text, uuid, jsonb, text);
+
+            CREATE OR REPLACE FUNCTION public.__arches_create_spatial_view_attribute_table(
+                spatial_view_name_slug text,
+                geometry_node_id uuid,
+                attribute_node_list jsonb,
+                schema_name text DEFAULT 'public'::text)
+                RETURNS text
+                LANGUAGE 'plpgsql'
+                COST 100
+                VOLATILE STRICT PARALLEL UNSAFE
+            AS $BODY$
+                declare
+                    att_table_name  text;
+                    tile_create     text := '';
+                    node_create     text := '';
+                    att_view_tbl    text;
+                    att_comments    text := '';
+                begin
+                    att_table_name := format('%s.sp_attr_%s', schema_name, spatial_view_name_slug);
+                    
+                    att_comments = att_comments || format(
+                                    'comment on column %s.%s is ''%s'';',
+                                    att_table_name,
+                                    'resourceinstanceid',
+                                    'Globally unique Arches resource ID'
+                                    );
+                    
+                    declare
+                        tmp_nodegroupid_slug  text;
+                        node_name_slug        text;
+                        n                     record;
+                    begin
+                        for n in 
+                                with attribute_nodes as (
+                                    select * from jsonb_to_recordset(attribute_node_list) as x(nodeid uuid, description text)
+                                )
+                                select 
+                                    n1.name, 
+                                    n1.nodeid, 
+                                    n1.nodegroupid,
+                                    att_nodes.description
+                                from nodes n1
+                                    join (select * from attribute_nodes) att_nodes ON n1.nodeid = att_nodes.nodeid
+                        loop
+                            tmp_nodegroupid_slug := __arches_slugify(n.nodegroupid::text);
+                            node_name_slug := __arches_slugify(n.name);
+                            node_create = node_create || 
+                                format('
+                                    ,__arches_agg_get_node_display_value(distinct "tile_%s".tiledata, ''%s'') as %s
+                                    ',
+                                        tmp_nodegroupid_slug,
+                                        n.nodeid::text,
+                                        node_name_slug
+                                    );
+                            
+                            if tile_create not like (format('%%tile_%s%%',tmp_nodegroupid_slug)) then
+                                tile_create = tile_create || 
+                                    format(' 
+                                    left outer join tiles "tile_%s" on r.resourceinstanceid = "tile_%s".resourceinstanceid
+                                        and "tile_%s".nodegroupid = ''%s''
+                                    ',
+                                    tmp_nodegroupid_slug,
+                                    tmp_nodegroupid_slug,
+                                    tmp_nodegroupid_slug,
+                                    n.nodegroupid::text);
+                            end if;
+
+                            if n.description is not null AND n.description <> '' then
+                                att_comments = att_comments || format(
+                                    'comment on column %s.%s is ''%s'';',
+                                    att_table_name,
+                                    node_name_slug,
+                                    n.description
+                                    );
+                            end if;
+
+                        end loop;
+                    end;
+                    
+                    att_view_tbl := format(
+                        '
+                        create table %s 
+                        tablespace pg_default
+                        as
+                        (
+                            select 
+                                r.resourceinstanceid::text as resourceinstanceid
+                                %s
+                            from resource_instances r
+                                join geojson_geometries geo on geo.resourceinstanceid::text = r.resourceinstanceid::text
+                                    and geo.nodeid = ''%s''
+                                %s
+                            group by
+                                r.resourceinstanceid::text
+                        )
+                        with data;
+                        
+                        %s
+
+                        create index on %s (resourceinstanceid);
+                        
+                        ',
+                        att_table_name,
+                        node_create, 
+                        geometry_node_id, 
+                        tile_create,
+                        att_comments,
+                        att_table_name);
+                    
+                    execute att_view_tbl;
+                    
+                    return att_table_name;
+                end;
+                            
+            $BODY$;
+                
+            -- FUNCTION: public.__arches_trg_fnc_update_spatial_attributes()
+
+            -- DROP FUNCTION IF EXISTS public.__arches_trg_fnc_update_spatial_attributes();
+
+            CREATE OR REPLACE FUNCTION public.__arches_trg_fnc_update_spatial_attributes()
+                RETURNS trigger
+                LANGUAGE 'plpgsql'
+                COST 100
+                VOLATILE NOT LEAKPROOF
+            AS $BODY$
+                declare
+                    trigger_tile  record;
+                    spv           record;
+                begin
+                    if tg_op = 'DELETE' then 
+                        trigger_tile := old;
+                    else
+                        trigger_tile := new;
+                    end if;
+
+                    for spv in
+                            select * from spatial_views where isactive = true
+                    loop
+                        declare
+                            resource_geom_count   integer := 0;
+                            found_attr_key_count  integer := 0;
+                            insert_attr           text    := '';
+                            delete_existing       text    := '';
+                        begin
+                            with attribute_nodes as (
+                                select * from jsonb_to_recordset(spv.attributenodes) as x(nodeid uuid, description text)
+                            )
+                            select count(*) into found_attr_key_count 
+                            from (select jsonb_object_keys(trigger_tile.tiledata) as node_id) keys
+                            where keys.node_id::text in (select nodeid::text from attribute_nodes)
+                                or keys.node_id::text = spv.geometrynodeid::text;
+
+                            if found_attr_key_count < 1 then
+                                continue; 
+                            end if;
+                            
+                            declare
+                                att_table_name        text := spv.schema || '.sp_attr_' || spv.slug;
+                                tmp_nodegroupid_slug  text;
+                                n                     record;
+                                node_create           text := '';
+                                tile_create           text := '';
+                            begin
+
+                                delete_existing := format('
+                                    delete from %1$s where resourceinstanceid::uuid = %2$L::uuid;
+                                    ',
+                                    att_table_name,
+                                    trigger_tile.resourceinstanceid
+                                    );
+                                execute delete_existing;
+
+                                for n in 
+                                        with attribute_nodes1 as (
+                                            select * from jsonb_to_recordset(spv.attributenodes) as x(nodeid uuid, description text)
+                                        )
+                                        select 
+                                            n1.name, 
+                                            n1.nodeid, 
+                                            n1.nodegroupid,
+                                            att_nodes.description
+                                        from nodes n1
+                                            join (select * from attribute_nodes1) att_nodes ON n1.nodeid = att_nodes.nodeid
+                                loop
+                                    tmp_nodegroupid_slug := __arches_slugify(n.nodegroupid::text);
+                                    node_create = node_create || 
+                                        format(' ,__arches_agg_get_node_display_value(distinct "tile_%s".tiledata, %L::uuid) as %s '
+                                            ,tmp_nodegroupid_slug
+                                            ,n.nodeid::text
+                                            ,__arches_slugify(n.name)
+                                        );
+                                    
+                                    if tile_create not like (format('%%tile_%s%%',tmp_nodegroupid_slug)) then
+                                        tile_create = tile_create || 
+                                            format(' left outer join tiles "tile_%s" on r.resourceinstanceid = "tile_%s".resourceinstanceid
+                                                and "tile_%s".nodegroupid = ''%s''::uuid ',
+                                            tmp_nodegroupid_slug,
+                                            tmp_nodegroupid_slug,
+                                            tmp_nodegroupid_slug,
+                                            n.nodegroupid::text);
+                                    end if;
+
+                                end loop;
+
+                                insert_attr := format(
+                                    '
+                                    insert into %s
+                                        select 
+                                            r.resourceinstanceid
+                                            %s
+                                        from resource_instances r
+                                            join geojson_geometries geo on geo.resourceinstanceid = r.resourceinstanceid
+                                                and geo.nodeid = %L
+                                            %s
+                                        group by
+                                            r.resourceinstanceid
+                                        having r.resourceinstanceid = %L::uuid
+                                    ',
+                                    att_table_name,
+                                    node_create, 
+                                    spv.geometrynodeid::text, 
+                                    tile_create,
+                                    trigger_tile.resourceinstanceid::text);
+
+                            end;
+                            execute insert_attr;
+
+                        end;
+                    end loop;
+
+                    return trigger_tile;
+                end;
+                            
+            $BODY$;
+        """
+
+    reverse_sql_string = """
+            DROP FUNCTION IF EXISTS public.__arches_create_spatial_view_attribute_table;
+            DROP FUNCTION IF EXISTS public.__arches_trg_fnc_update_spatial_attributes;
+        """
+
+    operations = [
+        migrations.RunSQL(sql_string, reverse_sql_string),
+    ]

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
@@ -4,7 +4,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "9436_relational_view_null_geom_support"),
+        ("models", "9055_add_branch_publication_to_node"),
     ]
 
     sql_string = """

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
@@ -30,26 +30,26 @@ class Migration(migrations.Migration):
                     att_comments    text := '';
                 begin
                     att_table_name := format('%s.sp_attr_%s', schema_name, spatial_view_name_slug);
-                    
+
                     att_comments = att_comments || format(
                                     'comment on column %s.%s is ''%s'';',
                                     att_table_name,
                                     'resourceinstanceid',
                                     'Globally unique Arches resource ID'
                                     );
-                    
+
                     declare
                         tmp_nodegroupid_slug  text;
                         node_name_slug        text;
                         n                     record;
                     begin
-                        for n in 
+                        for n in
                                 with attribute_nodes as (
                                     select * from jsonb_to_recordset(attribute_node_list) as x(nodeid uuid, description text)
                                 )
-                                select 
-                                    n1.name, 
-                                    n1.nodeid, 
+                                select
+                                    n1.name,
+                                    n1.nodeid,
                                     n1.nodegroupid,
                                     att_nodes.description
                                 from nodes n1
@@ -57,7 +57,7 @@ class Migration(migrations.Migration):
                         loop
                             tmp_nodegroupid_slug := __arches_slugify(n.nodegroupid::text);
                             node_name_slug := __arches_slugify(n.name);
-                            node_create = node_create || 
+                            node_create = node_create ||
                                 format('
                                     ,__arches_agg_get_node_display_value(distinct "tile_%s".tiledata, ''%s'') as %s
                                     ',
@@ -65,10 +65,10 @@ class Migration(migrations.Migration):
                                         n.nodeid::text,
                                         node_name_slug
                                     );
-                            
+
                             if tile_create not like (format('%%tile_%s%%',tmp_nodegroupid_slug)) then
-                                tile_create = tile_create || 
-                                    format(' 
+                                tile_create = tile_create ||
+                                    format('
                                     left outer join tiles "tile_%s" on r.resourceinstanceid = "tile_%s".resourceinstanceid
                                         and "tile_%s".nodegroupid = ''%s''
                                     ',
@@ -89,14 +89,14 @@ class Migration(migrations.Migration):
 
                         end loop;
                     end;
-                    
+
                     att_view_tbl := format(
                         '
-                        create table %s 
+                        create table %s
                         tablespace pg_default
                         as
                         (
-                            select 
+                            select
                                 r.resourceinstanceid::text as resourceinstanceid
                                 %s
                             from resource_instances r
@@ -107,11 +107,11 @@ class Migration(migrations.Migration):
                                 r.resourceinstanceid::text
                         )
                         with data;
-                        
+
                         %s
 
                         create index on %s (resourceinstanceid);
-                        
+
                         ',
                         att_table_name,
                         node_create, 

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
@@ -2,16 +2,11 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("models", "9055_add_branch_publication_to_node"),
     ]
 
     sql_string = """
-            -- FUNCTION: public.__arches_create_spatial_view_attribute_table(text, uuid, jsonb, text)
-
-            -- DROP FUNCTION IF EXISTS public.__arches_create_spatial_view_attribute_table(text, uuid, jsonb, text);
-
             CREATE OR REPLACE FUNCTION public.__arches_create_spatial_view_attribute_table(
                 spatial_view_name_slug text,
                 geometry_node_id uuid,
@@ -126,10 +121,6 @@ class Migration(migrations.Migration):
                 end;
 
             $BODY$;
-
-            -- FUNCTION: public.__arches_trg_fnc_update_spatial_attributes()
-
-            -- DROP FUNCTION IF EXISTS public.__arches_trg_fnc_update_spatial_attributes();
 
             CREATE OR REPLACE FUNCTION public.__arches_trg_fnc_update_spatial_attributes()
                 RETURNS trigger
@@ -249,8 +240,232 @@ class Migration(migrations.Migration):
         """
 
     reverse_sql_string = """
-            DROP FUNCTION IF EXISTS public.__arches_create_spatial_view_attribute_table;
-            DROP FUNCTION IF EXISTS public.__arches_trg_fnc_update_spatial_attributes;
+            create or replace function __arches_create_spatial_view_attribute_table(
+                    spatial_view_name_slug text,
+                    geometry_node_id uuid,
+                    attribute_node_list jsonb,
+                    schema_name text default 'public'
+                ) returns text
+                language plpgsql 
+                strict
+                as 
+                $$
+                declare
+                    att_table_name  text;
+                    tile_create     text := '';
+                    node_create     text := '';
+                    att_view_tbl    text;
+                    att_comments    text := '';
+                begin
+                    att_table_name := format('%s.sp_attr_%s', schema_name, spatial_view_name_slug);
+
+                    att_comments = att_comments || format(
+                                    'comment on column %s.%s is ''%s'';',
+                                    att_table_name,
+                                    'resourceinstanceid',
+                                    'Globally unique Arches resource ID'
+                                    );
+
+                    declare
+                        tmp_nodegroupid_slug  text;
+                        node_name_slug	      text;
+                        n                     record;
+                    begin
+                        for n in 
+                                with attribute_nodes as (
+                                    select * from jsonb_to_recordset(attribute_node_list) as x(nodeid uuid, description text)
+                                )
+                                select 
+                                    n1.name, 
+                                    n1.nodeid, 
+                                    n1.nodegroupid,
+                                    att_nodes.description
+                                from nodes n1
+                                    join (select * from attribute_nodes) att_nodes ON n1.nodeid = att_nodes.nodeid
+                        loop
+                            tmp_nodegroupid_slug := __arches_slugify(n.nodegroupid::text);
+                            node_name_slug := __arches_slugify(n.name);
+                            node_create = node_create || 
+                                format('
+                                    ,__arches_agg_get_node_display_value(distinct tile_%s.tiledata, ''%s'') as %s
+                                    ',
+                                        tmp_nodegroupid_slug,
+                                        n.nodeid::text,
+                                        node_name_slug
+                                    );
+
+                            if tile_create not like (format('%%tile_%s%%',tmp_nodegroupid_slug)) then
+                                tile_create = tile_create || 
+                                    format(' 
+                                    left outer join tiles tile_%s on r.resourceinstanceid = tile_%s.resourceinstanceid
+                                        and tile_%s.nodegroupid = ''%s''
+                                    ',
+                                    tmp_nodegroupid_slug,
+                                    tmp_nodegroupid_slug,
+                                    tmp_nodegroupid_slug,
+                                    n.nodegroupid::text);
+                            end if;
+
+                            if n.description is not null AND n.description <> '' then
+                                att_comments = att_comments || format(
+                                    'comment on column %s.%s is ''%s'';',
+                                    att_table_name,
+                                    node_name_slug,
+                                    n.description
+                                    );
+                            end if;
+
+                        end loop;
+                    end;
+
+                    att_view_tbl := format(
+                        '
+                        create table %s 
+                        tablespace pg_default
+                        as
+                        (
+                            select 
+                                r.resourceinstanceid::text as resourceinstanceid
+                                %s
+                            from resource_instances r
+                                join geojson_geometries geo on geo.resourceinstanceid::text = r.resourceinstanceid::text
+                                    and geo.nodeid = ''%s''
+                                %s
+                            group by
+                                r.resourceinstanceid::text
+                        )
+                        with data;
+                        
+                        %s
+
+                        create index on %s (resourceinstanceid);
+                        
+                        ',
+                        att_table_name,
+                        node_create, 
+                        geometry_node_id, 
+                        tile_create,
+                        att_comments,
+                        att_table_name);
+                    
+                    execute att_view_tbl;
+                    
+                    return att_table_name;
+                end;
+                $$;
+
+            create or replace function __arches_trg_fnc_update_spatial_attributes()
+                returns trigger 
+                language plpgsql
+                as $func$
+                declare
+                    trigger_tile  record;
+                    spv           record;
+                begin
+                    if tg_op = 'DELETE' then 
+                        trigger_tile := old;
+                    else
+                        trigger_tile := new;
+                    end if;
+
+                    for spv in
+                            select * from spatial_views where isactive = true
+                    loop
+                        declare
+                            resource_geom_count   integer := 0;
+                            found_attr_key_count  integer := 0;
+                            insert_attr           text    := '';
+                            delete_existing       text    := '';
+                        begin
+                            with attribute_nodes as (
+                                select * from jsonb_to_recordset(spv.attributenodes) as x(nodeid uuid, description text)
+                            )
+                            select count(*) into found_attr_key_count 
+                            from (select jsonb_object_keys(trigger_tile.tiledata) as node_id) keys
+                            where keys.node_id::text in (select nodeid::text from attribute_nodes)
+                                or keys.node_id::text = spv.geometrynodeid::text;
+
+                            if found_attr_key_count < 1 then
+                                continue; 
+                            end if;
+
+                            declare
+                                att_table_name        text := spv.schema || '.sp_attr_' || spv.slug;
+                                tmp_nodegroupid_slug  text;
+                                n                     record;
+                                node_create           text := '';
+                                tile_create           text := '';
+                            begin
+
+                                delete_existing := format('
+                                    delete from %1$s where resourceinstanceid::uuid = %2$L::uuid;
+                                    ',
+                                    att_table_name,
+                                    trigger_tile.resourceinstanceid
+                                    );
+                                execute delete_existing;
+
+                                for n in 
+                                        with attribute_nodes1 as (
+                                            select * from jsonb_to_recordset(spv.attributenodes) as x(nodeid uuid, description text)
+                                        )
+                                        select 
+                                            n1.name, 
+                                            n1.nodeid, 
+                                            n1.nodegroupid,
+                                            att_nodes.description
+                                        from nodes n1
+                                            join (select * from attribute_nodes1) att_nodes ON n1.nodeid = att_nodes.nodeid
+                                loop
+                                    tmp_nodegroupid_slug := __arches_slugify(n.nodegroupid::text);
+                                    node_create = node_create || 
+                                        format(' ,__arches_agg_get_node_display_value(distinct tile_%s.tiledata, %L::uuid) as %s '
+                                            ,tmp_nodegroupid_slug
+                                            ,n.nodeid::text
+                                            ,__arches_slugify(n.name)
+                                        );
+
+                                    if tile_create not like (format('%%tile_%s%%',tmp_nodegroupid_slug)) then
+                                        tile_create = tile_create || 
+                                            format(' left outer join tiles tile_%s on r.resourceinstanceid = tile_%s.resourceinstanceid
+                                                and tile_%s.nodegroupid = ''%s''::uuid ',
+                                            tmp_nodegroupid_slug,
+                                            tmp_nodegroupid_slug,
+                                            tmp_nodegroupid_slug,
+                                            n.nodegroupid::text);
+                                    end if;
+
+                                end loop;
+
+                                insert_attr := format(
+                                    '
+                                    insert into %s
+                                        select 
+                                            r.resourceinstanceid
+                                            %s
+                                        from resource_instances r
+                                            join geojson_geometries geo on geo.resourceinstanceid = r.resourceinstanceid
+                                                and geo.nodeid = %L
+                                            %s
+                                        group by
+                                            r.resourceinstanceid
+                                        having r.resourceinstanceid = %L::uuid
+                                    ',
+                                    att_table_name,
+                                    node_create, 
+                                    spv.geometrynodeid::text, 
+                                    tile_create,
+                                    trigger_tile.resourceinstanceid::text);
+
+                            end;
+                            execute insert_attr;
+
+                        end;
+                    end loop;
+
+                    return trigger_tile;
+                end;
+                $func$;
         """
 
     operations = [

--- a/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
+++ b/arches/app/models/migrations/9477_fix_for_spatial_view_dbf_function_table_alias_error.py
@@ -324,7 +324,7 @@ class Migration(migrations.Migration):
                         tablespace pg_default
                         as
                         (
-                            select 
+                            select
                                 r.resourceinstanceid::text as resourceinstanceid
                                 %s
                             from resource_instances r
@@ -349,7 +349,7 @@ class Migration(migrations.Migration):
                         att_table_name);
 
                     execute att_view_tbl;
-                    
+
                     return att_table_name;
                 end;
                 $$;
@@ -405,7 +405,7 @@ class Migration(migrations.Migration):
                                     );
                                 execute delete_existing;
 
-                                for n in 
+                                for n in
                                         with attribute_nodes1 as (
                                             select * from jsonb_to_recordset(spv.attributenodes) as x(nodeid uuid, description text)
                                         )
@@ -440,7 +440,8 @@ class Migration(migrations.Migration):
                                 insert_attr := format(
                                     '
                                     insert into %s
-                                        select 
+
+                                        select
                                             r.resourceinstanceid
                                             %s
                                         from resource_instances r


### PR DESCRIPTION
Fixes #9477 

- Fixes EDTF datatype values coming through as null.
- Fixes an issue where the UUID that forms part of a table alias can sometimes cause a compile error with PGSQL. This was achieved by simply wrapping the aliases in quotes.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @RobOatesHistoricEngland
*   Tested by: @RobOatesHistoricEngland
*   Designed by: @aj-he @RobOatesHistoricEngland


