### PR TITLE
Add primevue services to vue app wrapper #10621

### DIFF
--- a/arches/app/media/js/utils/create-vue-application.js
+++ b/arches/app/media/js/utils/create-vue-application.js
@@ -1,4 +1,9 @@
 import PrimeVue from 'primevue/config';
+import AnimateOnScroll from 'primevue/animateonscroll';
+import ConfirmationService from 'primevue/confirmationservice';
+import DialogService from 'primevue/dialogservice';
+import FocusTrap from 'primevue/focustrap';
+import StyleClass from 'primevue/styleclass';
 import ToastService from 'primevue/toastservice';
 import Tooltip from 'primevue/tooltip';
 
@@ -34,7 +39,12 @@ export default async function createVueApp(vueComponent){
         const app = createApp(vueComponent);
         app.use(PrimeVue);
         app.use(gettext);
+        app.use(ConfirmationService);
+        app.use(DialogService);
         app.use(ToastService);
+        app.directive('animateonscroll', AnimateOnScroll);
+        app.directive('focustrap', FocusTrap);
+        app.directive('styleclass', StyleClass);
         app.directive('tooltip', Tooltip);
 
         return app;

--- a/arches/app/media/js/utils/create-vue-application.js
+++ b/arches/app/media/js/utils/create-vue-application.js
@@ -1,4 +1,6 @@
 import PrimeVue from 'primevue/config';
+import ToastService from 'primevue/toastservice';
+import Tooltip from 'primevue/tooltip';
 
 import { createApp } from 'vue';
 import { createGettext } from "vue3-gettext";
@@ -32,6 +34,8 @@ export default async function createVueApp(vueComponent){
         const app = createApp(vueComponent);
         app.use(PrimeVue);
         app.use(gettext);
+        app.use(ToastService);
+        app.directive('tooltip', Tooltip);
 
         return app;
     });

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -3,6 +3,10 @@ Arches 7.6.0 Release Notes
 
 ### Major enhancements
 
+An interface for contributing front-end features in Vue is now provided via the ``createVueApp()`` function. A minimal example is available in the [Arches Vue Integration Styleguide](https://github.com/archesproject/arches-docs/blob/master/docs/developing/vue/arches-vue-integration.md).
+
+The ``createVueApp()`` function is experimental in 7.6. It currently registers all available ``PrimeVue`` services and directives, such as [toast (error messaging) plugins](https://primevue.org/toast/), [tooltip animations](https://primevue.org/tooltip/), and more. Over time, if some of these features do not see significant use in core Arches (or if registering them leads to a performance drag), they may be dropped from the ``createVueApp()`` wrapper. Implementers may always register any needed plugins/services in their own Vue applications. (Note: The vast majority of ``PrimeVue``'s functionality does not require these services or directives.)
+
 ### Performance Improvments
 
 ### Additional improvements and bug fixes

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -7,7 +7,7 @@ An interface for contributing front-end features in Vue is now provided via the 
 
 The ``createVueApp()`` function is experimental in 7.6. It currently registers all available ``PrimeVue`` services and directives, such as [toast (error messaging) plugins](https://primevue.org/toast/), [tooltip animations](https://primevue.org/tooltip/), and more. Over time, if some of these features do not see significant use in core Arches (or if registering them leads to a performance drag), they may be dropped from the ``createVueApp()`` wrapper. Implementers may always register any needed plugins/services in their own Vue applications. (Note: The vast majority of ``PrimeVue``'s functionality does not require these services or directives.)
 
-### Performance Improvments
+### Performance Improvements
 
 ### Additional improvements and bug fixes
 - 10490 Fixes an issue where webpack receives multiple build calls when running in a container


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add ~toast (error message) and tooltip~all services and directives from PrimeVue to the `createVueApplication()` util so that they're available out of the 🎁 .

### Issues Solved
Closes #10621