### PR TITLE
Avoid trying to update the publication of an unpublished graph #10409

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1785,7 +1785,7 @@ class Graph(models.GraphModel):
                 published_graph_query = published_graphs.filter(language=language_tuple[0])
                 if not len(published_graph_query):
                     published_graph = models.PublishedGraph.objects.create(
-                        publication=self.publication,
+                        publication_id=self.publication_id,
                         serialized_graph=serialized_graph,
                         language=models.Language.objects.get(code=language_tuple[0]),
                     )

--- a/arches/app/utils/i18n.py
+++ b/arches/app/utils/i18n.py
@@ -322,5 +322,5 @@ class LanguageSynchronizer:
 
             if update_published_graphs:
                 for graph in Graph.objects.all():
-                    if graph.publication:
+                    if graph.publication_id:
                         graph.update_published_graphs()

--- a/arches/management/commands/graph.py
+++ b/arches/management/commands/graph.py
@@ -96,7 +96,8 @@ class Command(BaseCommand):
             print(graph.name)
             
             if self.update:
-                graph.update_published_graphs()
+                if graph.publication_id:
+                    graph.update_published_graphs()
             else:
                 graph.publish(user)
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The other caller of `update_published_graphs()` already guarded against unpublished graphs. Port that same check to the management command.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10409

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
Adds an optimization to avoid fetching the publication, should save 1 query per published graph.