### PR TITLE
Add a "View Report" button to resource editor

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -393,9 +393,9 @@
 
                         {% if nav.report_view %}
                         <a href="{% url 'resource_report' resourceid %}" class="ep-tools ep-tools-right"
-                            data-bind="click:function () { navigate('{% url 'resource_report' resourceid %}') }">
+                            data-bind="click:function () { navigate('{% url 'resource_report' resourceid %}') }" aria-label="{% trans 'View Report' %}">
                             <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "View Report" %}">
-                                <i class="ion-document-text"></i>
+                                <i class="ion-android-document"></i>
                             </div>
                         </a>
                         {% endif %}

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -391,6 +391,15 @@
                         </a>
                         {% endif %}
 
+                        {% if nav.report_view %}
+                        <a href="{% url 'resource_report' resourceid %}" class="ep-tools ep-tools-right"
+                            data-bind="click:function () { navigate('{% url 'resource_report' resourceid %}') }">
+                            <div class="" data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "View Report" %}">
+                                <i class="ion-document-text"></i>
+                            </div>
+                        </a>
+                        {% endif %}
+
                         {% if nav.help %}
                         <a href="javascript:void(0)" class="ep-help-toggle ep-tools ep-tools-right"
                             data-bind="click: function(){ {{ nav.help.templates }}.forEach(template => getHelp(template)); helpOpen(true) }">

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -342,6 +342,8 @@ class ResourceEditorView(MapBaseManagerView):
 
         context["nav"]["title"] = ""
         context["nav"]["menu"] = nav_menu
+        context["nav"]["report_view"] = True
+
 
         if resourceid == settings.RESOURCE_INSTANCE_ID:
             context["nav"]["help"] = {"title": _("Managing System Settings"), "templates": ["system-settings-help"]}

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -201,6 +201,7 @@ class ResourceEditorView(MapBaseManagerView):
             creator = instance_creator["creatorid"]
             user_created_instance = instance_creator["user_can_edit_instance_permissions"]
 
+
         ontologyclass = None
         nodegroups = []
         editable_nodegroups = []
@@ -342,8 +343,9 @@ class ResourceEditorView(MapBaseManagerView):
 
         context["nav"]["title"] = ""
         context["nav"]["menu"] = nav_menu
-        context["nav"]["report_view"] = True
-
+    
+        if resourceid not in (None, ""):
+            context["nav"]["report_view"] = True
 
         if resourceid == settings.RESOURCE_INSTANCE_ID:
             context["nav"]["help"] = {"title": _("Managing System Settings"), "templates": ["system-settings-help"]}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds a "View Report" button to the resource editor view, acting as a reverse to the edit resource button.
![image](https://github.com/archesproject/arches/assets/119508494/c8ce7923-aac6-4ad2-8510-a2578d69e534)


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments
Currently the only way to see the report from the resource editor view is to replace "resource" with "report" in the URL or to go via Manage -> Jump to report, however this may be missed by some users.
The icon current in use is ion-android-document.

Interested in whether people think this is a necessary addition.