### PR TITLE
Fix for cards losing their values when in "dirty" state & adding back highlight

### DIFF
--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -70,6 +70,7 @@ class URLDataType(BaseDataType):
 
     def validate(self, value, row_number=None, source=None, node=None, nodeid=None, strict=False, **kwargs):
         errors = []
+
         if value is not None:
             try:
                 if value.get("url") is not None:
@@ -82,6 +83,18 @@ class URLDataType(BaseDataType):
                 title = _("Invalid HTTP/HTTPS URL")
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
+            
+            #10592 raise error if label added without URL 
+            if value.get("url_label") and not value.get("url"):
+                message = _("URL label cannot be saved without a URL")
+                title = _("No URL added")
+                error_message = self.create_error_message(value, source, row_number, message, title)
+                errors.append(error_message)
+
+            #10593 adds url_label to JSON if no label added
+            if "url_label" not in value:
+                value["url_label"] = ""
+                
         return errors
 
     def transform_value_for_tile(self, value, **kwargs):

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -84,14 +84,13 @@ class URLDataType(BaseDataType):
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
             
-            #10592 raise error if label added without URL 
+            # raise error if label added without URL (#10592)
             if value.get("url_label") and not value.get("url"):
                 message = _("URL label cannot be saved without a URL")
                 title = _("No URL added")
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
 
-            #10593 adds url_label to JSON if no label added
             if "url_label" not in value:
                 value["url_label"] = ""
                 

--- a/arches/app/media/css/tree.scss
+++ b/arches/app/media/css/tree.scss
@@ -159,6 +159,12 @@
             margin-right: -2px;
         }
     }
+
+    .unsaved-edit {
+        background: #ffdb70;
+        color: #fff;
+        border-width: 2px;
+    }
     
     a.tree-display-tool {
         margin: 0px;

--- a/arches/app/media/js/viewmodels/node-value-select.js
+++ b/arches/app/media/js/viewmodels/node-value-select.js
@@ -121,6 +121,11 @@ define([
             initSelection: function(element, callback) {
                 var id = $(element).val();
                 var tiles = self.tiles();
+                
+                if (self.value()) {
+                    id = self.value()
+                }
+                
                 if (id !== "") {
                     var setSelection = function(tiles, callback)   {
                         var selection =  _.find(tiles, function(tile) {

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -21,6 +21,14 @@ define([
     const viewModel = function(params) {
         params.configKeys = ['placeholder', 'width', 'maxLength', 'defaultValue', 'uneditable'];
 
+        // If the defaultValue of the selected language is empty set to ""
+        // fixes #10027 where inputted values will be reset after navigating away
+        if (params?.config?.()?.defaultValue != "") {
+            if (params?.config?.()?.defaultValue[arches.activeLanguage]["value"] == '') {
+                params.config().defaultValue = ""
+            }
+        }
+
         WidgetViewModel.apply(this, [params]);
         const self = this;
 

--- a/arches/app/media/js/views/components/widgets/urldatatype.js
+++ b/arches/app/media/js/views/components/widgets/urldatatype.js
@@ -11,6 +11,18 @@ define([
          
         WidgetViewModel.apply(this, [params]);
 
+
+        // #10027 assign this.url & this.url_label with value versions for updating UI with edits
+        if (typeof (this.value) === "function") {
+            if (this.value()) {
+                var valueUrl = this.value().url
+                var valueUrlLabel = this.value().url_label
+                this.url(valueUrl)
+                this.url_label(valueUrlLabel)
+            }
+        }
+
+
         this.urlPreviewText = ko.pureComputed(function() {
             if (this.url()) {
                 if (this.url_label && this.url_label()) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The main bug linked shows that some datatypes do not persist card data that is entered but not saved, a feature that almost all datatypes have.  This bug is present for three datatypes: String, URL and Node Value.
This PR fixes all three (details on each fix below).



### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Main issue: #10027 
Datatype Issues: #10592 & #8451

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments
String dtype:
This bug was caused by the `defaultValue` of the string datatype being set to the i18n dictionary of language and value, causing the data entered in the string card to be reset by the empty default value dictionary.  The change in this PR checks whether the active language value is an empty string, and if so then sets the default value as an empty string, allowing the data to persist once again.

URL dtype:
The values `this.url` and `this.url_label` are used in the front end HTM for the datatype, but the variable changed when entering data is `this.value().url` & `url_label`.  The two were not visually synced, as navigating back and forth from the card would reset the UI (`this.url` & `this.url_label`) data but not the 'this.value().X' data.  This fix updates the visual variables with what has been entered.
This PR also includes a fix for #10592 by raising an error if the URL label has been inputted without the URL itself.
It also includes a fix for #8451 by adding the url_label to the object with the value of an empty string.

Node Value dtype:
When a node value is selected and navigated from and to, the `$(el).val()` in `select2-query` is not retained unlike the other select widgets (concept, resource-instance etc).  Similarly, the `initSelection` function within `select2config` id value was reset each time the node was navigated away from.  Assigning the `self.value()` to the id allows data to be retained. 

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
