### PR TITLE
Fix bulk_update() on I18n_JSON fields for homogenous values #10618

### DIFF
--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from arches.app.models.models import DDataType
 from arches.app.models.fields.i18n import I18n_String, I18n_TextField, I18n_JSON, I18n_JSONField
@@ -394,11 +393,7 @@ class I18nJSONFieldBulkUpdateTests(ArchesTestCase):
                 obj.refresh_from_db()
                 self.assertEqual(str(obj.defaultconfig), str(new_config))
 
-    @unittest.expectedFailure
     def test_bulk_update_heterogenous_values(self):
-        """Situation may improve in Django 5.1?
-        https://github.com/archesproject/arches/issues/10619
-        """
         new_configs = [
             I18n_JSON({
                 "en": "some",
@@ -412,10 +407,20 @@ class I18nJSONFieldBulkUpdateTests(ArchesTestCase):
             dt.defaultconfig = new_configs[i]
             for_bulk_update.append(dt)
 
-        DDataType.objects.bulk_update(for_bulk_update, fields=["defaultconfig"])
+        with self.assertRaises(NotImplementedError):
+            DDataType.objects.bulk_update(for_bulk_update, fields=["defaultconfig"])
 
-        for i, obj in enumerate(for_bulk_update):
-            new_config_as_string = str(new_configs[i])
-            with self.subTest(new_config=new_config_as_string):
-                obj.refresh_from_db()
-                self.assertEqual(str(obj.defaultconfig), new_config_as_string)
+        # If the above starts failing, it's likely the underlying Django
+        # regression was fixed.
+        # https://code.djangoproject.com/ticket/35167
+        
+        # In that case, remove the with statement, de-indent the bulk_update,
+        # and comment the following code back in:
+
+        # for i, obj in enumerate(for_bulk_update):
+        #     new_config_as_string = str(new_configs[i])
+        #     with self.subTest(new_config=new_config_as_string):
+        #         obj.refresh_from_db()
+        #         self.assertEqual(str(obj.defaultconfig), new_config_as_string)
+
+        # Also consider removing the code at the top of I18n_JSON._parse()

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -1,4 +1,7 @@
 import json
+import unittest
+
+from arches.app.models.models import DDataType
 from arches.app.models.fields.i18n import I18n_String, I18n_TextField, I18n_JSON, I18n_JSONField
 from tests.base_test import ArchesTestCase
 from django.contrib.gis.db import models
@@ -6,7 +9,7 @@ from django.utils import translation
 from django.db import connection
 
 # these tests can be run from the command line via
-# python manage.py test tests/localization/field_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests.localization.field_tests --settings="tests.test_settings"
 
 
 class Customi18nTextFieldTests(ArchesTestCase):
@@ -371,3 +374,45 @@ class Customi18nJSONFieldTests(ArchesTestCase):
         m.save()
         m = self.LocalizationTestJsonModel.objects.get(pk=3)
         self.assertEqual(m.config.raw_value, expected_output_json)
+
+
+class I18nJSONFieldBulkUpdateTests(ArchesTestCase):
+    def test_bulk_update_node_config_homogenous_value(self):
+        new_config = I18n_JSON({
+            "en": "some",
+            "zh": "json",
+        })
+        for_bulk_update = []
+        for dt in DDataType.objects.all()[:3]:
+            dt.defaultconfig = new_config
+            for_bulk_update.append(dt)
+
+        DDataType.objects.bulk_update(for_bulk_update, fields=["defaultconfig"])
+
+        for i, obj in enumerate(for_bulk_update):
+            with self.subTest(obj_index=i):
+                obj.refresh_from_db()
+                self.assertEqual(str(obj.defaultconfig), str(new_config))
+
+    @unittest.skip("https://github.com/archesproject/arches/issues/10619")
+    def test_bulk_update_heterogenous_values(self):
+        new_configs = [
+            I18n_JSON({
+                "en": "some",
+                "zh": "json",
+            }),
+            I18n_JSON({}),
+            None,
+        ]
+        for_bulk_update = []
+        for i, dt in enumerate(DDataType.objects.all()[:3]):
+            dt.defaultconfig = new_configs[i]
+            for_bulk_update.append(dt)
+
+        DDataType.objects.bulk_update(for_bulk_update, fields=["defaultconfig"])
+
+        for i, obj in enumerate(for_bulk_update):
+            new_config_as_string = str(new_configs[i])
+            with self.subTest(new_config=new_config_as_string):
+                obj.refresh_from_db()
+                self.assertEqual(str(obj.defaultconfig), new_config_as_string)

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -394,8 +394,11 @@ class I18nJSONFieldBulkUpdateTests(ArchesTestCase):
                 obj.refresh_from_db()
                 self.assertEqual(str(obj.defaultconfig), str(new_config))
 
-    @unittest.skip("https://github.com/archesproject/arches/issues/10619")
+    @unittest.expectedFailure
     def test_bulk_update_heterogenous_values(self):
+        """Situation may improve in Django 5.1?
+        https://github.com/archesproject/arches/issues/10619
+        """
         new_configs = [
             I18n_JSON({
                 "en": "some",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, there was silent data loss when using `bulk_update()` on I18n_JSON fields such as node, datatype, widget, plugin configs.

Now, we at least allow bulk_updates to homogenous values. Heterogenous values (not yet supported) throw an error to prevent a silent failure.

The situation may improve in Django 5.1 if someone submits a PR with the patch identified in [this ticket](https://code.djangoproject.com/ticket/35167). Maybe that someone is one of us? :D

### Issues Solved
Closes #10618 

Opened a followup #10619 for the issue demo'd in the skipped test.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: GCI
*   Found by: @jacobtylerwalls 
*   Tested by: @jacobtylerwalls
