### PR TITLE
pre-queries for geojson geoms in bounding box before cluster query re…

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -311,15 +311,6 @@ class EditLog(models.Model):
             models.Index(fields=["transactionid"]),
         ]
 
-@receiver(post_save, sender=EditLog)
-def cache_editlog_nodegroup_count(sender, instance, **kwargs):
-    cache = caches["default"]
-    cache.set(
-        f'editlog_nodegroupid_{instance.nodegroupid}_count',
-        EditLog.objects.filter(nodegroupid=instance.nodegroupid).count(),
-        settings.CACHE_BY_USER["editlog"]
-    )
-
 
 class ExternalOauthToken(models.Model):
     token_id = models.UUIDField(primary_key=True, serialize=False, unique=True)

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -311,6 +311,11 @@ class EditLog(models.Model):
             models.Index(fields=["transactionid"]),
         ]
 
+@receiver(post_save, sender=EditLog)
+def cache_editlog_nodegroup_count(sender, instance, **kwargs):
+    cache = caches["default"]
+    cache.set(f'editlog_nodegroupid_{instance.nodegroupid}_count', EditLog.objects.filter(nodegroupid=instance.nodegroupid).count(), settings.CACHE_BY_USER["editlog"])
+
 
 class ExternalOauthToken(models.Model):
     token_id = models.UUIDField(primary_key=True, serialize=False, unique=True)

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -314,7 +314,11 @@ class EditLog(models.Model):
 @receiver(post_save, sender=EditLog)
 def cache_editlog_nodegroup_count(sender, instance, **kwargs):
     cache = caches["default"]
-    cache.set(f'editlog_nodegroupid_{instance.nodegroupid}_count', EditLog.objects.filter(nodegroupid=instance.nodegroupid).count(), settings.CACHE_BY_USER["editlog"])
+    cache.set(
+        f'editlog_nodegroupid_{instance.nodegroupid}_count',
+        EditLog.objects.filter(nodegroupid=instance.nodegroupid).count(),
+        settings.CACHE_BY_USER["editlog"]
+    )
 
 
 class ExternalOauthToken(models.Model):

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -295,8 +295,8 @@ class MVT(APIBase):
                     min_points = int(config["clusterMinPoints"])
                     distance = settings.CLUSTER_DISTANCE_MAX if distance > settings.CLUSTER_DISTANCE_MAX else distance
 
-                    pre_query = """
-                    SELECT id FROM geojson_geometries
+                    count_query = """
+                    SELECT count(*) FROM geojson_geometries
                     WHERE
                     ST_Intersects(geom, TileBBox(%s, %s, %s, 3857))
                     AND

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -402,11 +402,19 @@ class MVT(APIBase):
 
     def create_mvt_cache_key(node, zoom, x, y, user, mvt_snapshot=None):
         if not mvt_snapshot:
