### PR TITLE
Support Python 3.11

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -284,7 +284,7 @@ class StringDataType(BaseDataType):
     def transform_value_for_tile(self, value, **kwargs):
         language = None
         try:
-            regex = re.compile("(.+)\|([A-Za-z-]+)$", flags=re.DOTALL | re.MULTILINE)
+            regex = re.compile(r"(.+)\|([A-Za-z-]+)$", flags=re.DOTALL | re.MULTILINE)
             match = regex.match(value)
             if match is not None:
                 language = match.groups()[1]

--- a/arches/app/utils/data_management/resources/importer.py
+++ b/arches/app/utils/data_management/resources/importer.py
@@ -110,7 +110,7 @@ class BusinessDataImporter(object):
                 if isfile(join(path)):
                     self.file_format = os.path.splitext(file[0])[1].strip(".")
                     if self.file_format == "json":
-                        with open(file[0], "rU") as f:
+                        with open(file[0], "r") as f:
                             archesfile = JSONDeserializer().deserialize(f)
                             if "graph" in list(archesfile.keys()):
                                 self.graphs = archesfile["graph"]
@@ -205,7 +205,7 @@ class BusinessDataImporter(object):
                     business_data, mapping=mapping, overwrite=overwrite, prevent_indexing=prevent_indexing, transaction_id=transaction_id
                 )
             elif file_format == "jsonl":
-                with open(self.file[0], "rU") as openf:
+                with open(self.file[0], "r") as openf:
                     lines = openf.readlines()
                     if use_multiprocessing is True:
                         pool = Pool(cpu_count())

