### PR TITLE
Add support for Elasticsearch API key authentication #9700 AB#57245

### DIFF
--- a/arches/app/search/search_engine_factory.py
+++ b/arches/app/search/search_engine_factory.py
@@ -33,9 +33,13 @@ class SearchEngineFactory(object):
         components = backend.split(".")
         classname = components[len(components) - 1]
         modulename = (".").join(components[0 : len(components) - 1])
-        # _temp = __import__(modulename, globals(), locals(), [classname], -1)
         _temp = __import__(modulename, globals(), locals(), [classname])  # in py3, level must be >= 0
-        return getattr(_temp, classname)(hosts=hosts, prefix=prefix, **connection_options)
+        args = {}
+        args["prefix"] = prefix
+        if "cloud_id" not in settings.ELASTICSEARCH_CONNECTION_OPTIONS:
+            args["hosts"] = hosts
+
+        return getattr(_temp, classname)(**args, **connection_options)
 
 
 SearchEngineInstance = SearchEngineFactory().create()

--- a/arches/app/search/search_engine_factory.py
+++ b/arches/app/search/search_engine_factory.py
@@ -33,13 +33,9 @@ class SearchEngineFactory(object):
         components = backend.split(".")
         classname = components[len(components) - 1]
         modulename = (".").join(components[0 : len(components) - 1])
+        # _temp = __import__(modulename, globals(), locals(), [classname], -1)
         _temp = __import__(modulename, globals(), locals(), [classname])  # in py3, level must be >= 0
-        args = {}
-        args["prefix"] = prefix
-        if "cloud_id" not in settings.ELASTICSEARCH_CONNECTION_OPTIONS:
-            args["hosts"] = hosts
-
-        return getattr(_temp, classname)(**args, **connection_options)
+        return getattr(_temp, classname)(hosts=hosts, prefix=prefix, **connection_options)
 
 
 SearchEngineInstance = SearchEngineFactory().create()

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -56,6 +56,21 @@ ROOT_URLCONF = '{{ project_name }}.urls'
 # Modify this line as needed for your project to connect to elasticsearch with a password that you generate
 ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "basic_auth": ("elastic", "E1asticSearchforArche5")}
 
+# If you need to connect to Elasticsearch via an API key instead of username/password, use the syntax below:
+# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": "<API_KEY>"}
+
+# Your Elasticsearch instance needs to be configured with xpack.security.enabled=true to use API keys - update elasticsearch.yml or .env file and restart.
+
+# Set the ELASTIC_PASSWORD environment variable in either the docker-compose.yml or .env file to the password you set for the elastic user,
+# otherwise a random password will be generated.
+
+# An API key can be generated using a POST to http://localhost:9200/_security/api_key with a minimum body of { "name": "<API_NAME>" }
+# ensuring you specify the basic authorization username and password credentials e.g. "elastic", "E1asticSearchforArche5". <API_NAME>
+# can be whatever you like e.g. "Arches API Key".
+
+# The response will return "api_key" and "encoded" - use "encoded" as <API_KEY>, not "api_key" as it has already been base64 encoded.
+# Alternatively, an API key can be generated in Kibaba - go to Management, Stack Management, Security, API keys and create a new API key.
+
 # a prefix to append to all elasticsearch indexes, note: must be lower case
 ELASTICSEARCH_PREFIX = '{{ project_name }}'
 

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -57,7 +57,8 @@ ROOT_URLCONF = '{{ project_name }}.urls'
 ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "basic_auth": ("elastic", "E1asticSearchforArche5")}
 
 # If you need to connect to Elasticsearch via an API key instead of username/password, use the syntax below:
-# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": "<API_KEY>"}
+# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": "<ENCODED_API_KEY>"}
+# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": ("<ID>", "<API_KEY>")}
 
 # Your Elasticsearch instance needs to be configured with xpack.security.enabled=true to use API keys - update elasticsearch.yml or .env file and restart.
 

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -64,12 +64,8 @@ ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "basic
 # Set the ELASTIC_PASSWORD environment variable in either the docker-compose.yml or .env file to the password you set for the elastic user,
 # otherwise a random password will be generated.
 
