### PR TITLE
Add a button to copy node UUIDs to clipboard in graph designer tree

### DIFF
--- a/arches/app/media/js/bindings/clipboard.js
+++ b/arches/app/media/js/bindings/clipboard.js
@@ -4,24 +4,23 @@ define([
 ], function($, ko) {
     ko.bindingHandlers.clipboard = {
         init: function(element, valueAccessor) {
-            var value = valueAccessor();
-            var input = $(element).find('input'); // an input or textarea is needed for copying to clipboard
-            input = $(element).find('textarea');
-            if (input.length === 0) { // if there's no input or textarea in the element, we'll create a tempoarary one and copy the value from it
-                $(element).click(function(){
-                    var html = '<input value="' + ko.unwrap(value) + '"></input>';
-                    $(element).append(html);
-                    var tempInput = $(element).find('input');
-                    tempInput[0].select();
-                    window.document.execCommand("copy");
-                    tempInput.remove('input');
-                });
-            } else {
-                $(element).click(function(){
-                    input.select();
-                    window.document.execCommand("copy");
-                });
+            const data = valueAccessor();
+            if (data.tooltip) {
+                $(element).attr('data-original-title', data.beforeCopiedText);
             }
+            function resetText() {
+                $(element).tooltip('hide');
+                $(element).attr('data-original-title', data.beforeCopiedText);
+                $(element).off('mouseleave', resetText);
+            };
+            $(element).click(function(){                
+                if (data.tooltip) {
+                    $(element).attr('data-original-title', data.afterCopiedText);
+                    $(element).tooltip('show');
+                    $(element).on('mouseleave', resetText);
+                }
+                navigator.clipboard.writeText(ko.unwrap(data.value));
+            });
         }
     };
     return ko.bindingHandlers.clipboard;

--- a/arches/app/media/js/views/graph/graph-designer/graph-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/graph-tree.js
@@ -248,6 +248,11 @@ define([
         },
         toggleGrid: function(){
             this.showGrid(!this.showGrid());
+        },
+
+        copyNodeId: function(node, e) {
+            var nodeId = node.nodeid
+            navigator.clipboard.writeText(nodeId);
         }
     });
     return GraphTree;

--- a/arches/app/media/js/views/graph/graph-designer/graph-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/graph-tree.js
@@ -251,6 +251,17 @@ define([
         },
 
         copyNodeId: function(node, e) {
+            const copyUUIDelement = $(copy_node_id)
+
+            function restoreTitle(e) {
+                copyUUIDelement.tooltip('hide') 
+                copyUUIDelement.attr('data-original-title', 'Copy UUID to Clipboard')
+                copyUUIDelement.off('mouseleave', restoreTitle)
+            };
+            copyUUIDelement.attr('data-original-title', 'Copied to Clipboard!')
+            copyUUIDelement.tooltip('show')
+            copyUUIDelement.on('mouseleave', restoreTitle)
+
             var nodeId = node.nodeid
             navigator.clipboard.writeText(nodeId);
         }

--- a/arches/app/media/js/views/graph/graph-designer/graph-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/graph-tree.js
@@ -251,16 +251,14 @@ define([
         },
 
         copyNodeId: function(node, e) {
-            const copyUUIDelement = $(copy_node_id)
-
             function restoreTitle(e) {
-                copyUUIDelement.tooltip('hide') 
-                copyUUIDelement.attr('data-original-title', 'Copy UUID to Clipboard')
-                copyUUIDelement.off('mouseleave', restoreTitle)
+                $(e.target).tooltip('hide') 
+                $(e.target).attr('data-original-title', 'Copy UUID to Clipboard')
+                $(e.target).off('mouseleave', restoreTitle)
             };
-            copyUUIDelement.attr('data-original-title', 'Copied to Clipboard!')
-            copyUUIDelement.tooltip('show')
-            copyUUIDelement.on('mouseleave', restoreTitle)
+            $(e.target).attr('data-original-title', 'Copied to Clipboard!')
+            $(e.target).tooltip('show')
+            $(e.target).on('mouseleave', restoreTitle)
 
             var nodeId = node.nodeid
             navigator.clipboard.writeText(nodeId);

--- a/arches/app/media/js/views/graph/graph-designer/graph-tree.js
+++ b/arches/app/media/js/views/graph/graph-designer/graph-tree.js
@@ -4,6 +4,7 @@ define([
     'underscore',
     'arches',
     'views/tree-view',
+    'bindings/clipboard',
 ], function($, ko, _, arches, TreeView) {
     var loading = ko.observable(false);
 
@@ -73,6 +74,7 @@ define([
             this.toggleIds = function() {
                 self.showIds(!self.showIds());
             };
+            this.translations = arches.translations;
             this.showGrid = ko.observable(false);
             this.activeLanguageDir = ko.observable(arches.activeLanguageDir);
             TreeView.prototype.initialize.apply(this, arguments);
@@ -248,21 +250,8 @@ define([
         },
         toggleGrid: function(){
             this.showGrid(!this.showGrid());
-        },
-
-        copyNodeId: function(node, e) {
-            function restoreTitle(e) {
-                $(e.target).tooltip('hide') 
-                $(e.target).attr('data-original-title', 'Copy UUID to Clipboard')
-                $(e.target).off('mouseleave', restoreTitle)
-            };
-            $(e.target).attr('data-original-title', 'Copied to Clipboard!')
-            $(e.target).tooltip('show')
-            $(e.target).on('mouseleave', restoreTitle)
-
-            var nodeId = node.nodeid
-            navigator.clipboard.writeText(nodeId);
         }
+
     });
     return GraphTree;
 });

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -814,6 +814,8 @@
         apply-to-selected-files='{% trans "Apply to Selected Files" as applyToSelectedFiles %} "{{ applyToSelectedFiles|escapejs }}"'
         apply-same-loader-to-all='{% trans "Apply the same loader to all selected files in the dataset" as applySameLoaderToAll %} "{{ applySameLoaderToAll|escapejs }}"'
         id-column-selection='{% trans "Use as an id" as idColumnSelection %} "{{ idColumnSelection|escapejs }}"'
+        copy-node-id-to-clipboard='{% trans "Copy Node ID to Clipboard" as copyNodeIdToClipboard %} "{{ copyNodeIdToClipboard|escapejs }}"'
+        copied-node-id-to-clipboard='{% trans "Copied to Clipboard!" as copiedNodeIdToClipboard %} "{{ copiedNodeIdToClipboard|escapejs }}"'
     ></div>
     {% endblock arches_translations %}
     {% block arches_urls %}

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -43,7 +43,7 @@
                     <span data-bind="text: $root.translations.geojsonUrl"></span>
                 </label>
                 <!-- ko if: format() === 'geojson' && hasResourceTypeFilter -->
-                <div data-bind="clipboard: geojsonUrl">
+                <div data-bind="clipboard: {value: geojsonUrl, tooltip: false}">
                     <div style="padding: 5px 0px"><textarea style="width: 300px;" data-bind="value: geojsonUrl"></textarea></div>
                     <button class="btn btn-shim btn-labeled btn-sm fa fa-clipboard btn-primary">
                         <span data-bind="text: $root.translations.copyToClipboard"></span>

--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -53,7 +53,7 @@
             <span style="font-weight:bold;" data-bind="text: ': ' + node.nodeid"></span>
             <!-- /ko -->
             <span class="spacer"></span>
-            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree), visible: graphTree.showIds()" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
+            <i id="copy_node_id" class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree), visible: graphTree.showIds()" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
             <!--ko if: graphTree.restrictedNodegroups.includes(node.nodeGroupId()) === false -->
             <i class="jstree-node-action-icon fa fa-plus-circle" role="presentation" data-bind="click: graphTree.addChildNode.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Child Node" %}"></i>
             <i class="jstree-node-action-icon ion-merge" role="presentation" data-bind="click: graphTree.toggleBranchList.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Branch" %}"></i>

--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -53,7 +53,7 @@
             <span style="font-weight:bold;" data-bind="text: ': ' + node.nodeid"></span>
             <!-- /ko -->
             <span class="spacer"></span>
-            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree), visible: graphTree.showIds()" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
+            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="visible: graphTree.showIds(), clipboard: {value: node.nodeid, tooltip: true, beforeCopiedText: graphTree.translations.copyNodeIdToClipboard, afterCopiedText: graphTree.translations.copiedNodeIdToClipboard}" data-toggle="tooltip" data-placement="auto" data-container="body"></i>
             <!--ko if: graphTree.restrictedNodegroups.includes(node.nodeGroupId()) === false -->
             <i class="jstree-node-action-icon fa fa-plus-circle" role="presentation" data-bind="click: graphTree.addChildNode.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Child Node" %}"></i>
             <i class="jstree-node-action-icon ion-merge" role="presentation" data-bind="click: graphTree.toggleBranchList.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Branch" %}"></i>

