### PR TITLE
Fix race condition when saving cards in graph designer #9858

### DIFF
--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -146,16 +146,15 @@ class Card(models.CardModel):
                         card_id = widget.get("card_id", None)
                         widget_id = widget.get("widget_id", None)
                         if cardxnodexwidgetid is None and (node_id is not None and card_id is not None and widget_id is not None):
-                            try:
-                                wm = models.CardXNodeXWidget.objects.get(node_id=node_id, card_id=card_id)
-                                cardxnodexwidgetid = wm.pk
-                            except:
-                                pass
-                        widget_model = models.CardXNodeXWidget()
-                        widget_model.pk = cardxnodexwidgetid
-                        widget_model.node_id = node_id
-                        widget_model.card_id = card_id
-                        widget_model.widget_id = widget_id
+                            widget_model, _ = models.CardXNodeXWidget.objects.get_or_create(
+                                node_id=node_id, card_id=card_id, widget_id=widget_id
+                            )
+                        else:
+                            widget_model = models.CardXNodeXWidget()
+                            widget_model.pk = cardxnodexwidgetid
+                            widget_model.node_id = node_id
+                            widget_model.card_id = card_id
+                            widget_model.widget_id = widget_id
                         widget_model.config = widget.get("config", {})
                         widget_model.label = widget.get("label", "")
                         widget_model.visible = widget.get("visible", None)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The frontend saves cards twice, once to update the card tree, and once to update the permissions tree. If these two requests are pending, and both requests "think" a new CardXNodeXWidget must be created (on a fast architecture like an M1 Mac), then the second will fail with an IntegrityError.

https://github.com/archesproject/arches/blob/9959ce34a4485fc636bdf4e258de5f84daab96ca/arches/app/media/js/views/graph-designer.js#L294-L295

Alleviated this race condition with `get_or_create()`, so that we can be sure we don't have multiple requests each trying to insert a new CardsXNodesXWidgets.

### Issues Solved
Closes #9858

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @jacobtylerwalls 
*   Tested by: @jacobtylerwalls 
*   Designed by: @ <!--- Who designed this new feature-->
