### PR TITLE
Properly assign provisional flag during index, re #10130

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -428,7 +428,7 @@ class Resource(models.ResourceInstance):
         document["numbers"] = []
         document["date_ranges"] = []
         document["ids"] = []
-        tiles_have_authoritative_data = any([any(val for val in t.data.values()) for t in tiles])
+        tiles_have_authoritative_data = any(any(val is not None for val in t.data.values()) for t in tiles)
         document["provisional_resource"] = "true" if tiles and not tiles_have_authoritative_data else "false"
 
         terms = []

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -428,7 +428,8 @@ class Resource(models.ResourceInstance):
         document["numbers"] = []
         document["date_ranges"] = []
         document["ids"] = []
-        document["provisional_resource"] = "true" if sum([len(t.data) for t in tiles]) == 0 else "false"
+        tiles_have_authoritative_data = any([any(val for val in t.data.values()) for t in tiles])
+        document["provisional_resource"] = "true" if tiles and not tiles_have_authoritative_data else "false"
 
         terms = []
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Prevents the provisional flag from getting assigned to resources that have no tiles. Also, fixes logic to assign the provisional flag to resources that have tiles, but none with authoritative data.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10130

To QA:
1. Using a provisional editor, create a resource with one provisional tile. Confirm in search that it has the provisional flag.
2. Using an authoritative editor, create a second, authoritative tile. Confirm it still has a provisional flag.
3. Delete all tiles from the resource instance. Confirm in search that it has no provisional flag.