### PR TITLE
Add system check for using dummy cache in production

### DIFF
--- a/arches/apps.py
+++ b/arches/apps.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.core.checks import register, Tags, Error
+
+
+@register(Tags.security)
+def check_cache_backend_for_production(app_configs, **kwargs):
+    errors = []
+    your_cache = settings.CACHES["default"]["BACKEND"]
+    if not settings.DEBUG and your_cache == "django.core.cache.backends.dummy.DummyCache":
+        errors.append(
+            Error(
+                "Using dummy cache in production",
+                id="arches.E001",
+            )
+        )
+    return errors


### PR DESCRIPTION
The dummy cache shouldn't be used in production. Users won't get:
- rate-limiting on auth views
- map tile caching

Add a system check that only fires if DEBUG is False.