### PR TITLE
Harden link resolution of resource report

### DIFF
--- a/arches/app/media/js/views/components/resource-report-abstract.js
+++ b/arches/app/media/js/views/components/resource-report-abstract.js
@@ -37,7 +37,7 @@ define([
                     && params?.report?.attributes?.resourceid) 
                     || !params.cache
                 ) {
-                    url = arches.urls.api_bulk_disambiguated_resource_instance + `?v=beta&resource_ids=${params.report.attributes.resourceid != '' ? params.report.attributes.resourceid : window.location.pathname.split("/")[2]}`;
+                    url = arches.urls.api_bulk_disambiguated_resource_instance + `?v=beta&resource_ids=${params.report.attributes.resourceid != '' ? params.report.attributes.resourceid : window.location.pathname.split("/").reverse()[0]}`;
                     if(params.report.defaultConfig?.uncompacted_reporting) {
                         url += '&uncompacted=true';
                     }


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
If the core arches views are included in a project under /arches,
this path wouldn't resolve correctly. Harden this so that it gets the resource id more reliably.

### Issues Solved


### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @jacobtylerwalls
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->

### Testing instructions
Ideally, do this in a project that includes core arches views under `/arches`.
1. Create a resource.
2. Click the top level node in the sidebar to view the resource report. Ensure the page loads.
