### PR TITLE
Fix function registration (again) re #10286

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -799,7 +799,7 @@ class Command(BaseCommand):
 
                 modules = []
                 if not os.path.isdir(extension):
-                    modules.extend(extension)
+                    modules.append(extension)
                 modules.extend(glob.glob(os.path.join(extension, "*.json")))
                 modules.extend(glob.glob(os.path.join(extension, "*.py")))
 


### PR DESCRIPTION
Haste makes waste, re #10286. 😅

Was getting a hilarious array of modules:
```py
(Pdb) modules
['/', 'w', 'e', 'b', '_', 'r', 'o', 'o', 't', '/', 'a', 'r', 'c', 'h', 'e', 's', '-', 'f', 'o', 'r', '-', 's', 'c', 'i', 'e', 'n', 'c', 'e', '/', 'a', 'r', 'c', 'h', 'e', 's', '_', 'f', 'o', 'r', '_', 's', 'c', 'i', 'e', 'n', 'c', 'e', '/', 'p', 'k', 'g', '/', 'e', 'x', 't', 'e', 'n', 's', 'i', 'o', 'n', 's', '/', 'f', 'u', 'n', 'c', 't', 'i', 'o', 'n', 's', '/', 'm', 'u', 'l', 't', 'i', 'c', 'a', 'r', 'd', '_', 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e', '_', 'd', 'e', 's', 'c', 'r', 'i', 'p', 't', 'o', 'r', '.', 'p', 'y']
```