### PR TITLE
[7.4.x] Fix version number of arches-django-revproxy in release note

### DIFF
--- a/releases/7.0.0.md
+++ b/releases/7.0.0.md
@@ -41,7 +41,7 @@ Python:
         pyotp>=2.6.0
         qrcode>=7.3.1
         django-webpack-loader==1.5.0
-        arches-django-revproxy==1.10.0
+        arches-django-revproxy==0.10.0
 
 JavaScript:
     Upgraded:


### PR DESCRIPTION
Forwardport of #10025 (different files involved)