### PR TITLE
Harden ResourceReport.get() against null sortorder

### DIFF
--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -15,7 +15,6 @@ from rdflib import RDF
 from rdflib.namespace import SKOS, DCTERMS
 from revproxy.views import ProxyView
 from slugify import slugify
-from operator import attrgetter
 from urllib import parse
 from collections import OrderedDict
 from django.contrib.auth import authenticate
@@ -1155,7 +1154,10 @@ class ResourceReport(APIBase):
 
             cardwidgets = [
                 widget
-                for widgets in [sorted(card.cardxnodexwidget_set.all(), key=attrgetter("sortorder")) for card in permitted_cards]
+                for widgets in [
+                    sorted(card.cardxnodexwidget_set.all(), key=lambda x: x.sortorder or 0)
+                    for card in permitted_cards
+                ]
                 for widget in widgets
             ]
 


### PR DESCRIPTION


<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
I suggested a pattern when reviewing #10546 that I just now discovered doesn't work for null sortorders on CardXNodeXWidget records.

Would appreciate a review @whatisgalen if you are available, thanks!

To test, ensure you can view a resource report for a resource with a null sortorder on a cardxnodexwidget row.

Was seeing:
```py
  File "/web_root/arches/arches/app/views/api.py", line 1158, in get
    for widgets in [sorted(card.cardxnodexwidget_set.all(), key=attrgetter("sortorder")) for card in permitted_cards]
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/web_root/arches/arches/app/views/api.py", line 1158, in <listcomp>
    for widgets in [sorted(card.cardxnodexwidget_set.all(), key=attrgetter("sortorder")) for card in permitted_cards]
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```