### PR TITLE
Emend Photo Card max-photo-size-warning.

### DIFF
--- a/arches/app/media/js/views/components/cards/photo-gallery-card.js
+++ b/arches/app/media/js/views/components/cards/photo-gallery-card.js
@@ -50,7 +50,7 @@ define([
         this.fileListNodeId = getfileListNode();
 
         this.maxFilesize = ko.computed(function(){
-            var mfs = "Missing maxFilesize"
+            var mfs = "Missing maxFilesize";
             self.card.widgets().forEach(function(widget){
                 if (widget.node_id() === self.fileListNodeId) {
                     mfs = widget.config.maxFilesize();

--- a/arches/app/media/js/views/components/cards/photo-gallery-card.js
+++ b/arches/app/media/js/views/components/cards/photo-gallery-card.js
@@ -53,7 +53,7 @@ define([
             var mfs = "Missing maxFilesize";
             self.card.widgets().forEach(function(widget){
                 if (widget.node_id() === self.fileListNodeId) {
-                    mfs = widget.config.maxFilesize();
+                    mfs = widget.config.maxFilesize() || "--";
                 }
             });
             return mfs;

--- a/arches/app/media/js/views/components/cards/photo-gallery-card.js
+++ b/arches/app/media/js/views/components/cards/photo-gallery-card.js
@@ -49,6 +49,16 @@ define([
 
         this.fileListNodeId = getfileListNode();
 
+        this.maxFilesize = ko.computed(function(){
+            var mfs = "Missing maxFilesize"
+            self.card.widgets().forEach(function(widget){
+                if (widget.node_id() === self.fileListNodeId) {
+                    mfs = widget.config.maxFilesize();
+                }
+            });
+            return mfs;
+        });
+
         this.cleanUrl = function(url) {
             const httpRegex = /^https?:\/\//;
             return !url || httpRegex.test(url) || url.startsWith(arches.urls.url_subpath) ? url :

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -524,7 +524,7 @@
         uploaded-files='{% trans "Uploaded Files" as uploadedFiles %} "{{ uploadedFiles|escapejs }}"'
         allowed-document-formats='{% trans "Allowed document formats:" as allowedDocumentFormats %} "{{ allowedDocumentFormats|escapejs }}"'
         max-file-size-warning='{% trans "You may upload as many documents as you wish, but the maximum size of any single file is" as maxFileSizeWarning %} "{{ maxFileSizeWarning|escapejs }}"'
-        max-photo-size-warning='{% trans "You may upload as many photos as you wish, but the maximum size of any single file is" as maxPhotoSizeWarning %} "{{ maxPhotoSizeWarning|escapejs }}"'
+        max-photo-size-warning='(maxFilesize) => {return {% trans "You may upload as many photos as you wish, but the maximum size of any single file is ${maxFilesize} MB" as maxPhotoSizeWarning %} `{{ maxPhotoSizeWarning|escapejs }}` }'
         adding-documents-optional='{% trans "Adding documents to this record is optional." as addingDocumentsOptional %} "{{ addingDocumentsOptional|escapejs }}"'
         adding-photos-optional='{% trans "Adding photos to this record is optional." as addingPhotosOptional %} "{{ addingPhotosOptional|escapejs }}"'
         select-files='{% trans "Select Files" as selectFiles %} "{{ selectFiles|escapejs }}"'

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -524,7 +524,7 @@
         uploaded-files='{% trans "Uploaded Files" as uploadedFiles %} "{{ uploadedFiles|escapejs }}"'
         allowed-document-formats='{% trans "Allowed document formats:" as allowedDocumentFormats %} "{{ allowedDocumentFormats|escapejs }}"'
         max-file-size-warning='{% trans "You may upload as many documents as you wish, but the maximum size of any single file is" as maxFileSizeWarning %} "{{ maxFileSizeWarning|escapejs }}"'
-        max-photo-size-warning='(maxFilesize) => {return {% trans "You may upload as many photos as you wish, but the maximum size of any single file is ${maxFilesize} MB" as maxPhotoSizeWarning %} `{{ maxPhotoSizeWarning|escapejs }}` }'
+        max-photo-size-warning='(maxFilesize) => {return {% trans "You may upload as many photos as you wish, but the maximum size of any single file is ${maxFilesize} MB." as maxPhotoSizeWarning %} `{{ maxPhotoSizeWarning|escapejs }}` }'
         adding-documents-optional='{% trans "Adding documents to this record is optional." as addingDocumentsOptional %} "{{ addingDocumentsOptional|escapejs }}"'
         adding-photos-optional='{% trans "Adding photos to this record is optional." as addingPhotosOptional %} "{{ addingPhotosOptional|escapejs }}"'
         select-files='{% trans "Select Files" as selectFiles %} "{{ selectFiles|escapejs }}"'

--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -524,7 +524,7 @@
         uploaded-files='{% trans "Uploaded Files" as uploadedFiles %} "{{ uploadedFiles|escapejs }}"'
         allowed-document-formats='{% trans "Allowed document formats:" as allowedDocumentFormats %} "{{ allowedDocumentFormats|escapejs }}"'
         max-file-size-warning='{% trans "You may upload as many documents as you wish, but the maximum size of any single file is" as maxFileSizeWarning %} "{{ maxFileSizeWarning|escapejs }}"'
-        max-photo-size-warning='{% trans "You may upload as many photos as you wish, but the maximum size of any single file is 8MB." as maxPhotoSizeWarning %} "{{ maxPhotoSizeWarning|escapejs }}"'
+        max-photo-size-warning='{% trans "You may upload as many photos as you wish, but the maximum size of any single file is" as maxPhotoSizeWarning %} "{{ maxPhotoSizeWarning|escapejs }}"'
         adding-documents-optional='{% trans "Adding documents to this record is optional." as addingDocumentsOptional %} "{{ addingDocumentsOptional|escapejs }}"'
         adding-photos-optional='{% trans "Adding photos to this record is optional." as addingPhotosOptional %} "{{ addingPhotosOptional|escapejs }}"'
         select-files='{% trans "Select Files" as selectFiles %} "{{ selectFiles|escapejs }}"'

--- a/arches/app/templates/views/components/photo-workbench.htm
+++ b/arches/app/templates/views/components/photo-workbench.htm
@@ -114,8 +114,7 @@
                                 <span data-bind="text: $root.translations.addingPhotosOptional"></span>
                             </p>
                             <p>
-                                <span data-bind="text: $root.translations.maxPhotoSizeWarning + ' : '"></span>
-                                <span data-bind="text: maxFilesize() + ' MB'"></span>
+                                <span data-bind="text: $root.translations.maxPhotoSizeWarning(maxFilesize())"></span>
                             </p>
                         </div>
 

--- a/arches/app/templates/views/components/photo-workbench.htm
+++ b/arches/app/templates/views/components/photo-workbench.htm
@@ -114,7 +114,8 @@
                                 <span data-bind="text: $root.translations.addingPhotosOptional"></span>
                             </p>
                             <p>
-                                <span data-bind="text: $root.translations.maxPhotoSizeWarning"></span>
+                                <span data-bind="text: $root.translations.maxPhotoSizeWarning + ' : '"></span>
+                                <span data-bind="text: maxFilesize() + ' MB'"></span>
                             </p>
                         </div>
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Upload Photographs widget changed to display max-photo-size-warning containing dynamic "maximum size of any single file" value corresponding to the Max File Size as set on the widget manager / db.

![image](https://github.com/archesproject/arches/assets/53860784/346b1eb8-16bf-423c-a521-38933fa13f65)

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10653 
