### PR TITLE
Add mgmt command for rectifying nodeless nodegroups from Arches 7.3

### DIFF
--- a/arches/app/models/migrations/3201_second_removal_of_node_nodetype_branch.py
+++ b/arches/app/models/migrations/3201_second_removal_of_node_nodetype_branch.py
@@ -17,8 +17,11 @@ def forwards_func(apps, schema_editor):
 
     try:
         GraphModel.objects.get(graphid="22000000-0000-0000-0000-000000000001").delete()
+    except GraphModel.DoesNotExist:
+        pass
+    try:
         NodeGroup.objects.get(nodegroupid="20000000-0000-0000-0000-100000000001").delete()
-    except (GraphModel.DoesNotExist, NodeGroup.DoesNotExist):
+    except NodeGroup.DoesNotExist:
         pass
 
 

--- a/arches/management/commands/remove_nodeless_nodegroups.py
+++ b/arches/management/commands/remove_nodeless_nodegroups.py
@@ -1,0 +1,53 @@
+"""
+ARCHES - a program developed to inventory and manage immovable cultural heritage.
+Copyright (C) 2013 J. Paul Getty Trust and World Monuments Fund
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from arches.app.models import models
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Exists, OuterRef
+
+
+class Command(BaseCommand):
+    """
+    Rectifies issue described at:
+    https://github.com/archesproject/arches/issues/9847
+    """
+    help = "Identify and remove nodeless node groups/cards that were created in Arches 7.3."
+
+    def add_arguments(self, parser):
+        parser.add_argument("-d", "--dry", action="store_true", dest="dry_run", default=False,
+                            help="Identify and print nodeless node groups; does not delete them.")
+
+    def handle(self, *args, **options):
+        nodeless = models.NodeGroup.objects.filter(
+            ~Exists(models.Node.objects.filter(nodegroup_id=OuterRef("nodegroupid")))
+        )
+
+        num = len(nodeless)
+        print(num, "nodeless nodegroups.")
+
+        if options["dry_run"]:
+            print("No action taken.")
+            return
+
+        print("Deleting ...")
+
+        with transaction.atomic():
+            nodeless.delete()
+
+        print(num, "nodeless nodegroups deleted (with any associated cards).")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
In a scenario described on the [forum](https://community.archesproject.org/t/adding-new-node-published-resource-model-with-instances/2053/5), Arches 7.3 could leave behind node groups without any child nodes. These would appear in cards or corrupt reports and couldn't be deleted from the graph view.

I could not reproduce this issue on Arches 7.4. Providing this management command to allow users to identify affected records on their system created on Arches 7.3 and to delete them.

### Issues Solved
Closes #9847

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @junaidjabbar
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->

### Testing instructions (on 7.3)
**Create some corrupt node groups**.
1. Create a graph with no nodes. Save.
2. Create a child node of type number. Save.
3. Publish.
4. Create an instance.
5. Edit the model: attempt to add another node directly under the root.
6. Observe Graph Validation Error. (A corrupted node group is created at this point).
7. Delete the instance you created.
8. Reattempt step 5.) --> You should have "New Node" and "New Node_1" directly under the root.
9. Unpublish the graph.
10. Create a grandchild node under "New Node_1".
11. Switch to card view: notice an extra "New Node_1" from the earlier failed attempts.
(12. Try some variations if 11.) didn't look off...)

13. To test deletion still works, you might want to publish and create another instance at this point.

**Checkout this branch to get the management command**
0. Stop the server.
1. `python manage.py remove_nodeless_nodegroups --dry`
2. Observe 1-2 nodegroups will be deleted. (We determined one exists in the system by default, see [migration] altered in this PR to prevent this on new databases. (https://github.com/archesproject/arches/blob/2446c39f8292d6e2c6b458891b38ae3618409e6e/arches/app/models/migrations/3201_remove_node_and_nodetype_branches.py#L18-L22)).
3. `python manage.py remove_nodeless_nodegroups`
4. Observe 1-2 nodegroups _were_ deleted.

**Checkout 7.3**
Ensure CRUD operations still work, e.g. the instance you created in 13.) still can be deleted. I saw some tile delete operations failing, but I believe it was because I still had my server up while running the management command.