### PR TITLE
Let errors bubble up in `ManifestManagerView` #9986

### DIFF
--- a/arches/app/views/manifest_manager.py
+++ b/arches/app/views/manifest_manager.py
@@ -6,7 +6,7 @@ import shutil
 import uuid
 from revproxy.views import ProxyView
 from django.core.files.storage import default_storage
-from django.http import HttpRequest
+from django.http.response import Http404
 from django.utils.translation import gettext as _
 from django.views.generic import View
 from arches.app.utils.response import JSONResponse, JSONErrorResponse
@@ -208,10 +208,7 @@ class ManifestManagerView(View):
             canvases = []
             for f in files:
                 if os.path.splitext(f.name)[1].lower() in acceptable_types:
-                    try:
-                        image_json, image_id, file_url = create_image(f)
-                    except:
-                        return
+                    image_json, image_id, file_url = create_image(f)
 
                     canvas = create_canvas(image_json, file_url, os.path.splitext(f.name)[0], image_id)
                     canvases.append(canvas)
@@ -250,10 +247,7 @@ class ManifestManagerView(View):
                 canvases = []
                 for f in files:
                     if os.path.splitext(f.name)[1].lower() in acceptable_types:
-                        try:
-                            image_json, image_id, file_url = create_image(f)
-                        except:
-                            return
+                        image_json, image_id, file_url = create_image(f)
                         canvas = create_canvas(image_json, file_url, os.path.splitext(f.name)[0], image_id)
                         canvases.append(canvas)
                     else:
@@ -261,7 +255,7 @@ class ManifestManagerView(View):
                 add_canvases(manifest, canvases)
             except:
                 logger.warning("You have to select a manifest to add images")
-                return None
+                raise
 
         change_manifest_metadata(manifest)
 
@@ -274,7 +268,7 @@ class ManifestManagerView(View):
             return resp.json()
         except:
             logger.warning("Manifest not created. Check if Cantaloupe running")
-            return None
+            raise
 
     def on_import(self, tile):
         raise NotImplementedError


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Reraise errors instead of swallowing them and returning None. Allows error banner to appear in UI and django debug response to appear in network tab.

### Issues Solved
Closes #9986

### Demo
Before, failures in the manifest manager were almost always silent.
![Screenshot 2023-09-15 at 4 35 29 PM](https://github.com/archesproject/arches/assets/38668450/adb6138d-9bc8-4cf1-a71f-9056f5199e50)