--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -53,6 +53,9 @@
             <span style="font-weight:bold;" data-bind="text: ': ' + node.nodeid"></span>
             <!-- /ko -->
             <span class="spacer"></span>
+            <!-- ko if: graphTree.showIds-->
+            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
+            <!-- /ko -->
             <!--ko if: graphTree.restrictedNodegroups.includes(node.nodeGroupId()) === false -->
             <i class="jstree-node-action-icon fa fa-plus-circle" role="presentation" data-bind="click: graphTree.addChildNode.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Child Node" %}"></i>
             <i class="jstree-node-action-icon ion-merge" role="presentation" data-bind="click: graphTree.toggleBranchList.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Branch" %}"></i>

--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -53,7 +53,7 @@
             <span style="font-weight:bold;" data-bind="text: ': ' + node.nodeid"></span>
             <!-- /ko -->
             <span class="spacer"></span>
-            <i id="copy_node_id" class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree), visible: graphTree.showIds()" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
+            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree), visible: graphTree.showIds()" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
             <!--ko if: graphTree.restrictedNodegroups.includes(node.nodeGroupId()) === false -->
             <i class="jstree-node-action-icon fa fa-plus-circle" role="presentation" data-bind="click: graphTree.addChildNode.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Child Node" %}"></i>
             <i class="jstree-node-action-icon ion-merge" role="presentation" data-bind="click: graphTree.toggleBranchList.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Branch" %}"></i>

