### PR TITLE
Fix for graphs with forward slash ("/") in name when using create_package 

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -400,7 +400,8 @@ class Command(BaseCommand):
                 output_graph = {"graph": [graph], "metadata": system_metadata()}
                 graph_json = JSONSerializer().serialize(output_graph, indent=4)
                 if graph["graphid"] not in existing_resource_graphs:
-                    output_file = os.path.join(dest_dir, str(I18n_String(graph["name"])) + ".json")
+                    graph_name = str(I18n_String(graph["name"])).replace("/", "-")
+                    output_file = os.path.join(dest_dir, graph_name + ".json")
                     with open(output_file, "w") as f:
                         print("writing", output_file)
                         f.write(graph_json)


### PR DESCRIPTION
Graphs with forward slash in cause an error when running create_package.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
If a graph name has a forward slash ("/") in the name, replace it with a dash before writing the file. The graph name will still include the forward slash but the file written will have replaced it with a dash so linux doesn't recognise it as a directory.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9777 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @SDScandrettKint  <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @SDScandrettKint  <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @SDScandrettKint  <!--- Who designed this new feature-->

### Further comments

Unsure if back slash ("\") also needs changing for windows paths.
