### PR TITLE
Update `update_fields` in custom save() methods #10352

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -937,9 +937,13 @@ class ResourceXResource(models.Model):
 
         if not self.created:
             self.created = datetime.datetime.now()
+            if (update_fields := kwargs.get("update_fields")) is not None:
+                update_fields.add("created")
         self.modified = datetime.datetime.now()
+        if (update_fields := kwargs.get("update_fields")) is not None:
+            update_fields.add("modified")
 
-        super(ResourceXResource, self).save()
+        super(ResourceXResource, self).save(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         super(ResourceXResource, self).__init__(*args, **kwargs)
@@ -965,7 +969,9 @@ class ResourceInstance(models.Model):
             self.graph_publication = self.graph.publication
         except ResourceInstance.graph.RelatedObjectDoesNotExist:
             pass
-        super(ResourceInstance, self).save()
+        if (update_fields := kwargs.get("update_fields")) is not None:
+            update_fields.add("graph_publication")
+        super(ResourceInstance, self).save(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         super(ResourceInstance, self).__init__(*args, **kwargs)
@@ -1122,8 +1128,12 @@ class TileModel(models.Model):  # Tile
                 nodegroup_id=self.nodegroup_id, resourceinstance_id=self.resourceinstance_id
             ).aggregate(Max("sortorder"))["sortorder__max"]
             self.sortorder = sortorder_max + 1 if sortorder_max is not None else 0
+            if (update_fields := kwargs.get("update_fields")) is not None:
+                update_fields.add("sortorder")
         if not self.tileid:
             self.tileid = uuid.uuid4()
+            if (update_fields := kwargs.get("update_fields")) is not None:
+                update_fields.add("tileid")
         super(TileModel, self).save(*args, **kwargs)  # Call the "real" save() method.
 
 


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
`update_or_create()` will break on Django 4.2 for models with custom save methods that set model fields unless we account for this by updating the `update_fields` argument. See [release notes](https://docs.djangoproject.com/en/4.2/releases/4.2/#setting-update-fields-in-model-save-may-now-be-required).

Added two tests (for the more important models of the three affected) that fail on the target branch.

I'm fairly certain we're okay with the proxy model save methods; just need to look at the ones that actually accept `**kwargs`.

### Issues Solved
Closes #10352

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @jacobtylerwalls
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->