### PR TITLE
Remove duplicative spinner in `.search-result-details` #10159

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -1519,22 +1519,7 @@ ul.tabbed-report-tab-list {
 
 .file-viewer .loading-mask:after,
 .search-result-details .loading-mask::after {
-    position: fixed;
-    opacity: .5;
-    color: #7b7b7b;
-    content: '\f110';
-    -webkit-animation: fa-spin 2s infinite linear;
-    animation: fa-spin 2s infinite linear;
-    display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
-    font-size: 10vw;
-    margin-top: 42vh;
-    margin-left: 32vw;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    transform: translate(0, 0);
-    z-index: 100000001;
+    display: none;
 }
 
 .chart .plotly {


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The spinner is usually put on `.loading-mask::before`. For layout reasons, `.search-result-details` and `.file-viewer` are putting it on `.loading-mask::after`. Need to suppress the other spinner.

### Testing instructions
Try the workflow from #10159, specifically interacting with the footer of the Update Project Collection workflow in AFS, e.g. the last two pages. Add network throttle if needed.

### Issues Solved
Closes #10159

### Further comments
I'm open to other ways of doing this.