### PR TITLE
Fix for allowing double quotation marks in i18n inputs (dev/7.4.x)

### DIFF
--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -22,6 +22,10 @@ class I18n_String(object):
         ret = {}
 
         if isinstance(value, str) and value != "null":
+            # fix for issue #9623 - using double quotation marks in i18n input
+            if value.startswith('"') and value.endswith('"'):
+                value = value.replace('"', r'\"')
+
             try:
                 ret = json.loads(value)
             except:

--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -22,12 +22,20 @@ class I18n_String(object):
         ret = {}
 
         if isinstance(value, str) and value != "null":
-            # fix for issue #9623 - using double quotation marks in i18n input
-            if value.startswith('"') and value.endswith('"'):
-                value = value.replace('"', r'\"')
-
             try:
                 ret = json.loads(value)
+
+                # the following is a fix for issue #9623 - using double quotation marks in i18n input
+                # re https://github.com/archesproject/arches/issues/9623
+                # the reason we have to do this next check is that we assumed that if the 
+                # json.loads method doesn't fail we have a python dict.  That's usually 
+                # true unless you have a simple string wrapped in quotes 
+                # eg: '"hello world"' rather than simply 'hello world'
+                # the quoted string loads without error but is not a dict
+                # hence the need for this check
+                if not isinstance(ret, dict):
+                    ret = {}
+                    raise Exception("value is not a json object")
             except:
                 ret[lang] = value
                 self.value_is_primitive = True

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -183,6 +183,23 @@ class Customi18nTextFieldTests(ArchesTestCase):
         self.assertEqual(str(m.name), "Marco")
         self.assertEqual(m.name.raw_value, {"en": "Marco"})
 
+    def test_quoted_string_i18n_text_field_data_consistency_before_and_after_save(self):
+        # re https://github.com/archesproject/arches/issues/9623
+        translation.activate("en")
+        m = self.LocalizationTestModel()
+        m.name = "\"Hello World\""
+        m.id = 11
+        self.assertEqual(str(m.name),"\"Hello World\"")
+        m.save()
+
+        # test that post save everything is the same
+        self.assertEqual(str(m.name), "\"Hello World\"")
+
+        # test that the object retrieved from the database is the same
+        m = self.LocalizationTestModel.objects.get(pk=11)
+        self.assertEqual(str(m.name), "\"Hello World\"")
+        self.assertEqual(m.name.raw_value, {"en": "\"Hello World\""})
+
     def test_equality(self):
         value = I18n_String("toast")
         self.assertEqual(value, "toast")


### PR DESCRIPTION
This fix allows users to have strings that start and end with double quotation marks (" ") in i18n text inputs.
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Inputting a string that starts and ends with double quotation marks (e.g. "Hello, world") into any Resource Model text input box that used internationalisation would save incorrectly - e.g. as "Hello, world" rather than {"en":""\Hello, world"\"}. Strings which included double quotations not at the start and end (e.g. "Hello", world) would save correctly (e.g. {"en": ""\Hello"\, world"}. 
This change converts inputs with double quotations at the start and end to the raw literal for the character - "\ .


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9623

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
