### PR TITLE
Prevent concept widget from allowing selection of concepts outside collection

### DIFF
--- a/arches/app/models/concept.py
+++ b/arches/app/models/concept.py
@@ -639,6 +639,13 @@ class Concept(object):
                             JOIN values ON(values.conceptid = c.conceptidto)
                             WHERE LOWER(values.value) like %(query)s
                             AND values.valuetype in ('prefLabel')
+                            AND LOWER(values.value) != %(match)s
+                                UNION
+                            SELECT c.conceptidfrom, c.conceptidto, '0' as row, c.depth, c.collector
+                            FROM children c
+                            JOIN values ON(values.conceptid = c.conceptidto)
+                            WHERE LOWER(values.value) = %(match)s
+                            AND values.valuetype in ('prefLabel')
                                 UNION
                             SELECT c.conceptidfrom, c.conceptidto, c.row, c.depth, c.collector
                             FROM children c
@@ -662,6 +669,7 @@ class Concept(object):
                     "limit": limit,
                     "offset": offset,
                     "query": "%" + query.lower() + "%",
+                    "match": query.lower(),
                     "recursive_table": AsIs(recursive_table),
                     "languageid": languageid,
                     "short_languageid": languageid.split("-")[0] + "%",

--- a/arches/app/views/concept.py
+++ b/arches/app/views/concept.py
@@ -392,7 +392,6 @@ def paged_dropdown(request):
         for d in data
     ]
 
-
     return JSONResponse({"results": data, "more": offset + limit < total_count})
 
 

--- a/arches/app/views/concept.py
+++ b/arches/app/views/concept.py
@@ -392,42 +392,6 @@ def paged_dropdown(request):
         for d in data
     ]
 
-    # This try/except block trys to find an exact match to the concept the user is searching and if found
-    # it will insert it into the results as the first item so that users don't have to scroll to find it.
-    # See: https://github.com/archesproject/arches/issues/8355
-    try:
-        if page == 1:
-            found = False
-            for i, d in enumerate(data):
-                if i <= 7 and d["text"].lower() == query.lower():
-                    found = True
-                    break
-            if not found:
-                languageid = get_language().lower()
-                cursor = connection.cursor()
-                cursor.execute(
-                    """
-                        SELECT value, valueid
-                        FROM
-                        (
-                            SELECT *, CASE WHEN LOWER(languageid) = %(languageid)s THEN 10
-                            WHEN LOWER(languageid) like %(short_languageid)s THEN 5
-                            ELSE 0
-                            END score
-                            FROM values
-                        ) as vals
-                        WHERE LOWER(value)=%(query)s AND score > 0
-                        AND valuetype in ('prefLabel')
-                        ORDER BY score desc limit 1
-                    """,
-                    {"languageid": languageid, "short_languageid": languageid.split("-")[0] + "%", "query": query.lower()},
-                )
-                rows = cursor.fetchall()
-
-                if len(rows) == 1:
-                    data.insert(0, {"id": str(rows[0][1]), "text": rows[0][0], "depth": 1, "collector": False})
-    except:
-        pass
 
     return JSONResponse({"results": data, "more": offset + limit < total_count})
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Previously a second db query was performed to identify exact matches and place them at the top of a concept widget result set. This allowed concepts to appear that existed outside of a nodes collection. This fix identifies exact matches limited within a nodes collection. 

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10307, #10306
