### PR TITLE
9561 Json-Ld fix : Omit Edge from Null Domain

### DIFF
--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -149,6 +149,11 @@ class RdfWriter(Writer):
             # Nothing to do here
             if pkg["r_uri"] is None and pkg["range_tile_data"] is None:
                 return
+            
+            # JSON-LD fails assert if domain node empty while range node has data. 
+            # Unknown!=Undefined, but reasonable substitution to omit edge from null domain.
+            if pkg["d_uri"] is None:
+                return
 
             # FIXME:  Why is this not in datatype.to_rdf()
 

--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -152,7 +152,8 @@ class RdfWriter(Writer):
             
             # JSON-LD fails assert if domain node empty while range node has data. 
             # Unknown!=Undefined, but reasonable substitution to omit edge from null domain.
-            if pkg["d_uri"] is None:
+            if pkg["d_uri"] is None and pkg["range_tile_data"]:
+                self.logger.warn(_("Unable to return range value because domain is None, re https://github.com/archesproject/arches/pull/9783/files"))
                 return
 
             # FIXME:  Why is this not in datatype.to_rdf()


### PR DESCRIPTION
Issue : JSON-LD concept model handling does not handle null **domain nodes** whilst there is data in the **range node** on rdffile.py edge relationship generation.

ArchesProject GitHub Giveback Issue : #9561 

Fix : Do not parse the null. Domain node as Undefined (omitted from JSON) substitution used for Unknown (NULL value).

@chiatt @aj-he : Happy to rebase to dev/7.5.x if that'd be of help!  ^_^

