### PR TITLE
fix for transaction reversal 403 

### DIFF
--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -522,7 +522,10 @@ def user_created_transaction(user, transactionid):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if EditLog.objects.filter(transactionid=transactionid, userid=user.id).count() > 0:
+        if EditLog.objects.filter(transactionid=transactionid).count() > 0:
+            if EditLog.objects.filter(transactionid=transactionid, userid=user.id).count() > 0:
+                return True
+        else:
             return True
     return False
 

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -360,7 +360,7 @@ def user_has_resource_model_permissions(user, perms, resource):
 
     nodegroups = get_nodegroups_by_perm(user, perms)
     nodes = Node.objects.filter(nodegroup__in=nodegroups).filter(graph_id=resource.graph_id).select_related("graph")
-    return nodes.count() > 0
+    return nodes.exists()
 
 
 def check_resource_instance_permissions(user, resourceid, permission):
@@ -405,7 +405,8 @@ def check_resource_instance_permissions(user, resourceid, permission):
                 return result
 
     except ObjectDoesNotExist:
-        return None
+        result["permitted"] = True # if the object does not exist, no harm in returning true - this prevents strange 403s.
+        return result
 
     return result
 
@@ -522,8 +523,8 @@ def user_created_transaction(user, transactionid):
     if user.is_authenticated:
         if user.is_superuser:
             return True
-        if EditLog.objects.filter(transactionid=transactionid).count() > 0:
-            if EditLog.objects.filter(transactionid=transactionid, userid=user.id).count() > 0:
+        if EditLog.objects.filter(transactionid=transactionid).exists():
+            if EditLog.objects.filter(transactionid=transactionid, userid=user.id).exists():
                 return True
         else:
             return True


### PR DESCRIPTION
fixes #9698 - where transaction reversal fails if no records exist in the transaction table for non-superusers.  The fix modifies the user_created_transaction method to return "true" if there are no transactions to be rolled back.  Since there are no transactions, this will effectively make the reverse method a no-op that returns 200, rather than causing it to fail with 403.