### PR TITLE
creates concat str from node names on card, searches facetFilterText …

### DIFF
--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -50,7 +50,7 @@ define([
                     card.nodes = _.filter(response.nodes, function(node) {
                         return node.nodegroup_id === card.nodegroup_id;
                     });
-                    card.nodeStrConcat = card.nodes.map(node => node.name).join(' ');
+                    card.nodeNamesConcatenated = card.nodes.map(node => node.name).join(' ');
                     card.addFacet = function() {
                         _.each(card.nodes, function(node) {
                             if (self.cardNameDict[node.nodegroup_id] && node.nodeid === node.nodegroup_id) {
@@ -90,7 +90,7 @@ define([
                                 if (facetFilterText) {
                                     graph.collapsed(false);
                                     return _.filter(graphCards, function(card) {
-                                        return card.name.toLowerCase().indexOf(facetFilterText) > -1 || card.nodeStrConcat.toLowerCase().indexOf(facetFilterText) > -1;
+                                        return card.name.toLowerCase().indexOf(facetFilterText) > -1 || card.nodeNamesConcatenated.toLowerCase().indexOf(facetFilterText) > -1;
                                     });
                                 } else {
                                     return graphCards;

--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -50,6 +50,7 @@ define([
                     card.nodes = _.filter(response.nodes, function(node) {
                         return node.nodegroup_id === card.nodegroup_id;
                     });
+                    card.nodeStrConcat = card.nodes.map(node => node.name).join(' ');
                     card.addFacet = function() {
                         _.each(card.nodes, function(node) {
                             if (self.cardNameDict[node.nodegroup_id] && node.nodeid === node.nodegroup_id) {
@@ -89,7 +90,7 @@ define([
                                 if (facetFilterText) {
                                     graph.collapsed(false);
                                     return _.filter(graphCards, function(card) {
-                                        return card.name.toLowerCase().indexOf(facetFilterText) > -1;
+                                        return card.name.toLowerCase().indexOf(facetFilterText) > -1 || card.nodeStrConcat.toLowerCase().indexOf(facetFilterText) > -1;
                                     });
                                 } else {
                                     return graphCards;


### PR DESCRIPTION
…against them and card names re #10147

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This PR includes a small change to create a concatenated string of all node names on a card so that when a user types in a text string to search among advanced search facets, a match for a node contained by a card will show that facet as a match.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10147 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Los Angeles OHR
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
