### PR TITLE
removes python-docx from arches core requirements

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -14,7 +14,6 @@ arches-django-revproxy==0.10.0
 django-cors-headers==3.1.1
 django-oauth-toolkit==1.2.0
 polib==1.1.1
-python-docx==0.8.10
 PyLD[requests]==1.0.5
 pyprind==2.11.3
 pycryptodome<4.0.0,>=3.3.1


### PR DESCRIPTION
Removes python-docx from core requirements - it doesn't appear to be used.