### PR TITLE
Fix incorrect language labels on concept select widgets #9848

### DIFF
--- a/arches/app/models/concept.py
+++ b/arches/app/models/concept.py
@@ -804,7 +804,7 @@ class Concept(object):
 
         ranked_labels = sorted(
             concept.values,
-            key=lambda label: rank_label(kind=label.type, value_lang=label.language, sought_lang=lang),
+            key=lambda label: rank_label(kind=label.type, source_lang=label.language, target_lang=lang),
             reverse=True,
         )
         if len(ranked_labels) == 0:
@@ -1257,7 +1257,7 @@ class Concept(object):
 
         def best_language_last(rec):
             """_findNarrower updates via recursive search, so sort the best language last."""
-            label_rank = rank_label(kind=rec["vtype"], value_lang=rec["languageid"])
+            label_rank = rank_label(kind=rec["vtype"], source_lang=rec["languageid"])
             return (rec["depth"], rec["conceptpath"], label_rank)
 
         records = [dict(list(zip(column_names, row))) for row in rows]
@@ -1415,8 +1415,8 @@ def get_preflabel_from_conceptid(conceptid, lang):
     ranked = sorted(
         preflabels,
         key=lambda prefLabel: rank_label(kind=prefLabel["_source"]["type"],
-                                         value_lang=prefLabel["_source"]["language"],
-                                         sought_lang=lang,
+                                         source_lang=prefLabel["_source"]["language"],
+                                         target_lang=lang,
                                          ),
         reverse=True,
     )

--- a/arches/app/models/concept.py
+++ b/arches/app/models/concept.py
@@ -804,7 +804,7 @@ class Concept(object):
 
         ranked_labels = sorted(
             concept.values,
-            key=lambda label: rank_label(label.value, kind=label.type, label_lang=label.language, sought_lang=lang),
+            key=lambda label: rank_label(kind=label.type, value_lang=label.language, sought_lang=lang),
             reverse=True,
         )
         if len(ranked_labels) == 0:
@@ -1257,11 +1257,7 @@ class Concept(object):
 
         def best_language_last(rec):
             """_findNarrower updates via recursive search, so sort the best language last."""
-            label_rank = rank_label(
-                value=rec["valueto"],
-                kind=rec["vtype"],
-                label_lang=rec["languageid"],
-            )
+            label_rank = rank_label(kind=rec["vtype"], value_lang=rec["languageid"])
             return (rec["depth"], rec["conceptpath"], label_rank)
 
         records = [dict(list(zip(column_names, row))) for row in rows]
