### PR TITLE
default canvas names should be blank - not 'undefined' #10204

### DIFF
--- a/arches/app/media/js/views/components/plugins/manifest-manager.js
+++ b/arches/app/media/js/views/components/plugins/manifest-manager.js
@@ -222,7 +222,7 @@ define([
                 self.formData.append("manifest_attribution", ko.unwrap(self.manifestAttribution));
                 self.formData.append("manifest_logo", ko.unwrap(self.manifestLogo));
                 self.formData.append("manifest", ko.unwrap(self.manifest));
-                self.formData.append("canvas_label", ko.unwrap(self.canvasLabel)); //new label for canvas
+                self.formData.append("canvas_label", ko.unwrap(self.canvasLabel) ?? ''); //new label for canvas
                 self.formData.append("canvas_id", ko.unwrap(self.canvas)); //canvas id for label change
                 self.formData.append("metadata", JSON.stringify(koMapping.toJS(self.manifestMetadata)));
                 self.updateCanvas = false;

--- a/arches/app/views/manifest_manager.py
+++ b/arches/app/views/manifest_manager.py
@@ -95,7 +95,7 @@ class ManifestManagerView(View):
                         },
                     }
                 ],
-                "label": f"{file_name}",
+                "label": "",
                 "license": "TBD",
                 "thumbnail": {
                     "@id": thumbnail_id,

--- a/arches/app/views/manifest_manager.py
+++ b/arches/app/views/manifest_manager.py
@@ -95,7 +95,7 @@ class ManifestManagerView(View):
                         },
                     }
                 ],
-                "label": "",
+                "label": f"{file_name}",
                 "license": "TBD",
                 "thumbnail": {
                     "@id": thumbnail_id,


### PR DESCRIPTION
sets the default canvas name to 'blank' - corrects issue where it can occasionally be 'undefined'.