### PR TITLE
9555 Skip to content link added upon first keyboard tab

### DIFF
--- a/arches/app/media/css/base-manager.css
+++ b/arches/app/media/css/base-manager.css
@@ -21,6 +21,36 @@
     width: 100vw;
 }
 
+#skip-link-holder a, #skip-link-holder a:link, #skip-link-holder a:visited {
+  color: #000;
+  background-color: #fae619;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 10px;
+  text-align: center;
+  outline: none !important;
+  max-height: 38px;
+  display: block;
+  width: 100%;
+  position: fixed;
+  top: -38px;
+  left: 0;
+  z-index: 10001;
+}
+
+#skip-target-holder {
+  position: absolute;
+  top: -38px;
+  left: 0;
+}
+
+#skip-link-holder a:focus, #skip-link-holder a:active {
+  text-decoration: underline !important;
+  left: 0;
+  top: 0;
+  z-index: 10000000;
+}
+
 @media print {
     .base-manager-grid {
         display: block;

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -28,6 +28,8 @@
     </div>
     <!-- /ko -->
 
+    <div id="skip-link-holder"><a id="skip-link" data-bind="text: $root.translations.skipToContent" tabindex="1" href="#skiptocontent"></a></div>
+
     <div id="container" class="base-manager-grid effect aside-left aside-bright navbar-fixed sidenav-sm"
         data-bind="css: {'mainnav-in': tabsActive() && showTabs(), 'sidenav-sm': !navExpanded(), 'sidenav-lg': navExpanded()}">
 
@@ -490,6 +492,11 @@
         </header>
         
         <main id="main-content" role="main">
+            <p id="skip-target-holder">
+                <a id="skiptocontent" name="skiptocontent" class="skip" tabindex="-1" data-bind="attr:{
+                    'aria-label': $root.translations.skipToContent,
+                    innertext: $root.translations.skipToContent}"></a>
+            </p>
             {% block main_content %}
             {% endblock main_content %}
         </main>

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -794,6 +794,8 @@
         apply-to-selected-files='{% trans "Apply to Selected Files" as applyToSelectedFiles %} "{{ applyToSelectedFiles|escapejs }}"'
         apply-same-loader-to-all='{% trans "Apply the same loader to all selected files in the dataset" as applySameLoaderToAll %} "{{ applySameLoaderToAll|escapejs }}"'
         id-column-selection='{% trans "Use as an id" as idColumnSelection %} "{{ idColumnSelection|escapejs }}"'
+        skip-to-content='{% trans "Skip to content" as skipToContent %} "{{ skipToContent|escapejs }}"'
+
     ></div>
     {% endblock arches_translations %}
     {% block arches_urls %}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Added a skip to content link at the top of every page, that targets a hidden element just inside 'main'. This is necessary and ideal for users using screen readers as it will skip all the left navigation menu items and top links, as this could become tiresome when listening to navigate the site.

The code has been previously used and audited successfully on HE specific Arches sites such as Warden and GLHER.

For now, the css styling has been included in the base-manager.css file which contains specific items regarding the base manager template. Obviously this can be moved one day into a suitable file within the SASS structure.

The hidden element was used to tab to instead of main because there were problems with the page contents shifting down. With the hidden element trick, no content moving will take place.

### Issues Solved
#9555 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he
*   Tested by: @phudson-he
*   Designed by: @phudson-he