### PR TITLE
Remove double-click handler from time wheel #10293

### DIFF
--- a/arches/app/media/js/bindings/time-wheel.js
+++ b/arches/app/media/js/bindings/time-wheel.js
@@ -131,9 +131,6 @@ define([
             var clickmanager = d3ClickManager();
             clickmanager.on("click", function(event, d) {
                 selectedPeriod(d);
-            })
-            .on("dblclick", function(event, d) {
-                dblclick(d);
             });
 
             function highlightPeriod(event, d) {
@@ -230,35 +227,7 @@ define([
                     .attr("fill", "none")
                     .attr("pointer-events", "all")
                     .call(clickmanager);
-    
-                function dblclick(p) {
-                    parent.datum(p.parent || root);
-    
-                    root.each(d => d.target = {
-                    x0: Math.max(0, Math.min(1, (d.x0 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI,
-                    x1: Math.max(0, Math.min(1, (d.x1 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI,
-                    y0: Math.max(0, d.y0 - p.depth),
-                    y1: Math.max(0, d.y1 - p.depth)
-                    });
-    
-                    var t = g.transition().duration(750);
-    
-                    // Transition the data on all arcs, even the ones that aren’t visible,
-                    // so that if this transition is interrupted, entering arcs will start
-                    // the next transition from the desired position.
-                    path.transition(t)
-                        .tween("data", d => {
-                            var i = d3.interpolate(d.current, d.target);
-                            return t => d.current = i(t);
-                        })
-                        .filter(function(d) {
-                            return +this.getAttribute("fill-opacity") || arcVisible(d.target);
-                        })
-                        .attr("fill-opacity", d => arcVisible(d.target) ? (d.children ? 0.6 : 0.4) : 0)
-                        .attrTween("d", d => () => arc(d.current));
-    
-                }
-                
+
                 function arcVisible(d) {
                     return true;
                     return d.y1 <= depth && d.y0 >= 1 && d.x1 > d.x0;

--- a/arches/app/templates/views/components/search/time-filter.htm
+++ b/arches/app/templates/views/components/search/time-filter.htm
@@ -65,7 +65,7 @@
     </div>
 
     <h3 class="time-wheel-title">{% trans "Time Wheel" %}</h3>
-    <div class="time-wheel-instructions">{% trans "(Click on a block to set a filter, double-click to zoom in, double-click center to zoom out)" %}</div>
+    <div class="time-wheel-instructions">{% trans "(Click on a block to set a filter)" %}</div>
     <hr class="title-underline"><div class="sequence" data-bind="visible: loading">{% trans 'Loading time wheel...' %}</div>
     <div class="time-wheel-wrap relative" data-bind="timeWheel: { config: wheelConfig, selectedPeriod: selectedPeriod, breadCrumb: breadCrumb}, css:{'time-wheel-loading-mask': loading}">
         <div class="sequence" data-bind="text: breadCrumb"></div>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The double-click handler on the time wheel was not functional.

### Issues Solved
Closes #10293

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
The UI still distinguishes between a click and a double-click. Is that desired? Additional code could be removed in that case.