### PR TITLE
Avoid publishing graphs in migrations

### DIFF
--- a/arches/app/models/migrations/10150_add_default_value_file_list.py
+++ b/arches/app/models/migrations/10150_add_default_value_file_list.py
@@ -2,25 +2,6 @@
 
 from django.db import migrations
 
-from arches.app.models.graph import Graph
-
-
-def using_custom_file_widgets(apps, schema_editor):
-    CardXNodeXWidget = apps.get_model("models", "CardXNodeXWidget")
-    return (
-        CardXNodeXWidget.objects.filter(widget_id="10000000-0000-0000-0000-000000000019").values_list("node__graph", flat=True).distinct()
-    )
-
-
-def publish_graph(apps, schema_editor):
-    for graph in Graph.objects.filter(pk__in=using_custom_file_widgets(apps, schema_editor)):
-        graph.publish(user=None)
-
-
-def unpublish_graph(apps, schema_editor):
-    for graph in Graph.objects.filter(pk__in=using_custom_file_widgets(apps, schema_editor)):
-        graph.unpublish()
-
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -28,8 +9,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Changes to cards_x_nodes_x_widgets have no effect without republishing graph.
-        migrations.RunPython(unpublish_graph, publish_graph),
+        # Note this won't actually appear to have an effect w/o republishing graphs.
         migrations.RunSQL(
             sql="""
             UPDATE widgets
@@ -48,5 +28,4 @@ class Migration(migrations.Migration):
             WHERE widgetid = '10000000-0000-0000-0000-000000000019';
             """,
         ),
-        migrations.RunPython(publish_graph, unpublish_graph),
     ]

--- a/arches/app/templates/views/user-profile-manager.htm
+++ b/arches/app/templates/views/user-profile-manager.htm
@@ -221,7 +221,7 @@
                                         </div>
                                         <div class="col-sm-5">
                                             <p class="account-tips" id="edit-email-tip">
-                                                {% trans 'Arches uses your e-maill to alert you to projects and tasks assigned to you.' %}
+                                                {% trans 'Arches uses your e-mail to alert you to projects and tasks assigned to you.' %}
                                             </p>
                                         </div>
                                     </div>

--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -1,5 +1,11 @@
+import arches
+import os
+import shutil
+
 from django.core.management.base import BaseCommand
 from django.core import management
+from django.db import connection
+from arches.app.models.system_settings import settings
 
 
 class Command(BaseCommand):
@@ -9,7 +15,58 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
+        self.update_to_v7()
         self.update_to_v7_5()
 
