### PR TITLE
 Fix for cards losing their values when in "dirty" state & adding back highlight - 7.5.x 

### DIFF
--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -70,6 +70,7 @@ class URLDataType(BaseDataType):
 
     def validate(self, value, row_number=None, source=None, node=None, nodeid=None, strict=False, **kwargs):
         errors = []
+
         if value is not None:
             try:
                 if value.get("url") is not None:
@@ -82,6 +83,18 @@ class URLDataType(BaseDataType):
                 title = _("Invalid HTTP/HTTPS URL")
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
+            
+            #10592 raise error if label added without URL 
+            if value.get("url_label") and not value.get("url"):
+                message = _("URL label cannot be saved without a URL")
+                title = _("No URL added")
+                error_message = self.create_error_message(value, source, row_number, message, title)
+                errors.append(error_message)
+
+            #10593 adds url_label to JSON if no label added
+            if "url_label" not in value:
+                value["url_label"] = ""
+                
         return errors
 
     def transform_value_for_tile(self, value, **kwargs):

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -266,8 +266,5 @@ class URLDataType(BaseDataType):
         }
 
     def pre_tile_save(self, tile, nodeid):
-        try:
-            if "url_label" not in tile.data[nodeid]:
-                tile.data[nodeid]["url_label"] = ""
-        except AttributeError:
-            pass
+        if tile and "url_label" not in tile.data[nodeid]:
+            tile.data[nodeid]["url_label"] = ""

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -266,5 +266,6 @@ class URLDataType(BaseDataType):
         }
 
     def pre_tile_save(self, tile, nodeid):
-        if tile and "url_label" not in tile.data[nodeid]:
-            tile.data[nodeid]["url_label"] = ""
+        if tile.data[nodeid]:
+            if tile and "url_label" not in tile.data[nodeid]:
+                tile.data[nodeid]["url_label"] = ""

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -73,7 +73,7 @@ class URLDataType(BaseDataType):
 
         if value is not None:
             try:
-                if value.get("url") is not None:
+                if value.get("url"):
                     # check URL conforms to URL structure
                     url_test = self.URL_REGEX.match(value["url"])
                     if url_test is None:

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -266,6 +266,5 @@ class URLDataType(BaseDataType):
         }
 
     def pre_tile_save(self, tile, nodeid):
-        if tile.data[nodeid]:
-            if tile and "url_label" not in tile.data[nodeid]:
-                tile.data[nodeid]["url_label"] = ""
+        if (tile_val := tile.data[nodeid]) and "url_label" not in tile_val:
+            tile_val["url_label"] = ""

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -90,9 +90,6 @@ class URLDataType(BaseDataType):
                 title = _("No URL added")
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
-
-            if "url_label" not in value:
-                value["url_label"] = ""
                 
         return errors
 
@@ -267,3 +264,10 @@ class URLDataType(BaseDataType):
                 },
             }
         }
+
+    def pre_tile_save(self, tile, nodeid):
+        try:
+            if "url_label" not in tile.data[nodeid]:
+                tile.data[nodeid]["url_label"] = ""
+        except AttributeError:
+            pass

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -268,3 +268,15 @@ class URLDataType(BaseDataType):
     def pre_tile_save(self, tile, nodeid):
         if (tile_val := tile.data[nodeid]) and "url_label" not in tile_val:
             tile_val["url_label"] = ""
+
+    def clean(self, tile, nodeid):
+        if (data := tile.data[nodeid]):
+            try:
+                if not any([val.strip() for val in data.values()]):
+                    tile.data[nodeid] = None
+            except:
+                pass # Let self.validate handle malformed data
+
+    def pre_structure_tile_data(self, tile, nodeid, **kwargs):
+        if (tile_val := tile.data[nodeid]) and "url_label" not in tile_val:
+            tile_val["url_label"] = ""

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -84,14 +84,13 @@ class URLDataType(BaseDataType):
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
             
-            #10592 raise error if label added without URL 
+            # raise error if label added without URL (#10592)
             if value.get("url_label") and not value.get("url"):
                 message = _("URL label cannot be saved without a URL")
                 title = _("No URL added")
                 error_message = self.create_error_message(value, source, row_number, message, title)
                 errors.append(error_message)
 
