### PR TITLE
Fixes issue where setting the arches version stage to "alpha" or "rc" stops package.json being created correctly #10048

### DIFF
--- a/arches/install/arches-admin
+++ b/arches/install/arches-admin
@@ -145,7 +145,7 @@ class ArchesProjectCommand(TemplateCommand):
         options["arches_version"] = "master"
         if complete_version[3] == 'final':
             options["arches_version"] = f"stable/{__version__}"
-        elif complete_version[3] == 'beta':
+        elif complete_version[3] in ['alpha','beta','rc']:
             options["arches_version"] = f"dev/{complete_version[0]}.{complete_version[1]}.x"
 
         super(ArchesProjectCommand, self).handle('project', project_name, target, **options)

--- a/arches/install/arches-project
+++ b/arches/install/arches-project
@@ -56,7 +56,7 @@ class ArchesCommand(TemplateCommand):
         options["arches_version"] = "master"
         if complete_version[3] == 'final':
             options["arches_version"] = f"stable/{arches.__version__}"
-        elif complete_version[3] == 'beta':
+        elif complete_version[3] in ['alpha','beta','rc']:
             options["arches_version"] = f"dev/{complete_version[0]}.{complete_version[1]}.x"
         options["arches_semantic_version"] = ".".join([str(arches.VERSION[0]), str(arches.VERSION[1]), str(arches.VERSION[2])])
         super(ArchesCommand, self).handle('project', project_name, target, **options)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixes issue where on using the arches-project create command, if the arches version development stage is "alpha" or "rc" (as documented in the file), it sets the `dependencies` and `devDependencies` reference to master instead of the development branch. This causes the created project to not start correctly.

dev/7.5.x doesn not currently create a working project without then manually setting the package.json branch references.

The solution ensures that when the arches version is "alpha" and "rc", it uses the current dev branch.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
fixes #10048 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @aj-he and @csmith-he 
*   Tested by: @aj-he
*   Designed by: @aj-he

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
