### PR TITLE
resolves issue with 2 sets of save/discard buttons appearing in some edge cases #9591

### DIFF
--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -50,7 +50,7 @@ define([
                 else if (viewModel.graphSettingsViewModel && viewModel.graphSettingsViewModel.dirty()) {
                     shouldShowGraphPublishButtons = false;
                 }
-                else if (viewModel.selectedNode() && viewModel.selectedNode().dirty() && viewModel.selectedNode().istopnode == false) {
+                else if (viewModel.isNodeDirty()) {
                     shouldShowGraphPublishButtons = false;
                 }
                 else if (ko.unwrap(viewModel.cardTree.selection)) {
@@ -67,6 +67,10 @@ define([
                 return shouldShowGraphPublishButtons;
             });
             viewModel.primaryDescriptorFunction = ko.observable(data['primaryDescriptorFunction']);
+
+            viewModel.isNodeDirty = ko.pureComputed(function() {
+                return viewModel.selectedNode() && viewModel.selectedNode().dirty() && viewModel.selectedNode().istopnode == false;
+            });
 
             var resources = ko.utils.arrayFilter(viewData.graphs, function(graph) {
                 return graph.isresource;

--- a/arches/app/templates/views/graph-designer.htm
+++ b/arches/app/templates/views/graph-designer.htm
@@ -121,7 +121,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
         <div class="ep-form-toolbar-tools">
             <span class="graph-settings" data-bind="visible: graphSettingsVisible()" style="display: none;">
-                <!-- ko if: graphSettingsViewModel.dirty() -->
+                <!-- ko if: graphSettingsViewModel.dirty() && !isNodeDirty() -->
                     <button class="btn btn-sm btn-danger btn-labeled fa fa-trash" data-bind="click: graphSettingsViewModel.reset"><span>{% trans "Discard Edits" %}</span></button>
                     <!-- ko if: !$data.isGraphPublished() -->
                         <button class="btn btn-sm btn-primary btn-labeled fa fa-check" data-bind="click: graphSettingsViewModel.save"><span>{% trans "Save Edits" %}</span></button>
@@ -130,7 +130,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             </span>
 
             <span class="graph-settings" data-bind="visible: selectedNode() && activeTab() === 'graph'" style="display: none;">
-                <!-- ko if: selectedNode() && selectedNode().dirty() && selectedNode().istopnode == false -->
+                <!-- ko if: isNodeDirty() -->
                     <button class="btn btn-sm btn-danger btn-labeled fa fa-trash" data-bind="click: function(){graphModel.get('selectedNode')().reset()}"><span>{% trans "Discard Edits" %}</span></button>
                     <!-- ko if: !$data.isGraphPublished() -->
                         <button class="btn btn-sm btn-primary btn-labeled fa fa-check" data-bind="click: saveSelectedNode"><span>{% trans "Save Edits" %}</span></button>

--- a/arches/app/templates/views/graph/graph-designer/node-form.htm
+++ b/arches/app/templates/views/graph/graph-designer/node-form.htm
@@ -267,7 +267,7 @@
                                         class="switch switch-small arches-switch" 
                                         data-bind="
                                             css: {
-                                                'on': $data.nodegroup() && $data.nodegroup().cardinality() === 'n', 
+                                                'on': $data.node() && $data.node().nodeid === $data.node().nodeGroupId() && $data.nodegroup().cardinality() === 'n', 
                                                 'disabled': !$data.nodegroup() || $data.node() && $data.node().nodeid !== $data.node().nodeGroupId()
                                             }, 
                                             click: $data.updateCardinality


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9591 

TO REPRODUCE:
1. In the graph designer create a node, then a child node, save the edits.
2. click 'place nodes in separate card' switch to be truthy, save the edit.
3. Interact with the `allow multiple values swtich` and the `place nodes in separate card` switch, trying various combinations
4. Notice that only one set of save/edit buttons appears