### PR TITLE
10119 add graph slug as class

### DIFF
--- a/arches/app/media/js/viewmodels/card-component.js
+++ b/arches/app/media/js/viewmodels/card-component.js
@@ -40,6 +40,13 @@ define([
             return this.card.widgets().length === 0;
         }, this);
 
+        this.componentCssClasses = function(widget) {
+            return ["card_component",
+                ko.unwrap(widget.node?.graph?.attributes?.slug),
+                ko.unwrap(widget.node?.alias),
+                widget?.widgetLookup[ko.unwrap(widget?.widget_id)].name].join(" ");
+        };
+
 
         this.initialize = function() {
             self.card.showForm(true);
@@ -66,7 +73,7 @@ define([
             self.dirty = ko.computed(function() {
                 if (!ko.unwrap(self.tiles)) {
                     return true;
-                } 
+                }
                 else {
                     return ko.unwrap(self.tiles).reduce(function(acc, tile) {
                         if (tile.dirty()) {
@@ -202,7 +209,7 @@ define([
             TODO: Reverse this logic to be in-line with card UX in resource_editor using this logic:
                     params.card && params.card.cardinality === 'n'
                     && params.form.componentData.cardinalityOverride !== '1'
-        */ 
+        */
         if (params.renderContext === 'workflow') {
             if (params.form.componentData.cardinalityOverride === 'n') {
                 self.card.selected(true);  // cardinality 'n' cards will display appropriately
@@ -242,7 +249,7 @@ define([
                 }
             });
         };
-        
+
         this.createParentAndChild = async(parenttile, childcard) => {
             try{
                 const newSave = await self.card.saveParentTile(parenttile);

--- a/arches/app/media/js/viewmodels/widget.js
+++ b/arches/app/media/js/viewmodels/widget.js
@@ -64,6 +64,7 @@ define([
 
         this.nodeCssClasses = ko.pureComputed(function() {
             return [ko.unwrap(self.node?.alias),
+                self.node?.graph?.attributes?.slug,
                 self.widget?.widgetLookup[ko.unwrap(self.widget?.widget_id)].name
                 ].join(" ").trim();
         });

--- a/arches/app/media/js/views/resource/editor.js
+++ b/arches/app/media/js/views/resource/editor.js
@@ -26,7 +26,7 @@ define([
     var selection = ko.observable('root');
     var scrollTo = ko.observable();
     let parsedDisplayName = undefined;
-    try { 
+    try {
         if(typeof data.displayname == 'string') {
             parsedDisplayName = JSON.parse(data.displayname);
         }
@@ -89,8 +89,8 @@ define([
     };
 
     var graphModel = new GraphModel({
-        data: {nodes: data.nodes, nodegroups: data.nodegroups, edges: []},
-        datatypes: data.datatypes
+        data: {nodes: data.nodes, nodegroups: data.nodegroups, edges: [], name: data.graph.name, slug: data.graph.slug},
+        datatypes: data.datatypes,
     });
 
     var topCards = _.filter(data.cards, function(card) {
@@ -159,6 +159,7 @@ define([
         nodeLookup: createLookup(graphModel.get('nodes')(), 'nodeid'),
         graphid: data.graphid,
         graphname: data.graphname,
+        graphslug: data.graph.slug,
         issystemsettings: data.issystemsettings,
         reviewer: data.userisreviewer,
         graphiconclass: data.graphiconclass,
@@ -170,6 +171,7 @@ define([
         graph: {
             graphid: data.graphid,
             name: data.graphname,
+            slug: data.graph.slug,
             iconclass: data.graphiconclass,
             ontologyclass: data.ontologyclass
         },
@@ -215,10 +217,10 @@ define([
         copyResource: function() {
             if (data.graph && !data.graph.publication_id) {
                 vm.alert(new AlertViewModel(
-                    'ep-alert-red', 
-                    arches.translations.resourceHasUnpublishedGraph.title, 
-                    arches.translations.resourceHasUnpublishedGraph.text, 
-                    null, 
+                    'ep-alert-red',
+                    arches.translations.resourceHasUnpublishedGraph.title,
+                    arches.translations.resourceHasUnpublishedGraph.text,
+                    null,
                     function(){}
                 ));
             }
@@ -230,10 +232,10 @@ define([
                     url: arches.urls.resource_copy.replace('//', '/' + resourceId() + '/'),
                     success: function(data) {
                         vm.alert(new AlertViewModel(
-                            'ep-alert-blue', 
-                            arches.translations.resourceCopySuccess.title, 
-                            "<a style='color: #fff; font-weight: 700;' target='_blank' href=" + arches.urls.resource_editor + data.resourceid + ">" + arches.translations.resourceCopySuccess.text + "</a>", 
-                            null, 
+                            'ep-alert-blue',
+                            arches.translations.resourceCopySuccess.title,
+                            "<a style='color: #fff; font-weight: 700;' target='_blank' href=" + arches.urls.resource_editor + data.resourceid + ">" + arches.translations.resourceCopySuccess.text + "</a>",
+                            null,
                             function(){}
                         ));
                     },
@@ -247,10 +249,10 @@ define([
             }
             else {
                 vm.alert(new AlertViewModel(
-                    'ep-alert-red', 
-                    arches.translations.resourceCopyFailed.title, 
-                    arches.translations.resourceCopyFailed.text, 
-                    null, 
+                    'ep-alert-red',
+                    arches.translations.resourceCopyFailed.title,
+                    arches.translations.resourceCopyFailed.text,
+                    null,
                     function(){}
                 ));
             }
@@ -258,12 +260,12 @@ define([
         deleteResource: function() {
             if (resourceId()) {
                 vm.menuActive(false);
-                vm.alert(new AlertViewModel('ep-alert-red', 
-                    arches.translations.confirmResourceDelete.title, 
-                    arches.translations.confirmResourceDelete.text, 
+                vm.alert(new AlertViewModel('ep-alert-red',
+                    arches.translations.confirmResourceDelete.title,
+                    arches.translations.confirmResourceDelete.text,
                     function() {
                         return;
-                    }, 
+                    },
                     function(){
                         loading(true);
                         $.ajax({

--- a/arches/app/templates/views/components/cards/default.htm
+++ b/arches/app/templates/views/components/cards/default.htm
@@ -257,9 +257,9 @@
                 <div class='new-provisional-edits-title'>
                     <span data-bind="text: $root.translations.provisionalEdits"></span>
                 </div>
-                <div 
-                    class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all" 
-                    style="padding: 3px;" 
+                <div
+                    class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all"
+                    style="padding: 3px;"
                     data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}"
                 >
                     <span data-bind="text: $root.translations.deleteAllEdits"></span>
@@ -291,7 +291,7 @@
 
                 <!-- ko if: card.model.helpenabled -->
                 <span>
-                    <a data-bind="click: function () {card.model.get('helpactive')(true) }" style="cursor:pointer;"> 
+                    <a data-bind="click: function () {card.model.get('helpactive')(true) }" style="cursor:pointer;">
                         <span data-bind="text: $root.translations.help"></span>
                         <i class="fa fa-question-circle"></i>
                     </a>
@@ -333,7 +333,9 @@
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
-            }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
+            }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } },
+            mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible,
+            class: self.componentCssClasses(widget)'></div>
                 </div>
             </form>
             {% endblock form_widgets %}
@@ -389,8 +391,8 @@
             {% block form_buttons %}
             <div class="install-buttons">
                 <!-- ko if: tile.tileid && self.deleteTile -->
-                <button 
-                    class="btn btn-shim btn-labeled btn-lg fa fa-trash" 
+                <button
+                    class="btn btn-shim btn-labeled btn-lg fa fa-trash"
                     data-bind="click: self.deleteTile, css: {disabled: (!card.isWritable && !self.preview), 'btn-warning': card.isWritable }"
                 >
                     <span data-bind="text: $root.translations.deleteThisRecord"></span>
@@ -410,7 +412,7 @@
                     </button>
                     <!-- /ko -->
                 <!-- /ko -->
-                
+
                 <!-- ko if: !tile.tileid && !showChildCards() -->
                 <button class="btn btn-shim btn-labeled btn-lg fa fa-plus" data-bind="click: self.saveTile, css: {disabled: (!card.isWritable && !self.preview), 'btn-mint': card.isWritable }">
                     <span data-bind="text: $root.translations.add"></span>

--- a/arches/app/templates/views/components/cards/grouping.htm
+++ b/arches/app/templates/views/components/cards/grouping.htm
@@ -24,7 +24,7 @@
     </a>
     <ul class="jstree-children" aria-expanded="true">
         <!-- ko foreach: {data: sortedWidgetIds, as: 'nodeId'} -->
-        <!-- ko let: $parent.getDataForDisplay(nodeId) --> 
+        <!-- ko let: $parent.getDataForDisplay(nodeId) -->
         <!-- ko if: widget.visible -->
         <!-- the let statement above returns an object of the form {widget: null, tile: null: tileData: null, card: null} -->
             <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.cards.length > 0 && expanded), 'jstree-closed' : (card.cards.length > 0 && !expanded()), 'jstree-leaf': card.cards.length === 0, 'hide-background': !self.showGrid()}">
@@ -113,7 +113,7 @@
             </li>
             <!-- /ko -->
         </div>
-       
+
     </ul>
     <!-- /ko -->
 </li>
@@ -154,9 +154,9 @@
                 <div class='new-provisional-edits-title'>
                     <span data-bind="text: $root.translations.provisionalEdits"></span>
                 </div>
-                <div 
-                    class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all" 
-                    style="padding: 3px;" 
+                <div
+                    class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all"
+                    style="padding: 3px;"
                     data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}"
                 >
                     <span data-bind="text: $root.translations.deleteAllEdits"></span>
@@ -190,7 +190,7 @@
                 <!-- /ko -->
                 <!-- ko if: card.model.helpenabled -->
                 <span>
-                    <a data-bind="click: function () {card.model.get('helpactive')(true) }" style="cursor:pointer;"> 
+                    <a data-bind="click: function () {card.model.get('helpactive')(true) }" style="cursor:pointer;">
                         <span data-bind="text: $root.translations.help"></span>
                         <i class="fa fa-question-circle"></i>
                     </a>
@@ -222,7 +222,7 @@
                                 disabled: !self.card.isWritable && !self.preview
                             }
                         }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
-                    }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
+                    }, class: self.componentCssClasses(widget), click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
                 }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
                     </div>
                 </form>
@@ -335,7 +335,7 @@
             <i class="fa report-expander print-hide" data-bind="css: {'fa-angle-down': reportExpanded(), 'fa-angle-right': !reportExpanded()}, click: function () { reportExpanded(!reportExpanded()) }"></i>
             <!-- ko if: reportExpanded() -->
             <!-- ko foreach: { data: sortedWidgetIds, as: 'nodeId' } -->
-            <!-- ko let: $parent.getDataForDisplay(nodeId) --> 
+            <!-- ko let: $parent.getDataForDisplay(nodeId) -->
             <!-- the let statement above returns an object of the form {widget: null, tile: null: tileData: null, card: null} -->
                 <div class="rp-card-section" data-bind="css: {'provisional': ko.unwrap(tile.provisionaledits) !== null && tile.userisreviewer === false, 'fullyprovisional': tile.isfullyprovisional()}">
 
@@ -402,15 +402,15 @@
 
 {% block config %}
 <div>
-    <select 
-        class="resources" 
-        multiple 
+    <select
+        class="resources"
+        multiple
         data-bind="
             placeholder: $root.translations.chooseASiblingCard + '...',
-            selectedOptions: groupedCardIds, 
-            options: siblingCards, 
-            optionsText: 'name', 
-            optionsValue: 'id', 
+            selectedOptions: groupedCardIds,
+            options: siblingCards,
+            optionsText: 'name',
+            optionsValue: 'id',
             chosen: {multiple: true, disable_search_threshold: 10, width: '100%'}
         "
     ></select>

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -8,7 +8,7 @@
 <div class="workbench-card-sidebar-tab" data-bind="click: function(){ if (self.card.tiles().length) {
         toggleTab('manage');
     }
-}, css: {'disabled': self.card.tiles().length === 0, 
+}, css: {'disabled': self.card.tiles().length === 0,
     'active': activeTab() === 'manage'
 }">
     <i class="fa fa-pencil"></i>
@@ -17,7 +17,7 @@
 <div class="workbench-card-sidebar-tab" data-bind="click: function(){ if (self.card.tiles().length) {
     toggleTab('edit');
 }
-}, css: {'disabled': self.card.tiles().length === 0, 
+}, css: {'disabled': self.card.tiles().length === 0,
     'active': activeTab() === 'edit'
 }">
     <i class="fa fa-pencil"></i>
@@ -62,7 +62,7 @@
                                         context: 'render',
                                         loading: $parent.loading
                                         }
-                                    } --> 
+                                    } -->
                                 <!-- /ko -->
                             <!--/ko-->
                         <!--/ko-->
@@ -100,7 +100,7 @@
                                         </h3>
                                     </div>
                                     <!--/ko-->
-                                    
+
                                     <!--ko if: $parent.displayContent().availableRenderers.length > 0 -->
                                     <div class="bord-top file-select loader-select">
                                         <div class="">
@@ -111,7 +111,7 @@
                                                 <span data-bind="text: ' ' + $root.translations.loaderLowercase"></span>
                                             </h4>
                                             <!--/ko-->
-                                            
+
                                             <h2>
                                                 <span data-bind="text: $root.translations.selectFileLoader"></span>
                                             </h2>
@@ -132,11 +132,11 @@
                                                                 <span><i data-bind="attr:{class: ($data.iconclass +' r-select-icon')}" class="fa fa fa-user r-select-icon"></i></span>
                                                             </div>
                                                             <div class="r-desc-container">
-                                                                <p data-bind="text: $data.description" style="color: #30517a; background-color: #fdfdfd" class="r-select-desc"></p> 
-                                                            </div>  
+                                                                <p data-bind="text: $data.description" style="color: #30517a; background-color: #fdfdfd" class="r-select-desc"></p>
+                                                            </div>
                                                         </div>
                                                     </div>
-                                    
+
                                                     <!-- card Tools -->
                                                     <div class="r-select-card-footer">
                                                         <div class="">
@@ -150,17 +150,17 @@
                                             <!--/ko-->
                                         </div>
                                     </div>
-                                    <br>  
+                                    <br>
                                 </div>
                                 <div class="file-upload-footer">
                                     <span class="loader-selector" data-bind="component: { name: 'views/components/simple-switch', params: {value: applyToAll, config:{label: $root.translations.applySameLoaderToAll}}}"></span>
                                 </div>
                                 <!--/ko-->
                                </div>
-                    
+
                             </div>
                         </div>
-                    
+
                     </div>
 
                         <!--/ko-->
@@ -229,12 +229,12 @@
     <h2 class="file-workbench-filter-header">
         <span data-bind="text: $root.translations.fileFilter"></span>
     </h2>
-    <input 
-        type="text" 
-        class="form-control" 
-        style="width: 100%; height:initial" 
+    <input
+        type="text"
+        class="form-control"
+        style="width: 100%; height:initial"
         data-bind="
-            attr: { placeholder: $root.translations.egText }, 
+            attr: { placeholder: $root.translations.egText },
             textInput: filter
         "
     ></input>
@@ -318,12 +318,12 @@
     <h2 class="file-workbench-filter-header">
         <span data-bind="text: $root.translations.fileFilter"></span>
     </h2>
-    <input 
-        type="text" 
-        class="form-control" 
-        style="width: 100%; height:initial" 
+    <input
+        type="text"
+        class="form-control"
+        style="width: 100%; height:initial"
         data-bind="
-            attr: { placeholder: $root.translations.egText }, 
+            attr: { placeholder: $root.translations.egText },
             textInput: filter
         "
     ></input>
@@ -441,7 +441,8 @@
                         "active": widget.selected,
                         "hover": widget.hovered,
                         "widget-preview": self.preview
-                    }, click: function(data, e) {
+                    }, class: self.componentCssClasses(widget),
+                    click: function(data, e) {
                         if (!widget.selected() && self.preview) widget.selected(true);
                     }, event: {
                         mouseover: function(){

--- a/arches/app/templates/views/components/iiif-annotation.htm
+++ b/arches/app/templates/views/components/iiif-annotation.htm
@@ -133,8 +133,8 @@
                                                 </label>
                                                 <div class="col-sm-8">
                                                     <div class="colorpicker-component input-group">
-                                                        <input 
-                                                            class="form-control input-md widget-input" 
+                                                        <input
+                                                            class="form-control input-md widget-input"
                                                             data-bind="
                                                                 attr: {placeholder: $root.translations.lineColor},
                                                                 colorPicker: {color: self.lineColor, format:'hex'}
@@ -150,8 +150,8 @@
                                                 </label>
                                                 <div class="col-sm-8">
                                                     <div class="colorpicker-component input-group">
-                                                        <input 
-                                                            class="form-control input-md widget-input" 
+                                                        <input
+                                                            class="form-control input-md widget-input"
                                                             data-bind="
                                                                 attr: {placeholder: $root.translations.fillColor},
                                                                 colorPicker: {color: self.fillColor, format:'hex'}
@@ -197,7 +197,7 @@
                                     </div>
                                     <div class="map-card-feature-list">
                                         <div class="add-new-feature" data-bind="visible: !self.disableDrawing()">
-                                            <select 
+                                            <select
                                                 data-bind="
                                                     placeholder: $root.translations.addANewFeature + '...',
                                                     value: self.featureLookup[widget.node_id()].selectedTool,
@@ -231,7 +231,7 @@
                                             ></select>
                                         </div>
                                         <div class="add-new-feature" data-bind="visible: self.disableDrawing">
-                                            <select 
+                                            <select
                                                 data-bind="
                                                     placeholder: $root.translations.addANewFeature + '...',
                                                     value: self.featureLookup[widget.node_id()].selectedTool,
@@ -313,7 +313,8 @@
                             "active": widget.selected,
                             "hover": widget.hovered,
                             "widget-preview": self.preview
-                        }, click: function(data, e) {
+                        }, class: self.componentCssClasses(widget),
+                        click: function(data, e) {
                             if (!widget.selected() && self.preview) widget.selected(true);
                         }, event: {
                             mouseover: function(){

--- a/arches/app/templates/views/components/map-editor.htm
+++ b/arches/app/templates/views/components/map-editor.htm
@@ -142,7 +142,7 @@
                             data:card.widgets, as: 'widget'
                         }">
                         <!-- ko if: ko.unwrap(self.form.nodeLookup[widget.node_id()].datatype) === 'geojson-feature-collection' -->
-                        <div class="row widget-wrapper">
+                        <div class="row widget-wrapper" data-bind="class: self.componentCssClasses(widget)">
                             <div class="form-group">
                                 <label class="control-label widget-input-label" for="" data-bind="text:widget.label"></label>
                                 <i data-bind="css: {'ion-asterisk widget-label-required': self.form.nodeLookup[widget.node_id()].isrequired}"></i>
@@ -150,7 +150,7 @@
                                 <div class="col-xs-12">
                                     <div class="map-card-feature-list">
                                         <div class="add-new-feature">
-                                            <select 
+                                            <select
                                                 data-bind="
                                                     placeholder: $root.translations.addANewFeature + '...',
                                                     value: self.featureLookup[widget.node_id()].selectedTool,
@@ -291,7 +291,8 @@
                             "active": widget.selected,
                             "hover": widget.hovered,
                             "widget-preview": self.preview
-                        }, click: function(data, e) {
+                        }, class: self.componentCssClasses(widget),
+                        click: function(data, e) {
                             if (!widget.selected() && self.preview) widget.selected(true);
                         }, event: {
                             mouseover: function(){

--- a/arches/app/templates/views/components/photo-workbench.htm
+++ b/arches/app/templates/views/components/photo-workbench.htm
@@ -273,7 +273,9 @@
                         "active": widget.selected,
                         "hover": widget.hovered,
                         "widget-preview": self.preview
-                    }, click: function(data, e) {
+                    },
+                    class: self.componentCssClasses(widget),
+                    click: function(data, e) {
                         if (!widget.selected() && self.preview) widget.selected(true);
                     }, event: {
                         mouseover: function(){

--- a/arches/app/templates/views/components/related-resources-map-editor.htm
+++ b/arches/app/templates/views/components/related-resources-map-editor.htm
@@ -153,12 +153,12 @@
                         <div class="buffer-control" style="padding-left: 0px">
                             <div style="display: inline-flex; justify-content: space-between; width: 100%">
                                 <div class="form-inline">
-                                <input 
-                                    type="number" 
-                                    min=0.0 
-                                    id="buffer-input" 
+                                <input
+                                    type="number"
+                                    min=0.0
+                                    id="buffer-input"
                                     class="form-control"
-                                    style="height: 34px; width: 95px" 
+                                    style="height: 34px; width: 95px"
                                     data-bind="
                                         attr: {placeholder: $root.translations.buffer},
                                         textInput: self.mapFilter.buffer
@@ -168,7 +168,7 @@
                                 </div>
                                 <div style="display: flex;">
                                     <button class="btn btn-sm btn-primary" data-bind="
-                                        click: function(){self.appendBufferToTileFeatures(widget.node_id());}, 
+                                        click: function(){self.appendBufferToTileFeatures(widget.node_id());},
                                         disable: !ko.unwrap(self.mapFilter.buffer) || !ko.unwrap(self.mapFilter.searchGeometries).length
                                         ">
                                         <span data-bind="text: $root.translations.addBufferToFeatures"></span>
@@ -207,7 +207,7 @@
                 </div>
             </div>
             <!-- /ko-->
-            
+
             {% include 'views/components/coordinate-editor.htm' %}
 
             <div class="card" style="padding-top: 45px;" data-bind="visible: geoJSONString() === undefined && showRelatedQuery() === false">
@@ -250,7 +250,8 @@
                             "active": widget.selected,
                             "hover": widget.hovered,
                             "widget-preview": self.preview
-                        }, click: function(data, e) {
+                        }, class: self.componentCssClasses(widget),
+                        click: function(data, e) {
                             if (!widget.selected() && self.preview) widget.selected(true);
                         }, event: {
                             mouseover: function(){
@@ -262,7 +263,7 @@
                         }, visible: widget.visible'></div>
                         <!--/ko-->
                         <!-- ko if: ko.unwrap(self.form.nodeLookup[widget.node_id()].datatype) === 'geojson-feature-collection' -->
-                        <div class="row widget-wrapper">
+                        <div class="row widget-wrapper" data-bind="class: self.componentCssClasses(widget)">
                             <div class="form-group">
                                 <label class="control-label widget-input-label" for="" data-bind="text:widget.label"></label>
                                 <i data-bind="css: {'ion-asterisk widget-label-required': self.form.nodeLookup[widget.node_id()].isrequired}"></i>
@@ -270,7 +271,7 @@
                                 <div class="col-xs-12">
                                     <div class="map-card-feature-list">
                                         <div class="add-new-feature">
-                                            <select 
+                                            <select
                                                 data-bind="
                                                     placeholder: $root.translations.addANewFeature + '...',
                                                     value: self.featureLookup[widget.node_id()].selectedTool,


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
- Adds the graph slug as a class to widget HTML nodes.
- Adds graph slug, widget name, node alias and static string `card_component` to widget parent HTML tag to allow more flexible formatting of page via CSS

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10119 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
