### PR TITLE
Remove `mock` from dev dependencies

### DIFF
--- a/arches/install/requirements_dev.txt
+++ b/arches/install/requirements_dev.txt
@@ -2,5 +2,4 @@ livereload
 sst
 coverage
 sauceclient
-mock==2.0.0
 django-silk==4.2.0

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -27,6 +27,7 @@ Python:
             webtest
             django-webtest
             django-nose
+            mock
 
 JavaScript:
     Upgraded:

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-from mock import Mock
+from unittest.mock import Mock
 from tests import test_settings
 from tests.base_test import ArchesTestCase
 from arches.app.utils.betterJSONSerializer import JSONDeserializer

--- a/tests/importer/datatype_from_rdf_tests.py
+++ b/tests/importer/datatype_from_rdf_tests.py
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+from unittest.mock import Mock
 from tests import test_settings
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resource_graphs.importer import import_graph as ResourceGraphImporter
@@ -28,7 +29,6 @@ from arches.app.datatypes.datatypes import DataTypeFactory
 from rdflib import Namespace, URIRef, Literal, Graph
 from rdflib.namespace import RDF, RDFS, XSD
 from arches.app.utils.data_management.resources.formats.rdffile import RdfWriter
-from mock import Mock
 
 # these tests can be run from the command line via
 # python manage.py test tests/importer/datatype_from_rdf_tests.py --pattern="*.py" --settings="tests.test_settings"

--- a/tests/utils/activitystream.py
+++ b/tests/utils/activitystream.py
@@ -17,17 +17,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+from unittest.mock import Mock
 from tests import test_settings
 from tests.base_test import ArchesTestCase
 from rdflib import Namespace
 from arches.app.utils.activity_stream_jsonld import ActivityStreamCollection, ActivityStreamCollectionPage
 
-# mocking libraries
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resource_graphs.importer import import_graph as ResourceGraphImporter
 from arches.app.models.models import ResourceInstance
 from arches.app.utils.skos import SKOSReader
-from mock import Mock
 from uuid import uuid4
 from itertools import cycle
 from datetime import datetime


### PR DESCRIPTION
`mock` was just a backport of the unittest.mock module, which has been available in the stdlib since Python 3.3.

Noticed this when trying to run tests after forgetting to install the dev dependencies.

Other dev dependencies are already being removed in 7.5, so it seemed a good time to propose one more cleanup.