+    def update_to_v7(self):
+        # copy webpack config files to project
+        print("Copying webpack directory to project root directory")
+        project_webpack_path = os.path.join(settings.APP_ROOT, "webpack")
+
+        if os.path.exists(project_webpack_path):
+            shutil.rmtree(project_webpack_path)
+
+        shutil.copytree(os.path.join(settings.ROOT_DIR, "install", "arches-templates", "project_name", "webpack"), project_webpack_path)
+
+        # copy dotfiles
+        for dotfile in [".eslintrc.js", ".eslintignore", ".babelrc", ".browserslistrc", ".stylelintrc.json"]:
+            print("Copying {} to project root directory".format(dotfile))
+            shutil.copy2(os.path.join(settings.ROOT_DIR, dotfile), settings.APP_ROOT)
+
+        # ensure project has a `media/img` directory
+        if not os.path.isdir(os.path.join(settings.APP_ROOT, "media", "img")):
+            print("Creating /media/img directory")
+            os.mkdir(os.path.join(settings.APP_ROOT, "media", "img"))
+
+        #  check if temp_graph_status table exists
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT EXISTS (
+                    SELECT FROM 
+                        pg_tables
+                    WHERE 
+                        schemaname = 'public' AND 
+                        tablename  = 'temp_graph_status'
+                );
+                """
+            )
+            result = cursor.fetchone()
+
+            # publish graphs that were previously active
+            if result[0]:  # parses result from row
+                cursor.execute("select * from temp_graph_status;")
+                rows = cursor.fetchall()
+                graphs = []
+                for row in rows:
+                    graphid = str(row[0])
+                    active = row[1]
+                    if active:
+                        graphs.append(graphid)
+                management.call_command("graph", operation="publish", update_instances=True, graphs=",".join(graphs))
+                cursor.execute("drop table if exists temp_graph_status")
+
     def update_to_v7_5(self):
+        # Republish to pick up CardsXNodeXWidget changes from
+        # migration 10150_add_default_value_file_list.py
         management.call_command("graph", operation="publish")

--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -1,11 +1,5 @@
-import arches
-import os
-import shutil
-
 from django.core.management.base import BaseCommand
 from django.core import management
-from django.db import connection
-from arches.app.models.system_settings import settings
 
 
 class Command(BaseCommand):
@@ -15,52 +9,7 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        self.update_to_v7()
+        self.update_to_v7_5()
 
-    def update_to_v7(self):
-        # copy webpack config files to project
-        print("Copying webpack directory to project root directory")
-        project_webpack_path = os.path.join(settings.APP_ROOT, "webpack")
-
-        if os.path.exists(project_webpack_path):
-            shutil.rmtree(project_webpack_path)
-
-        shutil.copytree(os.path.join(settings.ROOT_DIR, "install", "arches-templates", "project_name", "webpack"), project_webpack_path)
-
-        # copy dotfiles
-        for dotfile in [".eslintrc.js", ".eslintignore", ".babelrc", ".browserslistrc", ".stylelintrc.json"]:
-            print("Copying {} to project root directory".format(dotfile))
-            shutil.copy2(os.path.join(settings.ROOT_DIR, dotfile), settings.APP_ROOT)
-
-        # ensure project has a `media/img` directory
-        if not os.path.isdir(os.path.join(settings.APP_ROOT, "media", "img")):
-            print("Creating /media/img directory")
-            os.mkdir(os.path.join(settings.APP_ROOT, "media", "img"))
-
-        #  check if temp_graph_status table exists
-        with connection.cursor() as cursor:
-            cursor.execute(
-                """
-                SELECT EXISTS (
-                    SELECT FROM 
-                        pg_tables
-                    WHERE 
-                        schemaname = 'public' AND 
-                        tablename  = 'temp_graph_status'
-                );
-                """
-            )
-            result = cursor.fetchone()
-
-            # publish graphs that were previously active
-            if result[0]:  # parses result from row
-                cursor.execute("select * from temp_graph_status;")
-                rows = cursor.fetchall()
-                graphs = []
-                for row in rows:
-                    graphid = str(row[0])
-                    active = row[1]
-                    if active:
-                        graphs.append(graphid)
-                management.call_command("graph", operation="publish", update_instances=True, graphs=",".join(graphs))
-                cursor.execute("drop table if exists temp_graph_status")
+    def update_to_v7_5(self):
+        management.call_command("graph", operation="publish")

--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -69,4 +69,4 @@ class Command(BaseCommand):
     def update_to_v7_5(self):
         # Republish to pick up CardsXNodeXWidget changes from
         # migration 10150_add_default_value_file_list.py
-        management.call_command("graph", operation="publish")
+        management.call_command("graph", operation="publish", update=True)

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -76,6 +76,11 @@ None
     python manage.py migrate
     ```
 
+2. Reindex your database:
+    ```
+    python manage.py es reindex_database
+    ```
+
 3. If you have made customizations to files in your webpack directory, backup that directory as those files will be overwritten in the following steps. Read [this](https://github.com/archesproject/arches/blob/dev/7.5.x/arches/webpack/README.md) for more information.
 
 4. If you have javascript dependencies listed in `webpack/webpack-node-modules-aliases.js`, move them to your package.json file and update the paths. For example, if you have dependencies in `webpack/webpack-node-modules-aliases.js` like this:

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -76,11 +76,6 @@ None
     python manage.py migrate
     ```
 
-2. Reindex your database:
-    ```
-    python manage.py es reindex_database
-    ```
-
 3. If you have made customizations to files in your webpack directory, backup that directory as those files will be overwritten in the following steps. Read [this](https://github.com/archesproject/arches/blob/dev/7.5.x/arches/webpack/README.md) for more information.
 
 4. If you have javascript dependencies listed in `webpack/webpack-node-modules-aliases.js`, move them to your package.json file and update the paths. For example, if you have dependencies in `webpack/webpack-node-modules-aliases.js` like this:


### PR DESCRIPTION
### Description of Change
Using a proxy model in a migration can create drift. Better to accomplish this with a `publish` command inside the `updateproject` command.


### Issues Solved
Follow-up to #9333

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
