### PR TITLE
Replace `strtobool()` #10460

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -11,7 +11,6 @@ import os
 from pathlib import Path
 import ast
 import time
-from distutils import util
 from datetime import datetime
 from mimetypes import MimeTypes
 
@@ -28,6 +27,7 @@ from arches.app.utils.module_importer import get_class_from_modulename
 from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.utils.geo_utils import GeoUtils
 from arches.app.utils.i18n import get_localized_value
+from arches.app.utils.string_utils import str_to_bool
 from arches.app.search.elasticsearch_dsl_builder import (
     Bool,
     Dsl,
@@ -484,8 +484,8 @@ class BooleanDataType(BaseDataType):
         errors = []
         try:
             if value is not None:
-                type(bool(util.strtobool(str(value)))) is True
-        except Exception:
+                str_to_bool(str(value))
+        except ValueError:
             message = _("Not of type boolean")
             title = _("Invalid Boolean")
             error_message = self.create_error_message(value, source, row_number, message, title)
@@ -522,7 +522,7 @@ class BooleanDataType(BaseDataType):
             return self.compile_json(tile, node, display_value=label, value=value)
 
     def transform_value_for_tile(self, value, **kwargs):
-        return bool(util.strtobool(str(value)))
+        return str_to_bool(str(value))
 
     def append_search_filters(self, value, node, query, request):
         try:

--- a/arches/app/utils/string_utils.py
+++ b/arches/app/utils/string_utils.py
@@ -1,0 +1,7 @@
+def str_to_bool(value):
+    match value:
+        case "y" | "yes" | "t" | "true" | "on" | "1":
+            return True
+        case "n" | "no" | "f" | "false" | "off" | "0":
+            return False
+    raise ValueError

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -19,8 +19,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import json
 import uuid
 
-from distutils.util import strtobool
-
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.contrib.auth.models import User, Group, Permission
 from django.db import transaction
@@ -59,6 +57,7 @@ from arches.app.utils.permission_backend import (
     user_can_read_resource,
 )
 from arches.app.utils.response import JSONResponse, JSONErrorResponse
+from arches.app.utils.string_utils import str_to_bool
 from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Query, Terms
 from arches.app.search.mappings import RESOURCES_INDEX
@@ -871,7 +870,7 @@ class RelatedResourcesView(BaseManagerView):
         else:
             lang = request.GET.get("lang", request.LANGUAGE_CODE)
             resourceinstance_graphid = request.GET.get("resourceinstance_graphid")
-            paginate = strtobool(request.GET.get("paginate", "true"))  # default to true
+            paginate = str_to_bool(request.GET.get("paginate", "true"))  # default to true
             resource = Resource.objects.get(pk=resourceid)
 
             if paginate:

--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -7,7 +7,6 @@ django-guardian==2.4.0
 python-memcached==1.59
 celery==5.3.6
 django-celery-results==2.5.1
-mapbox-vector-tile==1.2.0
 SPARQLWrapper==1.8.5
 django-recaptcha==3.0.0
 edtf==4.0.1

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -39,6 +39,11 @@ JavaScript:
     pip install --upgrade arches==7.6.0
     ```
 
+4. Uninstall removed dependencies:
+    ```
+    pip uninstall mapbox-vector-tile
+    ```
+
 ### Upgrading an Arches project
 
 

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -16,6 +16,7 @@ Python:
     Added:
 
     Removed:
+        mapbox-vector-tile
 
 JavaScript:
     Upgraded:
@@ -36,14 +37,6 @@ JavaScript:
 3. Upgrade to Arches 7.6.0
     ```
     pip install --upgrade arches==7.6.0
-    ```
-
-4. Uninstall mooted dev dependencies:
-    ```
-    pip uninstall webtest
-    pip uninstall django-webtest
-    pip uninstall django-nose
-    pip uninstall mock
     ```
 
 ### Upgrading an Arches project

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -26,6 +26,36 @@ from tests.base_test import ArchesTestCase
 # python manage.py test tests/utils/datatype_tests.py --pattern="*.py" --settings="tests.test_settings"
 
 
+class BooleanDataTypeTests(ArchesTestCase):
+    def test_validate(self):
+        boolean = DataTypeFactory().get_instance("boolean")
+
+        for good in ["true", "false", "yes", "no", None]:
+            with self.subTest(input=good):
+                no_errors = boolean.validate(good)
+                self.assertEqual(len(no_errors), 0)
+
+        for bad in ["garbage", "True", "False", "None"]:
+            with self.subTest(input=bad):
+                errors = boolean.validate(bad)
+                self.assertEqual(len(errors), 1)
+
+    def test_tile_transform(self):
+        boolean = DataTypeFactory().get_instance("boolean")
+
+        truthy_values = []
+        falsy_values = []
+        for truthy in truthy_values:
+            with self.subTest(input=truthy):
+                self.assertTrue(boolean.transform_value_for_tile(truthy))
+        for falsy in falsy_values:
+            with self.subTest(input=truthy):
+                self.assertFalse(boolean.transform_value_for_tile(falsy))
+
+        with self.assertRaises(ValueError):
+            boolean.transform_value_for_tile(None)
+
+
 class StringDataTypeTests(ArchesTestCase):
     def test_string_validate(self):
         string = DataTypeFactory().get_instance("string")


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Depends on archesproject/arches#10456

On python 3.12, Arches had an undeclared dependency on a util (`strtobool()`) from older versions of `setuptools` which still vendored distutils, since `distutils` is no longer in the stdlib. Instead just reimplement the functionality to avoid pulling in setuptools or anything else as a dep.

~Bumps `mapbox-vector-tile` to a version that doesn't pull in `setuptools` as a dependency (and a version that explicitly supports python 3.11).~ EDIT: removes it altogether.

### Issues Solved
Closes #10460

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
