### PR TITLE
Avoid logging exceptions for tiles with only None values

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -200,7 +200,7 @@ class BaseDataType(object):
                 logger.warning(_("Multiple provisional edits. Returning first edit"))
             userid = list(provisionaledits.keys())[0]
             return provisionaledits[userid]["value"]
-        else:
+        elif not data:
             logger.exception(_("Tile has no authoritative or provisional data"))
 
 

--- a/releases/7.5.1.md
+++ b/releases/7.5.1.md
@@ -15,7 +15,6 @@ Arches 7.5.1 Release Notes
 - Surface card help panel in main file widget area #10477
 - z-index issue: When Adding Geometry, The Edit toolbar is still visible when opening the Help Option #10432
 - Handle empty node values in map report #10473
-- Observe nodegroup permissions in tile excel export #10441
 
 
 ### Dependency changes:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
@chiatt [points out](https://github.com/archesproject/arches/pull/10572#discussion_r1486902445) that a tile can have only None saved to it after saved data is deleted, so this shouldn't emit a logged exception.

Then, remove release note duplicated from 7.5.0 in 7.5.1.

### History
4b02d35d097230f273d34e8aac86204efe5d2057 changed the if/else logic so that tiles with only falsy values reach the else catchall and log an exception (7.5.0)
e4a519e531a tightened that up to "only None values" to exempt falsy values like `[]` in the file-list datatype. (7.5.0)
