### PR TITLE
Hide the separator line for invisible card, #10219

### DIFF
--- a/arches/app/templates/views/report-templates/default.htm
+++ b/arches/app/templates/views/report-templates/default.htm
@@ -55,7 +55,7 @@
     <div class="rp-report-section relative rp-report-section-root">
         <div class="rp-report-section-title">
             <!-- ko foreach: { data: report.cards, as: 'card' } -->
-                <!-- ko if: ($parent.hideEmptyNodes() === false || card.tiles().length > 0) && card.params.card.visible -->
+                <!-- ko if: ($parent.hideEmptyNodes() === false || card.tiles().length > 0) && ko.unwrap(card.model.visible) -->
                 <!-- ko if: $index() !== 0 --><hr class="rp-tile-separator"><!-- /ko -->
                 <div class="rp-card-section">
                     <!-- ko component: {

--- a/arches/app/templates/views/report-templates/default.htm
+++ b/arches/app/templates/views/report-templates/default.htm
@@ -55,7 +55,7 @@
     <div class="rp-report-section relative rp-report-section-root">
         <div class="rp-report-section-title">
             <!-- ko foreach: { data: report.cards, as: 'card' } -->
-                <!-- ko if: $parent.hideEmptyNodes() === false || card.tiles().length > 0 -->
+                <!-- ko if: ($parent.hideEmptyNodes() === false || card.tiles().length > 0) && card.params.card.visible -->
                 <!-- ko if: $index() !== 0 --><hr class="rp-tile-separator"><!-- /ko -->
                 <div class="rp-card-section">
                     <!-- ko component: {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The default report will hide the tile separator lines when the card is invisible. #10219 
Fix the issue with showing only the separator with no contents in the card that participate in the other grouping card.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10219 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
