### PR TITLE
Account for missing file metadata fields #10217

### DIFF
--- a/arches/app/media/js/viewmodels/file-widget.js
+++ b/arches/app/media/js/viewmodels/file-widget.js
@@ -247,9 +247,13 @@ define([
             // Hydrate the metadata fields in place with the active language keys if missing
             const vals = self.value();
             vals.forEach(val => {
-                Object.values(val).filter(innerVal => typeof innerVal === 'object').forEach(i18nObj => {
-                    if (i18nObj[arches.activeLanguage] === undefined) {
-                        i18nObj[arches.activeLanguage] = createStrObject('')[arches.activeLanguage];
+                ['altText', 'title', 'attribution', 'description'].forEach(metadataAttr => {
+                    if (!val[metadataAttr]) {
+                        // Metadata fields missing entirely
+                        val[metadataAttr] = createStrObject('');  // ensures active language
+                    } else if (!val[metadataAttr][arches.activeLanguage]) {
+                        // Active language missing
+                        val[metadataAttr][arches.activeLanguage] = createStrObject('')[arches.activeLanguage];
                     }
                 });
             });


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fix the hydration of file metadata fields when loading saved tile data. As of #9934 (dev/7.5), only specific missing languages were handled, not *all* languages (which would be the case for existing tile data).

The intent here is to stay flexible and avoid a data migration where we need to store a bunch of empty key-value pairs for each possible language in the db.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10217

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
