### PR TITLE
Handle multiple Subcard levels in Search Export.  #10199

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -68,10 +68,10 @@ class SearchResultsExporter(object):
                 if main_card.nodegroup_id == sub_card.nodegroup.parentnodegroup_id:
                     if sub_card not in main_card_list:
                         sub_cards_to_add.append(sub_card)
-                        subcards_added[0] = True
+                        subcards_added = True
             index_number = main_card_list.index(main_card) + 1
             main_card_list[index_number:index_number] = sub_cards_to_add
-            
+        return subcards_added    
         
 
     def return_ordered_header(self, graphid, export_type):
@@ -98,15 +98,14 @@ class SearchResultsExporter(object):
 
         subcard_list_with_sort.sort(key=lambda x: x.sortorder, reverse=True)
 
-        # Loop down through the levels of subcards, 'till no more sub-levels may be added.
-        subcards_added = [True]
-        while subcards_added[0]:
-            subcards_added = [False]
-            self.insert_subcard_below_parent_card(sorted_card_list, card_list_no_sort, subcards_added)
+        def order_cards(subcards_added=True):
+            if subcards_added == True:
+                subcards_added = False
+                unsorted_subcards_added = self.insert_subcard_below_parent_card(sorted_card_list, card_list_no_sort, subcards_added)
+                sorted_subcards_added = self.insert_subcard_below_parent_card(sorted_card_list, subcard_list_with_sort, unsorted_subcards_added)
+                order_cards(sorted_subcards_added)
 
-            # Cards in subcard_list_with_sort are added after cards with no sort
-
-            self.insert_subcard_below_parent_card(sorted_card_list, subcard_list_with_sort, subcards_added)
+        order_cards()
 
         # Create a list of nodes within each card and order them according to sort
         # order then add them to the main list of

--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -61,13 +61,18 @@ class SearchResultsExporter(object):
         self.output = {}
         self.set_precision = GeoUtils().set_precision
 
-    def insert_subcard_below_parent_card(self, main_card_list, sub_card_list):
-        for sub_card in sub_card_list:
-            parent_obj = sub_card.nodegroup.parentnodegroup_id
-            for main_card in main_card_list:
-                if main_card.nodegroup_id == parent_obj:
-                    index_number = main_card_list.index(main_card) + 1
-                    main_card_list.insert(index_number, sub_card)
+    def insert_subcard_below_parent_card(self, main_card_list, sub_card_list, subcards_added):
+        for main_card in main_card_list:
+            sub_cards_to_add = []
+            for sub_card in sub_card_list:
+                if main_card.nodegroup_id == sub_card.nodegroup.parentnodegroup_id:
+                    if sub_card not in main_card_list:
+                        sub_cards_to_add.append(sub_card)
+                        subcards_added[0] = True
+            index_number = main_card_list.index(main_card) + 1
+            main_card_list[index_number:index_number] = sub_cards_to_add
+            
+        
 
     def return_ordered_header(self, graphid, export_type):
 
@@ -93,11 +98,15 @@ class SearchResultsExporter(object):
 
         subcard_list_with_sort.sort(key=lambda x: x.sortorder, reverse=True)
 
-        self.insert_subcard_below_parent_card(sorted_card_list, card_list_no_sort)
+        # Loop down through the levels of subcards, 'till no more sub-levels may be added.
+        subcards_added = [True]
+        while subcards_added[0]:
+            subcards_added = [False]
+            self.insert_subcard_below_parent_card(sorted_card_list, card_list_no_sort, subcards_added)
 
-        # Cards in subcard_list_with_sort are added after cards with no sort
+            # Cards in subcard_list_with_sort are added after cards with no sort
 
-        self.insert_subcard_below_parent_card(sorted_card_list, subcard_list_with_sort)
+            self.insert_subcard_below_parent_card(sorted_card_list, subcard_list_with_sort, subcards_added)
 
         # Create a list of nodes within each card and order them according to sort
         # order then add them to the main list of


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

In the example below, I am attempting to nest:

**Discovery
└─> Location Data
____└─>Geometry**

However as **Geometry Card** is processed before it's parent **Location Data Card** is added, it can never be appended..

![image](https://github.com/archesproject/arches/assets/53860784/24f34800-21b1-475c-84a1-9f64687c5405)


To address this I have introduced a loop whilst sub-cards have been added to the main card list, to check if they have sub-cards in turn.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10199 


### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This is likely an historical remnant of when Arches only allowed sub-cards nested two levels deep.