### PR TITLE
Use I18n for mapping file export #9680

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/exporter.py
+++ b/arches/app/utils/data_management/resource_graphs/exporter.py
@@ -7,6 +7,7 @@ import csv
 import zipfile
 from io import StringIO
 from io import BytesIO
+from django.utils.translation import get_language
 
 from arches.app.models.graph import Graph
 from arches.app.models.concept import Concept
@@ -178,6 +179,7 @@ def create_mapping_configuration_file(graphid, include_concepts=True, data_dir=N
     nodes = []
     values = {}
     export_json = OrderedDict()
+    language = get_language()
     if graphid != False:
         if graphid is None or graphid == "all" or graphid == [""]:
             node_query = (
@@ -279,7 +281,7 @@ def create_mapping_configuration_file(graphid, include_concepts=True, data_dir=N
         buffer.flush()
         zip_stream = buffer.getvalue()
         buffer.close()
-        with open(os.path.join(data_dir, file_name + ".zip"), "wb") as archive:
+        with open(os.path.join(data_dir, file_name[language] + ".zip"), "wb") as archive:
             archive.write(zip_stream)
     else:
         return files_for_export


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The path construction for the mapping file was using an internationalized string (file_name) and a regular one (".zip"). Added language index access to file_name. Had to add the import to Django's language library to do that in a clean way. Could do with a simple str() or other less graceful ways (would also work perfectly).


### Issues Solved
Now the mapping file can be generated from the command line (UI worked fine).
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
The [provided command to run tests](https://github.com/archesproject/arches/blob/master/CONTRIBUTING.md) wouldn't run in my local development environment.

#### Ticket Background
*   Sponsored by: [MAPHSA](https://www.upf.edu/web/maphsa), [Arcadia Fund](https://www.arcadiafund.org.uk/)
*   Found by: [atapscott](https://github.com/atapscott)
