### PR TITLE
Update 7.5 breaking changes with `<select>` admonition

### DIFF
--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -154,6 +154,7 @@ JavaScript:
 - The iiif_manifest table now has a globalid column (uuid). Imports to this table will need a uuid value for this field.
 - Descriptors will not always be calculated and saved on index. Custom import scripts will need to call `resource.save_descriptors()` before `resource.index()` to ensure descriptors are updated. 
 - The `calculate_descriptors` method on the Resource proxy model has been renamed `save_descriptors`. Custom import scripts may need to reflect this change.
+- The `select2-query` knockout binding now uses the `selectWoo` JS library in order to provide better accessibility than `select2`. As of this change, any HTML element with a binding like `data-bind="select2Query: { ... }"` must be a `<select>` element.
 
 ### Upgrading Arches
 

--- a/releases/7.5.0.md
+++ b/releases/7.5.0.md
@@ -154,7 +154,7 @@ JavaScript:
 - The iiif_manifest table now has a globalid column (uuid). Imports to this table will need a uuid value for this field.
 - Descriptors will not always be calculated and saved on index. Custom import scripts will need to call `resource.save_descriptors()` before `resource.index()` to ensure descriptors are updated. 
 - The `calculate_descriptors` method on the Resource proxy model has been renamed `save_descriptors`. Custom import scripts may need to reflect this change.
-- The `select2-query` knockout binding now uses the `selectWoo` JS library in order to provide better accessibility than `select2`. As of this change, any HTML element with a binding like `data-bind="select2Query: { ... }"` must be a `<select>` element.
+- The `select2-query` knockout binding now uses the `selectWoo` JS library in order to provide better accessibility than `select2`. As of this change, any HTML element with a binding like `data-bind="select2Query: { ... }"` must be a `<select>` element. These elements should also have an aria-label, however the normal `aria-label` attribute will not work. To do this, use `attr: {'data-label': ...}` in the binding. 
 
 ### Upgrading Arches
 


### PR DESCRIPTION
Came up in an Arches implementation upgrading to 7.5.