### PR TITLE
Add missing `{{ block.super }}` to javascript.htm instructions

### DIFF
--- a/releases/7.0.0.md
+++ b/releases/7.0.0.md
@@ -216,6 +216,7 @@ following example with our `reports/default.js` component:
     {% load i18n %}
 
     {% block arches_translations %}
+    {{ block.super }}
     <div 
         class='arches-translations'
         my-key-name='{% trans "My key value." as myKeyValue %} "{{ myKeyValue|escapejs }}"'

--- a/releases/7.1.0.md
+++ b/releases/7.1.0.md
@@ -324,6 +324,7 @@ following example with our `reports/default.js` component:
     {% load i18n %}
 
     {% block arches_translations %}
+    {{ block.super }}
     <div 
         class='arches-translations'
         my-key-name='{% trans "My key value." as myKeyValue %} "{{ myKeyValue|escapejs }}"'

--- a/releases/7.1.1.md
+++ b/releases/7.1.1.md
@@ -339,6 +339,7 @@ following example with our `reports/default.js` component:
     {% load i18n %}
 
     {% block arches_translations %}
+    {{ block.super }}
     <div 
         class='arches-translations'
         my-key-name='{% trans "My key value." as myKeyValue %} "{{ myKeyValue|escapejs }}"'

--- a/releases/7.2.0.md
+++ b/releases/7.2.0.md
@@ -343,6 +343,7 @@ following example with our `reports/default.js` component:
     {% load i18n %}
 
     {% block arches_translations %}
+    {{ block.super }}
     <div 
         class='arches-translations'
         my-key-name='{% trans "My key value." as myKeyValue %} "{{ myKeyValue|escapejs }}"'


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
`{{ block.super }}` is necessary to avoid losing all of the strings defined in core arches.

### Issues Solved
Noticed upgrading an arches project to 7.5 and including a new string.