### PR TITLE
Add system check for cache backends capable of rate-limiting

### DIFF
--- a/arches/apps.py
+++ b/arches/apps.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.core.checks import register, Tags, Warning
+
+@register(Tags.security)
+def check_cache_backend(app_configs, **kwargs):
+    errors = []
+    supported_by_django_ratelimit = (
+        "django.core.cache.backends.memcached.PyLibMCCache",
+        "django.core.cache.backends.memcached.PyMemcacheCache",
+        "django.core.cache.backends.redis.RedisCache",
+    )
+    your_cache = settings.CACHES["default"]["BACKEND"]
+    if your_cache not in supported_by_django_ratelimit:
+        errors.append(
+            Warning(
+                "Cache backend does not support rate-limiting",
+                hint=f"Your cache: {your_cache}\n\tSupported caches: {supported_by_django_ratelimit}",
+                id="arches.W001",
+            )
+        )
+    return errors


### PR DESCRIPTION
Adds a system check (warning) if your configuration is not using a cache backend that supports rate-limiting the auth views.

Refs #10323



```
arches % python3 manage.py check
System check identified some issues:

WARNINGS:
?: (arches.W001) Cache backend does not support rate-limiting
        HINT: Your cache: django.core.cache.backends.locmem.LocMemCache
        Supported caches: ('django.core.cache.backends.memcached.PyLibMCCache', 'django.core.cache.backends.memcached.PyMemcacheCache', 'django.core.cache.backends.redis.RedisCache')
```

Other manage.py commands also surface checks, e.g. `runserver` and `migrate`. The check can be silenced with `SILENCED_SYSTEM_CHECKS`.


@chiatt I'll defer to you on what you think the release note should be, if any.