### PR TITLE
Rate-limit login views

### DIFF
--- a/arches/app/templates/login.htm
+++ b/arches/app/templates/login.htm
@@ -72,7 +72,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 						<div style="{% if not auth_failed %}display:none;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert">
 							<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans "Close" %}</span></button>
 							<h4>{% trans "Login failed" %}</h4>
-							<span>{% trans "Invalid username and/or password." %}</span>
+							<span>{% if rate_limited %}{% trans "Too many requests." %}{% else %}{% trans "Invalid username and/or password." %}{% endif %}</span>
 						</div>
 					</div>
 				</form>

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1061,10 +1061,7 @@ class SearchExport(View):
         download_limit = settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
         format = request.GET.get("format", "tilecsv")
         report_link = request.GET.get("reportlink", False)
-        if "HTTP_AUTHORIZATION" in request.META and (
-            (request.user is not None and request.user.is_authenticated and not request.user.is_anonymous)
-            or not request.get("limited", False)
-        ):
+        if "HTTP_AUTHORIZATION" in request.META and not request.get("limited", False):
             request_auth = request.META.get("HTTP_AUTHORIZATION").split()
             if request_auth[0].lower() == "basic":
                 user_cred = b64decode(request_auth[1]).decode().split(":")

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -30,6 +30,7 @@ from django.utils.translation import ugettext as _
 from django.core.files.base import ContentFile
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
+from django_ratelimit.decorators import ratelimit
 from arches.app.models import models
 from arches.app.models.concept import Concept
 from arches.app.models.card import Card as CardProxyModel
@@ -1054,12 +1055,16 @@ class Card(APIBase):
 
 
 class SearchExport(View):
+    @method_decorator(ratelimit(key="header:http-authorization", rate=settings.RATE_LIMIT, block=False))
     def get(self, request):
         total = int(request.GET.get("total", 0))
         download_limit = settings.SEARCH_EXPORT_IMMEDIATE_DOWNLOAD_THRESHOLD
         format = request.GET.get("format", "tilecsv")
         report_link = request.GET.get("reportlink", False)
-        if "HTTP_AUTHORIZATION" in request.META:
+        if "HTTP_AUTHORIZATION" in request.META and (
+            (request.user is not None and request.user.is_authenticated and not request.user.is_anonymous)
+            or not request.get("limited", False)
+        ):
             request_auth = request.META.get("HTTP_AUTHORIZATION").split()
             if request_auth[0].lower() == "basic":
                 user_cred = b64decode(request_auth[1]).decode().split(":")

--- a/arches/app/views/auth.py
+++ b/arches/app/views/auth.py
@@ -37,6 +37,7 @@ from django.contrib.auth.models import User, Group
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 import django.contrib.auth.password_validation as validation
+from django_ratelimit.decorators import ratelimit
 from arches import __version__
 from arches.app.utils.response import JSONResponse, Http401Response
 from arches.app.utils.forms import ArchesUserCreationForm, ArchesPasswordResetForm, ArchesSetPasswordForm
@@ -72,13 +73,22 @@ class LoginView(View):
                 },
             )
 
+    @method_decorator(ratelimit(key="post:username", rate=settings.RATE_LIMIT, block=False))
     def post(self, request):
         # POST request is taken to mean user is logging in
-        auth_attempt_success = None
+        next = request.POST.get("next", reverse("home"))
+
+        if getattr(request, "limited", False):
+            return render(
+                request,
+                "login.htm",
+                {"auth_failed": True, "rate_limited": True, "next": next, "user_signup_enabled": settings.ENABLE_USER_SIGNUP},
+                status=429,
+            )
+
         username = request.POST.get("username", None)
         password = request.POST.get("password", None)
         user = authenticate(username=username, password=password)
-        next = request.POST.get("next", reverse("home"))
 
         if user is not None and user.is_active:
             login(request, user)
@@ -215,8 +225,13 @@ class ChangePasswordView(View):
         messages = {"invalid_password": None, "password_validations": None, "success": None, "other": None, "mismatched": None}
         return JSONResponse(messages)
 
+    @method_decorator(ratelimit(key="user", rate=settings.RATE_LIMIT, block=False))
     def post(self, request):
         messages = {"invalid_password": None, "password_validations": None, "success": None, "other": None, "mismatched": None}
+
+        if getattr(request, "limited", False):
+            messages["invalid_password"] = _("Too many requests")
+            return JSONResponse(messages)
         try:
             user = request.user
             old_password = request.POST.get("old_password")
@@ -254,6 +269,7 @@ class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
 
 @method_decorator(csrf_exempt, name="dispatch")
 class UserProfileView(View):
+    @method_decorator(ratelimit(key="post:username", rate=settings.RATE_LIMIT))
     def post(self, request):
         username = request.POST.get("username", None)
         password = request.POST.get("password", None)
@@ -276,6 +292,7 @@ class UserProfileView(View):
 
 @method_decorator(csrf_exempt, name="dispatch")
 class GetClientIdView(View):
+    @method_decorator(ratelimit(key="post:username", rate=settings.RATE_LIMIT))
     def post(self, request):
         if settings.MOBILE_OAUTH_CLIENT_ID == "":
             message = _("Make sure to set your MOBILE_OAUTH_CLIENT_ID in settings.py")
@@ -294,6 +311,7 @@ class GetClientIdView(View):
 
 @method_decorator(csrf_exempt, name="dispatch")
 class ServerSettingView(View):
+    @method_decorator(ratelimit(key="post:username", rate=settings.RATE_LIMIT))
     def post(self, request):
         if settings.MOBILE_OAUTH_CLIENT_ID == "":
             message = _("Make sure to set your MOBILE_OAUTH_CLIENT_ID in settings.py")

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -174,6 +174,10 @@ LOGGING = {
     }
 }
 
+# Rate limit for authentication views
+# See options (including None or python callables):
+# https://django-ratelimit.readthedocs.io/en/stable/rates.html#rates-chapter
+RATE_LIMIT = "5/m"
 
 # Sets default max upload size to 15MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 15728640

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -28,3 +28,4 @@ django_compressor==3.1
 django-libsass==0.9
 filetype==1.0.13
 defusedxml==0.7.1
+django-ratelimit==4.1.0

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -417,6 +417,10 @@ LOGGING = {
 }
 
 LOGIN_URL = "auth"
+# Rate limit for authentication views
+# See options (including None or python callables):
+# https://django-ratelimit.readthedocs.io/en/stable/rates.html#rates-chapter
+RATE_LIMIT = "5/m"
 
 PROFILE_LOG_BASE = os.path.join(ROOT_DIR, "logs")
 

--- a/releases/6.2.6.md
+++ b/releases/6.2.6.md
@@ -13,7 +13,9 @@ Arches 6.2.6 release notes
 
 ### Dependency changes:
 ```
-None
+Python:
+    Added:
+        django-ratelimit 4.1.0
 ```
 
 ### Upgrading Arches


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add rate limiting to auth views. Expose `RATE_LIMIT` as a setting. See [accepted possibilities](https://django-ratelimit.readthedocs.io/en/stable/rates.html#rates-chapter), e.g. `12/5m`, or a python callable.