### PR TITLE
Surface card help panel in main file widget area #10318

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -2204,10 +2204,6 @@ div.final-cons-step-separator>h4 {
     margin-right: 400px;
 }
 
-.workbench-card-container-wrapper.workbench-card-container-sidepanel-active {
-    z-index: 249;
-}
-
 .workbench-card-sidebar-tab {
     color: #787878;
     min-height: 65px;

--- a/arches/app/templates/views/components/file-workbench.htm
+++ b/arches/app/templates/views/components/file-workbench.htm
@@ -173,6 +173,34 @@
     <div class="file-chart-upload-panel">
         <div class="gallery-controls new-tile">
             <div class="dropzone-photo-upload" data-bind="dropzone: dropzoneOptions">
+                <!-- ko if: card.model.helpenabled -->
+                <span>
+                    <a class="pull-right card-help help editable-help" data-bind="click: function () {
+                        card.model.get('helpactive')(true)
+                    }" style="cursor:pointer;">
+                        <span data-bind="text: $root.translations.help"></span>
+                        <i class="fa fa-question-circle"></i>
+                    </a>
+                </span>
+                <aside id="card-help-panel" class="card-help-panel" style="display: none;" data-bind="visible: card.model.get('helpactive')">
+                    <div class="relative">
+                        <a id="add-basemap-wizard-help-close" href="#" class="help-close fa fa-times fa-lg" style="" data-bind="click: function () {
+                            card.model.get('helpactive')(false);
+                        }"></a>
+                    </div>
+                    <div id="add-basemap-wizard-help-content">
+                        <div>
+                            <div class="panel-heading">
+                                <h3 class="panel-title help-panel-title">
+                                    <span data-bind="html: card.model.get('helptitle')"></span>
+                                </h3>
+                            </div>
+                            <div class="panel-body" style="padding: 10px 10px 15px 10px;" data-bind="html: card.model.get('helptext')">
+                            </div>
+                        </div>
+                    </div>
+                </aside>
+                <!-- /ko -->
                 <div class="file-select-window">
                    <div class="bord-top pad-ver file-select">
                        <div class="" style="padding: 5px">

--- a/arches/app/templates/views/components/photo-workbench.htm
+++ b/arches/app/templates/views/components/photo-workbench.htm
@@ -66,6 +66,34 @@
     <div class="file-chart-upload-panel">
         <div class="gallery-controls new-tile">
             <div class="dropzone-photo-upload" data-bind="dropzone: dropzoneOptions">
+                <!-- ko if: card.model.helpenabled -->
+                <span>
+                    <a class="pull-right card-help help editable-help" data-bind="click: function () {
+                        card.model.get('helpactive')(true)
+                    }" style="cursor:pointer;">
+                        <span data-bind="text: $root.translations.help"></span>
+                        <i class="fa fa-question-circle"></i>
+                    </a>
+                </span>
+                <aside id="card-help-panel" class="card-help-panel" style="display: none;" data-bind="visible: card.model.get('helpactive')">
+                    <div class="relative">
+                        <a id="add-basemap-wizard-help-close" href="#" class="help-close fa fa-times fa-lg" style="" data-bind="click: function () {
+                            card.model.get('helpactive')(false);
+                        }"></a>
+                    </div>
+                    <div id="add-basemap-wizard-help-content">
+                        <div>
+                            <div class="panel-heading">
+                                <h3 class="panel-title help-panel-title" style="">
+                                    <span data-bind="html: card.model.get('helptitle')"></span>
+                                </h3>
+                            </div>
+                            <div class="panel-body" style="padding: 10px 10px 15px 10px;" data-bind="html: card.model.get('helptext')">
+                            </div>
+                        </div>
+                    </div>
+                </aside>
+                <!-- /ko -->
                 <div class="file-select-window">
                    <div class="bord-top pad-ver file-select">
                        <div class="" style="padding: 5px">


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, for the file viewer and image gallery cards, the card level help was only accessible from the "edit" tab, which in the case of the file viewer card, is only accessible after uploading one file.

Now, the help is surfaced outside the side tabs in the main file widget area.

### Issues Solved
Closes #10318

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Auckland
*   Found by: @JPdelaRosa83
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
Should regression test both cards, both locations (main area and edit tab), and before and after a file is uploaded.