### PR TITLE
Add resource editing CTRL+S save functionality

### DIFF
--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -148,6 +148,17 @@ define([
             params.dirty(true);
         };
 
+        // ctrl+S saves any edited/dirty tiles in resource view 
+        document.addEventListener("keydown", e => {
+            if (e.ctrlKey && e.key === "s") {
+                e.preventDefault();
+                if (self.tile && self.tile.dirty() == true) {
+                    self.saveTile();
+                };
+
+            }
+        })
+
         this.saveTile = function(callback) {
             self.loading(true);
             self.tile.transactionId = params.form?.workflowId || undefined;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds an event listener for the keyboard shortcut CTRL and S. When activated, the event checks for the edited tiles and their "dirty" status, and if true then runs the save tile function.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9830

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
