### PR TITLE
Add upper bound on urllib3 (<2) #9826

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,5 +1,6 @@
 Django==3.2.20
 psycopg2==2.9.6
+urllib3<2
 elasticsearch>=8.3.1,<9.0.0
 rdflib==4.2.2
 django-guardian==2.3.0


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
`requests` lifted its upper bound of `urllib3` from <1.26 to <3 in 2.30.0, but this conflicts with `elastic-transport`'s upper bound of <2. Add this upper bound back.

Lets `pip install -r arches/install/requirements.txt` succeed.


### Issues Solved
Closes #9826

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @jacobtylerwalls
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->
