### PR TITLE
Fix text entry after switching language in rich-text widget #10468

### DIFF
--- a/arches/app/media/js/views/components/widgets/rich-text.js
+++ b/arches/app/media/js/views/components/widgets/rich-text.js
@@ -80,6 +80,9 @@ define([
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
+            if(!currentValue?.[currentLanguage.code]){
+                currentValue[currentLanguage.code] = {};
+            }
             currentValue[currentLanguage.code].value = newValue?.[currentLanguage.code] ? newValue[currentLanguage.code]?.value : newValue;
             if (ko.isObservable(self.value)) {
                 self.value(currentValue);
@@ -91,6 +94,9 @@ define([
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
+            if(!currentValue?.[currentLanguage.code]){
+                currentValue[currentLanguage.code] = {};
+            }
             currentValue[currentLanguage.code].direction = newValue;
 
             if (ko.isObservable(self.value)) {

--- a/arches/app/media/js/views/components/widgets/rich-text.js
+++ b/arches/app/media/js/views/components/widgets/rich-text.js
@@ -29,6 +29,7 @@ define([
         const currentLanguage = {"code": arches.activeLanguage};
         let currentValue = koMapping.toJS(self.value) || initialCurrent;
         self.currentLanguage = ko.observable(currentLanguage);
+        let updating = false;
 
         if(self.form){
             self.form.on('tile-reset', (x) => {
@@ -71,7 +72,10 @@ define([
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
-            if(JSON.stringify(currentValue) != JSON.stringify(ko.toJS(ko.unwrap(self.value)))){
+            if(!updating && (JSON.stringify(currentValue) != JSON.stringify(ko.toJS(ko.unwrap(self.value))))){
+                // Don't attempt to update currentText if we are in the middle of another update.
+                // currentValue will already be correct, and self.value has not yet finished updating.
+                // https://github.com/archesproject/arches/issues/10468
                 self.currentText(newValue?.[currentLanguage.code]?.value || newValue);
             }
         });
@@ -80,6 +84,7 @@ define([
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
+            updating = true;
             if(!currentValue?.[currentLanguage.code]){
                 currentValue[currentLanguage.code] = {};
             }
@@ -89,11 +94,13 @@ define([
             } else {
                 self.value[currentLanguage.code].value(newValue);
             }
+            updating = false;
         });
         self.currentDirection.subscribe(newValue => {
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
 
+            updating = true;
             if(!currentValue?.[currentLanguage.code]){
                 currentValue[currentLanguage.code] = {};
             }
@@ -104,6 +111,7 @@ define([
             } else {
                 self.value[currentLanguage.code].direction(newValue);
             }
+            updating = false;
         });
 
         self.currentLanguage.subscribe(() => {

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -138,6 +138,10 @@ define([
         self.currentText.subscribe(newValue => {
             const currentLanguage = self.currentLanguage();
             if(!currentLanguage) { return; }
+
+            if(!currentValue?.[currentLanguage.code]){
+                currentValue[currentLanguage.code] = {};
+            }
             currentValue[currentLanguage.code].value = newValue?.[currentLanguage.code] ? newValue[currentLanguage.code]?.value : newValue;
             
             if (ko.isObservable(self.value)) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Previously, for a string node allowing multiple values, leaving
no value for the first node entry, clicking the "+" to get a second
entry box, switching the language, and then typing in the text
entry caused a perpetual restoration of the original blank value.

Also include a backport of #10140.

### Issues Solved
Fixes #10468

#### Ticket Background
*   Sponsored by: Auckland
*   Found by: @JPdelaRosa83
*   Tested by: @jacobtylerwalls

### Further comments
There is probably a deeper cause either with change listeners not being deregistered or with mutating objects that might be better as immutable, but those would be bigger refactors.