### PR TITLE
Fix language selection in text widgets #10122

### DIFF
--- a/arches/app/media/js/views/components/widgets/rich-text.js
+++ b/arches/app/media/js/views/components/widgets/rich-text.js
@@ -80,6 +80,9 @@ define([
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
+            if(!currentValue?.[currentLanguage.code]){
+                currentValue[currentLanguage.code] = {};
+            }
             currentValue[currentLanguage.code].value = newValue?.[currentLanguage.code] ? newValue[currentLanguage.code]?.value : newValue;
             if (ko.isObservable(self.value)) {
                 self.value(currentValue);
@@ -91,6 +94,9 @@ define([
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
+            if(!currentValue?.[currentLanguage.code]){
+                currentValue[currentLanguage.code] = {};
+            }
             currentValue[currentLanguage.code].direction = newValue;
 
             if (ko.isObservable(self.value)) {

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -138,6 +138,10 @@ define([
         self.currentText.subscribe(newValue => {
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
+
+            if(!currentValue?.[currentLanguage.code]){
+                currentValue[currentLanguage.code] = {};
+            }
             currentValue[currentLanguage.code].value = newValue?.[currentLanguage.code] ? newValue[currentLanguage.code]?.value : newValue;
             
             if (ko.isObservable(self.value)) {


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, using the language picker in the text/rich text widgets would not actually save language/direction to the tile, as only the key in the I18n object was the language before changing (likely to be English).

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10122

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Testing instructions
- [ ] Text widget
  - Manipulate language, direction, save
  - Check tile data
- [ ] Repeat with rich text widget

### Further comments
LMK if I should target 7.4.x instead.