### PR TITLE
Adjustments to eslint / typescript configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
             "files": [ "*.vue" ],
             "rules": {
                 "vue/html-indent": [2, 4],
-                "vue/this-in-template": "off"
             }
         },
         {

--- a/arches/app/src/declarations.d.ts
+++ b/arches/app/src/declarations.d.ts
@@ -54,6 +54,7 @@ declare module "moment-timezone";
 declare module "nouislider";
 declare module "numeral";
 declare module "primevue";
+declare module "primevue/*";
 declare module "proj4";
 declare module "regenerator-runtime";
 declare module "requirejs";

--- a/arches/install/arches-app-templates/.eslintrc.js
+++ b/arches/install/arches-app-templates/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
             "files": [ "*.vue" ],
             "rules": {
                 "vue/html-indent": [2, 4],
-                "vue/this-in-template": "off"
             }
         },
         {

--- a/arches/install/arches-app-templates/tsconfig.json
+++ b/arches/install/arches-app-templates/tsconfig.json
@@ -26,4 +26,7 @@
     "**/*.ts",
     "**/*.vue",
   ],
+  "vueCompilerOptions": {
+    "skipTemplateCodegen": true
+  }
 }

--- a/arches/install/arches-app-templates/tsconfig.json
+++ b/arches/install/arches-app-templates/tsconfig.json
@@ -18,13 +18,13 @@
     "paths": {
       "@/*": [
         "*.ts",
-        "*.vue",
-      ],
-    },
+        "*.vue"
+      ]
+    }
   },
   "include": [
     "**/*.ts",
-    "**/*.vue",
+    "**/*.vue"
   ],
   "vueCompilerOptions": {
     "skipTemplateCodegen": true

--- a/arches/install/arches-templates/project_name/.eslintrc.js
+++ b/arches/install/arches-templates/project_name/.eslintrc.js
@@ -40,7 +40,6 @@ module.exports = {
             "files": [ "*.vue" ],
             "rules": {
                 "vue/html-indent": [2, 4],
-                "vue/this-in-template": "off"
             }
         },
         {

--- a/arches/install/arches-templates/project_name/tsconfig.json
+++ b/arches/install/arches-templates/project_name/tsconfig.json
@@ -26,4 +26,7 @@
     "**/*.ts",
     "**/*.vue",
   ],
+  "vueCompilerOptions": {
+    "skipTemplateCodegen": true
+  }
 }

--- a/arches/install/arches-templates/project_name/tsconfig.json
+++ b/arches/install/arches-templates/project_name/tsconfig.json
@@ -18,13 +18,13 @@
     "paths": {
       "@/*": [
         "*.ts",
-        "*.vue",
-      ],
-    },
+        "*.vue"
+      ]
+    }
   },
   "include": [
     "**/*.ts",
-    "**/*.vue",
+    "**/*.vue"
   ],
   "vueCompilerOptions": {
     "skipTemplateCodegen": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,4 +26,7 @@
     "**/*.ts",
     "**/*.vue",
   ],
+  "vueCompilerOptions": {
+    "skipTemplateCodegen": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,13 +18,13 @@
     "paths": {
       "@/*": [
         "*.ts",
-        "*.vue",
-      ],
-    },
+        "*.vue"
+      ]
+    }
   },
   "include": [
     "**/*.ts",
-    "**/*.vue",
+    "**/*.vue"
   ],
   "vueCompilerOptions": {
     "skipTemplateCodegen": true


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
I found these small adjustments to be necessary when dev'ing #10569.

- [Declare primevue submodules](https://github.com/archesproject/arches/commit/bcd6f8e6c3a5d5e38ed30b97d5e4fbd3106304e5): was getting:
```
arches/app/src/plugins/ControlledListManager.vue:4:19 - error TS2307: Cannot find module 'primevue/toast' or its corresponding type declarations.

4 import Toast from "primevue/toast";
                    ~~~~~~~~~~~~~~~~
```
- [Turn off typescript in vue templates (for now)](https://github.com/archesproject/arches/commit/92123cdf9d85576f3c0ffaf5e74cf2cb7bd63313): We weren't getting meaningful type-checking in the templates, and moreover we were getting friction from having to use `this` in the templates to avoid false positives, which is discouraged, not ergonomic, and can cause behavior changes. More info [here](https://github.com/archesproject/arches/pull/10569#issuecomment-1924787017).
- [Enable vue/this-in-template](https://github.com/archesproject/arches/commit/0e0ca89fe585cf4daa79034848365af7b9ec97e2) re: previous commit
- [Remove trailing commas in tsconfig](https://github.com/archesproject/arches/commit/854f5e52e32d063fdc9996ae26cf7384a07c328a) - cosmetic change noticed while doing above (trailing commas not allowed in json, but clearly microsoft added some syntactic sugar around this? anyway, if we rig up prettier to format json, it'll do this anyway...)

### Future work
It would be great to find out why we're not getting meaningful type-checking in the templates, but it shouldn't block roll out of typescript (typing of `<script setup>` is better than nuthin'). I can open a follow-up issue.

- [ ] docs update after