--- a/arches/install/arches-app-templates/setup.py
+++ b/arches/install/arches-app-templates/setup.py
@@ -10,6 +10,7 @@ setup(
     license="GNU AGPL3",
     packages=find_packages(),
     include_package_data=True,
+    python_requires=">=3.8",
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
@@ -24,6 +25,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Django :: 4.2",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     ],

--- a/arches/install/arches-project
+++ b/arches/install/arches-project
@@ -5,7 +5,6 @@ import argparse
 import codecs
 import django
 import errno
-import imp
 import os
 import sys
 import subprocess

--- a/arches/management/commands/datatype.py
+++ b/arches/management/commands/datatype.py
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """This module contains commands for building Arches."""
 
 import os
+import sys
+
 from arches.management.commands import utils
 from arches.app.models import models
 from django.core.management.base import BaseCommand, CommandError
@@ -55,11 +57,8 @@ class Command(BaseCommand):
         Inserts a datatype into the arches db
 
         """
-
-        import imp
-
-        dt_source = imp.load_source("", source)
-        details = dt_source.details
+        utils.load_source("dt_source", source)
+        details = sys.modules["dt_source"].details
         self.validate_details(details)
 
         dt = models.DDataType(
@@ -103,11 +102,8 @@ class Command(BaseCommand):
         Updates an existing datatype in the arches db
 
         """
-
-        import imp
-
-        dt_source = imp.load_source("", source)
-        details = dt_source.details
+        utils.load_source("dt_source", source)
+        details = sys.modules["dt_source"].details
         self.validate_details(details)
 
         instance = models.DDataType.objects.get(datatype=details["datatype"])

--- a/arches/management/commands/fn.py
+++ b/arches/management/commands/fn.py
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+import sys
 import uuid
 from arches.management.commands import utils
 from arches.app.models import models
@@ -58,11 +59,8 @@ class Command(BaseCommand):
         Inserts a function into the arches db
 
         """
-
-        import imp
-
-        fn_config = imp.load_source("", source)
-        details = fn_config.details
+        utils.load_source("fn_config", source)
+        details = sys.modules["fn_config"].details
 
         try:
             uuid.UUID(details["functionid"])

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -1243,7 +1243,7 @@ class Command(BaseCommand):
         for path in data_source:
             if os.path.isfile(os.path.join(path)):
                 print(os.path.join(path))
-                with open(path, "rU") as f:
+                with open(path, "r") as f:
                     archesfile = JSONDeserializer().deserialize(f)
                     errs, importer = ResourceGraphImporter(archesfile["graph"], overwrite_graphs)
                     errors.extend(errs)
@@ -1251,7 +1251,7 @@ class Command(BaseCommand):
                 file_paths = [file_path for file_path in os.listdir(path) if file_path.endswith(".json")]
                 for file_path in file_paths:
                     print(os.path.join(path, file_path))
-                    with open(os.path.join(path, file_path), "rU") as f:
+                    with open(os.path.join(path, file_path), "r") as f:
                         archesfile = JSONDeserializer().deserialize(f)
                         errs, importer = ResourceGraphImporter(archesfile["graph"], overwrite_graphs)
                         errors.extend(errs)
@@ -1388,6 +1388,6 @@ class Command(BaseCommand):
 
         for path in source:
             if os.path.isfile(os.path.join(path)):
-                with open(path, "rU") as f:
+                with open(path, "r") as f:
                     mapping_file = json.load(f)
                     graph_importer.import_mapping_file(mapping_file)

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -7,7 +7,6 @@ import uuid
 import sys
 import urllib.request, urllib.parse, urllib.error
 import os
-import imp
 import logging
 from arches.setup import unzip_file
 from arches.management.commands import utils
@@ -817,10 +816,14 @@ class Command(BaseCommand):
             root = settings.APP_ROOT if settings.APP_ROOT is not None else os.path.join(settings.ROOT_DIR, "app")
             dest_dir = os.path.join(root, "search_indexes")
 
+            if index_files:
+                module_name = "package_settings"
+                file_path = os.path.join(settings.APP_ROOT, "package_settings.py")
+                utils.load_source(module_name, file_path)
+
             for index_file in index_files:
                 shutil.copy(index_file, dest_dir)
-                package_settings = imp.load_source("", os.path.join(settings.APP_ROOT, "package_settings.py"))
-                for index in package_settings.ELASTICSEARCH_CUSTOM_INDEXES:
+                for index in sys.modules[module_name].ELASTICSEARCH_CUSTOM_INDEXES:
                     es_index = import_class_from_string(index["module"])(index["name"])
                     es_index.prepare_index()
 

--- a/arches/management/commands/search.py
+++ b/arches/management/commands/search.py
@@ -16,10 +16,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
+import sys
 import uuid
-import imp
+
 from arches.app.models import models
+from arches.management.commands import utils
 from django.core.management.base import BaseCommand, CommandError
 
 
@@ -57,10 +58,10 @@ class Command(BaseCommand):
 
         """
 
-        dt_source = imp.load_source("", source)
+        utils.load_source("sc_source", source)
 
-        if getattr(dt_source, "details", None):
-            details = dt_source.details
+        if getattr(sys.modules, "sc_source", None):
+            details = sys.modules["sc_source"].details
 
             try:
                 uuid.UUID(details["searchcomponentid"])
@@ -89,8 +90,8 @@ class Command(BaseCommand):
 
         """
 
-        dt_source = imp.load_source("", source)
-        name = dt_source.details["componentname"]
+        utils.load_source("sc_source", source)
+        name = sys.modules["sc_source"].details["componentname"]
 
         self.unregister(name)
         self.register(source)

--- a/arches/management/commands/utils.py
+++ b/arches/management/commands/utils.py
@@ -1,4 +1,6 @@
+import importlib.util
 import os
+import sys
 import codecs
 
 
@@ -60,3 +62,13 @@ def get_valid_path(path):
 def print_message(message):
     border = "*" * 80
     print("{1}\n{0}\n{1}".format(message, border))
+
+
+def load_source(module_name, file_path):
+    """Replacement for deprecated imp.load_source(). Recipe from
+    https://docs.python.org/3.12/library/importlib.html#importlib.abc.Loader.exec_module"""
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Django :: 4.2",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     ],

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -77,7 +77,7 @@ class ArchesTestCase(TestCase):
         super(ArchesTestCase, self).__init__(*args, **kwargs)
         if settings.DEFAULT_BOUNDS is None:
             management.call_command("migrate")
-            with open(os.path.join("tests/fixtures/system_settings/Arches_System_Settings_Model.json"), "rU") as f:
+            with open(os.path.join("tests/fixtures/system_settings/Arches_System_Settings_Model.json"), "r") as f:
                 archesfile = JSONDeserializer().deserialize(f)
             ResourceGraphImporter(archesfile["graph"], True)
             BusinessDataImporter("tests/fixtures/system_settings/Arches_System_Settings_Local.json").import_business_data()

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -52,7 +52,7 @@ class RDFExportUnitTests(ArchesTestCase):
 
         # Models
         for model_name in ["object_model", "document_model"]:
-            with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "rU") as f:
+            with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "r") as f:
                 archesfile = JSONDeserializer().deserialize(f)
             ResourceGraphImporter(archesfile["graph"])
 

--- a/tests/exporter/jsonld_export_tests.py
+++ b/tests/exporter/jsonld_export_tests.py
@@ -38,35 +38,35 @@ class JsonLDExportTests(ArchesTestCase):
         ret = skos.save_concepts_from_skos(rdf)
 
         # Load up the models and data only once
