### PR TITLE
9889 Filter out unpublished graphs in resource instance widget

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -482,7 +482,8 @@ define([
                     const iconClass = self.graphLookup[item._source.graph_id]?.iconclass;
                     return `<i class="fa ${iconClass} sm-icon-wrap"></i> ${item._source.displayname}`;
                 } else {
-                    if (self.allowInstanceCreation) {
+                    const graph = self.graphLookup[item._id];
+                    if (self.allowInstanceCreation && graph.publication_id) {
                         return '<b> ' + arches.translations.riSelectCreateNew.replace('${graphName}', item.name) + ' . . . </b>';
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Unpublished graphs should not be available for resource creation in resource instance widget. These changes remove that ability.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9889 