### PR TITLE
[6.2.x] Fix version number of arches-django-revproxy in release note

### DIFF
--- a/releases/6.2.0.md
+++ b/releases/6.2.0.md
@@ -50,7 +50,7 @@ Python:
         django-libsass 0.7 -> 0.9
 
     Added:
-        arches-django-revproxy==1.10.0
+        arches-django-revproxy==0.10.0
     
     Removed:
         django-revproxy==0.9.15

--- a/releases/6.2.1.md
+++ b/releases/6.2.1.md
@@ -51,7 +51,7 @@ Python:
         django-libsass 0.7 -> 0.9
 
     Added:
-        arches-django-revproxy==1.10.0
+        arches-django-revproxy==0.10.0
     
     Removed:
         django-revproxy==0.9.15


### PR DESCRIPTION
Fix the version number of `arches-django-revproxy` in release notes. Discovered installing 6.2 a couple weeks ago that the given version number doesn't exist.