### PR TITLE
Bump celery to 5.3.6

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -5,7 +5,7 @@ elasticsearch>=8.3.1,<9.0.0
 rdflib==4.2.2
 django-guardian==2.4.0
 python-memcached==1.59
-celery==5.2.7
+celery==5.3.6
 django-celery-results==2.5.1
 mapbox-vector-tile==1.2.0
 SPARQLWrapper==1.8.5

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -19,6 +19,7 @@ Python:
         django-recaptcha 2.0.6 > 3.0.0
         django-oauth-toolkit 1.2.0 > 1.7.0
         django-webpack-loader 1.5.0 > 2.0.1
+        celery 5.2.7 > 5.3.6
         psycopg2 2.9.6 > 2.9.9
 
     Added:


### PR DESCRIPTION
Adds Python 3.11 compatibility