-# An API key can be generated using a POST to http://localhost:9200/_security/api_key with a minimum body of { "name": "<API_NAME>" }
-# ensuring you specify the basic authorization username and password credentials e.g. "elastic", "E1asticSearchforArche5". <API_NAME>
-# can be whatever you like e.g. "Arches API Key".
-
-# The response will return "api_key" and "encoded" - use "encoded" as <API_KEY>, not "api_key" as it has already been base64 encoded.
-# Alternatively, an API key can be generated in Kibaba - go to Management, Stack Management, Security, API keys and create a new API key.
+# API keys can be generated via the Elasticsearch API: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+# Or Kibana: https://www.elastic.co/guide/en/kibana/current/api-keys.html
 
 # a prefix to append to all elasticsearch indexes, note: must be lower case
 ELASTICSEARCH_PREFIX = '{{ project_name }}'

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -75,12 +75,8 @@ ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30}
 # Set the ELASTIC_PASSWORD environment variable in either the docker-compose.yml or .env file to the password you set for the elastic user,
 # otherwise a random password will be generated.
 
-# An API key can be generated using a POST to http://localhost:9200/_security/api_key with a minimum body of { "name": "<API_NAME>" }
-# ensuring you specify the basic authorization username and password credentials e.g. "elastic", "E1asticSearchforArche5". <API_NAME>
-# can be whatever you like e.g. "Arches API Key".
-
-# The response will return "api_key" and "encoded" - use "encoded" as <API_KEY>, not "api_key" as it has already been base64 encoded.
-# Alternatively, an API key can be generated in Kibaba - go to Management, Stack Management, Security, API keys and create a new API key.
+# API keys can be generated via the Elasticsearch API: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+# Or Kibana: https://www.elastic.co/guide/en/kibana/current/api-keys.html
 
 # a prefix to append to all elasticsearch indexes, note: must be lower case
 ELASTICSEARCH_PREFIX = "arches"

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -68,7 +68,8 @@ ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30}
 # ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "basic_auth": ("elastic", "E1asticSearchforArche5")}
 
 # If you need to connect to Elasticsearch via an API key instead of username/password, use the syntax below:
-# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": "<API_KEY>"}
+# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": "<ENCODED_API_KEY>"}
+# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": ("<ID>", "<API_KEY>")}
 
 # Your Elasticsearch instance needs to be configured with xpack.security.enabled=true to use API keys - update elasticsearch.yml or .env file and restart.
 

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -67,6 +67,21 @@ ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30}
 # Uncomment this line for a development setup after running the ubuntu_setup.sh script (do not use in production)
 # ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "basic_auth": ("elastic", "E1asticSearchforArche5")}
 
+# If you need to connect to Elasticsearch via an API key instead of username/password, use the syntax below:
+# ELASTICSEARCH_CONNECTION_OPTIONS = {"timeout": 30, "verify_certs": False, "api_key": "<API_KEY>"}
+
+# Your Elasticsearch instance needs to be configured with xpack.security.enabled=true to use API keys - update elasticsearch.yml or .env file and restart.
+
+# Set the ELASTIC_PASSWORD environment variable in either the docker-compose.yml or .env file to the password you set for the elastic user,
+# otherwise a random password will be generated.
+
+# An API key can be generated using a POST to http://localhost:9200/_security/api_key with a minimum body of { "name": "<API_NAME>" }
+# ensuring you specify the basic authorization username and password credentials e.g. "elastic", "E1asticSearchforArche5". <API_NAME>
+# can be whatever you like e.g. "Arches API Key".
+
+# The response will return "api_key" and "encoded" - use "encoded" as <API_KEY>, not "api_key" as it has already been base64 encoded.
+# Alternatively, an API key can be generated in Kibaba - go to Management, Stack Management, Security, API keys and create a new API key.
+
 # a prefix to append to all elasticsearch indexes, note: must be lower case
 ELASTICSEARCH_PREFIX = "arches"
 
@@ -755,6 +770,7 @@ JSON_LD_SORT_FUNCTIONS = [lambda x: x.get("@id", "~")]
 
 def JSON_LD_FIX_DATA_FUNCTION(data, jsdata, model):
     return jsdata
+
 
 ##########################################
 ### END RUN TIME CONFIGURABLE SETTINGS ###


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Update settings.py and settings.py-tpl to show how to implement Elasticsearch API key credentials. This will only work with a non-Elastic Cloud instance of Elasticsearch. #9850 is required if you need to connect to Elastic Cloud using an API key. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Fixes #9700

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England 
*   Found by: @RobOatesHistoricEngland 
*   Tested by: @RobOatesHistoricEngland 
*   Designed by: @RobOatesHistoricEngland 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
