### PR TITLE
Fix "invalid escape sequence" warnings

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -403,4 +403,4 @@ class SearchResultsExporter(object):
 
 
 def sanitize_csv_value(value):
-    return re.sub(r"^([@]|[=]|[+]|[-])", "'\g<1>", value)
+    return re.sub(r"^([@]|[=]|[+]|[-])", r"'\g<1>", value)

--- a/arches/app/utils/data_management/resources/formats/csvfile.py
+++ b/arches/app/utils/data_management/resources/formats/csvfile.py
@@ -79,7 +79,7 @@ class CsvWriter(Writer):
 
         # for export of multilingual nodes/columns
         if column:
-            lang_regex = re.compile(".+ \(([A-Za-z-]+)\)")
+            lang_regex = re.compile(r".+ \(([A-Za-z-]+)\)")
             matches = lang_regex.match(column)
             if len(matches.groups()) > 0:
                 lang = matches.groups()[0]
@@ -460,7 +460,7 @@ class CsvReader(Reader):
         new_languages = []
         first_business_data_row = next(iter(business_data))
         for column in first_business_data_row.keys():
-            column_regex = re.compile("^.+ \(([A-Za-z-]+)\)$")
+            column_regex = re.compile(r"^.+ \(([A-Za-z-]+)\)$")
             match = column_regex.match(column)
             if match is not None:
                 new_language_candidate = match.groups()[0]
@@ -790,7 +790,7 @@ class CsvReader(Reader):
                                 # is used to push this value deeper into the import process.  A later check will retrieve this
                                 # value and add it to the i18n string object
                                 else:
-                                    column_regex = re.compile("{column} \(([A-Za-z-]+)\)$".format(column=row["file_field_name"].upper()))
+                                    column_regex = re.compile(r"{column} \(([A-Za-z-]+)\)$".format(column=row["file_field_name"].upper()))
                                     column_match = column_regex.match(key.upper())
                                     if column_match is not None:
                                         language = column_match.groups()[0]


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fixes warnings for "invalid escape sequence" (DeprecationWarning on 3.11; SyntaxWarning on 3.12+). Since these sequences are regex syntax, marking them as raw strings dismisses the warnings.
[See blog post for deep dive](https://adamj.eu/tech/2022/11/04/why-does-python-deprecationwarning-invalid-escape-sequence/)
