### PR TITLE
10381 Move csv-import-module celery file size threshold into etl module config

### DIFF
--- a/arches/app/etl_modules/import_single_csv.py
+++ b/arches/app/etl_modules/import_single_csv.py
@@ -150,7 +150,7 @@ class ImportSingleCsv(BaseImportModule):
         temp_dir = os.path.join(settings.UPLOADED_FILES_DIR, "tmp", self.loadid)
         csv_file_path = os.path.join(temp_dir, csv_file_name)
         csv_size = default_storage.size(csv_file_path)  # file size in byte
-        use_celery_threshold = 500  # 500 bytes
+        use_celery_threshold = settings.CELERY_FILE_SIZE_THRESHOLD
 
         if csv_size > use_celery_threshold:
             response = self.run_load_task_async(request, self.loadid)

--- a/arches/app/etl_modules/import_single_csv.py
+++ b/arches/app/etl_modules/import_single_csv.py
@@ -151,7 +151,7 @@ class ImportSingleCsv(BaseImportModule):
         temp_dir = os.path.join(settings.UPLOADED_FILES_DIR, "tmp", self.loadid)
         csv_file_path = os.path.join(temp_dir, csv_file_name)
         csv_size = default_storage.size(csv_file_path)  # file size in byte
-        use_celery_threshold = self.config.get("celeryByteSizeLimit", 5000)
+        use_celery_threshold = self.config.get("celeryByteSizeLimit", 500)
 
         if csv_size > use_celery_threshold:
             response = self.run_load_task_async(request, self.loadid)

--- a/arches/app/etl_modules/import_single_csv.py
+++ b/arches/app/etl_modules/import_single_csv.py
@@ -10,7 +10,7 @@ from django.db import connection
 from django.db.models.functions import Lower
 from django.utils.translation import gettext as _
 from arches.app.datatypes.datatypes import DataTypeFactory
-from arches.app.models.models import GraphModel, Node, NodeGroup
+from arches.app.models.models import GraphModel, Node, NodeGroup, ETLModule
 from arches.app.models.system_settings import settings
 import arches.app.tasks as tasks
 from arches.app.utils.betterJSONSerializer import JSONSerializer
@@ -26,6 +26,7 @@ class ImportSingleCsv(BaseImportModule):
         self.loadid = request.POST.get("load_id") if request else loadid
         self.userid = request.user.id if request else None
         self.moduleid = request.POST.get("module") if request else None
+        self.config = ETLModule.objects.get(pk=self.moduleid).config if self.moduleid else {}
         self.datatype_factory = DataTypeFactory()
         self.node_lookup = {}
         self.blank_tile_lookup = {}
@@ -150,7 +151,7 @@ class ImportSingleCsv(BaseImportModule):
         temp_dir = os.path.join(settings.UPLOADED_FILES_DIR, "tmp", self.loadid)
         csv_file_path = os.path.join(temp_dir, csv_file_name)
         csv_size = default_storage.size(csv_file_path)  # file size in byte
-        use_celery_threshold = 500  # 500 bytes
+        use_celery_threshold = self.config.get("celeryByteSizeLimit", 5000)
 
         if csv_size > use_celery_threshold:
             response = self.run_load_task_async(request, self.loadid)

--- a/arches/app/etl_modules/import_single_csv.py
+++ b/arches/app/etl_modules/import_single_csv.py
@@ -150,7 +150,7 @@ class ImportSingleCsv(BaseImportModule):
         temp_dir = os.path.join(settings.UPLOADED_FILES_DIR, "tmp", self.loadid)
         csv_file_path = os.path.join(temp_dir, csv_file_name)
         csv_size = default_storage.size(csv_file_path)  # file size in byte
-        use_celery_threshold = settings.CELERY_FILE_SIZE_THRESHOLD
+        use_celery_threshold = 500  # 500 bytes
 
         if csv_size > use_celery_threshold:
             response = self.run_load_task_async(request, self.loadid)

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -663,6 +663,7 @@ CELERY_RESULT_BACKEND = "django-db"  # Use 'django-cache' if you want to use you
 CELERY_TASK_SERIALIZER = "json"
 CELERY_SEARCH_EXPORT_EXPIRES = 24 * 3600  # seconds
 CELERY_SEARCH_EXPORT_CHECK = 3600  # seconds
+CELERY_FILE_SIZE_THRESHOLD = 500  # bytes
 
 CELERY_BEAT_SCHEDULE = {
     "delete-expired-search-export": {"task": "arches.app.tasks.delete_file", "schedule": CELERY_SEARCH_EXPORT_CHECK},

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -663,7 +663,6 @@ CELERY_RESULT_BACKEND = "django-db"  # Use 'django-cache' if you want to use you
 CELERY_TASK_SERIALIZER = "json"
 CELERY_SEARCH_EXPORT_EXPIRES = 24 * 3600  # seconds
 CELERY_SEARCH_EXPORT_CHECK = 3600  # seconds
-CELERY_FILE_SIZE_THRESHOLD = 500  # bytes
 
 CELERY_BEAT_SCHEDULE = {
     "delete-expired-search-export": {"task": "arches.app.tasks.delete_file", "schedule": CELERY_SEARCH_EXPORT_CHECK},


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Moves hard-coded file size threshold out of the import single csv module python file and into the ETL module's config

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10381 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: @scholiumtech
*   Found by: @whatisgalen 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
