### PR TITLE
Include .ts files in gettext extraction

### DIFF
--- a/arches/install/arches-app-templates/gettext.config.js
+++ b/arches/install/arches-app-templates/gettext.config.js
@@ -2,7 +2,7 @@
 module.exports = {
     input: {
       path: "./{{ app_name }}/src", // only files in this directory are considered for extraction
-      include: ["**/*.vue"], // glob patterns to select files for extraction
+      include: ["**/*.vue", "**/*.ts"], // glob patterns to select files for extraction
       exclude: [], // glob patterns to exclude files from extraction
       jsExtractorOpts:[ // custom extractor keyword. default empty.
           {

--- a/arches/install/arches-templates/project_name/gettext.config.js
+++ b/arches/install/arches-templates/project_name/gettext.config.js
@@ -2,7 +2,7 @@
 module.exports = {
     input: {
       path: "./src", // only files in this directory are considered for extraction
-      include: ["**/*.vue"], // glob patterns to select files for extraction
+      include: ["**/*.vue", "**/*.ts"], // glob patterns to select files for extraction
       exclude: [], // glob patterns to exclude files from extraction
       jsExtractorOpts:[ // custom extractor keyword. default empty.
           {

--- a/gettext.config.js
+++ b/gettext.config.js
@@ -2,7 +2,7 @@
 module.exports = {
     input: {
       path: "./arches/app/src", // only files in this directory are considered for extraction
-      include: ["**/*.vue"], // glob patterns to select files for extraction
+      include: ["**/*.vue", "**/*.ts"], // glob patterns to select files for extraction
       exclude: [], // glob patterns to exclude files from extraction
       jsExtractorOpts:[ // custom extractor keyword. default empty.
           {


### PR DESCRIPTION
Follow-up to 01ffc0e5214940455c8418eeff8c1277ef0bde91

I guess we may hold this if we decide not to allow typescript functions to take `$gettext` callbacks, but I'm currently doing it, and figure would be nice to support:

https://github.com/archesproject/arches/blob/c677d557791c678cad03b51bc969964cc506f086/arches/app/src/components/ControlledListManager/api.ts#L38-L42