### PR TITLE
Bump django-silk to 5.1.0

### DIFF
--- a/arches/install/requirements_dev.txt
+++ b/arches/install/requirements_dev.txt
@@ -2,4 +2,4 @@ livereload
 sst
 coverage
 sauceclient
-django-silk==4.2.0
+django-silk==5.1.0

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -23,7 +23,7 @@ System:
 Python:
     Upgraded:
         Django 4.2.8 > 4.2.9
-        openpyxl 3.0.7 > 3.1.2
+        openpyxl 3.0.7 > 3.0.10
 
     Added:
 
@@ -69,6 +69,7 @@ The minimum supported version of Python is now 3.10. Python 3.11 is encouraged, 
 
 4. Uninstall removed dependencies:
     ```
+    pip uninstall django_compressor
     pip uninstall mapbox-vector-tile
     ```
 


### PR DESCRIPTION
Resolves RemovedInDjango51Warning re: get_storage_class:
```py
2024-03-13 12:23:44 /web_root/ENV/lib/python3.11/site-packages/silk/models.py:28: RemovedInDjango51Warning: django.core.files.storage.get_storage_class is deprecated in favor of using django.core.files.storage.storages.
2024-03-13 12:23:44   silk_storage = get_storage_class(SilkyConfig().SILKY_STORAGE_CLASS)()
```