### PR TITLE
Fix file widget incorrectly showing unsaved #10058

### DIFF
--- a/arches/app/media/js/viewmodels/file-widget.js
+++ b/arches/app/media/js/viewmodels/file-widget.js
@@ -29,7 +29,7 @@ define([
 
 
         if (this.form) {
-            $(this.form).on('after-update', function(req, tile) {
+            this.form.on('after-update', function(req, tile) {
                 var hasdata = _.filter(tile.data, function(val, key) {
                     val = ko.unwrap(val);
                     if (val) {


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the file widget didn't update with the saved state of the tile. (The bug report shows this affecting the second uploaded file only, but after the bugfix in #10115, I started seeing it with even the first file.) 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10058

Refs f8748cfdd091cf032b3dd1fa543078763155e581
