### PR TITLE
update workflow component abstract to default to null value

### DIFF
--- a/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
+++ b/arches/app/media/js/views/components/workflows/workflow-component-abstract.js
@@ -641,7 +641,7 @@ define([
         this.saving = ko.observable(false);
 
         this.savedComponentPaths = {};
-        this.value = ko.observable();
+        this.value = ko.observable(null);
 
         this.complete = ko.observable(false);
         this.error = ko.observable();
@@ -657,7 +657,7 @@ define([
             }
         });
 
-        this.savedData = ko.observable();
+        this.savedData = ko.observable(null);
         this.savedData.subscribe(function(savedData) {
             self.setToWorkflowHistory('value', savedData);
         });


### PR DESCRIPTION
Fixes arches for science workflow issue where default step value of undefined is not equal to resource instance select empty value of null.  