### PR TITLE
9224 - Do not require hostname in resource instance search string

### DIFF
--- a/arches/app/media/js/viewmodels/resource-instance-select.js
+++ b/arches/app/media/js/viewmodels/resource-instance-select.js
@@ -10,7 +10,7 @@ define([
     var graphCache = {};
 
     require(['views/components/related-instance-creator']);
-    
+
     /**
     * A viewmodel used for generic alert messages
     *
@@ -18,7 +18,7 @@ define([
     * @name ResourceInstanceSelectViewModel
     *
     * @param  {object} params
-    * @param  {object} params.node (optional) - if supplied will assume that a node in an editor is being managed and will show 
+    * @param  {object} params.node (optional) - if supplied will assume that a node in an editor is being managed and will show
     * the table of ontologyProperties below the dropdown otherwise the table will be hidden and you will have to populate params.graphids
     * @param  {boolean} params.graphids (optional) - if params.node is not supplied then you need to supply a list of graphids that can be used to get resource instances for the dropdown
     * @param  {boolean} params.multiple - whether to display multiple values in the dropdown/table
@@ -43,10 +43,10 @@ define([
         this.preview = arches.graphs.length > 0;
         this.renderContext = params.renderContext;
         this.relationship = ko.observable();
-        /* 
-            shoehorn logic to piggyback off of search context functionality. 
+        /*
+            shoehorn logic to piggyback off of search context functionality.
             Should be refactored when we get the chance for better component clarity.
-        */ 
+        */
         if (params.renderContext === 'workflow') {
             self.renderContext = 'search';
         }
@@ -99,7 +99,7 @@ define([
             }
         };
 
-        // depending on where the widget is being rendered there are several ways to get the ontologyclass 
+        // depending on where the widget is being rendered there are several ways to get the ontologyclass
         if(!!params.node && params.state !== 'display_value'){
             if(!!params.node.graph && !!params.node.graph.get('root')){
                 this.rootOntologyClass = params.node.graph.get('root').ontologyclass();
@@ -123,7 +123,7 @@ define([
                 self.downloadGraph(graphid);
             });
         }
-    
+
         this.resourceInstanceDisplayName = params.form && params.form.displayname ? params.form.displayname() : '';
         this.makeFriendly = ontologyUtils.makeFriendly;
         this.getSelect2ConfigForOntologyProperties = ontologyUtils.getSelect2ConfigForOntologyProperties;
@@ -144,7 +144,7 @@ define([
                 }
             }
         };
-        
+
         WidgetViewModel.apply(this, [params]);
 
         // if a default resource instance is defined, then show them in the ui
@@ -167,7 +167,7 @@ define([
                 ri.inverseOntologyProperty.subscribe(function(){
                     self.defaultResourceInstance(self.value());
                 });
-                ret.push(ri); 
+                ret.push(ri);
             });
             // only set the default values if the tile has never been saved before OR if this is the config form
             if ((this.tile && !this.tile.noDefaults && ko.unwrap(this.tile.tileid) == "" && ret.length > 0) || !!params.configForm) {
@@ -176,16 +176,16 @@ define([
         }
 
         this.displayValue = ko.observable('');
-        
+
         //
-        // this.close is only called if newResourceInstance is True and the user 
+        // this.close is only called if newResourceInstance is True and the user
         // decides not to add the new resource instance, and closes the window without adding it
         //
         this.close = function(){
             this.newResourceInstance(null);
         };
-        
-        
+
+
         this.setValue = function(valueObject) {
             if (self.multiple) {
                 valueObject = [valueObject];
@@ -200,7 +200,7 @@ define([
                 self.defaultResourceInstance(self.value());
             }
         };
-        
+
         this.lookupResourceInstanceData = function(resourceid) {
             if (resourceLookup[resourceid]) {
                 return Promise.resolve(resourceLookup[resourceid]);
@@ -219,7 +219,7 @@ define([
                     });
             }
         };
-        
+
         if(self.renderContext !== 'search'){
             var updateNameAndOntologyClass = function(values) {
                 var names = [];
@@ -253,7 +253,7 @@ define([
                     });
                 }
             };
-    
+
             self.value.subscribe(updateNameAndOntologyClass);
             // Resolve Resource Instance Names from the incoming values
             self.value.valueHasMutated();
@@ -288,10 +288,10 @@ define([
                     if (ontologyProperties) {
                         if (ontologyProperties.useOntologyRelationship) {
                             ontologyProperty = ontologyProperty || ontologyProperties.ontologyProperty;
-                            inverseOntologyProperty = inverseOntologyProperty || ontologyProperties.inverseOntologyProperty;    
+                            inverseOntologyProperty = inverseOntologyProperty || ontologyProperties.inverseOntologyProperty;
                         } else {
                             ontologyProperty = ontologyProperties.relationshipConcept;
-                            inverseOntologyProperty = ontologyProperties.inverseRelationshipConcept;    
+                            inverseOntologyProperty = ontologyProperties.inverseRelationshipConcept;
                         }
                     }
                 }
@@ -302,7 +302,7 @@ define([
                 "ontologyProperty": ko.observable(ontologyProperty || ""),
                 "inverseOntologyProperty": ko.observable(inverseOntologyProperty || ""),
                 "resourceXresourceId": ""
-            };            
+            };
             Object.defineProperty(ret, 'resourceName', {value: ko.observable(esSource.displayname)});
             Object.defineProperty(ret, 'ontologyClass', {value: ko.observable(esSource.root_ontology_class)});
             Object.defineProperty(ret, 'iconClass', {value: ko.observable(iconClass)});
@@ -314,7 +314,7 @@ define([
                     self.defaultResourceInstance(self.value());
                 });
             }
-            
+
             return ret;
         };
 
@@ -325,7 +325,7 @@ define([
         this.disabled = ko.computed(function() {
             return ko.unwrap(self.waitingForGraphToDownload) || ko.unwrap(params.disabled) || !!ko.unwrap(params.form?.locked);
         });
-        
+
         this.select2Config = {
             value: self.renderContext === 'search' ? self.value : self.resourceToAdd,
             clickBubble: true,
@@ -347,7 +347,7 @@ define([
                                 if(self.displayOntologyTable){
                                     self.resourceToAdd("");
                                 }
-                            }, 250);    
+                            }, 250);
                         }
                     } else {
                         // This section is used when creating a new resource Instance
@@ -414,9 +414,9 @@ define([
                         self.url(arches.urls.search_results);
                         var queryString = new URLSearchParams();
                         if (self.searchString) {
-                            const searchUrl = new URL(self.searchString);
+                            const searchUrl = new URL(self.searchString.startsWith("/") ? `${window.location.origin}${self.searchString}` : self.searchString);
                             queryString = new URLSearchParams(searchUrl.search);
-                        } 
+                        }
                         queryString.set('paging-filter', page);
 
                         // merge resource type filters
@@ -516,7 +516,7 @@ define([
                         var resourceInstance = self.lookupResourceInstanceData(resourceId).then(
                             function(resourceInstance) { return resourceInstance; }
                         );
-           
+
                         if (resourceInstance) { lookups.push(resourceInstance); }
                     });
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This change allows the resource instance select search string to be an absolute path without location origin sections of the url (`https://<hostname>:<port>`

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9224 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Did not include omission of the context root as that is likely specific to our implementation and would require a larger change.
