### PR TITLE
Demote no-ontologies UI error to a logged warning #9649

### DIFF
--- a/arches/app/utils/data_management/resource_graphs/importer.py
+++ b/arches/app/utils/data_management/resource_graphs/importer.py
@@ -92,7 +92,7 @@ def import_graph(graphs, overwrite_graphs=True, user=None):
                 ]:
                     errors.append("The ontologyid of the graph you're trying to load does not exist in Arches.")
             else:
-                errors.append("No ontologies have been loaded. Any GraphModel that depends on an ontology cannot be loaded.")
+                logger.warning("No ontologies have been loaded. Any GraphModel that depends on an ontology cannot be loaded.")
 
             reporter.name = resource["name"]
             reporter.resource_model = resource["isresource"]

--- a/arches/app/utils/thumbnail_factory.py
+++ b/arches/app/utils/thumbnail_factory.py
@@ -33,7 +33,7 @@ class ThumbnailFactory(object):
                 modulename = (".").join(components[0 : len(components) - 1])
                 return getattr(importlib.import_module(modulename), classname)()
             except:
-                logger.warn(f"A 'THUMBNAIL_GENERATOR' in settings.py is specified but can't be found or instantiated.  Thumbnails for uploaded files won't be created")
+                logger.warning(f"A 'THUMBNAIL_GENERATOR' in settings.py is specified but can't be found or instantiated.  Thumbnails for uploaded files won't be created")
                 return None
         else:
             logger.info(f"A thumbnail generator isn't specified.  Set 'THUMBNAIL_GENERATOR' in settings.py to enable generation of thumbnails for uploded files.")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
There's nothing wrong with importing graphs into an environment without ontologies in their db. Demote this UI error to a logged warning.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #9649
