### PR TITLE
9623 Fix for allowing double quotation marks in i18n inputs 

### DIFF
--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -22,7 +22,7 @@ class I18n_String(object):
         ret = {}
 
         if isinstance(value, str) and value != "null":
-            # issue #9623 
+            # fix for issue #9623 
             if value.startswith('"') and value.endswith('"'):
                 value = value.replace('"', r'\"')
 

--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -22,6 +22,10 @@ class I18n_String(object):
         ret = {}
 
         if isinstance(value, str) and value != "null":
+            # issue #9623 
+            if value.startswith('"') and value.endswith('"'):
+                value = value.replace('"', r'\"')
+
             try:
                 ret = json.loads(value)
             except:


### PR DESCRIPTION
This fix allows users to have strings that start and end with double quotation marks (" ") in i18n text inputs.
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Inputting a string that starts and ends with double quotation marks (e.g. "Hello, world") into any Resource Model text input box that used internationalisation would save incorrectly - e.g. as "Hello, world" rather than {"en":""\Hello, world"\"}. Strings which included double quotations not at the start and end (e.g. "Hello", world) would save correctly (e.g. {"en": ""\Hello"\, world"}. 
This change converts inputs with double quotations at the start and end to the raw literal for the character - "\ .


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9623

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
