### PR TITLE
Bump Django to 4.2.8 and django-revproxy to 0.12.0 #10117

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -11,7 +11,7 @@ mapbox-vector-tile==1.2.0
 SPARQLWrapper==1.8.5
 django-recaptcha==3.0.0
 edtf==4.0.1
-arches-django-revproxy==0.10.0
+django-revproxy==0.12.0
 django-cors-headers==4.2.0
 django-oauth-toolkit==1.7.0
 polib==1.1.1

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,5 +1,5 @@
 Django==4.2.4
-psycopg2==2.9.6
+psycopg2==2.9.9
 urllib3<2
 elasticsearch>=8.3.1,<9.0.0
 rdflib==4.2.2

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -22,8 +22,11 @@ Python:
         psycopg2 2.9.6 > 2.9.9
 
     Added:
+        django-revproxy==0.12.0
 
     Removed:
+        arches-django-revproxy
+
         (dev dependencies):
             webtest
             django-webtest

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -11,7 +11,7 @@ Arches 7.5.0 release notes
 ```
 Python:
     Upgraded:
-        Django 3.2.20 > 4.2.4
+        Django 3.2.20 > 4.2.8
         django-celery-results 2.4.0 > 2.5.1
         django-compressor 3.1 > 4.4
         django-cors-headers 3.1.1 > 4.2.0
@@ -19,6 +19,7 @@ Python:
         django-recaptcha 2.0.6 > 3.0.0
         django-oauth-toolkit 1.2.0 > 1.7.0
         django-webpack-loader 1.5.0 > 2.0.1
+        psycopg2 2.9.6 > 2.9.9
 
     Added:
 


### PR DESCRIPTION
### Description of Change
- Upgrade to latest Django patch release (from this morning)
- Upgrade to latest 2.x psycopg2 patch release
- Revert to upstream `django-revproxy`, with declared support for Django 4.2

### Issues Solved
Closes #10117

### Further comments
Uninstalling the arches fork of django-revproxy (`arches-django-revproxy`) is smart, but not strictly needed:
```py
>>> from revproxy import __version__
>>> __version__
'0.10.0'
```
And after installing `django-revproxy`:
```py
>>> from revproxy import __version__
>>> __version__
'0.12.0'
```