### PR TITLE
fix for download_ready_email_notification template

### DIFF
--- a/arches/app/templates/email/download_ready_email_notification.htm
+++ b/arches/app/templates/email/download_ready_email_notification.htm
@@ -23,8 +23,10 @@
         </div>
         <!-- /ko -->
 
+    {% if link != "" %}
     <a class="btn" href="{{email_link}}"><button
-            class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'><span>{{button_text}}</span></button></a>
+            class='btn btn-notifs-download btn-labeled btn-sm fa fa-download'><span>{{button_text}}</span></button></a>    
+    {% endif %}
     {% endif %}
     <p>{{closing}}</p>
 </body>


### PR DESCRIPTION
The download ready email template will not always have a zip file available - sometimes the zip is not generated if the files are too big to be zipped.