### PR TITLE
Require Python 3.10+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Install python packages
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 140
-target-version = ['py39']
+target-version = ['py310']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -26,6 +26,7 @@ JavaScript:
 
 ### Breaking changes
 
+The minimum supported version of Python is now 3.10. Python 3.11 is encouraged, as it is significantly faster.
 
 ### Upgrading Arches
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     scripts=["arches/install/arches-project", "arches/install/arches-admin"],
     cmdclass={"install": post_install},
     install_requires=requirements,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are
@@ -47,8 +47,6 @@ setup(
         "Intended Audience :: Information Technology",
         "Topic :: Software Development :: Build Tools",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Framework :: Django :: 4.2",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Require Python 3.10+ in Arches 7.6 (LTS)

Python 3.12 support should be declared once more (all?) Arches dependencies declare their support, although it may be functionally okay already.

This enables using Python 3.10 features like:
- `match`/`case` statements
- `zip(strict=True)` for added safety against iterating jagged arrays

### Issues Solved
Closes #9111