### PR TITLE
9535 Add close button for search popup panels

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -10384,6 +10384,24 @@ ul.pagination {
     flex-grow: 1;
 }
 
+.close-popup-panel:before {
+    content: "\f00d";
+    font-family: FontAwesome;
+    margin-right: 6px;
+    color: rgb(158, 158, 158);
+    font-weight: lighter;
+}
+
+.close-popup-panel:hover:before {
+    color: rgb(33, 62, 95);
+}
+
+.close-popup-panel-container {
+    display: flex;
+    font-size: 17px;
+    margin-bottom: 15px;
+}
+
 .title-underline {
     margin: 3px 0px;
     background: #ddd;

--- a/arches/app/media/js/views/components/search/saved-searches.js
+++ b/arches/app/media/js/views/components/search/saved-searches.js
@@ -11,6 +11,7 @@ define([
 
          
         self.urls = arches.urls;
+        self.selectedPopup = params.selectedPopup;
         self.items = ko.observableArray([]);
         $.ajax({
             type: "GET",

--- a/arches/app/media/js/views/components/search/search-export.js
+++ b/arches/app/media/js/views/components/search/search-export.js
@@ -14,6 +14,7 @@ define([
          
         this.total = params.total;
         this.query = params.query;
+        this.selectedPopup = params.selectedPopup;
         this.downloadStarted = ko.observable(false);
         this.reportlink = ko.observable(false);
         this.format = ko.observable('tilecsv');

--- a/arches/app/media/js/views/components/search/time-filter.js
+++ b/arches/app/media/js/views/components/search/time-filter.js
@@ -15,7 +15,7 @@ define([
         initialize: function(options) {
             options.name = 'Time Filter';
 
-             
+            this.selectedPopup = options.selectedPopup;
             this.dateDropdownEleId = 'dateDropdownEleId' + _.random(2000, 3000000);
             BaseFilter.prototype.initialize.call(this, options);
             this.filter = {

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -374,6 +374,7 @@
         list-item-five-email-address='{% trans "5. Email Address" as listItemFiveEmailAddress %} "{{ listItemFiveEmailAddress|escapejs }}"'
         list-item-five-email-address-text='{% trans "This download may take some time.  Tell us where to email a download link to your results" as listItemFiveEmailAddressText %} "{{ listItemFiveEmailAddressText|escapejs }}"'
         export-search-results='{% trans "Export Search Results" as exportSearchResults %} "{{ exportSearchResults|escapejs }}"'
+        close-export-search-results='{% trans "Close Export Search Results Panel" as closeExportSearchResults %} "{{ closeExportSearchResults|escapejs }}"'
         advanced-search='{% trans "Advanced Search" as advancedSearch %} "{{ advancedSearch|escapejs }}"'
         advanced-search-description='{% trans "With Advanced Search you can build more sophisticated search queries. Select the search facets you wish to query from the list on the right. Then enter your criteria to customize your search filters" as advancedSearchDescription %} "{{ advancedSearchDescription|escapejs }}"'
         map-search='{% trans "Map Search" as mapSearch %} "{{ mapSearch|escapejs }}"'

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -309,6 +309,8 @@
         date-type='{% trans "Date Type" as dateType %} "{{ dateType|escapejs }}"'
         search-date-type='{% trans "Select a date node to search" as searchDateType %} "{{ searchDateType|escapejs }}"'
         search-date-range='{% trans "Select a date range to search" as searchDateRange %} "{{ searchDateRange|escapejs }}"'
+        time-filter='{% trans "Time Filter" as timeFilter %} "{{ timeFilter|escapejs }}"'
+        close-time-filter='{% trans "Close Time Filter" as closeTimeFilter %} "{{ closeTimeFilter|escapejs }}"'
         date-interval='{% trans "Date Interval" as dateInterval %} "{{ dateInterval|escapejs }}"'
         minimum-date='{% trans "Minimum Date" as minimumDate %} "{{ minimumDate|escapejs }}"'
         maximum-date='{% trans "Maximum Date" as maximumDate %} "{{ maximumDate|escapejs }}"'

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -397,6 +397,8 @@
         view-search-string='{% trans "View search string" as viewSearchString %} "{{ viewSearchString|escapejs }}"'
         search-string-text='{% trans "Search String - use to filter resources displayed" as searchStringText %} "{{ searchStringText|escapejs }}"'
         saved-search='{% trans "Saved Search" as savedSearch %} "{{ savedSearch|escapejs }}"'
+        saved-searches='{% trans "Saved Searches" as savedSearches %} "{{ savedSearches|escapejs }}"'
+        close-saved-searches='{% trans "Close Saved Searches" as closeSavedSearches %} "{{ closeSavedSearches|escapejs }}"'
         no-saved-searches='{% trans "The Arches site administrator hasn't saved any searches yet." as noSavedSearches %} "{{ noSavedSearches|escapejs }}"'
         searching='{% trans "searching" as searching %} "{{ searching|escapejs }}"'
         search-facets='{% trans "Search Facets" as searchFacets %} "{{ searchFacets|escapejs }}"'

--- a/arches/app/templates/views/components/search/saved-searches.htm
+++ b/arches/app/templates/views/components/search/saved-searches.htm
@@ -4,6 +4,13 @@
 
 <div class="search-container saved-search-container relative" style="overflow-y: scroll;">
 
+    <div class="close-popup-panel-container" style="margin: 10px;" tabindex="0" role="button" data-bind="onEnterkeyClick, onSpaceClick, click: function(){selectedPopup('');},
+        attr: {'aria-label': $root.translations.closeSavedSearches},
+    ">
+        <span class="close-popup-panel" data-bind="text: $root.translations.savedSearches"></span>
+    </div>
+    <hr class="title-underline" style="margin: 3px 5px;">
+
     <!-- ko if: items().length === 0 -->
         <div id="rr-splash" class="rr-splash">
             <!-- Image -->

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -2,8 +2,10 @@
 {% load i18n %}
 
 <div class="search-container time-search-container relative" style="overflow-y: scroll;">
-    <div class="filter-title">
-        <span data-bind="text: $root.translations.exportSearchResults"></span>
+    <div class="close-popup-panel-container" tabindex="0" role="button" data-bind="onEnterkeyClick, onSpaceClick, click: function(){selectedPopup('');},
+        attr: {'aria-label': $root.translations.closeExportSearchResults},
+    ">
+        <span class="close-popup-panel" data-bind="text: $root.translations.exportSearchResults"></span>
     </div>
     <hr class="title-underline">
 

--- a/arches/app/templates/views/components/search/time-filter.htm
+++ b/arches/app/templates/views/components/search/time-filter.htm
@@ -2,7 +2,11 @@
 <div class="search-container time-search-container">
 
     <div class="filter-title">
-        <span data-bind="text: $root.translations.dateInterval"></span>
+        <span class="close-popup-panel" tabindex="0" role="button" data-bind="onEnterkeyClick, onSpaceClick, 
+            click: function(){selectedPopup('');},
+            attr: {'aria-label': $root.translations.closeTimeFilter},
+            text: $root.translations.dateInterval,
+        "></span>
         <div class="btn-group">
             <button class="btn btn-primary btn-active-primary dropdown-toggle" data-toggle="dropdown" type="button" data-bind="click: function () { clear(); }"> 
                 <i class="fa fa-close"></i>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
A user should not need to navigate back to the search toolbar to close the popup panels. These changes add close buttons for the time-filter, saved-searches, and search export components. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9535 