### PR TITLE
Bump Django to 3.2.23

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.21
+Django==3.2.23
 psycopg2==2.9.6
 elasticsearch>=7.11.0,<8.0.0
 rdflib==4.2.2

--- a/releases/6.2.6.md
+++ b/releases/6.2.6.md
@@ -10,10 +10,13 @@ Arches 6.2.6 release notes
 - Fixes edtf advanced search error message #10309
 - Disallows selection of concepts outside of a collection in concept widget #10308
 - Sorts resources in resource instance dropdown, #10305
+- Upgrades Django from 3.2.21 to 3.2.23
 
 ### Dependency changes:
 ```
 Python:
+    Upgraded:
+        Django 3.2.21 > 3.2.23
     Added:
         django-ratelimit 4.1.0
 ```


### PR DESCRIPTION
Apply two more security releases of Django to the 6.2 branch.