--- a/arches/app/templates/views/graph/graph-designer/graph-tree.htm
+++ b/arches/app/templates/views/graph/graph-designer/graph-tree.htm
@@ -53,9 +53,7 @@
             <span style="font-weight:bold;" data-bind="text: ': ' + node.nodeid"></span>
             <!-- /ko -->
             <span class="spacer"></span>
-            <!-- ko if: graphTree.showIds-->
-            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
-            <!-- /ko -->
+            <i class="jstree-node-action-icon ion-ios-copy-outline" role="presentation" data-bind="click: graphTree.copyNodeId.bind(graphTree), visible: graphTree.showIds()" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Copy UUID to Clipboard" %}"></i>
             <!--ko if: graphTree.restrictedNodegroups.includes(node.nodeGroupId()) === false -->
             <i class="jstree-node-action-icon fa fa-plus-circle" role="presentation" data-bind="click: graphTree.addChildNode.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Child Node" %}"></i>
             <i class="jstree-node-action-icon ion-merge" role="presentation" data-bind="click: graphTree.toggleBranchList.bind(graphTree)" data-toggle="tooltip" data-placement="auto" data-container="body" data-original-title="{% trans "Add Branch" %}"></i>


### PR DESCRIPTION
Adds a button to copy node UUIDs to clipboard in the graph designer tree.
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds a button that shows up in the graph designer node tree once 'show IDs is clicked' that allows the current node UUID to be copied to the clipboard. This provides a quicker way of obtaining a node UUID than the previous method of using inspect element.

When show IDs is off:
![image](https://github.com/archesproject/arches/assets/119508494/0ed22a40-36c5-412f-92b8-c8b10616330b)
When show IDs is on:
![image](https://github.com/archesproject/arches/assets/119508494/84af8576-82d4-4b81-b511-a852b3db0c5d)



### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments

At the moment the tooltip is not showing up even though the text has been set and the structure is the same as all other buttons on the bar- any suggestions/help would be greatly appreciated! :) 
