### PR TITLE
9484 report tile perm optimize

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -254,7 +254,8 @@ class Resource(models.ResourceInstance):
 
         self.tiles = list(models.TileModel.objects.filter(resourceinstance=self))
         if user:
-            self.tiles = [tile for tile in self.tiles if tile.nodegroup_id is not None and user.has_perm(perm, tile.nodegroup)]
+            readable_nodegroups = set(str(nodegroup.pk) for nodegroup in get_nodegroups_by_perm(user, perm, any_perm=True))
+            self.tiles = [tile for tile in self.tiles if tile.nodegroup_id is not None and str(tile.nodegroup_id) in readable_nodegroups]
 
     # # flatten out the nested tiles into a single array
     def get_flattened_tiles(self):

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -255,8 +255,8 @@ class Resource(models.ResourceInstance):
 
         self.tiles = list(models.TileModel.objects.filter(resourceinstance=self))
         if user:
-            readable_nodegroups = set(str(nodegroup.pk) for nodegroup in get_nodegroups_by_perm(user, perm, any_perm=True))
-            self.tiles = [tile for tile in self.tiles if tile.nodegroup_id is not None and str(tile.nodegroup_id) in readable_nodegroups]
+            readable_nodegroups = set(nodegroup.pk for nodegroup in get_nodegroups_by_perm(user, perm, any_perm=True))
+            self.tiles = [tile for tile in self.tiles if tile.nodegroup_id is not None and tile.nodegroup_id in readable_nodegroups]
 
     # # flatten out the nested tiles into a single array
     def get_flattened_tiles(self):

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -52,6 +52,7 @@ from arches.app.utils.permission_backend import (
     get_restricted_users,
     get_restricted_instances,
     user_can_read_graph,
+    get_nodegroups_by_perm,
 )
 from arches.app.datatypes.datatypes import DataTypeFactory
 

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -255,8 +255,8 @@ class Resource(models.ResourceInstance):
 
         self.tiles = list(models.TileModel.objects.filter(resourceinstance=self))
         if user:
-            readable_nodegroups = set(nodegroup.pk for nodegroup in get_nodegroups_by_perm(user, perm, any_perm=True))
-            self.tiles = [tile for tile in self.tiles if tile.nodegroup_id is not None and tile.nodegroup_id in readable_nodegroups]
+            readable_nodegroups = get_nodegroups_by_perm(user, perm, any_perm=True)
+            self.tiles = [tile for tile in self.tiles if tile.nodegroup is not None and tile.nodegroup in readable_nodegroups]
 
     # # flatten out the nested tiles into a single array
     def get_flattened_tiles(self):

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1115,7 +1115,7 @@ class ResourceReport(APIBase):
 
         if "cards" not in exclude:
             # collect the nodegroups for which this user has perm
-            readable_nodegroups = [str(nodegroup.pk) for nodegroup in get_nodegroups_by_perm(request.user, [perm], any_perm=True)]
+            readable_nodegroups = list(get_nodegroups_by_perm(request.user, [perm], any_perm=True))
             
             # query only the cards whose nodegroups are readable by user
             permitted_cards = list(CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup_id__in=readable_nodegroups).select_related("nodegroup").order_by("sortorder"))

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1108,11 +1108,8 @@ class ResourceReport(APIBase):
             resp["related_resources"] = related_resources_summary
 
         if "tiles" not in exclude:
-            permitted_tiles = []
-            for tile in TileProxyModel.objects.filter(resourceinstance=resource).select_related("nodegroup").order_by("sortorder"):
-                if request.user.has_perm(perm, tile.nodegroup):
-                    tile.filter_by_perm(request.user, perm)
-                    permitted_tiles.append(tile)
+            resource.load_tiles(user=request.user, perm=perm)
+            permitted_tiles = resource.tiles
 
             resp["tiles"] = permitted_tiles
 

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1107,8 +1107,6 @@ class ResourceReport(APIBase):
 
             resp["related_resources"] = related_resources_summary
 
-        # collect the nodegroups for which this user has perm
-        readable_nodegroups = list(str(nodegroup.pk) for nodegroup in get_nodegroups_by_perm(request.user, [perm], any_perm=True))
         
         if "tiles" not in exclude:
             resource.load_tiles(user=request.user, perm=perm)
