### PR TITLE
Account for `this.value` not being an observable #10043

### DIFF
--- a/arches/app/media/js/viewmodels/widget.js
+++ b/arches/app/media/js/viewmodels/widget.js
@@ -87,7 +87,7 @@ define([
             subscribeConfigObservable(obs, key);
         });
 
-        if (ko.isObservable(this.defaultValue)) {
+        if (ko.isObservable(this.value) && ko.isObservable(this.defaultValue)) {
             var defaultValue = this.defaultValue();
             if (this.tile && !this.tile.noDefaults && ko.unwrap(this.tile.tileid) == "" && defaultValue != null && defaultValue != "") {
                 this.value(defaultValue);


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
`this.value` is not always an observable:
https://github.com/archesproject/arches/blob/6346ab34e10e5cf2331108947e097d8285c183cc/arches/app/media/js/viewmodels/widget.js#L33

### Issues Solved
Closes #10043, see testing instructions there

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @jacobtylerwalls
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->
