### PR TITLE
10009 node script deprecation

### DIFF
--- a/arches/install/ubuntu_setup.sh
+++ b/arches/install/ubuntu_setup.sh
@@ -40,9 +40,14 @@ function install_postgres {
 }
 
 function install_yarn {
-  wget --quiet -O - https://deb.nodesource.com/setup_16.x | sudo -E bash -
   sudo apt-get update
-  sudo apt-get install -y nodejs
+  sudo apt-get install -y ca-certificates curl gnupg
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  echo NODE_MAJOR=18 >> ~/.profile
+  source ~/.profile
+  sudo apt-get update
+  sudo apt-get install nodejs -y
   sudo apt install curl
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
   echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/arches/install/ubuntu_setup.sh
+++ b/arches/install/ubuntu_setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # For Ubuntu 20.04+
+# Tested on Ubuntu 20.04
 
 # Use the yes command if you would like to install postgres/postgis,
 # node/yarn, and elasticsearch.
@@ -44,7 +45,7 @@ function install_yarn {
   sudo apt-get install -y ca-certificates curl gnupg
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-  echo NODE_MAJOR=16 >> ~/.profile
+  echo NODE_MAJOR=18 >> ~/.profile
   source ~/.profile
   sudo apt-get update
   sudo apt-get install nodejs -y

--- a/arches/install/ubuntu_setup.sh
+++ b/arches/install/ubuntu_setup.sh
@@ -46,10 +46,10 @@ function install_yarn {
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
   echo NODE_MAJOR=18 >> ~/.profile
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && apt-get update
   source ~/.profile
   sudo apt-get update
   sudo apt-get install nodejs -y
-  sudo apt install curl
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
   echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   sudo apt update

--- a/arches/install/ubuntu_setup.sh
+++ b/arches/install/ubuntu_setup.sh
@@ -46,7 +46,7 @@ function install_yarn {
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
   echo NODE_MAJOR=18 >> ~/.profile
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && apt-get update
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list && sudo apt-get update
   source ~/.profile
   sudo apt-get update
   sudo apt-get install nodejs -y

--- a/arches/install/ubuntu_setup.sh
+++ b/arches/install/ubuntu_setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# For Ubuntu 18.04+
+# For Ubuntu 20.04+
 
 # Use the yes command if you would like to install postgres/postgis,
 # node/yarn, and elasticsearch.
@@ -44,7 +44,7 @@ function install_yarn {
   sudo apt-get install -y ca-certificates curl gnupg
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-  echo NODE_MAJOR=18 >> ~/.profile
+  echo NODE_MAJOR=16 >> ~/.profile
   source ~/.profile
   sudo apt-get update
   sudo apt-get install nodejs -y

--- a/arches/install/ubuntu_setup.sh
+++ b/arches/install/ubuntu_setup.sh
@@ -46,8 +46,8 @@ function install_yarn {
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
   echo NODE_MAJOR=18 >> ~/.profile
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list && sudo apt-get update
   source ~/.profile
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list && sudo apt-get update
   sudo apt-get update
   sudo apt-get install nodejs -y
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null


### PR DESCRIPTION
Changes how node is installed in the ubuntu setup script.  Also adds note that removes support for Ubuntu 18.04 - which is now [out of standard support](https://ubuntu.com/about/release-cycle).  

Tested and verified working with Ubuntu 20.04.