@@ -1117,6 +1115,9 @@ class ResourceReport(APIBase):
             resp["tiles"] = permitted_tiles
 
         if "cards" not in exclude:
+            # collect the nodegroups for which this user has perm
+            readable_nodegroups = [str(nodegroup.pk) for nodegroup in get_nodegroups_by_perm(request.user, [perm], any_perm=True)]
+            
             # query only the cards whose nodegroups are readable by user
             permitted_cards = CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup_id__in=readable_nodegroups).select_related("nodegroup").order_by("sortorder")
 

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -14,6 +14,7 @@ from rdflib import RDF
 from rdflib.namespace import SKOS, DCTERMS
 from revproxy.views import ProxyView
 from slugify import slugify
+from operator import attrgetter
 from urllib import parse
 from collections import OrderedDict
 from django.contrib.auth import authenticate
@@ -1118,7 +1119,11 @@ class ResourceReport(APIBase):
             readable_nodegroups = get_nodegroups_by_perm(request.user, [perm], any_perm=True)
             
             # query only the cards whose nodegroups are readable by user
-            permitted_cards = list(CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup__in=readable_nodegroups))
+            permitted_cards = (
+                CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup__in=readable_nodegroups)
+                .prefetch_related("cardxnodexwidget_set")
+                .order_by("sortorder")
+            )
 
             cardwidgets = [
                 widget

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1118,7 +1118,7 @@ class ResourceReport(APIBase):
             readable_nodegroups = list(get_nodegroups_by_perm(request.user, [perm], any_perm=True))
             
             # query only the cards whose nodegroups are readable by user
-            permitted_cards = list(CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup_id__in=readable_nodegroups).select_related("nodegroup").order_by("sortorder"))
+            permitted_cards = list(CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup__in=readable_nodegroups))
 
             cardwidgets = [
                 widget

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1107,7 +1107,6 @@ class ResourceReport(APIBase):
 
             resp["related_resources"] = related_resources_summary
 
-        
         if "tiles" not in exclude:
             resource.load_tiles(user=request.user, perm=perm)
             permitted_tiles = resource.tiles
@@ -1119,7 +1118,7 @@ class ResourceReport(APIBase):
             readable_nodegroups = [str(nodegroup.pk) for nodegroup in get_nodegroups_by_perm(request.user, [perm], any_perm=True)]
             
             # query only the cards whose nodegroups are readable by user
-            permitted_cards = CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup_id__in=readable_nodegroups).select_related("nodegroup").order_by("sortorder")
+            permitted_cards = list(CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup_id__in=readable_nodegroups).select_related("nodegroup").order_by("sortorder"))
 
             cardwidgets = [
                 widget

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1115,7 +1115,7 @@ class ResourceReport(APIBase):
 
         if "cards" not in exclude:
             # collect the nodegroups for which this user has perm
-            readable_nodegroups = list(get_nodegroups_by_perm(request.user, [perm], any_perm=True))
+            readable_nodegroups = get_nodegroups_by_perm(request.user, [perm], any_perm=True)
             
             # query only the cards whose nodegroups are readable by user
             permitted_cards = list(CardProxyModel.objects.filter(graph_id=resource.graph_id, nodegroup__in=readable_nodegroups))

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1127,7 +1127,7 @@ class ResourceReport(APIBase):
 
             cardwidgets = [
                 widget
-                for widgets in [card.cardxnodexwidget_set.order_by("sortorder").all() for card in permitted_cards]
+                for widgets in [sorted(card.cardxnodexwidget_set.all(), key=attrgetter("sortorder")) for card in permitted_cards]
                 for widget in widgets
             ]
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
There are some examples where a list of tiles gets checked against a user's permissions. The issue (#9484)  is that we only care about whether the user has permission for the nodegroup, but we're checking all tiles and thus we're checking tile.nodegroup permissions even after we already know whether the user has permission for that nodegroup.

The two changes made in this PR are in the Resource proxy model to more efficiently leverage the permission backend in the `load_tiles` method, as well as in the Resource Report API to achieve the same for tiles and cards tied to the user's permissions for their related nodegroups.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#9484 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Los Angeles OHR
*   Found by: @whatisgalen 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
