### PR TITLE
Relax upper bound on Django patch releases #10650

### DIFF
--- a/arches/install/requirements.txt
+++ b/arches/install/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.11
+Django>=4.2.11,<5.0.0
 psycopg2==2.9.9
 urllib3<2
 elasticsearch>=8.3.1,<9.0.0

--- a/releases/7.5.2.md
+++ b/releases/7.5.2.md
@@ -8,8 +8,10 @@ Arches 7.5.2 Release Notes
 ```
 Python:
     Upgraded:
-        Django 4.2.10 > 4.2.11
+        Django 4.2.10 > 4.2.11 (or <5.0.0)
 ```
+
+This release relaxes the upper bound on Django to add compatibility with further Django 4.2.x patch releases without requiring a corresponding Arches patch release.
 
 ### Upgrading Arches
 
@@ -44,7 +46,7 @@ Python:
     - If running your project in production:
       - `yarn build_production` This builds a production bundle. **takes up to 2hrs depending on resources**
       - Alternatively you can `cd ..` up a directory and run `python manage.py build_production`. This will create a production bundle of frontend assessts and also call `collectstatic`.
-  
+
 
 6. If you are running Arches on Apache, be sure to run:
 


### PR DESCRIPTION
Closes #10650

There is no 4.3 of Django. 4.2 is the LTS; 5.0 is the current supported version; 5.1 comes out in August. We can probably loosen the upper bound to <5.2.0 in August when 5.1 comes out (in Arches dev/8.0.x).