### PR TITLE
10090 exact match dev7.5.x

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -10797,11 +10797,11 @@ table.table.dataTable {
 .resource_search_widget_dropdown ul .select2-disabled .group {
     padding: 0px;
     border-top: 1px solid #C1D4F3;
-    width: 383px;
+    width: 450px;
 }
 
 .resource_search_widget_dropdown ul .select2-disabled div span span button {
-    width: 195px;
+    width: 150px;
     height: 35px;
 }
 

--- a/arches/app/media/js/bindings/term-search.js
+++ b/arches/app/media/js/bindings/term-search.js
@@ -96,10 +96,21 @@ define([
                 },
                 formatResult: function(result, container, query, escapeMarkup) {
                     var markup = [];
-                    var indent = result.type === 'concept' || result.type === 'term' ? 'term-search-item indent' : (result.type === 'string' ? 'term-search-item' : 'term-search-group');
+                    var indent = result.type === 'concept' || result.type === 'exactmatch' || result.type === 'term' ? 'term-search-item indent' : (result.type === 'string' ? 'term-search-item' : 'term-search-group');
                     if (result.type === 'group') {
                         _.each(result.text, function(searchType, i) {
-                            var label = searchType === 'concepts' ? arches.translations.termSearchConcept : arches.translations.termSearchTerm;
+                            var label;
+                            switch (searchType) {
+                                case 'concepts':
+                                    label = arches.translations.termSearchConcept;
+                                    break;
+                                case 'terms':
+                                    label = arches.translations.termSearchTerm;
+                                    break;
+                                case 'resources':
+                                    label = arches.translations.termSearchResource;
+                                    break;
+                            }
                             var active = i === 0 ? 'active' : '';
                             markup.push('<button id="' + searchType + 'group" class="btn search-type-btn term-search-btn ' + active + ' ">' + label + '</button>');
                         });

--- a/arches/app/media/js/bindings/term-search.js
+++ b/arches/app/media/js/bindings/term-search.js
@@ -122,15 +122,27 @@ define([
                     container[0].className = container[0].className + ' ' + result.type;
                     $(container).click(function(event){
                         var btn = event.target.closest('button');
-                        if(!!btn && btn.id === 'termsgroup') {
-                            $(btn).addClass('active').siblings().removeClass('active');
-                            $('.term').show();
-                            $('.concept').hide();
-                        }
-                        if(!!btn && btn.id === 'conceptsgroup') {
-                            $(btn).addClass('active').siblings().removeClass('active');
-                            $('.concept').show();
-                            $('.term').hide();
+                        if (!!btn) {
+                            switch (btn.id) {
+                                case 'termsgroup':
+                                    $(btn).addClass('active').siblings().removeClass('active');
+                                    $('.term').show();
+                                    $('.concept').hide();
+                                    $('.exactmatch').hide();
+                                    break;
+                                case 'conceptsgroup':
+                                    $(btn).addClass('active').siblings().removeClass('active');
+                                    $('.concept').show();
+                                    $('.term').hide();
+                                    $('.exactmatch').hide();
+                                    break;
+                                case 'resourcesgroup':
+                                    $(btn).addClass('active').siblings().removeClass('active');
+                                    $('.exactmatch').show();
+                                    $('.term').hide();
+                                    $('.concept').hide();
+                                    break;
+                            }
                         }
                     });
                     return formatedresult;

--- a/arches/app/media/js/views/components/search/term-filter.js
+++ b/arches/app/media/js/views/components/search/term-filter.js
@@ -59,7 +59,7 @@ define([
 
         updateQuery: function() {
             var terms = _.filter(this.filter.terms(), function(term){
-                return term.type === 'string' || term.type === 'concept' || term.type === 'term';
+                return term.type === 'string' || term.type === 'concept' || term.type === 'term' || term.type === 'exactmatch';
             }, this);
             
             var queryObj = this.query();

--- a/arches/app/search/components/term_filter.py
+++ b/arches/app/search/components/term_filter.py
@@ -25,7 +25,10 @@ class TermFilter(BaseSearchFilter):
         querysting_params = self.request.GET.get(details["componentname"], "")
         language = self.request.GET.get("language", "*")
         for term in JSONDeserializer().deserialize(querysting_params):
-            if term["type"] == "term" or term["type"] == "string":
+            if term["type"] == "exactmatch":
+                ids_query = Ids(ids=[term["resourceinstanceid"]])
+                search_query.must(ids_query)
+            elif term["type"] == "term" or term["type"] == "string":
                 string_filter = Bool()
                 if term["type"] == "term":
                     string_filter.must(Match(field="strings.string", query=term["value"], type="phrase"))

--- a/arches/app/search/mappings.py
+++ b/arches/app/search/mappings.py
@@ -131,7 +131,23 @@ def prepare_search_index(create=False):
                 "legacyid": {"type": "text", "fields": {"keyword": {"ignore_above": 256, "type": "keyword"}}},
                 "resourceinstanceid": {"type": "keyword"},
                 "root_ontology_class": {"type": "keyword"},
-                "displayname": {"type": "nested", "properties": {"value": {"type": "keyword"}, "language": {"type": "keyword"}}},
+                "displayname": {
+                    "type": "nested",
+                    "properties": {
+                        "value": {
+                            "type": "text",
+                            "analyzer": "folding",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "language": {
+                            "type": "keyword"
+                        }
+                    }
+                },
                 "displaydescription": {"type": "nested", "properties": {"value": {"type": "keyword"}, "language": {"type": "keyword"}}},
                 "map_popup": {"type": "nested", "properties": {"value": {"type": "keyword"}, "language": {"type": "keyword"}}},
                 "provisional_resource": {"type": "keyword"},

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -582,6 +582,7 @@
         re-network-reponse-error='{% trans "Network response was not ok" as reNetworkReponseError %} "{{ reNetworkReponseError|escapejs }}"'
         term-search-concept='{% trans "Concepts" as termSearchConcept %} "{{ termSearchConcept|escapejs }}"'
         term-search-term='{% trans "Term Matches" as termSearchTerm %} "{{ termSearchTerm|escapejs }}"'
+        term-search-resource='{% trans "Exact Matches" as termSearchResource %} "{{ termSearchResource|escapejs }}"'
         time-wheel-date-matches='{% trans "${total} date values" as timeWheelDateMatches %} "{{ timeWheelDateMatches|escapejs }}"'
         card-constraints-placeholder='{% trans "Select Widgets" as cardConstraintsPlaceholder %} "{{ cardConstraintsPlaceholder|escapejs }}"'
         card-function-node-desc='{% trans "(This card data will define the resource description.)" as cardFunctionNodeDesc %} "{{ cardFunctionNodeDesc|escapejs }}"'

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -748,6 +748,18 @@ class ResourceCards(View):
 
 
 class ResourceDescriptors(View):
+    @staticmethod
+    def get_localized_descriptor_static(document, descriptor_type, language_codes=None):
+        if language_codes is None:
+            language_codes = (translation.get_language(), settings.LANGUAGE_CODE)
+        descriptor = document["_source"][descriptor_type]
+        result = descriptor[0] if len(descriptor) > 0 else {"value": _("Undefined")}
+        for language_code in language_codes:
+            for entry in descriptor:
+                if entry["language"] == language_code and entry["value"] != "":
+                    return entry["value"]
+        return result["value"]
+
     def get_localized_descriptor(self, document, descriptor_type):
         language_codes = (translation.get_language(), settings.LANGUAGE_CODE)
         descriptor = document["_source"][descriptor_type]

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -134,8 +134,7 @@ def search_terms(request):
 
     i = 0
     ret = {}
-    for index in ["terms", "concepts"]:
-        query = Query(se, start=0, limit=0)
+    for index in ["terms", "concepts", "resources"]:
         boolquery = Bool()
 
         if lang != "*":

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -192,15 +192,16 @@ def search_terms(request):
         if results is not None:
             if index == "resources" and results["hits"]["total"]["value"]:
                 for i, doc in enumerate(results["hits"]["hits"]):
+                    displayname_localized = ResourceDescriptors.get_localized_descriptor_static(doc, "displayname")
                     ret[index].append(
                         {
                             "type": "exactmatch",
                             "context": "",
-                            "context_label": f"{doc['_source']['displayname']} - Exact Match",
+                            "context_label": f"{displayname_localized} - {_('Exact Match')}",
                             "resourceinstanceid": doc['_id'],
                             "graph_id": doc['_source']['graph_id'],
                             "id": i,
-                            "text": doc['_source']['displayname'],
+                            "text": displayname_localized,
                             "value": doc['_id'],
                         }
                     )

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -42,6 +42,7 @@ from arches.app.search.time_wheel import TimeWheel
 from arches.app.search.components.base import SearchFilterFactory
 from arches.app.search.mappings import RESOURCES_INDEX
 from arches.app.views.base import MapBaseManagerView
+from arches.app.views.resource import ResourceDescriptors
 from arches.app.models.concept import get_preflabel_from_conceptid
 from arches.app.utils.permission_backend import get_nodegroups_by_perm, user_is_resource_reviewer, user_is_resource_exporter
 from arches.app.utils.decorators import group_required

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -180,7 +180,10 @@ def search_terms(request):
             query.add_aggregation(base_agg)
 
         ret[index] = []
-        results = query.search(index=index)
+        if index == "resources":
+            results = query.search(index=index, limit=10, scroll="1m")
+        else:
+            results = query.search(index=index)
         if results is not None:
             for result in results["aggregations"]["value_agg"]["buckets"]:
                 if len(result["top_concept"]["buckets"]) > 0:

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -142,11 +142,15 @@ def search_terms(request):
             boolquery.must(Match(field="language", query=lang, type="phrase_prefix"))
 
         if index == "resources":
+            bool_subquery = Bool()
+            bool_subquery.must(
+                Match(field="displayname.value", query=searchString.lower(), fuzziness=2)
+            )
+            if lang != "*":
+                bool_subquery.must(Match(field="displayname.language", query=lang, type="phrase_prefix"))
             nested_query = Nested( 
                 path="displayname",
-                query=Bool().must(
-                    Match(field="displayname.value", query=searchString.lower(), fuzziness=2)
-                )
+                query=bool_subquery
             )
             boolquery.must(nested_query)
             query = Query(se, start=0, limit=10, min_score=20, size=10)

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -163,19 +163,21 @@ def search_terms(request):
             boolquery.filter(Terms(field="provisional", terms=["false"]))
 
         query.add_query(boolquery)
-        base_agg = Aggregation(
-            name="value_agg", type="terms", field="value.raw", size=settings.SEARCH_DROPDOWN_LENGTH, order={"max_score": "desc"}
-        )
-        nodegroupid_agg = Aggregation(name="nodegroupid", type="terms", field="nodegroupid")
-        top_concept_agg = Aggregation(name="top_concept", type="terms", field="top_concept")
-        conceptid_agg = Aggregation(name="conceptid", type="terms", field="conceptid")
-        max_score_agg = MaxAgg(name="max_score", script="_score")
 
-        top_concept_agg.add_aggregation(conceptid_agg)
-        base_agg.add_aggregation(max_score_agg)
-        base_agg.add_aggregation(top_concept_agg)
-        base_agg.add_aggregation(nodegroupid_agg)
-        query.add_aggregation(base_agg)
+        if index != "resources":
+            base_agg = Aggregation(
+                name="value_agg", type="terms", field="value.raw", size=settings.SEARCH_DROPDOWN_LENGTH, order={"max_score": "desc"}
+            )
+            nodegroupid_agg = Aggregation(name="nodegroupid", type="terms", field="nodegroupid")
+            top_concept_agg = Aggregation(name="top_concept", type="terms", field="top_concept")
+            conceptid_agg = Aggregation(name="conceptid", type="terms", field="conceptid")
+            max_score_agg = MaxAgg(name="max_score", script="_score")
+
+            top_concept_agg.add_aggregation(conceptid_agg)
+            base_agg.add_aggregation(max_score_agg)
+            base_agg.add_aggregation(top_concept_agg)
+            base_agg.add_aggregation(nodegroupid_agg)
+            query.add_aggregation(base_agg)
 
         ret[index] = []
         results = query.search(index=index)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### TESTING THIS PR (PLEASE READ)
Because this PR changes the es mapping, you will need to reindex (delete the old and re-create with new mapping) the resources index only. it also has language support so testing with a different script is advised.

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This PR creates a new category of search term matches in the Search term-filter UX. See images below:
![Screen Shot 2023-10-01 at 4 45 18 PM](https://github.com/archesproject/arches/assets/8366985/42291bff-e8fa-4e19-823f-36edfe056a85)
![Screen Shot 2023-10-01 at 4 45 30 PM](https://github.com/archesproject/arches/assets/8366985/91303b7d-98fe-4c8a-837d-b8cf6be1b9ca)

A category of search terms called "Exact Matches" which shows any resources whose displayname is an exact or near-exact match with the entered term. On the backend, there is a significant refactor:

- the `mappings.py` file changes the property type from `"keyword"` to `"text"` and adds an analyzer so that this field can be searchable in a more optimal way akin to how values in the `terms` index are searchable:
```
"displayname": {
      "type": "nested",
      "properties": {
          "value": {
              "type": "text",
              "analyzer": "folding",
              "fields": {
                  "keyword": {
                      "type": "keyword"
                  }
              }
          },
          "language": {
              "type": "keyword"
          }
      }
  },
```

- the method `search_terms` in `views/search.py` now handles a third and different case for querying the `resources` index with the search term for a match among `displayname`. The query logic is different and the logic handling the results is different, however a context object is passed to the frontend in the same way as in the cases of `terms` and `concepts` indexes.

- the `term_filter.py` search component class now has a case for the `term.type` value of `"exactmatch"`:
```
if term["type"] == "exactmatch":
    ids_query = Ids(ids=[term["resourceinstanceid"]])
    search_query.must(ids_query)
```

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10090 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: City of Los Angeles Office of Historic Record
*   Found by: @whatisgalen 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
