### PR TITLE
9550 import graph with userid = 1

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/importer.py
+++ b/arches/app/utils/data_management/resource_graphs/importer.py
@@ -152,7 +152,7 @@ def import_graph(graphs, overwrite_graphs=True):
                             defaults={
                                 "notes": publication_data.get("notes"),
                                 "graph_id": publication_data.get("graph_id"),
-                                "user_id": publication_data.get("user_id"),
+                                "user_id": 1,
                                 "published_time": publication_data.get("published_time"),
                             },
                         )


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When importing a graph, the published by userid is rehydrated from the JSON file. This is an issue when loading a Arches instance from a package, or when importing a graph into a different Arches instance because the user_id may not exist or may not be associated with the same user in the target instance.

The graph should always be imported as the admin user to avoid the above issue.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9550 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded 
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
First cut of this just sets the user_id = 1 when saving the GraphXPublishedGraph record. Not sure if this is a valid assumption (don't know if it is possible / there are instances where the admin user has been removed). If that's the case perhaps we should use `min(auth_user.id)` instead?
