### PR TITLE
9407 - Sort cards, widgets and nodes on serialize

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1501,7 +1501,7 @@ class Graph(models.GraphModel):
             # TODO: Remove this section when PR 9112 / Issue 9053 is merged
             for key in ["cards", "widgets", "nodes"]:
                 if key in ret and ret[key]:
-                    ret[key].sort(key=lambda card: card["sortorder"] if card["sortorder"] else 0)
+                    ret[key].sort(key=lambda item: item["sortorder"] if item["sortorder"] else 0)
             # TODO: End section to remove
 
             res = JSONSerializer().serializeToPython(ret, use_raw_i18n_json=use_raw_i18n_json)

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1500,7 +1500,7 @@ class Graph(models.GraphModel):
 
             # TODO: Remove this section when PR 9112 / Issue 9053 is merged
             for key in ["cards", "widgets", "nodes"]:
-                if key in ret:
+                if key in ret and ret[key]:
                     ret[key].sort(key=lambda card: card["sortorder"] if card["sortorder"] else 0)
             # TODO: End section to remove
 

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1499,7 +1499,7 @@ class Graph(models.GraphModel):
                 ret.pop("nodes", None)
 
             # TODO: Remove this section when PR 9112 / Issue 9053 is merged
-            for key in ["cards","widgets","nodes"]:
+            for key in ["cards", "widgets", "nodes"]:
                 if key in ret:
                     ret[key].sort(key=lambda card: card["sortorder"] if card["sortorder"] else 0)
 

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1502,6 +1502,7 @@ class Graph(models.GraphModel):
             for key in ["cards", "widgets", "nodes"]:
                 if key in ret:
                     ret[key].sort(key=lambda card: card["sortorder"] if card["sortorder"] else 0)
+            # TODO: End section to remove
 
             res = JSONSerializer().serializeToPython(ret, use_raw_i18n_json=use_raw_i18n_json)
 

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1498,6 +1498,11 @@ class Graph(models.GraphModel):
             else:
                 ret.pop("nodes", None)
 
+            # TODO: Remove this section when PR 9112 / Issue 9053 is merged
+            for key in ["cards","widgets","nodes"]:
+                if key in ret:
+                    ret[key].sort(key=lambda card: card["sortorder"] if card["sortorder"] else 0)
+
             res = JSONSerializer().serializeToPython(ret, use_raw_i18n_json=use_raw_i18n_json)
 
             return res


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fixes an issue where publishing a graph and then restoring causes the sort order of nodes, cards and widgets to not be honoured

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9407 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @chiatt @bferguso 
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
This only addresses the publish->restore process that was causing the order of nodes, cards and widgets to mutate. The value of the sortorder attribute was persisted properly however the order of the objects in the JSON file was not well ordered.

Originally looked at sorting these objects when deserializing from the JSON file, but it seemed more performant to ensure the JSON object was well ordered so the sort only had to happen once. I'm still a bit on the fence whether to add that back in as it will become a self-healing fix and will guarantee order on deserialization of the graph from the `published_graphs.serialized_graph` JSON column. It means that the sort will happen every time the deserialization happens, which may (should) be redundant when the JSON value is correctly updated.

Without the above, to fix models that have a scrambled sort order, graphs need to be unpublished and then published again for the order to be fixed.

There appears to be a larger issue in the Graph Designer UI that isn't updating the sortorder on nodes and cards correctly or consistently. Also, sortorder of these objects can be updated in the Graph Designer without unpublishing the Resource Model which causes the data in the base tables (nodes, cards, cards_x_nodes_x_widgets) to be out of sync with the data in the published_graphs.serialized_graph column. The update of sortorder is currently pushed back to the server immediately, without having to press the save button to persist.