@@ -1418,9 +1414,8 @@ def get_preflabel_from_conceptid(conceptid, lang):
 
     ranked = sorted(
         preflabels,
-        key=lambda prefLabel: rank_label(value=prefLabel["_source"]["value"],
-                                         kind=prefLabel["_source"]["type"],
-                                         label_lang=prefLabel["_source"]["language"],
+        key=lambda prefLabel: rank_label(kind=prefLabel["_source"]["type"],
+                                         value_lang=prefLabel["_source"]["language"],
                                          sought_lang=lang,
                                          ),
         reverse=True,

--- a/arches/app/utils/i18n.py
+++ b/arches/app/utils/i18n.py
@@ -101,6 +101,38 @@ def get_localized_value(obj, lang=None, return_lang=False):
         return {found_lang: obj[found_lang]} if return_lang else obj[found_lang]
 
 
+def rank_label(value, *, kind='prefLabel', label_lang, sought_lang=None):
+    """Rank a label (value, label kind, and label language), preferring
+    the sought language over the system language, prefLabels over
+    altLabels, and both of those over anything else.
+    """
+
+    if kind == "prefLabel":
+        rank = 10
+    elif kind == "altLabel":
+        rank = 4
+    else:
+        rank = 1
+
+    label_language_exact = label_lang
+    label_language_fuzzy = label_lang.split("-")[0]
+    user_language_exact = sought_lang or get_language()
+    user_language_fuzzy = user_language_exact.split("-")[0]
+    system_language_exact = settings.LANGUAGE_CODE
+    system_language_fuzzy = settings.LANGUAGE_CODE.split("-")[0]
+
+    if label_language_exact == user_language_exact:
+        rank *= 10
+    elif label_language_fuzzy == user_language_fuzzy:
+        rank *= 5
+    elif label_language_exact == system_language_exact:
+        rank *= 3
+    elif label_language_fuzzy == system_language_fuzzy:
+        rank *= 2
+
+    return rank
+
+
 class ArchesPOFileFetcher:
     """Gets PO files for processing"""
 

--- a/arches/app/utils/i18n.py
+++ b/arches/app/utils/i18n.py
@@ -101,9 +101,9 @@ def get_localized_value(obj, lang=None, return_lang=False):
         return {found_lang: obj[found_lang]} if return_lang else obj[found_lang]
 
 
-def rank_label(kind="prefLabel", value_lang="", sought_lang=""):
+def rank_label(kind="prefLabel", source_lang="", target_lang=""):
     """Rank a label language, preferring prefLabel over altLabel,
-    the sought language over the system language, and both of those
+    the target language over the system language, and both of those
     languages over other languages.
     """
 
@@ -114,9 +114,9 @@ def rank_label(kind="prefLabel", value_lang="", sought_lang=""):
     else:
         rank = 1
 
-    label_language_exact = value_lang.lower()
-    label_language_fuzzy = value_lang.split("-")[0].lower()
-    user_language_exact = (sought_lang or get_language()).lower()
+    label_language_exact = source_lang.lower()
+    label_language_fuzzy = source_lang.split("-")[0].lower()
+    user_language_exact = (target_lang or get_language()).lower()
     user_language_fuzzy = user_language_exact.split("-")[0].lower()
     system_language_exact = settings.LANGUAGE_CODE.lower()
     system_language_fuzzy = settings.LANGUAGE_CODE.split("-")[0].lower()

--- a/arches/app/utils/i18n.py
+++ b/arches/app/utils/i18n.py
@@ -101,7 +101,7 @@ def get_localized_value(obj, lang=None, return_lang=False):
         return {found_lang: obj[found_lang]} if return_lang else obj[found_lang]
 
 
-def rank_label(kind='prefLabel', value_lang="", sought_lang=""):
+def rank_label(kind="prefLabel", value_lang="", sought_lang=""):
     """Rank a label language, preferring prefLabel over altLabel,
     the sought language over the system language, and both of those
     languages over other languages.
@@ -114,12 +114,12 @@ def rank_label(kind='prefLabel', value_lang="", sought_lang=""):
     else:
         rank = 1
 
-    label_language_exact = value_lang
-    label_language_fuzzy = value_lang.split("-")[0]
-    user_language_exact = sought_lang or get_language()
-    user_language_fuzzy = user_language_exact.split("-")[0]
-    system_language_exact = settings.LANGUAGE_CODE
-    system_language_fuzzy = settings.LANGUAGE_CODE.split("-")[0]
+    label_language_exact = value_lang.lower()
+    label_language_fuzzy = value_lang.split("-")[0].lower()
+    user_language_exact = (sought_lang or get_language()).lower()
+    user_language_fuzzy = user_language_exact.split("-")[0].lower()
+    system_language_exact = settings.LANGUAGE_CODE.lower()
+    system_language_fuzzy = settings.LANGUAGE_CODE.split("-")[0].lower()
 
     if label_language_exact == user_language_exact:
         rank *= 10

--- a/arches/app/utils/i18n.py
+++ b/arches/app/utils/i18n.py
@@ -101,10 +101,10 @@ def get_localized_value(obj, lang=None, return_lang=False):
         return {found_lang: obj[found_lang]} if return_lang else obj[found_lang]
 
 
-def rank_label(value, *, kind='prefLabel', label_lang, sought_lang=None):
-    """Rank a label (value, label kind, and label language), preferring
-    the sought language over the system language, prefLabels over
-    altLabels, and both of those over anything else.
+def rank_label(kind='prefLabel', value_lang="", sought_lang=""):
+    """Rank a label language, preferring prefLabel over altLabel,
+    the sought language over the system language, and both of those
+    languages over other languages.
     """
 
     if kind == "prefLabel":
@@ -114,8 +114,8 @@ def rank_label(value, *, kind='prefLabel', label_lang, sought_lang=None):
     else:
         rank = 1
 
-    label_language_exact = label_lang
-    label_language_fuzzy = label_lang.split("-")[0]
+    label_language_exact = value_lang
+    label_language_fuzzy = value_lang.split("-")[0]
     user_language_exact = sought_lang or get_language()
     user_language_fuzzy = user_language_exact.split("-")[0]
     system_language_exact = settings.LANGUAGE_CODE

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -172,7 +172,10 @@ def search_terms(request):
                 if len(result["top_concept"]["buckets"]) > 0:
                     for top_concept in result["top_concept"]["buckets"]:
                         top_concept_id = top_concept["key"]
-                        top_concept_label = get_preflabel_from_conceptid(top_concept["key"], lang)["value"]
+                        top_concept_label = get_preflabel_from_conceptid(
+                            top_concept["key"],
+                            lang=lang if lang != "*" else None
+                        )["value"]
                         for concept in top_concept["conceptid"]["buckets"]:
                             ret[index].append(
                                 {

--- a/tests/utils/i18n.py
+++ b/tests/utils/i18n.py
@@ -1,0 +1,57 @@
+from django.test import SimpleTestCase
+from django.utils import translation
+
+from arches.app.models.system_settings import settings
+from arches.app.utils.i18n import rank_label
+
+
+class I18nTests(SimpleTestCase):
+    def test_rank_label(self):
+        translation.activate("es-ES")
+        self.addCleanup(translation.activate, "en")
+
+        old_system_lang = settings.LANGUAGE_CODE
+        settings.LANGUAGE_CODE = "en-US"
+        self.addCleanup(setattr, settings, "LANGUAGE_CODE", old_system_lang)
+
+        cases = [
+            # Match an explicitly given language
+            (100, "prefLabel", "fr-CA", "fr-CA"),
+            (40, "altLabel", "fr-CA", "fr-CA"),
+            (10, "", "fr-CA", "fr-CA"),
+            # ...inexactly
+            (50, "prefLabel", "fr-FR", "fr-CA"),
+            (20, "altLabel", "fr-fr", "fr-CA"),
+            (5, "", "fr", "fr-CA"),
+
+            # Otherwise fall back to user language (es-ES)
+            # Good values
+            (100, "prefLabel", "es-ES", ""),
+            (40, "altLabel", "es-ES", ""),
+            (10, "", "es-ES", ""),
+            # Pretty good, but inexact
+            (50, "prefLabel", "es-MX", ""),
+            (20, "altLabel", "es-MX", ""),
+            (5, "", "es-MX", ""),
+            # Mediocre values: they at least match system language (en-US)
+            (30, "prefLabel", "en-US", ""),
+            (12, "altLabel", "en-US", ""),
+            (3, "", "en-US", ""),
+            # Mediocre and inexact
+            (20, "prefLabel", "en-GB", ""),
+            (8, "altLabel", "en-GB", ""),
+            (2, "", "en-GB", ""),
+
+            # Poor values: no relationship to any desired language,
+            # but at least preferred/alt labels are better than
+            # non-preferred labels
+            (10, "prefLabel", "", ""),
+            (4, "altLabel", "", ""),
+            (1, "", "", ""),
+        ]
+
+        # TODO(jtw): when we drop nose, add subTest for friendlier output
+        for case in cases:
+            score, kind, label_lang, sought_lang = case
+            result = rank_label(kind, label_lang, sought_lang)
+            self.assertEqual(score, result)

--- a/tests/utils/i18n.py
+++ b/tests/utils/i18n.py
@@ -4,6 +4,8 @@ from django.utils import translation
 from arches.app.models.system_settings import settings
 from arches.app.utils.i18n import rank_label
 
+# these tests can be run from the command line via
+# python manage.py test tests/utils/i18n.py --pattern="*.py" --settings="tests.test_settings"
 
 class I18nTests(SimpleTestCase):
     def test_rank_label(self):
@@ -52,6 +54,6 @@ class I18nTests(SimpleTestCase):
 
         # TODO(jtw): when we drop nose, add subTest for friendlier output
         for case in cases:
-            score, kind, label_lang, sought_lang = case
-            result = rank_label(kind, label_lang, sought_lang)
+            score, kind, source_lang, target_lang = case
+            result = rank_label(kind, source_lang, target_lang)
             self.assertEqual(score, result)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the `prefLabel` on a concept select widget control used the last label returned from the db, which may or may not correspond to the desired language.

Now, we prefer the user's selected language or the system default language when there are labels in multiple languages. (This requires sorting the best language last given how the recursive search overwrites previous values.)


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
closes #9848

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @chiatt
*   Tested by: @jacobtylerwalls 
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
Alternatives considered:

- doing the sort in the SQL query
  - it works, but it requires ugly CASE WHEN statements repeated in both parts of the recursive and non-recursive query, as well as additional interpolated query values
- short-circuiting inside the part of `_findNarrower` that does the overwriting, with a call to a helper function `get_preflabel_from_conceptid`
  - it possibly works, but the helper function adds overhead/queries, and the short-circuiting makes a dense part of `_findNarrower` denser. Or, it doesn't work, if there are nested concept labels that wouldn't be visited because of the short-circuiting.

Eager to hear suggestions about more idiomatic/reliable ways to do this kind of lookup/sorting.