### PR TITLE
Add search debounce of 500ms AB#59153

### DIFF
--- a/arches/app/media/js/bindings/term-search.js
+++ b/arches/app/media/js/bindings/term-search.js
@@ -36,6 +36,7 @@ define([
                 ajax: {
                     url: arches.urls.search_terms,
                     dataType: 'json',
+                    quietMillis: 500,
                     data: function(term, page) {
                         return {
                             q: term, // search term


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add a 500ms delay triggering the Ajax call to perform a search so that the number of Elasticsearch requests is reduced. Elasticsearch has a minimum character count of 2 characters before a search is requested. If the user supplied an 11 character search term - a total of 10 server requests would be made. Introducing a debounce will help reduce this number substantially.


### Issues Solved
Fixes #9820 
AB#59153

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @RobOatesHistoricEngland 
*   Tested by: @RobOatesHistoricEngland 
*   Designed by: @RobOatesHistoricEngland 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
