### PR TITLE
Stop map buttons from appearing over modals and help #10432

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -1991,7 +1991,7 @@ div.final-cons-step-separator>h4 {
     width: 75px;
     background-color: #f1f1f1;
     border-left: 1px solid #ddd;
-    z-index: 1000;
+    z-index: 500;
 }
 
 .workbench-card-sidebar-tab.disabled {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Prevent card help or graph publication modals from appearing behind the map workbench buttons.

### Issues Solved
Fixes #10432

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @JPdelaRosa83
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
The git history shows this change (200 -> 1000) was made for RTL, so a quick check that all is good in RTL at 500 would be wise. (Looked OK to me.)