### PR TITLE
Remove editable flag on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install python packages
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install .
           pip install -r arches/install/requirements.txt
           pip install -r arches/install/requirements_dev.txt
           echo Python packages installed


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Builds are failing with cryptic errors about path conflicts. Usually this is a symptom of unexpected entries in `sys.path`. Installing arches in "development mode" with `-e` adds the current directory to sys.path (or, at least it did in legacy mode, and that might be the source of the new problems). That's not needed for CI, and not ideal for testing purposes anyway, as tests will execute against the repo checkout, not against the installation as users will see it.


### Issues Solved
See recent failing builds

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @chrabyrd
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

Developers still running into cryptic errors locally can try this command to opt-in to "legacy" editable mode for now ([docs](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior)):
```
pip install -e . --config-settings editable_mode=compat
```