### PR TITLE
9180 Handles Tile Excel Export Generation for Windows

### DIFF
--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import shutil
+import sys
 from celery import shared_task
 from datetime import datetime
 from datetime import timedelta
@@ -65,12 +66,20 @@ def export_search_results(self, userid, request_values, format, report_link):
         exporter = SearchResultsExporter(search_request=new_request)
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
-        with NamedTemporaryFile() as tmp:
+
+        if sys.platform == "win32":
+            tmp = NamedTemporaryFile(dir=settings.TEMP_DIRECTORY, delete=False)
+        else:
+            tmp = NamedTemporaryFile()
+                    
+        with tmp:
             wb.save(tmp.name)
             tmp.seek(0)
             stream = tmp.read()
             export_files[0]["outputfile"] = tmp
             exportid = exporter.write_export_zipfile(export_files, export_info, export_name)
+
+            
     else:
         exporter = SearchResultsExporter(search_request=new_request)
         files, export_info = exporter.export(format, report_link)

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -21,6 +21,7 @@ from datetime import datetime
 import logging
 import os
 import json
+import sys
 from django.contrib.auth import authenticate
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.cache import cache
@@ -260,7 +261,13 @@ def export_results(request):
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
-        with NamedTemporaryFile() as tmp:
+        
+        if sys.platform != "win32":
+            tmp = NamedTemporaryFile()
+        else:
+            tmp = NamedTemporaryFile(dir=settings.TILE_EXCEL_EXPORT_TEMP_DIRECTORY, delete=settings.TILE_EXCEL_EXPORT_TEMP_FILE_DELETE)
+                    
+        with tmp:
             wb.save(tmp.name)
             tmp.seek(0)
             stream = tmp.read()

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -260,10 +260,10 @@ def export_results(request):
     elif format == "tilexl":
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)
-        wb = export_files[0]["outputfile"]
-        
+        wb = export_files[0]["outputfile"]  
+
         if sys.platform == "win32":
-            tmp = NamedTemporaryFile(dir=settings.TILE_EXCEL_EXPORT_TEMP_DIRECTORY, delete=settings.TILE_EXCEL_EXPORT_TEMP_FILE_DELETE)
+            tmp = NamedTemporaryFile(dir=settings.TEMP_DIRECTORY, delete=False)
         else:
             tmp = NamedTemporaryFile()
                     
@@ -273,6 +273,7 @@ def export_results(request):
             stream = tmp.read()
             export_files[0]["outputfile"] = tmp
             return zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
+
     else:
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -262,10 +262,10 @@ def export_results(request):
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
         
-        if sys.platform != "win32":
-            tmp = NamedTemporaryFile()
-        else:
+        if sys.platform == "win32":
             tmp = NamedTemporaryFile(dir=settings.TILE_EXCEL_EXPORT_TEMP_DIRECTORY, delete=settings.TILE_EXCEL_EXPORT_TEMP_FILE_DELETE)
+        else:
+            tmp = NamedTemporaryFile()
                     
         with tmp:
             wb.save(tmp.name)

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -519,6 +519,9 @@ UUID_REGEX = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-
 
 OAUTH2_PROVIDER = {"ACCESS_TOKEN_EXPIRE_SECONDS": 604800}  # one week
 
+TILE_EXCEL_EXPORT_TEMP_DIRECTORY = None
+TILE_EXCEL_EXPORT_TEMP_FILE_DELETE = True
+
 #######################################
 ###       END STATIC SETTINGS       ###
 #######################################

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -519,8 +519,8 @@ UUID_REGEX = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-
 
 OAUTH2_PROVIDER = {"ACCESS_TOKEN_EXPIRE_SECONDS": 604800}  # one week
 
-TILE_EXCEL_EXPORT_TEMP_DIRECTORY = None
-TILE_EXCEL_EXPORT_TEMP_FILE_DELETE = True
+TEMP_DIRECTORY = None
+
 
 #######################################
 ###       END STATIC SETTINGS       ###


### PR DESCRIPTION
### Types of changes

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

Addition of an If/Else statement to handle how NamedTemporaryFile is generated based on whether the operating system is Windows or not.  Also the addition, in settings.py, of default settings relating to the arguments required for NamedTemporaryFile in a Windows deployment.

### Issues Solved

#9180

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

Tested on local deployments, Linux and Windows, to ensure correct behaviour in both instances.

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @csmith-he 
*   Tested by: @csmith-he 
*   Designed by: @csmith-he 

