### PR TITLE
9678 Prevent rich text widget language options crowding

### DIFF
--- a/arches/app/templates/views/components/widgets/rich-text.htm
+++ b/arches/app/templates/views/components/widgets/rich-text.htm
@@ -8,7 +8,7 @@
         <div class="widget-inline-tools-collapser" data-bind=" click: function() {
             showi18nOptions(!showi18nOptions());
         }">
-            <span>
+            <span style="flex: 1">
                 <label class="control-label widget-input-label" data-bind="text:label"></label>
                 <!-- ko if: node -->
                 <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixes crowding of node name & i18n options on Rich text editor

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9678