### PR TITLE
Surface more meaningful error for missing graph publications #10189

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -481,13 +481,15 @@ class GraphModel(models.Model):
         else:
             return True
 
-    def get_published_graph(self, language=None):
+    def get_published_graph(self, language=None, raise_if_missing=False):
         if not language:
             language = translation.get_language()
 
         try:
             graph = PublishedGraph.objects.get(publication=self.publication, language=language)
         except PublishedGraph.DoesNotExist:
+            if raise_if_missing:
+                raise
             graph = None
 
         return graph


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
On attempting to `import_business_data` some resources belonging to an unpublished graph...
***Before***
```
2023-10-27 17:52:46,765 arches.app.utils.data_management.resources.formats.csvfile WARNING  2023-10-27 17:52:46.736085: WARNING: failed to save document in resource: 90e76649-d9ed-493f-88c3-92e4e5d2b77a on line 5. Exception detail:
'NoneType' object is not subscriptable
```
***After***
```
2023-10-27 17:50:44,986 arches.app.utils.data_management.resources.formats.csvfile WARNING  2023-10-27 17:50:44.960030: WARNING: failed to save document in resource: 90e76649-d9ed-493f-88c3-92e4e5d2b77a on line 5. Exception detail:
PublishedGraph matching query does not exist.
```

### Issues Solved
Closes #10189 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Testing instructions
This can be tested with AfS with these commands:
```sh
python3 manage.py packages -o load_package -a arches_for_science -db -dev
python3 manage.py packages -o load_business_data -s /usr/local/afs-test-pkg/pkg/business_data/Group.csv
```
