### PR TITLE
9540 index performance fix

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1488,6 +1488,8 @@ class Graph(models.GraphModel):
                 ret["nodes"] = []
                 for key, node in self.nodes.items():
                     nodeobj = JSONSerializer().serializeToPython(node, use_raw_i18n_json=use_raw_i18n_json)
+                    if node.istopnode:
+                        ret["topnode"] = nodeobj
                     nodeobj["parentproperty"] = parentproperties[node.nodeid]
                     ret["nodes"].append(nodeobj)
             else:

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -237,9 +237,11 @@ class Resource(models.ResourceInstance):
                 if "topnode" in self.serialized_graph:
                     return self.serialized_graph["topnode"]["ontologyclass"]
                 else:
-                    return SimpleNamespace(**next((x for x in self.get_serialized_graph()["nodes"] if x["istopnode"] is True), None)).ontologyclass
+                    return SimpleNamespace(
+                        **next((x for x in self.get_serialized_graph()["nodes"] if x["istopnode"] is True), None)
+                    ).ontologyclass
             except AttributeError:
-                pass #graph has no ontology
+                pass  # graph has no ontology
 
         graph_node = models.Node.objects.filter(graph_id=self.graph_id).filter(istopnode=True).first()
         return graph_node.ontologyclass if graph_node.ontologyclass else None

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -239,7 +239,7 @@ class Resource(models.ResourceInstance):
         except:
             pass
 
-        graph_node = next(models.Node.objects.filter(graph_id=self.graph_id).filter(istopnode=True))
+        graph_node = models.Node.objects.filter(graph_id=self.graph_id).filter(istopnode=True).first()
         return graph_node.ontologyclass if graph_node.ontologyclass else None
 
     def load_tiles(self, user=None, perm=None):

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -102,7 +102,7 @@ class Resource(models.ResourceInstance):
         Finds and returns the ontology class of the instance's root node
 
         """
-        if "topnode" in self.serialized_graph:
+        if "topnode" in self.get_serialized_graph():
             return self.get_serialized_graph()["topnode"]["ontologyclass"]
         else:
             return SimpleNamespace(**next((x for x in self.get_serialized_graph()["nodes"] if x["istopnode"] is True), None)).ontologyclass

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -198,7 +198,7 @@ class Resource(models.ResourceInstance):
 
         """
         # TODO: 7783 cbyrd throw error if graph is unpublished
-        # TODO: 9540 - this initializes serialized graph (for use in superclass?). Setup for the above TODO
+        # This initializes serialized graph (for use in superclass?). Setup for the above. NOt sure
         if not self.get_serialized_graph():
             pass
 

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -232,15 +232,14 @@ class Resource(models.ResourceInstance):
         Finds and returns the ontology class of the instance's root node
 
         """
-        try:
-            if self.serialized_graph:
-                return (
-                    self.serialized_graph["topnode"]
-                    if "topnode" in self.serialized_graph
-                    else SimpleNamespace(**next((x for x in self.get_serialized_graph()["nodes"] if x["istopnode"] is True), None))
-                ).ontologyclass
-        except:
-            pass
+        if self.serialized_graph:
+            try:
+                if "topnode" in self.serialized_graph:
+                    return self.serialized_graph["topnode"]["ontologyclass"]
+                else:
+                    return SimpleNamespace(**next((x for x in self.get_serialized_graph()["nodes"] if x["istopnode"] is True), None)).ontologyclass
+            except AttributeError:
+                pass #graph has no ontology
 
         graph_node = models.Node.objects.filter(graph_id=self.graph_id).filter(istopnode=True).first()
         return graph_node.ontologyclass if graph_node.ontologyclass else None

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -168,8 +168,10 @@ def index_resources_using_multiprocessing(
         pool.close()
         pool.join()
 
+
 def index_resources_using_singleprocessing(
-    resources: Iterable[Resource], batch_size=settings.BULK_IMPORT_BATCH_SIZE, quiet=False, title=None):
+    resources: Iterable[Resource], batch_size=settings.BULK_IMPORT_BATCH_SIZE, quiet=False, title=None
+):
     datatype_factory = DataTypeFactory()
     node_datatypes = {str(nodeid): datatype for nodeid, datatype in models.Node.objects.values_list("nodeid", "datatype")}
     with se.BulkIndexer(batch_size=batch_size, refresh=True) as doc_indexer:

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 def get_serialized_graph(graph):
     """
-    Finds and returns the ontology class of the instance's root node
+    Returns the serialized version of the graph from the database
 
     """
     if not graph:

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -39,7 +39,7 @@ def get_serialized_graph(graph):
     if not graph:
         return None
 
-    if not graph.graphid in serialized_graphs:
+    if graph.graphid not in serialized_graphs:
         serialized_graphs[graph.graphid] = (
             models.PublishedGraph.objects.filter(publication=graph.publication.publicationid, language=settings.LANGUAGE_CODE)
             .first()


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Modified how models/Resource class obtains its serialized graph, and the graph's root ontology

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9540 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
__*Proposed solution*__
1. Add an setter method to allow the graph to be set on the models/resource/Resource class
2. Remove the graph serialization logic out of `__index__`
3. For single-processing indexing called by index_resources_by_type, provide the Graph object so it can be set on all the Resources being index, negating the requirement of each Resource to serialize the graph
4. Modify the `models/graph.py/Graph.serialize()` function to set a key called `topnode` which contains the graph's root node definition
5. Update the `resource.py/Resource class` to:
     1.  add a function called get_serialized_graph() which only generates it if it isn't set. Caches it it in a local variable if it generates it
     2. modify the `get_root_ontology` to 
          1. first look in the serialized_graph["topnode"], then 
          2. iterate through the serialized_graph.nodes, then finally 
          3. access the database `nodes` table

__*Outstanding questions/issues*__
1. ~This is changing the assumption that the serialized graph is available on Resource instantiation. Is this an issue? If this assumption is made elsewhere in the code changing the direct field access resource.serialized_graph to resource.get_serialized_graph() should fix this.~ Looked at the dev/7.4.x branch and this doesn't seem t be an issue
2. Is there a way to regenerate all the published_graphs.serialized_graph values so that this update can fixed the missing "topnode" attributes?