### PR TITLE
Fix function registration

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -797,7 +797,10 @@ class Command(BaseCommand):
                     else:
                         logger.info("Not loading {0} from package. Extension already exists".format(components[0]))
 
-                modules = glob.glob(os.path.join(extension, "*.json"))
+                modules = []
+                if not os.path.isdir(extension):
+                    modules.extend(extension)
+                modules.extend(glob.glob(os.path.join(extension, "*.json")))
                 modules.extend(glob.glob(os.path.join(extension, "*.py")))
 
                 if len(modules) > 0:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The sample function file and the [docs](https://arches.readthedocs.io/en/stable/developing/extending/extensions/functions/#creating-a-function) both suggest
placing function.py files loose under /extensions/functions, e.g.
extensions/functions/foo.py.

The globbing pattern here was skipping over them, expecting
them instead at extensions/functions/foo/foo.py, like [card components and friends](https://github.com/archesproject/arches-for-science/tree/e2679e74ea14619c03e1b613db3cd9b40808d6cb/arches_for_science/pkg/extensions/card_components).

The intent here is to handle this without breaking the existing pattern for card components, etc., that _does_ expect a directory to contain them. Or, we should reject this change and start enforcing/documenting that functions need to be contained in a folder.