### PR TITLE
9441 Resource overlay styling and clustering input fixes

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -779,45 +779,6 @@ class GeojsonFeatureCollectionDataType(BaseDataType):
             except ValueError:
                 layer_def = "[]"
         else:
-            # default_values = {"radius":2,
-            #                   "haloRadius":4,
-            #                   "weight":2,
-            #                   "haloWeight":4,
-            #                   "outlineWeight":2}
-            # try:
-            #     for inp, val in default_values.items():
-            #         # check if input is string
-            #         if isinstance(node.config[inp], str):
-            #             print(inp, node.config[inp])
-            #             print(type(node.config[inp]))
-
-            #             node.config[inp] = int(val)
-            #             print(inp, node.config[inp])
-            #             print(type(node.config[inp]))
-
-            #             node.config[inp].save()
-                    
-
-            # except (AttributeError, KeyError):
-            #     pass
-            # for inp, val in default_values.items():
-            #     #try:
-            #     print(node.config[inp])
-            #     if node.config[inp].isnumeric() == False:
-            #         node.config[inp] = val
-            #     if node.config[inp] is None:
-            #         node.config[inp] = val
-            #     if node.config[inp] == "":
-            #         node.config[inp] = val
-            #     else:
-            #         print(node.config[inp])
-            #     node.config.save()
-
-                #except (AttributeError, KeyError):
-                #    print(inp)
-                #    pass
-
-
             layer_def = """[
                 {
                     "id": "resources-fill-%(nodeid)s",

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -779,6 +779,45 @@ class GeojsonFeatureCollectionDataType(BaseDataType):
             except ValueError:
                 layer_def = "[]"
         else:
+            # default_values = {"radius":2,
+            #                   "haloRadius":4,
+            #                   "weight":2,
+            #                   "haloWeight":4,
+            #                   "outlineWeight":2}
+            # try:
+            #     for inp, val in default_values.items():
+            #         # check if input is string
+            #         if isinstance(node.config[inp], str):
+            #             print(inp, node.config[inp])
+            #             print(type(node.config[inp]))
+
+            #             node.config[inp] = int(val)
+            #             print(inp, node.config[inp])
+            #             print(type(node.config[inp]))
+
+            #             node.config[inp].save()
+                    
+
+            # except (AttributeError, KeyError):
+            #     pass
+            # for inp, val in default_values.items():
+            #     #try:
+            #     print(node.config[inp])
+            #     if node.config[inp].isnumeric() == False:
+            #         node.config[inp] = val
+            #     if node.config[inp] is None:
+            #         node.config[inp] = val
+            #     if node.config[inp] == "":
+            #         node.config[inp] = val
+            #     else:
+            #         print(node.config[inp])
+            #     node.config.save()
+
+                #except (AttributeError, KeyError):
+                #    print(inp)
+                #    pass
+
+
             layer_def = """[
                 {
                     "id": "resources-fill-%(nodeid)s",

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -142,54 +142,54 @@ define([
                             layer.paint["fill-color"] = self.config.fillColor();
                             break;
                         case "resources-line-halo-" + params.nodeid:
-                            halo_weight_value = self.config.haloWeight();
+                            haloWeightValue = self.config.haloWeight();
                             //if empty string or combination of int+str convert to default values 
-                            if(halo_weight_value === ""){halo_weight_value = 4} 
-                            else (halo_weight_value = Number(halo_weight_value));
-                            layer.paint["line-width"] = halo_weight_value
+                            if(haloWeightValue === ""){haloWeightValue = 4;}
+                            else (haloWeightValue = Number(haloWeightValue));
+                            layer.paint["line-width"] = haloWeightValue
                             layer.paint["line-color"] = self.config.lineHaloColor();
                             break;
                         case "resources-line-" + params.nodeid:
-                            weight_value = self.config.weight();
-                            if(weight_value === ""){weight_value = 2} 
-                            else (weight_value = Number(weight_value));
-                            layer.paint["line-width"] = weight_value;
+                            weightValue = self.config.weight();
+                            if(weightValue === ""){weightValue = 2;} 
+                            else (weightValue = Number(weightValue));
+                            layer.paint["line-width"] = weightValue;
                             layer.paint["line-color"] = self.config.lineColor();
                             break;
                         case "resources-poly-outline-" + params.nodeid:
-                            outline_weight_value = self.config.outlineWeight();
-                            if(outline_weight_value === ""){outline_weight_value = 2} 
-                            else (outline_weight_value = Number(outline_weight_value));
-                            layer.paint["line-width"] = outline_weight_value;
+                            outlineWeightValue = self.config.outlineWeight();
+                            if(outlineWeightValue === ""){outlineWeightValue = 2;} 
+                            else (outlineWeightValue = Number(outlineWeightValue));
+                            layer.paint["line-width"] = outlineWeightValue;
                             layer.paint["line-color"] = self.config.outlineColor();
                             break;
                         case "resources-point-halo-" + params.nodeid:
-                            halo_radius_value = self.config.haloRadius();
-                            if(halo_radius_value === ""){halo_radius_value = 4} 
-                            else (halo_radius_value = Number(halo_radius_value));    
-                            layer.paint["circle-radius"] = halo_radius_value                        
+                            haloRadiusValue = self.config.haloRadius();
+                            if(haloRadiusValue === ""){haloRadiusValue = 4;} 
+                            else (haloRadiusValue = Number(haloRadiusValue));    
+                            layer.paint["circle-radius"] = haloRadiusValue                        
                         case "resources-cluster-point-halo-" + params.nodeid:
                             layer.paint["circle-color"] = self.config.pointHaloColor();
                             break;
                         case "resources-point-" + params.nodeid:
-                            radius_value = self.config.radius();
-                            if(radius_value === ""){radius_value = 2} 
-                            else (radius_value = Number(radius_value));   
-                            layer.paint["circle-radius"] = radius_value;
+                            radiusValue = self.config.radius();
+                            if(radiusValue === ""){radiusValue = 2;} 
+                            else (radiusValue = Number(radiusValue));   
+                            layer.paint["circle-radius"] = radiusValue;
                         case "resources-cluster-point-" + params.nodeid:
                             layer.paint["circle-color"] = self.config.pointColor();
-                            cluster_distance_value = self.config.clusterDistance();
-                            if(cluster_distance_value === ""){cluster_distance_value = 20} 
-                            else (cluster_distance_value = Number(cluster_distance_value));    
-                            cluster_max_zoom_value = self.config.clusterMaxZoom();
-                            if(cluster_max_zoom_value === ""){cluster_max_zoom_value = 5} 
-                            else (cluster_max_zoom_value = Number(cluster_max_zoom_value));    
-                            cluster_min_points_value = self.config.clusterMinPoints();
-                            if(cluster_min_points_value === ""){cluster_min_points_value = 3} 
-                            else (cluster_min_points_value = Number(cluster_min_points_value));    
-                            simplification_value = self.config.simplification();
-                            if(simplification_value === ""){simplification_value = 0.3} 
-                            else (simplification_value = Number(simplification_value));     
+                            clusterDistanceValue = self.config.clusterDistance();
+                            if(clusterDistanceValue === ""){clusterDistanceValue = 20;} 
+                            else (clusterDistanceValue = Number(clusterDistanceValue));    
+                            clusterMaxZoomValue = self.config.clusterMaxZoom();
+                            if(clusterMaxZoomValue === ""){clusterMaxZoomValue = 5;} 
+                            else (clusterMaxZoomValue = Number(clusterMaxZoomValue));    
+                            clusterMinPointsValue = self.config.clusterMinPoints();
+                            if(clusterMinPointsValue === ""){clusterMinPointsValue = 3;} 
+                            else (clusterMinPointsValue = Number(clusterMinPointsValue));    
+                            simplificationValue = self.config.simplification();
+                            if(simplificationValue === ""){simplificationValue = 0.3;} 
+                            else (simplificationValue = Number(simplificationValue));     
                             break;
                         default:
 
@@ -212,15 +212,15 @@ define([
 
                 this.saveNode = function() {
                     // do saving of config values at end to avoid double save button issue
-                    self.config.haloWeight(halo_weight_value);
-                    self.config.weight(weight_value);
-                    self.config.outlineWeight(outline_weight_value);
-                    self.config.haloRadius(halo_radius_value);
-                    self.config.radius(radius_value);
-                    self.config.clusterDistance(cluster_distance_value);
-                    self.config.clusterMaxZoom(cluster_max_zoom_value);
-                    self.config.clusterMinPoints(cluster_min_points_value);
-                    self.config.simplification(simplification_value);
+                    self.config.haloWeight(haloWeightValue);
+                    self.config.weight(weightValue);
+                    self.config.outlineWeight(outlineWeightValue);
+                    self.config.haloRadius(haloRadiusValue);
+                    self.config.radius(radiusValue);
+                    self.config.clusterDistance(clusterDistanceValue);
+                    self.config.clusterMaxZoom(clusterMaxZoomValue);
+                    self.config.clusterMinPoints(clusterMinPointsValue);
+                    self.config.simplification(simplificationValue);
                     
                     self.loading(true);
                     self.node.save(function() {

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -178,6 +178,18 @@ define([
                             layer.paint["circle-radius"] = radius_value;
                         case "resources-cluster-point-" + params.nodeid:
                             layer.paint["circle-color"] = self.config.pointColor();
+                            cluster_distance_value = self.config.clusterDistance();
+                            if(cluster_distance_value === ""){cluster_distance_value = 20} 
+                            else (cluster_distance_value = Number(cluster_distance_value));    
+                            cluster_max_zoom_value = self.config.clusterMaxZoom();
+                            if(cluster_max_zoom_value === ""){cluster_max_zoom_value = 5} 
+                            else (cluster_max_zoom_value = Number(cluster_max_zoom_value));    
+                            cluster_min_points_value = self.config.clusterMinPoints();
+                            if(cluster_min_points_value === ""){cluster_min_points_value = 3} 
+                            else (cluster_min_points_value = Number(cluster_min_points_value));    
+                            simplification_value = self.config.simplification();
+                            if(simplification_value === ""){simplification_value = 0.3} 
+                            else (simplification_value = Number(simplification_value));     
                             break;
                         default:
 
@@ -199,12 +211,16 @@ define([
 
                 this.saveNode = function() {
                     // do saving of config values at end to avoid double save button issue
-                    self.config.haloWeight(halo_weight_value)
-                    self.config.weight(weight_value)
-                    self.config.outlineWeight(outline_weight_value)
-                    self.config.haloRadius(halo_radius_value)
-                    self.config.radius(radius_value)
-
+                    self.config.haloWeight(halo_weight_value);
+                    self.config.weight(weight_value);
+                    self.config.outlineWeight(outline_weight_value);
+                    self.config.haloRadius(halo_radius_value);
+                    self.config.radius(radius_value);
+                    self.config.clusterDistance(cluster_distance_value);
+                    self.config.clusterMaxZoom(cluster_max_zoom_value);
+                    self.config.clusterMinPoints(cluster_min_points_value);
+                    self.config.simplification(simplification_value);
+                    
                     self.loading(true);
                     self.node.save(function() {
                         self.loading(false);

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -136,77 +136,47 @@ define([
                 };
 
                 var updateMapStyle = function() {
+                    console.log("update map style has been run")
                     _.each(overlays, function(layer) {
-                        console.log("am i here")
                         switch (layer.id) {
                         case "resources-fill-" + params.nodeid:
                             layer.paint["fill-color"] = self.config.fillColor();
                             break;
                         case "resources-line-halo-" + params.nodeid:
-                            // // if (!(/^\d+$/.test(self.config.haloWeight())) && !(self.config.haloWeight() === "") ) {
-                            //     if (!(/^\d+$/.test(self.config.haloWeight())) &&
-                            //         !(self.config.haloWeight() === "") &&
-                            //         !(self.config.haloWeight())) {
-
-                            //     console.log("\nBEFORE INP");
-                            //     console.log(self.config.haloWeight(), "whats in the box");
-                            //     console.log(typeof(layer.paint["line-width"]),layer.paint["line-width"], "   Line width");
-                            //     console.log(typeof(self.config.haloWeight()),self.config.haloWeight(), "   Halo weight"); 
-                            
-
-                            //     layer.paint["line-width"] = parseInt(self.config.haloWeight());
-                            //     self.config.haloWeight(layer.paint["line-width"]);
-                            //     layer.paint["line-color"] = self.config.lineHaloColor();
-
-                            //     console.log("\nAFTER");
-                            //     console.log(self.config.haloWeight(), "whats in the box");
-                            //     console.log(typeof(layer.paint["line-width"]),layer.paint["line-width"], "   Line width");
-                            //     console.log(typeof(self.config.haloWeight()),self.config.haloWeight(), "   Halo weight"); 
-                            //     break;
-                            // } else {
-                            //     console.log(self.config.haloWeight())
-                            //     layer.paint["line-width"] = 4;
-                            //     self.config.haloWeight(layer.paint["line-width"]);
-                            //     layer.paint["line-color"] = self.config.lineHaloColor();
-                            //     break;
-                            // };
-                            console.log(self.config.haloWeight())
-                            layer.paint["line-width"] = parseInt(self.config.haloWeight());
-                            console.log(typeof(layer.paint["line-width"]),layer.paint["line-width"], "Line width");
-                            console.log(typeof(self.config.haloWeight()),self.config.haloWeight(), "halo weight");
-                            if (!(/^\d+\.\d+$|^\d+$/.test(self.config.haloWeight()))) {layer.paint["line-width"] = 4;}
-                            if (self.config.haloWeight() === "") {layer.paint["line-width"] = 4;}
-                            //if (!(self.config.haloWeight() > 0)) { layer.paint["line-width"] = 10; }
-                            self.config.haloWeight(layer.paint["line-width"]);
-                            console.log(self.config.haloWeight(layer.paint["line-width"]));
+                            halo_weight_value = self.config.haloWeight();
+                            //if empty string or combination of int+str convert to default
+                            if(halo_weight_value === ""){halo_weight_value = 4} 
+                            else (halo_weight_value = Number(halo_weight_value));
+                            layer.paint["line-width"] = halo_weight_value
                             layer.paint["line-color"] = self.config.lineHaloColor();
-                            console.log("REACHED END")
                             break;
-
-
                         case "resources-line-" + params.nodeid:
-                            layer.paint["line-width"] = parseInt(self.config.weight());
-                            if (!(self.config.weight() > 0)) { layer.paint["line-width"] = 1; }
-                            self.config.weight(layer.paint["line-width"]);
+                            weight_value = self.config.weight();
+                            if(weight_value === ""){weight_value = 2} 
+                            else (weight_value = Number(weight_value));
+                            layer.paint["line-width"] = weight_value;
                             layer.paint["line-color"] = self.config.lineColor();
                             break;
                         case "resources-poly-outline-" + params.nodeid:
-                            layer.paint["line-width"] = parseInt(self.config.outlineWeight());
-                            if (!(self.config.outlineWeight() > 0)) { layer.paint["line-width"] = 1; }
-                            self.config.outlineWeight(layer.paint["line-width"]);
+                            outline_weight_value = self.config.outlineWeight();
+                            if(outline_weight_value === ""){outline_weight_value = 2} 
+                            else (outline_weight_value = Number(outline_weight_value));
+                            layer.paint["line-width"] = outline_weight_value;
                             layer.paint["line-color"] = self.config.outlineColor();
                             break;
                         case "resources-point-halo-" + params.nodeid:
-                            layer.paint["circle-radius"] = parseInt(self.config.haloRadius());
-                            if (!(self.config.haloRadius() > 0)) { layer.paint["circle-radius"] = 1; }
-                            self.config.haloRadius(layer.paint["circle-radius"]);
+                            halo_radius_value = self.config.haloRadius();
+                            if(halo_radius_value === ""){halo_radius_value = 4} 
+                            else (halo_radius_value = Number(halo_radius_value));    
+                            layer.paint["circle-radius"] = halo_radius_value                        
                         case "resources-cluster-point-halo-" + params.nodeid:
                             layer.paint["circle-color"] = self.config.pointHaloColor();
                             break;
                         case "resources-point-" + params.nodeid:
-                            layer.paint["circle-radius"] = parseInt(self.config.radius());
-                            if (!(self.config.radius() > 0)) { layer.paint["circle-radius"] = 1; }
-                            self.config.radius(layer.paint["circle-radius"]);
+                            radius_value = self.config.radius();
+                            if(radius_value === ""){radius_value = 2} 
+                            else (radius_value = Number(radius_value));   
+                            layer.paint["circle-radius"] = radius_value;
                         case "resources-cluster-point-" + params.nodeid:
                             layer.paint["circle-color"] = self.config.pointColor();
                             break;
@@ -222,14 +192,20 @@ define([
 
                 this.node.json.subscribe(updateMapStyle);
                 this.selectedBasemapName.subscribe(updateMapStyle);
-                console.log("test")
                 this.config.advancedStyling.subscribe(function(value) {
                     if (value && !self.config.advancedStyle()) {
                         self.config.advancedStyle(JSON.stringify(overlays, null, '\t'));
                     }
-                });
+                });                   
 
                 this.saveNode = function() {
+                    // do saving of config values at end to avoid double save button issue
+                    self.config.haloWeight(halo_weight_value)
+                    self.config.weight(weight_value)
+                    self.config.outlineWeight(outline_weight_value)
+                    self.config.haloRadius(halo_radius_value)
+                    self.config.radius(radius_value)
+
                     self.loading(true);
                     self.node.save(function() {
                         self.loading(false);

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -143,7 +143,7 @@ define([
                             break;
                         case "resources-line-halo-" + params.nodeid:
                             halo_weight_value = self.config.haloWeight();
-                            //if empty string or combination of int+str convert to default
+                            //if empty string or combination of int+str convert to default values 
                             if(halo_weight_value === ""){halo_weight_value = 4} 
                             else (halo_weight_value = Number(halo_weight_value));
                             layer.paint["line-width"] = halo_weight_value
@@ -203,11 +203,12 @@ define([
 
                 this.node.json.subscribe(updateMapStyle);
                 this.selectedBasemapName.subscribe(updateMapStyle);
+
                 this.config.advancedStyling.subscribe(function(value) {
                     if (value && !self.config.advancedStyle()) {
                         self.config.advancedStyle(JSON.stringify(overlays, null, '\t'));
                     }
-                });                   
+                });
 
                 this.saveNode = function() {
                     // do saving of config values at end to avoid double save button issue

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -136,7 +136,6 @@ define([
                 };
 
                 var updateMapStyle = function() {
-                    console.log("update map style has been run")
                     _.each(overlays, function(layer) {
                         switch (layer.id) {
                         case "resources-fill-" + params.nodeid:

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -16,6 +16,15 @@ define([
             this.config = params.config;
             this.graph = params.graph;
             this.layer = params.layer;
+            let haloWeightValue = self.config.haloWeight();
+            let outlineWeightValue = self.config.outlineWeight();
+            let weightValue = self.config.weight();
+            let haloRadiusValue = self.config.haloRadius();
+            let radiusValue = self.config.radius();
+            let clusterDistanceValue = self.config.clusterDistance();
+            let clusterMaxZoomValue = self.config.clusterMaxZoom();
+            let clusterMinPointsValue = self.config.clusterMinPoints();
+            let simplificationValue = self.config.simplification();
             if (this.layer) {
                 this.permissions = params.permissions;
                 this.iconFilter = ko.observable('');
@@ -141,55 +150,87 @@ define([
                         case "resources-fill-" + params.nodeid:
                             layer.paint["fill-color"] = self.config.fillColor();
                             break;
+
                         case "resources-line-halo-" + params.nodeid:
                             haloWeightValue = self.config.haloWeight();
-                            //if empty string or combination of int+str convert to default values 
-                            if(haloWeightValue === ""){haloWeightValue = 4;}
-                            else (haloWeightValue = Number(haloWeightValue));
-                            layer.paint["line-width"] = haloWeightValue
-                            layer.paint["line-color"] = self.config.lineHaloColor();
+                            if (haloWeightValue === "") {
+                                haloWeightValue = 4;
+                            } else {
+                                (haloWeightValue = Number(haloWeightValue));
+                            }
+                            layer.paint["line-width"] = haloWeightValue;
+                            layer.paint["line-color"] = self.config.lineHaloColor();                    
                             break;
+
                         case "resources-line-" + params.nodeid:
                             weightValue = self.config.weight();
-                            if(weightValue === ""){weightValue = 2;} 
-                            else (weightValue = Number(weightValue));
+                            if (weightValue === "") {
+                                weightValue = 4;
+                            } else {
+                                (weightValue = Number(weightValue));
+                            }
                             layer.paint["line-width"] = weightValue;
                             layer.paint["line-color"] = self.config.lineColor();
                             break;
+
                         case "resources-poly-outline-" + params.nodeid:
                             outlineWeightValue = self.config.outlineWeight();
-                            if(outlineWeightValue === ""){outlineWeightValue = 2;} 
-                            else (outlineWeightValue = Number(outlineWeightValue));
+                            if (outlineWeightValue === "") {
+                                outlineWeightValue = 2;
+                            } else {
+                                (outlineWeightValue = Number(outlineWeightValue));
+                            }
                             layer.paint["line-width"] = outlineWeightValue;
                             layer.paint["line-color"] = self.config.outlineColor();
                             break;
+
                         case "resources-point-halo-" + params.nodeid:
                             haloRadiusValue = self.config.haloRadius();
-                            if(haloRadiusValue === ""){haloRadiusValue = 4;} 
-                            else (haloRadiusValue = Number(haloRadiusValue));    
-                            layer.paint["circle-radius"] = haloRadiusValue                        
+                            if (haloRadiusValue === "") {
+                                haloRadiusValue = 4;
+                            } else {
+                                (haloRadiusValue = Number(haloRadiusValue));
+                            }    
+                            layer.paint["circle-radius"] = haloRadiusValue;
+
                         case "resources-cluster-point-halo-" + params.nodeid:
                             layer.paint["circle-color"] = self.config.pointHaloColor();
                             break;
+
                         case "resources-point-" + params.nodeid:
                             radiusValue = self.config.radius();
-                            if(radiusValue === ""){radiusValue = 2;} 
-                            else (radiusValue = Number(radiusValue));   
+                            if (radiusValue === "") {
+                                radiusValue = 2;
+                            } else {
+                                (radiusValue = Number(radiusValue));
+                            }
                             layer.paint["circle-radius"] = radiusValue;
+
                         case "resources-cluster-point-" + params.nodeid:
-                            layer.paint["circle-color"] = self.config.pointColor();
                             clusterDistanceValue = self.config.clusterDistance();
-                            if(clusterDistanceValue === ""){clusterDistanceValue = 20;} 
-                            else (clusterDistanceValue = Number(clusterDistanceValue));    
+                            if (clusterDistanceValue === "") {
+                                clusterDistanceValue = 20;
+                            } else {
+                                (clusterDistanceValue = Number(clusterDistanceValue));
+                            }
                             clusterMaxZoomValue = self.config.clusterMaxZoom();
-                            if(clusterMaxZoomValue === ""){clusterMaxZoomValue = 5;} 
-                            else (clusterMaxZoomValue = Number(clusterMaxZoomValue));    
+                            if (clusterMaxZoomValue === "") {
+                                clusterMaxZoomValue = 5;
+                            } else {
+                                (clusterMaxZoomValue = Number(clusterMaxZoomValue));
+                            }
                             clusterMinPointsValue = self.config.clusterMinPoints();
-                            if(clusterMinPointsValue === ""){clusterMinPointsValue = 3;} 
-                            else (clusterMinPointsValue = Number(clusterMinPointsValue));    
+                            if (clusterMinPointsValue === "") {
+                                clusterMinPointsValue = 3;
+                            } else {
+                                (clusterMinPointsValue = Number(clusterMinPointsValue));
+                            }
                             simplificationValue = self.config.simplification();
-                            if(simplificationValue === ""){simplificationValue = 0.3;} 
-                            else (simplificationValue = Number(simplificationValue));     
+                            if (simplificationValue === "") {
+                                simplificationValue = 0.3;
+                            } else {
+                                (simplificationValue = Number(simplificationValue));
+                            }
                             break;
                         default:
 

--- a/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
+++ b/arches/app/media/js/views/components/datatypes/geojson-feature-collection.js
@@ -137,16 +137,53 @@ define([
 
                 var updateMapStyle = function() {
                     _.each(overlays, function(layer) {
+                        console.log("am i here")
                         switch (layer.id) {
                         case "resources-fill-" + params.nodeid:
                             layer.paint["fill-color"] = self.config.fillColor();
                             break;
                         case "resources-line-halo-" + params.nodeid:
+                            // // if (!(/^\d+$/.test(self.config.haloWeight())) && !(self.config.haloWeight() === "") ) {
+                            //     if (!(/^\d+$/.test(self.config.haloWeight())) &&
+                            //         !(self.config.haloWeight() === "") &&
+                            //         !(self.config.haloWeight())) {
+
+                            //     console.log("\nBEFORE INP");
+                            //     console.log(self.config.haloWeight(), "whats in the box");
+                            //     console.log(typeof(layer.paint["line-width"]),layer.paint["line-width"], "   Line width");
+                            //     console.log(typeof(self.config.haloWeight()),self.config.haloWeight(), "   Halo weight"); 
+                            
+
+                            //     layer.paint["line-width"] = parseInt(self.config.haloWeight());
+                            //     self.config.haloWeight(layer.paint["line-width"]);
+                            //     layer.paint["line-color"] = self.config.lineHaloColor();
+
+                            //     console.log("\nAFTER");
+                            //     console.log(self.config.haloWeight(), "whats in the box");
+                            //     console.log(typeof(layer.paint["line-width"]),layer.paint["line-width"], "   Line width");
+                            //     console.log(typeof(self.config.haloWeight()),self.config.haloWeight(), "   Halo weight"); 
+                            //     break;
+                            // } else {
+                            //     console.log(self.config.haloWeight())
+                            //     layer.paint["line-width"] = 4;
+                            //     self.config.haloWeight(layer.paint["line-width"]);
+                            //     layer.paint["line-color"] = self.config.lineHaloColor();
+                            //     break;
+                            // };
+                            console.log(self.config.haloWeight())
                             layer.paint["line-width"] = parseInt(self.config.haloWeight());
-                            if (!(self.config.haloWeight() > 0)) { layer.paint["line-width"] = 1; }
+                            console.log(typeof(layer.paint["line-width"]),layer.paint["line-width"], "Line width");
+                            console.log(typeof(self.config.haloWeight()),self.config.haloWeight(), "halo weight");
+                            if (!(/^\d+\.\d+$|^\d+$/.test(self.config.haloWeight()))) {layer.paint["line-width"] = 4;}
+                            if (self.config.haloWeight() === "") {layer.paint["line-width"] = 4;}
+                            //if (!(self.config.haloWeight() > 0)) { layer.paint["line-width"] = 10; }
                             self.config.haloWeight(layer.paint["line-width"]);
+                            console.log(self.config.haloWeight(layer.paint["line-width"]));
                             layer.paint["line-color"] = self.config.lineHaloColor();
+                            console.log("REACHED END")
                             break;
+
+
                         case "resources-line-" + params.nodeid:
                             layer.paint["line-width"] = parseInt(self.config.weight());
                             if (!(self.config.weight() > 0)) { layer.paint["line-width"] = 1; }
@@ -185,7 +222,7 @@ define([
 
                 this.node.json.subscribe(updateMapStyle);
                 this.selectedBasemapName.subscribe(updateMapStyle);
-
+                console.log("test")
                 this.config.advancedStyling.subscribe(function(value) {
                     if (value && !self.config.advancedStyle()) {
                         self.config.advancedStyle(JSON.stringify(overlays, null, '\t'));


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Previously, a string could be force inputted all of the service styling and clustering config inputs. This change checks in the front end whether the number is valid i.e not an empty string or a combination of integers and strings. Additionally, the value is saved to the node config when the save button is used, rather than when the value is inputted in order to fix the double save button issue that existed previously.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9441

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
