### PR TITLE
Remove setup as default from `python manage.py packages` to prevent fatal mistakes

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -73,7 +73,6 @@ class Command(BaseCommand):
             "--operation",
             action="store",
             dest="operation",
-            default="Use the -h/--help argument to learn about this command",
             choices=[
                 "setup",
                 "install",
@@ -263,6 +262,10 @@ class Command(BaseCommand):
         parser.add_argument("--languages", action="store", dest="languages", help="languages desired as a comma separated list")
 
     def handle(self, *args, **options):
+        if options["operation"] is None:
+            self.print_help("manage.py", "packages")
+            return
+        
         print("operation: " + options["operation"])
         package_name = settings.PACKAGE_NAME
         celery_worker_running = task_management.check_if_celery_available()

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
             "--operation",
             action="store",
             dest="operation",
-            default="setup",
+            default="Use the -h/--help argument to learn about this command",
             choices=[
                 "setup",
                 "install",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Replaces the default `python manage.py packages` command with a helpful prompt to use --help to learn more about the command rather than resetting the database.  

Could replace `setup` with another of the commands, but a non-harming message seemed better even though it isn't in the choices list.  If the default value could call --help that would be better, but I'm not sure if that is possible

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10103 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
