### PR TITLE
Add regression test for #9198

### DIFF
--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -354,4 +354,4 @@ class ResourceTests(ArchesTestCase):
         r.save_descriptors()
 
         # Until 7.4, a RecursionError was caught after this value was repeated many times.
-        self.assertEqual(r.displayname(), "test value")
+        self.assertEqual(r.displayname(), "test value ")


### PR DESCRIPTION
### Description of Change
The recursion error described in #9198 for 7.2 was fixed in 7.4 by de4b9d2, which isolated the resource descriptor getting from resource descriptor calculating. The resource-instance datatype calls `displayname()`, but in 7.4 that just fetches--it doesn't recalculate. Before, that call to displayname() would recalculate, but the caller was already trying to recalculate.

Added a regression test that fails on 7.2:
```py
======================================================================
FAIL: test_self_referring_resource_instance_descriptor (tests.models.resource_test.ResourceTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jwalls/prj/arches/tests/models/resource_test.py", line 317, in test_self_referring_resource_instance_descriptor
    self.assertEqual(r.displayname(), "test value")
AssertionError: 'test value test value test value test value test va[2530 chars]lue ' != 'test value'
- test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value test value 
+ test value

```
### Issues Solved
Closes #9198

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Yale
*   Found by: @azaroth42
*   Tested by: @jacobtylerwalls

#### Additional Info
We have a wide catch that was trapping RecursionError, so it was only on @azaroth42's architecture that it blew up more spectacularly, otherwise on my architecture it was failing silently, e.g. only with an INFO message:
https://github.com/archesproject/arches/blob/a1c2b429f5aaa54af95a4111862eb87d56709107/arches/app/datatypes/datatypes.py#L2315-L2316
