### PR TITLE
Add contenttypes dependency to initial migration #10302

### DIFF
--- a/arches/app/models/migrations/0001_initial.py
+++ b/arches/app/models/migrations/0001_initial.py
@@ -92,7 +92,9 @@ def make_permissions(apps, schema_editor, with_create_permissions=True):
 
 class Migration(migrations.Migration):
 
-    dependencies = []
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+    ]
 
     initial = True
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fixes intermittent failures when migrating a fresh database like this:
```
django.db.utils.IntegrityError: null value in column "name" of relation "django_content_type" violates not-null constraint
DETAIL:  Failing row contains (1, null, models, bulkindexqueue).
```

The migration now depended on removes that `name` field, so that would make sense that it prevents the given error.

### Issues Solved
Closes #10302

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls 
*   Tested by: @jacobtylerwalls 
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
cc/ @aarongundel as we looked at this [once already in AFS](https://github.com/archesproject/arches-for-science/pull/1366/files#r1372042167). My plan is to remove the similar change I made in that PR to the second migration in AFS once we merge here in core.