### PR TITLE
Unwrap finally callback to ensure execution

### DIFF
--- a/arches/app/media/js/viewmodels/workflow-step.js
+++ b/arches/app/media/js/viewmodels/workflow-step.js
@@ -182,9 +182,9 @@ define([
                     .catch(function(error) {
                         reject(error);
                     })
-                    .finally(function() {
-                        self.saving(false);
-                    });
+                    .finally(
+                        self.saving(false)
+                    );
             });
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
self.saving() was never set False when a workflow step promise was rejected.
Although the prior syntax looks correct to me, it seems knockout might be expecting an unwrapped callback (?)


### Issues Solved
Refs archesproject/arches-for-science-prj#1258
Perhaps easiest to test by following the testing instructions at [arches-for-science-prj#1259](https://github.com/archesproject/arches-for-science-prj/pull/1282)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
