### PR TITLE
adds template loading to package load process

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -865,7 +865,7 @@ class Command(BaseCommand):
                     print(e)
 
         def load_templates(package_dir):
-            templates = glob.glob(os.path.join(package_dir, "templates", "*_template.*"))
+            templates = glob.glob(os.path.join(package_dir, "templates", "*_template*.*"))
             for template in templates:
                 try:
                     management.call_command("load_template", "-s", template)
@@ -965,6 +965,8 @@ class Command(BaseCommand):
         update_resource_geojson_geometries()
         print("loading post sql")
         load_sql(package_location, "post_sql")
+        print('loading templates')
+        load_templates(package_location)
         if defer_indexing is True:
             print("indexing database")
             management.call_command("es", "reindex_database")
@@ -972,8 +974,6 @@ class Command(BaseCommand):
             print("Celery detected: Resource instances loading. Log in to arches to be notified on completion.")
         else:
             print("package load complete")
-        print('loading templates')
-        load_templates(package_location)
 
     def setup(self, package_name, es_install_location=None):
         """

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -864,6 +864,14 @@ class Command(BaseCommand):
                 except CommandError as e:
                     print(e)
 
+        def load_templates(package_dir):
+            templates = glob.glob(os.path.join(package_dir, "templates", "*_template.*"))
+            for template in templates:
+                try:
+                    management.call_command("load_template", "-s", template)
+                except CommandError as e:
+                    print(e) # ok to fail, template engine may not be installed
+
         def handle_source(source):
             if os.path.isdir(source):
                 return source
@@ -964,6 +972,8 @@ class Command(BaseCommand):
             print("Celery detected: Resource instances loading. Log in to arches to be notified on completion.")
         else:
             print("package load complete")
+        print('loading templates')
+        load_templates(package_location)
 
     def setup(self, package_name, es_install_location=None):
         """


### PR DESCRIPTION
Adds template loading to package load command.  For this to work, the arches templating application must be installed, there must be properly named templates in the "templates" directory inside of the package, and PR https://github.com/archesproject/arches-templating/pull/10 must be merged