-            #10593 adds url_label to JSON if no label added
             if "url_label" not in value:
                 value["url_label"] = ""
                 

--- a/arches/app/media/css/tree.scss
+++ b/arches/app/media/css/tree.scss
@@ -159,6 +159,12 @@
             margin-right: -2px;
         }
     }
+
+    .unsaved-edit {
+        background: #ffdb70;
+        color: #fff;
+        border-width: 2px;
+    }
     
     a.tree-display-tool {
         margin: 0px;

--- a/arches/app/media/js/viewmodels/node-value-select.js
+++ b/arches/app/media/js/viewmodels/node-value-select.js
@@ -121,6 +121,11 @@ define([
             initSelection: function(element, callback) {
                 var id = $(element).val();
                 var tiles = self.tiles();
+                
+                if (self.value()) {
+                    id = self.value()
+                }
+                
                 if (id !== "") {
                     var setSelection = function(tiles, callback)   {
                         var selection =  _.find(tiles, function(tile) {

--- a/arches/app/media/js/viewmodels/node-value-select.js
+++ b/arches/app/media/js/viewmodels/node-value-select.js
@@ -122,6 +122,7 @@ define([
                 var id = $(element).val();
                 var tiles = self.tiles();
                 
+                // fixes #10027 where inputted values will be reset after navigating away  
                 if (self.value()) {
                     id = self.value()
                 }

--- a/arches/app/media/js/viewmodels/node-value-select.js
+++ b/arches/app/media/js/viewmodels/node-value-select.js
@@ -124,7 +124,7 @@ define([
                 
                 // fixes #10027 where inputted values will be reset after navigating away  
                 if (self.value()) {
-                    id = self.value()
+                    id = self.value();
                 }
                 
                 if (id !== "") {

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -21,6 +21,14 @@ define([
     const viewModel = function(params) {
         params.configKeys = ['placeholder', 'width', 'maxLength', 'defaultValue', 'uneditable'];
 
+        // If the defaultValue of the selected language is empty set to ""
+        // fixes #10027 where inputted values will be reset after navigating away
+        if (params?.config?.()?.defaultValue != "") {
+            if (params?.config?.()?.defaultValue[arches.activeLanguage]["value"] == '') {
+                params.config().defaultValue = ""
+            }
+        }
+
         WidgetViewModel.apply(this, [params]);
         const self = this;
 

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -21,14 +21,6 @@ define([
     const viewModel = function(params) {
         params.configKeys = ['placeholder', 'width', 'maxLength', 'defaultValue', 'uneditable'];
 
-        // If the defaultValue of the selected language is empty set to ""
-        // fixes #10027 where inputted values will be reset after navigating away
-        if (params?.config?.()?.defaultValue != "") {
-            if (params?.config?.()?.defaultValue?.[arches.activeLanguage]?.["value"] == '') {
-                params.config().defaultValue = ""
-            }
-        }
-
         WidgetViewModel.apply(this, [params]);
         const self = this;
 
@@ -187,6 +179,10 @@ define([
             self.currentDirection(koMapping.toJS(self.value)[currentLanguage.code]?.direction);
 
         });
+
+        if (self.currentDefaultText() === "") {
+            self.defaultValue("")
+        }
 
     };
 

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -181,7 +181,7 @@ define([
         });
 
         if (self.currentDefaultText() === "") {
-            self.defaultValue("")
+            self.defaultValue("");
         }
 
     };

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -24,7 +24,7 @@ define([
         // If the defaultValue of the selected language is empty set to ""
         // fixes #10027 where inputted values will be reset after navigating away
         if (params?.config?.()?.defaultValue != "") {
-            if (params?.config?.()?.defaultValue[arches.activeLanguage]["value"] == '') {
+            if (params?.config?.()?.defaultValue?.[arches.activeLanguage]?.["value"] == '') {
                 params.config().defaultValue = ""
             }
         }

--- a/arches/app/media/js/views/components/widgets/urldatatype.js
+++ b/arches/app/media/js/views/components/widgets/urldatatype.js
@@ -11,6 +11,18 @@ define([
          
         WidgetViewModel.apply(this, [params]);
 
+
+        // #10027 assign this.url & this.url_label with value versions for updating UI with edits
+        if (typeof (this.value) === "function") {
+            if (this.value()) {
+                var valueUrl = this.value().url
+                var valueUrlLabel = this.value().url_label
+                this.url(valueUrl)
+                this.url_label(valueUrlLabel)
+            }
+        }
+
+
         this.urlPreviewText = ko.pureComputed(function() {
             if (this.url()) {
                 if (this.url_label && this.url_label()) {

--- a/arches/app/media/js/views/components/widgets/urldatatype.js
+++ b/arches/app/media/js/views/components/widgets/urldatatype.js
@@ -14,10 +14,10 @@ define([
 
         // #10027 assign this.url & this.url_label with value versions for updating UI with edits
         if (ko.isObservable(this.value) && this.value()) {
-            var valueUrl = this.value().url
-            var valueUrlLabel = this.value().url_label
-            this.url(valueUrl)
-            this.url_label(valueUrlLabel)
+            var valueUrl = this.value().url;
+            var valueUrlLabel = this.value().url_label;
+            this.url(valueUrl);
+            this.url_label(valueUrlLabel);
         }
 
 

--- a/arches/app/media/js/views/components/widgets/urldatatype.js
+++ b/arches/app/media/js/views/components/widgets/urldatatype.js
@@ -13,13 +13,11 @@ define([
 
 
         // #10027 assign this.url & this.url_label with value versions for updating UI with edits
-        if (typeof (this.value) === "function") {
-            if (this.value()) {
-                var valueUrl = this.value().url
-                var valueUrlLabel = this.value().url_label
-                this.url(valueUrl)
-                this.url_label(valueUrlLabel)
-            }
+        if (ko.isObservable(this.value) && this.value()) {
+            var valueUrl = this.value().url
+            var valueUrlLabel = this.value().url_label
+            this.url(valueUrl)
+            this.url_label(valueUrlLabel)
         }
 
 

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -74,3 +74,50 @@ class StringDataTypeTests(ArchesTestCase):
         string.clean(tile2, nodeid)
 
         self.assertIsNotNone(tile2.data[nodeid])
+
+
+class URLDataTypeTests(ArchesTestCase):
+    def test_validate(self):
+        url = DataTypeFactory().get_instance("url")
+
+        no_errors = url.validate({"url": "https://www.google.com/", "url_label": "Google"})
+        self.assertEqual(len(no_errors), 0)
+
+        some_errors_invalid_url = url.validate({"url": "google", "url_label": "Google"})
+        self.assertEqual(len(some_errors_invalid_url), 1)
+
+        # this should probably just be 1 error, but the url empty string not None is causing both
+        some_errors_no_url = url.validate({"url": "", "url_label": "Google"})
+        self.assertEqual(len(some_errors_no_url), 2)
+
+    def test_pre_tile_save(self):
+        url = DataTypeFactory().get_instance("url")
+
+        nodeid = "c0ed4b2a-c4cc-11ee-9626-00155de1df34"
+        resourceinstanceid = "40000000-0000-0000-0000-000000000000"
+
+        url_no_label = {
+            "resourceinstance_id": resourceinstanceid,
+            "parenttile_id": "",
+            "nodegroup_id": nodeid,
+            "tileid": "",
+            "data": {nodeid: {"url": "https://www.google.com/"}},
+        }
+        tile1 = Tile(url_no_label)
+        url.pre_tile_save(tile1, nodeid)
+        self.assertIsNotNone(tile1.data[nodeid])
+        self.assertTrue("url_label" in tile1.data[nodeid])
+        self.assertFalse(tile1.data[nodeid]["url_label"])
+
+        url_with_label = {
+            "resourceinstance_id": resourceinstanceid,
+            "parenttile_id": "",
+            "nodegroup_id": nodeid,
+            "tileid": "",
+            "data": {nodeid: {"url": "https://www.google.com/", "url_label": "Google"}},
+        }
+        tile2 = Tile(url_with_label)
+        url.pre_tile_save(tile2, nodeid)
+        self.assertIsNotNone(tile2.data[nodeid])
+        self.assertTrue("url_label" in tile2.data[nodeid])
+        self.assertTrue(tile2.data[nodeid]["url_label"])

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -124,3 +124,39 @@ class URLDataTypeTests(ArchesTestCase):
         self.assertIsNotNone(tile2.data[nodeid])
         self.assertTrue("url_label" in tile2.data[nodeid])
         self.assertTrue(tile2.data[nodeid]["url_label"])
+
+    def test_clean(self):
+        url = DataTypeFactory().get_instance("url")
+
+        nodeid = "c0ed4b2a-c4cc-11ee-9626-00155de1df34"
+        resourceinstanceid = "40000000-0000-0000-0000-000000000000"
+
+        empty_data = {
+            "resourceinstance_id": resourceinstanceid,
+            "parenttile_id": "",
+            "nodegroup_id": nodeid,
+            "tileid": "",
+            "data": {nodeid: {"url": "", "url_label": ""}},
+        }
+        tile1 = Tile(empty_data)
+        url.clean(tile1, nodeid)
+        self.assertIsNone(tile1.data[nodeid])
+
+    def test_pre_structure_tile_data(self):
+        url = DataTypeFactory().get_instance("url")
+
+        nodeid = "c0ed4b2a-c4cc-11ee-9626-00155de1df34"
+        resourceinstanceid = "40000000-0000-0000-0000-000000000000"
+
+        data_without_label = {
+            "resourceinstance_id": resourceinstanceid,
+            "parenttile_id": "",
+            "nodegroup_id": nodeid,
+            "tileid": "",
+            "data": {nodeid: {"url": ""}},
+        }
+        tile1 = Tile(data_without_label)
+        url.pre_structure_tile_data(tile1, nodeid)
+        self.assertIsNotNone(tile1.data[nodeid])
+        self.assertTrue("url_label" in tile1.data[nodeid])
+        self.assertFalse(tile1.data[nodeid]["url_label"])

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -80,15 +80,18 @@ class URLDataTypeTests(ArchesTestCase):
     def test_validate(self):
         url = DataTypeFactory().get_instance("url")
 
+        # Valid tile
         no_errors = url.validate({"url": "https://www.google.com/", "url_label": "Google"})
         self.assertEqual(len(no_errors), 0)
-
+        # Invalid URL
         some_errors_invalid_url = url.validate({"url": "google", "url_label": "Google"})
         self.assertEqual(len(some_errors_invalid_url), 1)
-
-        # this should probably just be 1 error, but the url empty string not None is causing both
+        # No URL added - cannot save label without URL
+        some_errors_no_url = url.validate({"url_label": "Google"})
+        self.assertEqual(len(some_errors_no_url), 1)
+        # No URL added - with url empty string in object
         some_errors_no_url = url.validate({"url": "", "url_label": "Google"})
-        self.assertEqual(len(some_errors_no_url), 2)
+        self.assertEqual(len(some_errors_no_url), 1)
 
     def test_pre_tile_save(self):
         url = DataTypeFactory().get_instance("url")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The main bug linked shows that some datatypes do not persist card data that is entered but not saved, a feature that almost all datatypes have.  This bug is present for three datatypes: String, URL and Node Value.
This PR fixes all three (details on each fix below).



### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Main issue: #10027 
URL datatype issues: #10592, #8451

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Knowledge Integration
*   Found by: @SDScandrettKint 
*   Tested by: @SDScandrettKint 
*   Designed by: @SDScandrettKint 

### Further comments
String dtype:
This bug was caused by the `defaultValue` of the string datatype being set to the i18n dictionary of language and value, causing the data entered in the string card to be reset by the empty default value dictionary.  The change in this PR checks whether the active language value is an empty string, and if so then sets the default value as an empty string, allowing the data to persist once again.

URL dtype:
The values `this.url` and `this.url_label` are used in the front end HTM for the datatype, but the variable changed when entering data is `this.value().url` & `url_label`.  The two were not visually synced, as navigating back and forth from the card would reset the UI (`this.url` & `this.url_label`) data but not the 'this.value().X' data.  This fix updates the visual variables with what has been entered.
This PR also includes a fix for #10592 by raising an error if the URL label has been inputted without the URL itself.
It also includes a fix for #8451 by adding the url_label to the object with the value of an empty string.
Also found during testing this PR was #10732.

Node Value dtype:
When a node value is selected and navigated from and to, the `$(el).val()` in `select2-query` is not retained unlike the other select widgets (concept, resource-instance etc).  Similarly, the `initSelection` function within `select2config` id value was reset each time the node was navigated away from.  Assigning the `self.value()` to the id allows data to be retained. 

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
