### PR TITLE
9709 add focus indicator for accessibility mode

### DIFF
--- a/arches/app/media/css/accessibility.scss
+++ b/arches/app/media/css/accessibility.scss
@@ -1,3 +1,20 @@
 // Use this stylesheet to apply style specific to accessibility that can be 
 // applied over all other styles.  The admin can choose to run the site in
 // "accessibility mode" to apply these styles site-wide.
+
+a[href]:focus-visible,
+area[href]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+button:focus-visible,
+iframe:focus-visible,
+object:focus-visible,
+embed:focus-visible,
+*[tabindex]:focus-visible,
+*[contenteditable]:focus-visible {
+    border: 5px solid #fae619 !important;
+    outline: 2.5px solid #000 !important;
+    outline-offset: -2.5px !important;
+    box-sizing: border-box;
+}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Adds border and outline styles to interactable elements when in accessibility mode. This helps the user identify where their focus is on the screen

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9709 