### PR TITLE
Fix alignment of delete button in map widget #10332

### DIFF
--- a/arches/app/media/css/components/_index.scss
+++ b/arches/app/media/css/components/_index.scss
@@ -262,7 +262,7 @@
 }
 
 .map-card-feature-tool {
-    width: 65px;
+    width: 80px;
 }
 
 .map-card-feature-tool.intersect {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Issues Solved
Fixes #10332

### Checklist
75px seemed to do the trick for the word "Delete", but I opted for 80 just to add some headroom for other languages (without reinventing the whole ~map~ wheel here).