### PR TITLE
Adds v5 timewheel cache default

### DIFF
--- a/arches/app/search/time_wheel.py
+++ b/arches/app/search/time_wheel.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from arches.app.utils.date_utils import ExtendedDateFormat
 from arches.app.utils.permission_backend import get_nodegroups_by_perm
@@ -23,6 +24,9 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.mappings import RESOURCES_INDEX
 from arches.app.models.system_settings import settings
 from django.core.cache import cache
+from django.utils.translation import get_language, gettext as _
+
+logger = logging.getLogger(__name__)
 
 
 class TimeWheel(object):
@@ -124,7 +128,10 @@ class TimeWheel(object):
             if user.username in settings.CACHE_BY_USER:
                 cache.set(key, root, settings.CACHE_BY_USER[user.username])
             else:
-                cache.set(key, root, settings.CACHE_BY_USER['default'])
+                try:
+                    cache.set(key, root, settings.CACHE_BY_USER['default'])
+                except KeyError:
+                    logger.warning(_("CACHE_BY_USER setting does not have a 'default'. Adding a default can improve search page performance."))
 
             return root
 

--- a/arches/app/search/time_wheel.py
+++ b/arches/app/search/time_wheel.py
@@ -120,9 +120,11 @@ class TimeWheel(object):
             for child in root.children:
                 root.size = root.size + child.size
 
+            key = "time_wheel_config_{0}".format(user.username)
             if user.username in settings.CACHE_BY_USER:
-                key = "time_wheel_config_{0}".format(user.username)
                 cache.set(key, root, settings.CACHE_BY_USER[user.username])
+            else:
+                cache.set(key, root, settings.CACHE_BY_USER['default'])
 
             return root
 

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -259,7 +259,11 @@ DATE_IMPORT_EXPORT_FORMAT = "%Y-%m-%d" # Custom date format for dates imported f
 EXPORT_DATA_FIELDS_IN_CARD_ORDER = False
 
 #Identify the usernames and duration (seconds) for which you want to cache the time wheel
-CACHE_BY_USER = {'anonymous': 3600 * 24}
+CACHE_BY_USER = {
+    "default": 3600 * 24, #24hrs
+    "anonymous": 3600 * 24 #24hrs
+    }
+
 TILE_CACHE_TIMEOUT = 600 #seconds
 CLUSTER_DISTANCE_MAX = 5000 #meters
 GRAPH_MODEL_CACHE_TIMEOUT = None

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -501,7 +501,10 @@ DEFAULT_RESOURCE_IMPORT_USER = {"username": "admin", "userid": 1}
 TIMEWHEEL_DATE_TIERS = None
 
 # Identify the usernames and duration (seconds) for which you want to cache the timewheel
-CACHE_BY_USER = {"anonymous": 3600 * 24}
+CACHE_BY_USER = {
+    "default": 3600 * 24, #24hrs
+    "anonymous": 3600 * 24 #24hrs
+    }
 
 BYPASS_UNIQUE_CONSTRAINT_TILE_VALIDATION = False
 BYPASS_REQUIRED_VALUE_TILE_VALIDATION = False

--- a/releases/7.5.1.md
+++ b/releases/7.5.1.md
@@ -1,0 +1,58 @@
+Arches 7.5.1 Release Notes
+--------------------------
+
+### Bug Fixes and Enhancements
+
+- Adds 'default' user to timewheel cache config ('CACHE_BY_USER') to cache timewheel for all users 
+
+
+### Dependency changes:
+```
+None
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 7.5.0 before proceeding. If upgrading from an earlier version, refer to the upgrade process in the [Version 7.5.0 release notes](https://github.com/archesproject/arches/blob/dev/7.5.x/releases/7.5.0.md)
+
+2. Upgrade to Arches 7.5.1
+    ```
+    pip install --upgrade arches==7.5.1
+    ```
+
+3. Update the JavaScript dependencies and devDependencies:
+    In the project's `package.json` file change arches from `stable/7.5.0` to `stable/7.5.1`:
+    ```    
+        "dependencies": {
+            "arches": "archesproject/arches#stable/7.5.1",
+        },
+        "devDependencies": {
+            "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.5.1"
+        }
+    ```
+    In in your terminal navigate to the directory with your project's package.json file. Then run:
+
+        yarn install
+
+
+4. Start your application server in a separate terminal if it's not already running. Your webpack build will not complete without your application server running.
+
+5. In a different terminal navigate to the directory with your project's package.json file, run `yarn start` or `yarn build_development`. This will generate your `media/build` directory.
+   - If running your project in development:
+     -  `yarn start` will build the frontend of the application and then start a webpack development server
+      - `yarn build_development` will build a development bundle for the frontend assests of the application -- this should complete in less than 2 minutes
+    - If running your project in production:
+      - `yarn build_production` This builds a production bundle. **takes up to 2hrs depending on resources**
+      - Alternatively you can `cd ..` up a directory and run `python manage.py build_production`. This will create a production bundle of frontend assessts and also call `collectstatic`.
+  
+
+6. If you are running Arches on Apache, be sure to run:
+
+    ```
+    collectstatic
+    ```
+    and restart your server:
+    ```
+    sudo service apache2 reload
+    ```
+


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Performance improvement

### Description of Change
Adds a default cache timeout to the CACHE_BY_USER setting so that the timewheel config can be cached for all users.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10457
