### PR TITLE
removes the switching of file storage

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1600,12 +1600,7 @@ class FileListDataType(BaseDataType):
                 file_model.path = file_data
                 file_model.tile = tile
                 if models.TileModel.objects.filter(pk=tile.tileid).exists():
-                    original_storage = file_model.path.storage
-                    # Prevents Django's file storage API from overwriting files uploaded directly from client re #9321
-                    if file_data.name in [x.name for x in request.FILES.getlist("file-list_" + nodeid + "_preloaded", [])]:
-                        file_model.path.storage = FileSystemStorage()
                     file_model.save()
-                    file_model.path.storage = original_storage
                 if current_tile_data[nodeid] is not None:
                     resave_tile = False
                     updated_file_records = []
@@ -1613,6 +1608,7 @@ class FileListDataType(BaseDataType):
                         if file_json["name"] == file_data.name and file_json["url"] is None:
                             file_json["file_id"] = str(file_model.pk)
                             file_json["url"] = settings.MEDIA_URL + str(file_model.fileid)
+                            file_json["path"] = file_model.path.name
                             file_json["status"] = "uploaded"
                             resave_tile = True
                         updated_file_records.append(file_json)


### PR DESCRIPTION
Fixes #10109 which would temporarily switch the file storage to avoid writing zero byte files to the cloud to prevent duplication - this is no longer necessary.  Also outputs the file's path - which can sometimes be changed by the file storage backend.