-            mvt_snapshot = (
-                cache.get(f'editlog_nodegroupid_{str(node.nodegroup_id)}_count')
-                or
-                models.EditLog.objects.filter(nodegroupid=str(node.nodegroup_id)).count()
+            mvt_snapshot = cache.get(
+                f'editlog_nodegroupid_{str(node.nodegroup_id)}_count'
             )
+            if not mvt_snapshot:
+                mvt_snapshot = models.EditLog.objects.filter(
+                    nodegroupid=str(node.nodegroup_id)
+                ).count()
+                cache.set(
+                    f'editlog_nodegroupid_{str(node.nodegroup_id)}_count',
+                    mvt_snapshot, 
+                    settings.CACHE_BY_USER["editlog"]
+                )
+
         return f"mvt_{str(node.nodeid)}_{zoom}_{x}_{y}_{mvt_snapshot}_{user.id}"
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -279,6 +279,7 @@ class MVT(APIBase):
             node = models.Node.objects.get(nodeid=nodeid, nodegroup_id__in=viewable_nodegroups)
         except models.Node.DoesNotExist:
             raise Http404()
+        search_geometries = None
         config = node.config
         cache_key = f"mvt_{nodeid}_{zoom}_{x}_{y}"
         tile = cache.get(cache_key)
@@ -293,57 +294,73 @@ class MVT(APIBase):
                     distance = arc * float(config["clusterDistance"])
                     min_points = int(config["clusterMinPoints"])
                     distance = settings.CLUSTER_DISTANCE_MAX if distance > settings.CLUSTER_DISTANCE_MAX else distance
-                    cursor.execute(
-                        """WITH clusters(tileid, resourceinstanceid, nodeid, geom, cid)
-                        AS (
-                            SELECT m.*,
-                            ST_ClusterDBSCAN(geom, eps := %s, minpoints := %s) over () AS cid
-                            FROM (
-                                SELECT tileid,
-                                    resourceinstanceid,
-                                    nodeid,
-                                    geom
-                                FROM geojson_geometries
-                                WHERE nodeid = %s and resourceinstanceid not in %s
-                            ) m
-                        )
 
-                        SELECT ST_AsMVT(
-                            tile,
-                             %s,
-                            4096,
-                            'geom',
-                            'id'
-                        ) FROM (
-                            SELECT resourceinstanceid::text,
-                                row_number() over () as id,
-                                1 as total,
-                                ST_AsMVTGeom(
-                                    geom,
-                                    TileBBox(%s, %s, %s, 3857)
-                                ) AS geom,
-                                '' AS extent
-                            FROM clusters
-                            WHERE cid is NULL
-                            UNION
-                            SELECT NULL as resourceinstanceid,
-                                row_number() over () as id,
-                                count(*) as total,
-                                ST_AsMVTGeom(
-                                    ST_Centroid(
-                                        ST_Collect(geom)
-                                    ),
-                                    TileBBox(%s, %s, %s, 3857)
-                                ) AS geom,
-                                ST_AsGeoJSON(
-                                    ST_Extent(geom)
-                                ) AS extent
-                            FROM clusters
-                            WHERE cid IS NOT NULL
-                            GROUP BY cid
-                        ) as tile;""",
-                        [distance, min_points, nodeid, resource_ids, nodeid, zoom, x, y, zoom, x, y],
-                    )
+                    pre_query = """
+                    SELECT id FROM geojson_geometries
+                    WHERE
+                    ST_Intersects(geom, TileBBox(%s, %s, %s, 3857))
+                    AND
+                    nodeid = %s and resourceinstanceid not in %s
+                    """
+
+                    # Execute the potential_geometries_query to get the list of geometries
+                    cursor.execute(pre_query, [zoom, x, y, nodeid, resource_ids])
+                    search_geometries = tuple(str(row[0]) for row in cursor.fetchall())
+
+                    # unclear if the pre_query could be inserted into the clustering query as a subquery
+                    if len(search_geometries):
+                        cursor.execute(
+                            """WITH clusters(tileid, resourceinstanceid, nodeid, geom, cid)
+                            AS (
+                                SELECT m.*,
+                                ST_ClusterDBSCAN(geom, eps := %s, minpoints := %s) over () AS cid
+                                FROM (
+                                    SELECT tileid,
+                                        resourceinstanceid,
+                                        nodeid,
+                                        geom
+                                    FROM geojson_geometries
+                                    WHERE id in %s
+                                ) m
+                            )
+                            SELECT ST_AsMVT(
+                                tile,
+                                %s,
+                                4096,
+                                'geom',
+                                'id'
+                            ) FROM (
+                                SELECT resourceinstanceid::text,
+                                    row_number() over () as id,
+                                    1 as total,
+                                    ST_AsMVTGeom(
+                                        geom,
+                                        TileBBox(%s, %s, %s, 3857)
+                                    ) AS geom,
+                                    '' AS extent
+                                FROM clusters
+                                WHERE cid is NULL
+                                UNION
+                                SELECT NULL as resourceinstanceid,
+                                    row_number() over () as id,
+                                    count(*) as total,
+                                    ST_AsMVTGeom(
+                                        ST_Centroid(
+                                            ST_Collect(geom)
+                                        ),
+                                        TileBBox(%s, %s, %s, 3857)
+                                    ) AS geom,
+                                    ST_AsGeoJSON(
+                                        ST_Extent(geom)
+                                    ) AS extent
+                                FROM clusters
+                                WHERE cid IS NOT NULL
+                                GROUP BY cid
+                            ) as tile;""",
+                            [distance, min_points, search_geometries, nodeid, zoom, x, y, zoom, x, y],
+                        )
+                    else:
+                        raise Http404()
                 else:
                     cursor.execute(
                         """SELECT ST_AsMVT(tile, %s, 4096, 'geom', 'id') FROM (SELECT tileid,

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -379,7 +379,6 @@ class MVT(APIBase):
                     else:
                         tile = ""
                         cache.set(cache_key, tile, settings.TILE_CACHE_TIMEOUT)
-                        raise Http404()
                 else:
                     cursor.execute(
                         """SELECT ST_AsMVT(tile, %s, 4096, 'geom', 'id') FROM (SELECT tileid,

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -281,7 +281,7 @@ class MVT(APIBase):
             raise Http404()
         search_geometries = []
         config = node.config
-        cache_key = f"mvt_{nodeid}_{zoom}_{x}_{y}"
+        cache_key = MVT.create_mvt_cache_key(node, zoom, x, y, request.user)
         tile = cache.get(cache_key)
         if tile is None:
             resource_ids = get_restricted_instances(request.user, allresources=True)

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -279,7 +279,7 @@ class MVT(APIBase):
             node = models.Node.objects.get(nodeid=nodeid, nodegroup_id__in=viewable_nodegroups)
         except models.Node.DoesNotExist:
             raise Http404()
-        search_geometries = None
+        search_geometries = []
         config = node.config
         cache_key = f"mvt_{nodeid}_{zoom}_{x}_{y}"
         tile = cache.get(cache_key)

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -402,7 +402,11 @@ class MVT(APIBase):
 
     def create_mvt_cache_key(node, zoom, x, y, user, mvt_snapshot=None):
         if not mvt_snapshot:
-            mvt_snapshot = models.EditLog.objects.filter(nodegroupid=str(node.nodegroup_id)).count()
+            mvt_snapshot = (
+                cache.get(f'editlog_nodegroupid_{str(node.nodegroup_id)}_count')
+                or
+                models.EditLog.objects.filter(nodegroupid=str(node.nodegroup_id)).count()
+            )
         return f"mvt_{str(node.nodeid)}_{zoom}_{x}_{y}_{mvt_snapshot}_{user.id}"
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -382,6 +382,10 @@ class MVT(APIBase):
             raise Http404()
         return HttpResponse(tile, content_type="application/x-protobuf")
 
+    def create_mvt_cache_key(node, zoom, x, y, user, mvt_snapshot=None):
+        if not mvt_snapshot:
+            mvt_snapshot = models.EditLog.objects.filter(nodegroupid=str(node.nodegroup_id)).count()
+        return f"mvt_{str(node.nodeid)}_{zoom}_{x}_{y}_{mvt_snapshot}_{user.id}"
 
 @method_decorator(csrf_exempt, name="dispatch")
 class Graphs(APIBase):

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -360,6 +360,8 @@ class MVT(APIBase):
                             [distance, min_points, search_geometries, nodeid, zoom, x, y, zoom, x, y],
                         )
                     else:
+                        tile = ""
+                        cache.set(cache_key, tile, settings.TILE_CACHE_TIMEOUT)
                         raise Http404()
                 else:
                     cursor.execute(

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -400,22 +400,8 @@ class MVT(APIBase):
             raise Http404()
         return HttpResponse(tile, content_type="application/x-protobuf")
 
-    def create_mvt_cache_key(node, zoom, x, y, user, mvt_snapshot=None):
-        if not mvt_snapshot:
-            mvt_snapshot = cache.get(
-                f'editlog_nodegroupid_{str(node.nodegroup_id)}_count'
-            )
-            if not mvt_snapshot:
-                mvt_snapshot = models.EditLog.objects.filter(
-                    nodegroupid=str(node.nodegroup_id)
-                ).count()
-                cache.set(
-                    f'editlog_nodegroupid_{str(node.nodegroup_id)}_count',
-                    mvt_snapshot, 
-                    settings.CACHE_BY_USER["editlog"]
-                )
-
-        return f"mvt_{str(node.nodeid)}_{zoom}_{x}_{y}_{mvt_snapshot}_{user.id}"
+    def create_mvt_cache_key(node, zoom, x, y, user):
+        return f"mvt_{str(node.nodeid)}_{zoom}_{x}_{y}_{user.id}"
 
 @method_decorator(csrf_exempt, name="dispatch")
 class Graphs(APIBase):

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -378,7 +378,6 @@ class MVT(APIBase):
                         )
                     else:
                         tile = ""
-                        cache.set(cache_key, tile, settings.TILE_CACHE_TIMEOUT)
                 else:
                     cursor.execute(
                         """SELECT ST_AsMVT(tile, %s, 4096, 'geom', 'id') FROM (SELECT tileid,
@@ -394,7 +393,7 @@ class MVT(APIBase):
                         WHERE nodeid = %s and resourceinstanceid not in %s) AS tile;""",
                         [nodeid, zoom, x, y, nodeid, resource_ids],
                     )
-                tile = bytes(cursor.fetchone()[0])
+                tile = bytes(cursor.fetchone()[0]) if tile is None else tile
                 cache.set(cache_key, tile, settings.TILE_CACHE_TIMEOUT)
         if not len(tile):
             raise Http404()

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -319,7 +319,10 @@ class MVT(APIBase):
                                         nodeid,
                                         geom
                                     FROM geojson_geometries
-                                    WHERE id in %s
+                                    WHERE 
+                                    ST_Intersects(geom, TileBBox(%s, %s, %s, 3857))
+                                    AND
+                                    nodeid = %s and resourceinstanceid not in %s
                                 ) m
                             )
                             SELECT ST_AsMVT(
@@ -356,7 +359,7 @@ class MVT(APIBase):
                                 WHERE cid IS NOT NULL
                                 GROUP BY cid
                             ) as tile;""",
-                            [distance, min_points, search_geometries, nodeid, zoom, x, y, zoom, x, y],
+                            [distance, min_points, zoom, x, y, nodeid, resource_ids, nodeid, zoom, x, y, zoom, x, y],
                         )
                     else:
                         tile = ""

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -500,7 +500,6 @@ TIMEWHEEL_DATE_TIERS = None
 CACHE_BY_USER = {
     "default": 3600 * 24, #24hrs
     "anonymous": 3600 * 24, #24hrs
-    "editlog": 3600 * 24 * 7 #7 days
 }
 
 BYPASS_UNIQUE_CONSTRAINT_TILE_VALIDATION = False

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -499,7 +499,7 @@ TIMEWHEEL_DATE_TIERS = None
 # Identify the usernames and duration (seconds) for which you want to cache the timewheel
 CACHE_BY_USER = {
     "default": 3600 * 24, #24hrs
-    "anonymous": 3600 * 24, #24hrs
+    "anonymous": 3600 * 24 #24hrs
 }
 
 BYPASS_UNIQUE_CONSTRAINT_TILE_VALIDATION = False

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -499,8 +499,9 @@ TIMEWHEEL_DATE_TIERS = None
 # Identify the usernames and duration (seconds) for which you want to cache the timewheel
 CACHE_BY_USER = {
     "default": 3600 * 24, #24hrs
-    "anonymous": 3600 * 24 #24hrs
-    }
+    "anonymous": 3600 * 24, #24hrs
+    "editlog": 3600 * 24 * 7 #7 days
+}
 
 BYPASS_UNIQUE_CONSTRAINT_TILE_VALIDATION = False
 BYPASS_REQUIRED_VALUE_TILE_VALIDATION = False


### PR DESCRIPTION
… #10452

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This PR aims to do a much simpler `count_query` that, if the count is 0, skips a more complex query, caches an empty tile, and raises a 404 for the MVT.

The `count_query` first counts how many geojson geoms for the requested node actually lie within the tile bounding box. If count >= the `min_points` parameter for that node config, it proceeds to the clustering query which further narrows its query with the same subquery as the `count_query` to speed things up. If 0 < count < `min_points` it proceeds to render the unclustered mvt geometry tile.

This PR also creates a method to create a MVT cache key incorporating...
- nodeid, x, y, and zoom
- the userid (proxy for `viewable_nodegroups`)
- a snapshot of the database in the form of the editlog count for the nodegroup linked to the request node

...so that stale MVT/data won't override more recent MVT/data for that node/zoom/x/y/user.

Anecdotal benchmarks of this branch vs the target branch show up to a 30% speed improvement for rendering the largest clustered MVTs.

### Testing This PR
- To test the query-related performance enhancement, you'll want to set `tile = None` between lines 285 and 286 to temporarily disable MVT caching.
- To test the caching of 404's, you'll want to clear out your cache


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10452 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: @[scholiumtech](https://github.com/scholiumtech) & Los Angeles OHR
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
