### PR TITLE
Place JSON configs for card components etc in correct place #10160

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -802,10 +802,12 @@ class Command(BaseCommand):
                 modules.extend(glob.glob(os.path.join(extension, "*.py")))
 
                 if len(modules) > 0:
+                    if os.path.exists(module_dir) is False:
+                        os.mkdir(module_dir)
                     dest_path = os.path.join(module_dir, os.path.basename(modules[0]))
                     if os.path.exists(dest_path) is False:
                         module = modules[0]
-                        shutil.copy(module, module_dir)
+                        shutil.copy(module, dest_path)
                         management.call_command(cmd, "register", source=module)
                     else:
                         logger.info("Not loading {0} from package. Extension already exists".format(modules[0]))


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, on running `manage.py packages -o load_package`, JSON files for further card components, reports, or plugins beyond the first would overwrite the previous one in place.

Noticed this in DISCO, where [here](https://github.com/archesproject/disco/blob/main/disco/card_components) I would have expected a folder containing two card components (instead, one card component only, called "card_components".

Will open a separate cleanup PR to DISCO.

### Issues Solved
Closes #10160