### PR TITLE
Use widget label in TileValidationError #10486

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -308,7 +308,7 @@ class Tile(models.TileModel):
 
                     first_card_x_node_x_widget = node.cardxnodexwidget_set.first()
                     if first_card_x_node_x_widget:
-                        missing_nodes.append(first_card_x_node_x_widget.label)
+                        missing_nodes.append(str(first_card_x_node_x_widget.label))
                     else:
                         missing_nodes.append(node.name)
             except Exception:

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -303,14 +303,12 @@ class Tile(models.TileModel):
                 datatype = self.datatype_factory.get_instance(node.datatype)
                 datatype.clean(self, nodeid)
                 if self.data[nodeid] is None and node.isrequired is True:
-                    cardxnodexwidgets = None
-                    try:
-                        cardxnodexwidgets = node.cardxnodexwidget_set.all()
-                    except:
+                    if not isinstance(node, models.Node):
                         node = models.Node.objects.get(nodeid=nodeid)
 
-                    if cardxnodexwidgets is not None and len(cardxnodexwidgets) > 0:
-                        missing_nodes.append(cardxnodexwidgets[0].label)
+                    first_card_x_node_x_widget = node.cardxnodexwidget_set.first()
+                    if first_card_x_node_x_widget:
+                        missing_nodes.append(first_card_x_node_x_widget.label)
                     else:
                         missing_nodes.append(node.name)
             except Exception:
@@ -769,4 +767,4 @@ class TileValidationError(Exception):
 class TileCardinalityError(TileValidationError):
     def __init__(self, message, code=None):
         super(TileCardinalityError, self).__init__(message, code)
-        self.title = _("Tile Cardinaltiy Error")
+        self.title = _("Tile Cardinality Error")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
In the if block in this diff, the usual code path is to fetch from the Nodes table because `node` was a `SimpleNamespace` object from the serialized graph. Then, the cardxnodewidgets was never fetched, so we defaulted to the node name, even if a widget label was available.

Then, this uncovered #9280 again, so I fixed that also.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10486
Closes #9280

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