-        with open(os.path.join('tests/fixtures/jsonld_base/models/test_1_basic_object.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/test_1_basic_object.json'), 'r') as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile['graph'])
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_1_instance.json').import_business_data()
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/test_2_complex_object.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/test_2_complex_object.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph'])
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_2_instances.json').import_business_data()  
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/5136_res_inst_plus_res_inst.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/5136_res_inst_plus_res_inst.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph'])
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_3_instances.json').import_business_data()  
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/nesting_test.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/nesting_test.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph'])
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_nest_instances.json').import_business_data()  
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/4564-person.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/4564-person.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph'])        
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/4564-group.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/4564-group.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph']) 
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/4564-referenced.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/4564-referenced.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph']) 
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_4564_group.json').import_business_data()
@@ -75,12 +75,12 @@ class JsonLDExportTests(ArchesTestCase):
         management.call_command('datatype', 'register', source='tests/fixtures/datatypes/color.py')
         management.call_command('datatype', 'register', source='tests/fixtures/datatypes/semantic_like.py')
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/5299-basic.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/5299-basic.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph']) 
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_5299_instances.json').import_business_data()        
 
-        with open(os.path.join('tests/fixtures/jsonld_base/models/5299_complex.json'), 'rU') as f:
+        with open(os.path.join('tests/fixtures/jsonld_base/models/5299_complex.json'), 'r') as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2['graph']) 
         BusinessDataImporter('tests/fixtures/jsonld_base/data/test_5299_complex.json').import_business_data()       

--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -46,7 +46,7 @@ class BusinessDataExportTests(ArchesTestCase):
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_collection.xml")
         ret = skos.save_concepts_from_skos(rdf)
 
-        with open(os.path.join("tests/fixtures/resource_graphs/resource_export_test.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/resource_graphs/resource_export_test.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         LanguageSynchronizer.synchronize_settings_with_db()
         ResourceGraphImporter(archesfile["graph"])
@@ -68,7 +68,7 @@ class BusinessDataExportTests(ArchesTestCase):
 
         csv_output = list(csv.DictReader(export[0]["outputfile"].getvalue().split("\r\n")))[0]
         csvinputfile = "tests/fixtures/data/csv/resource_export_test.csv"
-        csv_input = list(csv.DictReader(open(csvinputfile, "rU", encoding="utf-8"), restkey="ADDITIONAL", restval="MISSING"))[0]
+        csv_input = list(csv.DictReader(open(csvinputfile, "r", encoding="utf-8"), restkey="ADDITIONAL", restval="MISSING"))[0]
 
         self.assertDictEqual(dict(csv_input), dict(csv_output))
 

--- a/tests/importer/datatype_from_rdf_tests.py
+++ b/tests/importer/datatype_from_rdf_tests.py
@@ -53,7 +53,7 @@ class RDFImportUnitTests(ArchesTestCase):
 
         # Models
         for model_name in ["object_model", "document_model"]:
-            with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "rU") as f:
+            with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "r") as f:
                 archesfile = JSONDeserializer().deserialize(f)
             ResourceGraphImporter(archesfile["graph"])
         # Fixture Instance Data for tests

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -56,15 +56,15 @@ class JsonLDImportTests(ArchesTestCase):
         ret = skos.save_concepts_from_skos(rdf)
 
         # Load up the models and data only once
-        with open(os.path.join("tests/fixtures/jsonld_base/models/test_1_basic_object.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/test_1_basic_object.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/test_1_basic_object_cardinality_n.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/test_1_basic_object_cardinality_n.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/test_2_complex_object.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/test_2_complex_object.json"), "r") as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2["graph"])
 
@@ -76,17 +76,17 @@ class JsonLDImportTests(ArchesTestCase):
         rdf = skos.read_file("tests/fixtures/jsonld_base/rdm/5098-collections.xml")
         ret = skos.save_concepts_from_skos(rdf)
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5098_concept_list.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5098_concept_list.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
         management.call_command("datatype", "register", source="tests/fixtures/datatypes/color.py")
         management.call_command("datatype", "register", source="tests/fixtures/datatypes/semantic_like.py")
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5299-basic.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5299-basic.json"), "r") as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2["graph"])
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5299_complex.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5299_complex.json"), "r") as f:
             archesfile2 = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile2["graph"])
 
