### PR TITLE
Fix TypeError when deleting all files from tile #10057

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -193,7 +193,7 @@ class BaseDataType(object):
         except:
             data = tile["data"]
             provisionaledits = tile["provisionaledits"]
-        if data is not None and any(data.values()):
+        if data is not None and any(val is not None for val in data.values()):
             return data
         elif provisionaledits is not None and len(list(provisionaledits.keys())) > 0:
             if len(list(provisionaledits.keys())) > 1:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When attempting to delete all files from a saved tile, TypeError was raised. Now it's fixed.

A tile value of `[]` is falsey, so it was bypassing this check, meaning get_tile_data() returned an implicit None after logging "Tile has no authoritative or provisional data".

### Issues Solved
Closes #10057
Refs #9704 (for initializing k/v pairs in tile data to None)
