### PR TITLE
Clean empty strings to None (to enforce field validation)

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -6,6 +6,7 @@ from arches.app.utils.file_validator import FileValidator
 import filetype
 import base64
 import re
+import itertools
 import logging
 import os
 from pathlib import Path
@@ -161,6 +162,13 @@ class StringDataType(BaseDataType):
     def clean(self, tile, nodeid):
         if tile.data[nodeid] in ["", "''"]:
             tile.data[nodeid] = None
+        elif isinstance(tile.data[nodeid], dict):
+            for language_dict in tile.data[nodeid].values():
+                if language_dict["value"]:
+                    break
+            else:
+                # No non-empty value was found.
+                tile.data[nodeid] = None
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
         if nodevalue is not None:

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -6,7 +6,6 @@ from arches.app.utils.file_validator import FileValidator
 import filetype
 import base64
 import re
-import itertools
 import logging
 import os
 from pathlib import Path

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models.models import Language
+from arches.app.models.tile import Tile
 from tests.base_test import ArchesTestCase
 
 
@@ -41,3 +42,35 @@ class StringDataTypeTests(ArchesTestCase):
         self.assertEqual(type(tile_value), dict)
         self.assertTrue("fa" in tile_value.keys())
         new_language.delete()
+
+    def test_tile_clean(self):
+        string = DataTypeFactory().get_instance("string")
+        nodeid = "72048cb3-adbc-11e6-9ccf-14109fd34195"
+        resourceinstanceid = "40000000-0000-0000-0000-000000000000"
+
+        json_all_empty_strings = {
+            "resourceinstance_id": resourceinstanceid,
+            "parenttile_id": "",
+            "nodegroup_id": nodeid,
+            "tileid": "",
+            "data": {nodeid: {"en": {"value": "", "direction": "ltr"}}},
+        }
+        tile1 = Tile(json_all_empty_strings)
+        string.clean(tile1, nodeid)
+
+        self.assertIsNone(tile1.data[nodeid])
+
+        json_some_empty_strings = {
+            "resourceinstance_id": resourceinstanceid,
+            "parenttile_id": "",
+            "nodegroup_id": nodeid,
+            "tileid": "",
+            "data": {nodeid: {
+                "en": {"value": "", "direction": "ltr"},
+                "de": {"value": "danke", "direction": "ltr"},
+            }},
+        }
+        tile2 = Tile(json_some_empty_strings)
+        string.clean(tile2, nodeid)
+
+        self.assertIsNotNone(tile2.data[nodeid])


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, a required string field could escape validation because an object shaped like the following didn't clean to None:
```py
{
    "en": {"value": "", "direction": "ltr"},
    ...
}
```

Now, they clean to None and the field validation works.

### Issues Solved
Closes #9281

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by:
*   Found by: @chiatt 
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
In #9281 @chiatt suggested implementing a new `is_empty()` method, but `clean()` seemed to already be designed for this, and there's already an implementation for the GeoJSON use case mentioned in the ticket:

https://github.com/archesproject/arches/blob/6346ab34e10e5cf2331108947e097d8285c183cc/arches/app/datatypes/datatypes.py#L892-L895