### PR TITLE
Add Windows compatibility to tile excel export #9180

### DIFF
--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -65,12 +65,13 @@ def export_search_results(self, userid, request_values, format, report_link):
         exporter = SearchResultsExporter(search_request=new_request)
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
-        with NamedTemporaryFile() as tmp:
+        with NamedTemporaryFile(delete=False) as tmp:
             wb.save(tmp.name)
             tmp.seek(0)
             stream = tmp.read()
             export_files[0]["outputfile"] = tmp
             exportid = exporter.write_export_zipfile(export_files, export_info, export_name)
+        os.unlink(tmp.name)
     else:
         exporter = SearchResultsExporter(search_request=new_request)
         files, export_info = exporter.export(format, report_link)

--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -43,6 +43,7 @@ def export_search_results(self, userid, request_values, format, report_link):
     from arches.app.search.search_export import SearchResultsExporter
     from arches.app.models.system_settings import settings
 
+    logger = logging.getLogger(__name__)
     settings.update_from_db()
 
     create_user_task_record(self.request.id, self.name, userid)
@@ -65,12 +66,16 @@ def export_search_results(self, userid, request_values, format, report_link):
         exporter = SearchResultsExporter(search_request=new_request)
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
-        with NamedTemporaryFile(delete=False) as tmp:
-            wb.save(tmp.name)
-            tmp.seek(0)
-            stream = tmp.read()
-            export_files[0]["outputfile"] = tmp
-            exportid = exporter.write_export_zipfile(export_files, export_info, export_name)
+        try:
+            with NamedTemporaryFile(delete=False) as tmp:
+                wb.save(tmp.name)
+                tmp.seek(0)
+                stream = tmp.read()
+                export_files[0]["outputfile"] = tmp
+                exportid = exporter.write_export_zipfile(export_files, export_info, export_name)
+        except OSError:
+            logger.error("Temp file could not be created.")
+            raise
         os.unlink(tmp.name)
     else:
         exporter = SearchResultsExporter(search_request=new_request)

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -260,12 +260,16 @@ def export_results(request):
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
-        with NamedTemporaryFile(delete=False) as tmp:
-            wb.save(tmp.name)
-            tmp.seek(0)
-            stream = tmp.read()
-            export_files[0]["outputfile"] = tmp
-            result = zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
+        try:
+            with NamedTemporaryFile(delete=False) as tmp:
+                wb.save(tmp.name)
+                tmp.seek(0)
+                stream = tmp.read()
+                export_files[0]["outputfile"] = tmp
+                result = zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
+        except OSError:
+            logger.error("Temp file could not be created.")
+            raise
         os.unlink(tmp.name)
         return result
     else:

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -260,12 +260,14 @@ def export_results(request):
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)
         wb = export_files[0]["outputfile"]
-        with NamedTemporaryFile() as tmp:
+        with NamedTemporaryFile(delete=False) as tmp:
             wb.save(tmp.name)
             tmp.seek(0)
             stream = tmp.read()
             export_files[0]["outputfile"] = tmp
-            return zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
+            result = zip_utils.zip_response(export_files, zip_file_name=f"{settings.APP_NAME}_export.zip")
+        os.unlink(tmp.name)
+        return result
     else:
         exporter = SearchResultsExporter(search_request=request)
         export_files, export_info = exporter.export(format, report_link)


### PR DESCRIPTION
Hey @csmith-he :wave: Thanks for the additional details on #9180--very helpful!

***
I opened this draft just to demo my idea at https://github.com/archesproject/arches/pull/10237#discussion_r1384194720.

Really, it's a lot like your solution in #10237, but it just programmatically deletes the file (and thus nothing left behind to clean up.)

From the traceback you posted, the failure on `wb.save()` suggests to me that the file was opened with `delete=True`, which I would [expect to fail on Windows](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) with PermissionError if reopened (as wb.save() tries to do).

***
I'd be grateful if you'd be willing to see if this diff solves your use case. Or if it doesn't, if it perhaps produces a different traceback.