### PR TITLE
Fix race condition in resource-instance-select.js #10210

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -93,7 +93,7 @@ define([
                     .then(function(json){
                         self.graphLookup[graphid] = json.graph;
                         self.graphLookupKeys(Object.keys(self.graphLookup));
-                        self.value.valueHasMutated();
+                        self.graphIds.push(json.graph.graphid);
                         return json.graph;
                     });
             }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
If a document has >1 resource instance select widgets, they may both try to initialize select2 widgets, which manage references to the DOM and cannot handle parallel init'ing.


### Issues Solved
Fixes #10210

Sourced to a36a9465c94a29831c499a7be89610658a225519.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Testing instructions

Ensure that icons still appear in the resource instance select widget per #8305.