@@ -99,27 +99,27 @@ class JsonLDImportTests(ArchesTestCase):
         ret = skos.save_concepts_from_skos(rdf)
 
         # Load up the models and data only once
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5121_false_ambiguity.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5121_false_ambiguity.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5121_external_model.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5121_external_model.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/6235_parenttile_id.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/6235_parenttile_id.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/Person.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/Person.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/nest_test.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/nest_test.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/required_ambiguous_nodes.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/required_ambiguous_nodes.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
@@ -660,7 +660,7 @@ class JsonLDImportTests(ArchesTestCase):
         """
 
         # Load up the models and data only once
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5098_b_resinst.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5098_b_resinst.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
@@ -697,7 +697,7 @@ class JsonLDImportTests(ArchesTestCase):
         ret = skos.save_concepts_from_skos(rdf)
 
         # Load up the models and data only once
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5126_collection_ambiguity.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5126_collection_ambiguity.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
@@ -834,13 +834,13 @@ class JsonLDImportTests(ArchesTestCase):
 
     def test_8_4564_resinst_models(self):
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/4564-person.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/4564-person.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
-        with open(os.path.join("tests/fixtures/jsonld_base/models/4564-group.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/4564-group.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
-        with open(os.path.join("tests/fixtures/jsonld_base/models/4564-referenced.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/4564-referenced.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
@@ -998,7 +998,7 @@ class JsonLDImportTests(ArchesTestCase):
 
     def test_b_5600_concept_label(self):
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/5600-external-label.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/5600-external-label.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
@@ -1042,7 +1042,7 @@ class JsonLDImportTests(ArchesTestCase):
 
     def test_c_path_with_array(self):
 
-        with open(os.path.join("tests/fixtures/jsonld_base/models/string_to_path_basic.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/jsonld_base/models/string_to_path_basic.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 

--- a/tests/models/mapped_archesjson_import_tests.py
+++ b/tests/models/mapped_archesjson_import_tests.py
@@ -39,7 +39,7 @@ class mappedArchesJSONImportTests(ArchesTestCase):
 
     def setUp(self):
         ResourceInstance.objects.all().delete()
-        with open(os.path.join("tests/fixtures/data/json/cardinality_test_data/target.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/data/json/cardinality_test_data/target.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -50,11 +50,11 @@ class mappedCSVFileImportTests(ArchesTestCase):
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_collection.xml")
         ret = skos.save_concepts_from_skos(rdf)
 
-        with open(os.path.join("tests/fixtures/data/json/cardinality_test_data/target.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/data/json/cardinality_test_data/target.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 
-        with open(os.path.join("tests/fixtures/data/json/cardinality_test_data/file-list.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/data/json/cardinality_test_data/file-list.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -52,7 +52,7 @@ class ResourceTests(ArchesTestCase):
         cls.client = Client()
         cls.client.login(username="admin", password="admin")
 
-        with open(os.path.join("tests/fixtures/resource_graphs/Resource Test Model.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/resource_graphs/Resource Test Model.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         resource_graph_importer(archesfile["graph"])
 

--- a/tests/utils/activitystream.py
+++ b/tests/utils/activitystream.py
@@ -106,7 +106,7 @@ class ActivityStreamCollectionTests(ArchesTestCase):
 
         # Models
         for model_name in ["object_model", "document_model"]:
-            with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "rU") as f:
+            with open(os.path.join("tests/fixtures/resource_graphs/rdf_export_{0}.json".format(model_name)), "r") as f:
                 archesfile = JSONDeserializer().deserialize(f)
             ResourceGraphImporter(archesfile["graph"])
 

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -54,19 +54,19 @@ class APITests(ArchesTestCase):
         geojson_nodeid = "3ebc6785-fa61-11e6-8c85-14109fd34195"
         cls.loadOntology()
         LanguageSynchronizer.synchronize_settings_with_db()
-        with open(os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "r") as f:
             json = JSONDeserializer().deserialize(f)
             cls.unique_graph = Graph(json["graph"][0])
             cls.unique_graph.publish(user=None)
             cls.unique_graph.save()
 
-        with open(os.path.join("tests/fixtures/resource_graphs/ambiguous_graph_shape.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/resource_graphs/ambiguous_graph_shape.json"), "r") as f:
             json = JSONDeserializer().deserialize(f)
             cls.ambiguous_graph = Graph(json["graph"][0])
             cls.ambiguous_graph.publish(user=None)
             cls.ambiguous_graph.save()
 
-        with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/resource_graphs/phase_type_assignment.json"), "r") as f:
             json = JSONDeserializer().deserialize(f)
             cls.phase_type_assignment_graph = Graph(json["graph"][0])
             cls.phase_type_assignment_graph.publish(user=None)

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -58,7 +58,7 @@ class SearchTests(ArchesTestCase):
 
         LanguageSynchronizer.synchronize_settings_with_db()
         models.ResourceInstance.objects.all().delete()
-        with open(os.path.join("tests/fixtures/resource_graphs/Search Test Model.json"), "rU") as f:
+        with open(os.path.join("tests/fixtures/resource_graphs/Search Test Model.json"), "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 


### PR DESCRIPTION
### Description of Change
- Fix incompatibility with Python 3.11 (remove deprecated/removed "universal" mode in `open()`) (See [forum post](https://community.archesproject.org/t/getting-error-valueerror-invalid-mode-ru-when-run-python-manage-py-setup-db/2127/2))
- Add classifiers showing Python 3.11 support
- Resolve DeprecationWarnings for `imp` module (deprecated in 3.4, removed in 3.12)


### Issues Solved
Closes #9832
Closes #8083

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->