### PR TITLE
Fix test invocation hint re #9260

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Arches unit tests
         run: |
-          python -W default::DeprecationWarning -m coverage run manage.py test tests --pattern="*.py" --settings="tests.test_settings"
+          python -W default::DeprecationWarning -m coverage run manage.py test tests --settings="tests.test_settings"
 
       - name: Report coverage
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
       python: 3.9
       script:
         - wait-on http://localhost:9200/
-        - python manage.py test tests --pattern="*.py" --settings="tests.test_settings"
+        - python manage.py test tests --settings="tests.test_settings"
     - name: "Javascript - Cypress.io tests"
       install:
         - yarn --cwd arches/install install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ If I am working on ticket "Cool New Feature (ticket #1231)" my branch may be nam
     Note 2: If you have created or deleted files in the file system, you'll have to precede this `commit` command with `git add .` which with add these new (or deleted) files to your git index.
 * Test your changes locally to ensure all the tests pass (make sure your virtual environment is activate first):
     ```shell
-   python manage.py test tests --pattern="*.py" --settings="tests.test_settings"
+   python manage.py test tests --settings="tests.test_settings"
    ```
 * Push your branch to GitHub:
     ```shell

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -367,7 +367,7 @@ run_tests() {
 	echo "----- RUNNING ARCHES TESTS -----"
 	echo ""
 	cd_arches_root
-	python manage.py test tests --pattern="*.py" --settings="tests.test_settings" --exe
+	python manage.py test tests --settings="tests.test_settings" --exe
 	if [ $? -ne 0 ]; then
         echo "Error: Not all tests ran succesfully."
 		echo "Exiting..."

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -42,7 +42,7 @@ from arches.app.search.mappings import (
 )
 
 # these tests can be run from the command line via
-# python manage.py test tests --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests --settings="tests.test_settings"
 
 OAUTH_CLIENT_ID = "AAac4uRQSqybRiO6hu7sHT50C4wmDp9fAmsPlCj9"
 OAUTH_CLIENT_SECRET = "7fos0s7qIhFqUmalDI1QiiYj0rAtEdVMY4hYQDQjOxltbRCBW3dIydOeMD4MytDM9ogCPiYFiMBW6o6ye5bMh5dkeU7pg1cH86wF6B\

--- a/tests/exporter/__init__.py
+++ b/tests/exporter/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/importer --settings="tests.test_settings"
+# python manage.py test tests.importer --settings="tests.test_settings"

--- a/tests/exporter/__init__.py
+++ b/tests/exporter/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests.importer --settings="tests.test_settings"
+# python manage.py test tests.exporter --settings="tests.test_settings"

--- a/tests/exporter/__init__.py
+++ b/tests/exporter/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/importer --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer --settings="tests.test_settings"

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -30,7 +30,7 @@ from rdflib.namespace import RDF, RDFS, XSD
 from django.utils import translation
 
 # these tests can be run from the command line via
-# python manage.py test tests/exporter/datatype_to_rdf_tests.py --settings="tests.test_settings"
+# python manage.py test tests.exporter.datatype_to_rdf_tests --settings="tests.test_settings"
 
 ARCHES_NS = Namespace(test_settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
 CIDOC_NS = Namespace("http://www.cidoc-crm.org/cidoc-crm/")

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -30,7 +30,7 @@ from rdflib.namespace import RDF, RDFS, XSD
 from django.utils import translation
 
 # these tests can be run from the command line via
-# python manage.py test tests/exporter/datatype_to_rdf_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/exporter/datatype_to_rdf_tests.py --settings="tests.test_settings"
 
 ARCHES_NS = Namespace(test_settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
 CIDOC_NS = Namespace("http://www.cidoc-crm.org/cidoc-crm/")

--- a/tests/exporter/jsonld_export_tests.py
+++ b/tests/exporter/jsonld_export_tests.py
@@ -14,7 +14,7 @@ from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.utils.skos import SKOSReader
 
 # these tests can be run from the command line via
-# python manage.py test tests/exporter/jsonld_export_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/exporter/jsonld_export_tests.py --settings="tests.test_settings"
 
 class JsonLDExportTests(ArchesTestCase):
     @classmethod

--- a/tests/exporter/jsonld_export_tests.py
+++ b/tests/exporter/jsonld_export_tests.py
@@ -14,7 +14,7 @@ from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.utils.skos import SKOSReader
 
 # these tests can be run from the command line via
-# python manage.py test tests/exporter/jsonld_export_tests.py --settings="tests.test_settings"
+# python manage.py test tests.exporter.jsonld_export_tests --settings="tests.test_settings"
 
 class JsonLDExportTests(ArchesTestCase):
     @classmethod

--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -31,7 +31,7 @@ from arches.app.utils.data_management.resource_graphs.importer import import_gra
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/exporter/resource_export_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/exporter/resource_export_tests.py --settings="tests.test_settings"
 
 
 class BusinessDataExportTests(ArchesTestCase):

--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -31,7 +31,7 @@ from arches.app.utils.data_management.resource_graphs.importer import import_gra
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/exporter/resource_export_tests.py --settings="tests.test_settings"
+# python manage.py test tests.exporter.resource_export_tests --settings="tests.test_settings"
 
 
 class BusinessDataExportTests(ArchesTestCase):

--- a/tests/importer/__init__.py
+++ b/tests/importer/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/importer --settings="tests.test_settings"
+# python manage.py test tests.importer --settings="tests.test_settings"

--- a/tests/importer/__init__.py
+++ b/tests/importer/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/importer --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer --settings="tests.test_settings"

--- a/tests/importer/concept_import_tests.py
+++ b/tests/importer/concept_import_tests.py
@@ -27,7 +27,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from arches.app.search.search_engine_factory import SearchEngineFactory
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/concept_import_tests.py --settings="tests.test_settings"
+# python manage.py test tests.importer.concept_import_tests --settings="tests.test_settings"
 
 
 class conceptImportTests(ArchesTestCase):

--- a/tests/importer/concept_import_tests.py
+++ b/tests/importer/concept_import_tests.py
@@ -27,7 +27,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from arches.app.search.search_engine_factory import SearchEngineFactory
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/concept_import_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer/concept_import_tests.py --settings="tests.test_settings"
 
 
 class conceptImportTests(ArchesTestCase):

--- a/tests/importer/datatype_from_rdf_tests.py
+++ b/tests/importer/datatype_from_rdf_tests.py
@@ -31,7 +31,7 @@ from rdflib.namespace import RDF, RDFS, XSD
 from arches.app.utils.data_management.resources.formats.rdffile import RdfWriter
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/datatype_from_rdf_tests.py --settings="tests.test_settings"
+# python manage.py test tests.importer.datatype_from_rdf_tests --settings="tests.test_settings"
 
 ARCHES_NS = Namespace(test_settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
 CIDOC_NS = Namespace("http://www.cidoc-crm.org/cidoc-crm/")

--- a/tests/importer/datatype_from_rdf_tests.py
+++ b/tests/importer/datatype_from_rdf_tests.py
@@ -31,7 +31,7 @@ from rdflib.namespace import RDF, RDFS, XSD
 from arches.app.utils.data_management.resources.formats.rdffile import RdfWriter
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/datatype_from_rdf_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer/datatype_from_rdf_tests.py --settings="tests.test_settings"
 
 ARCHES_NS = Namespace(test_settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
 CIDOC_NS = Namespace("http://www.cidoc-crm.org/cidoc-crm/")

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -20,7 +20,7 @@ from arches.app.utils.data_management.resources.formats.rdffile import JsonLdRea
 from pyld.jsonld import expand
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/jsonld_import_tests.py --settings="tests.test_settings"
+# python manage.py test tests.importer.jsonld_import_tests --settings="tests.test_settings"
 
 
 class JsonLDImportTests(ArchesTestCase):

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -20,7 +20,7 @@ from arches.app.utils.data_management.resources.formats.rdffile import JsonLdRea
 from pyld.jsonld import expand
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/jsonld_import_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer/jsonld_import_tests.py --settings="tests.test_settings"
 
 
 class JsonLDImportTests(ArchesTestCase):

--- a/tests/importer/ontology_import_tests.py
+++ b/tests/importer/ontology_import_tests.py
@@ -25,7 +25,7 @@ from arches.app.models import models
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/ontology_import_tests.py --settings="tests.test_settings"
+# python manage.py test tests.importer.ontology_import_tests --settings="tests.test_settings"
 
 
 class OntologyModelTests(ArchesTestCase):

--- a/tests/importer/ontology_import_tests.py
+++ b/tests/importer/ontology_import_tests.py
@@ -25,7 +25,7 @@ from arches.app.models import models
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 
 # these tests can be run from the command line via
-# python manage.py test tests/importer/ontology_import_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer/ontology_import_tests.py --settings="tests.test_settings"
 
 
 class OntologyModelTests(ArchesTestCase):

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -6,7 +6,7 @@ from django.utils import translation
 from django.db import connection
 
 # these tests can be run from the command line via
-# python manage.py test tests/localization/field_tests.py --settings="tests.test_settings"
+# python manage.py test tests.localization.field_tests --settings="tests.test_settings"
 
 
 class Customi18nTextFieldTests(ArchesTestCase):

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -6,7 +6,7 @@ from django.utils import translation
 from django.db import connection
 
 # these tests can be run from the command line via
-# python manage.py test tests/localization/field_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/localization/field_tests.py --settings="tests.test_settings"
 
 
 class Customi18nTextFieldTests(ArchesTestCase):

--- a/tests/localization/po_file_tests.py
+++ b/tests/localization/po_file_tests.py
@@ -11,7 +11,7 @@ from arches.app.models.system_settings import settings
 from unittest.mock import Mock, MagicMock
 
 # these tests can be run from the command line via
-# python manage.py test tests/localization/po_file_tests.py --settings="tests.test_settings"
+# python manage.py test tests.localization.po_file_tests --settings="tests.test_settings"
 
 
 class PoFileTests(TestCase):

--- a/tests/localization/po_file_tests.py
+++ b/tests/localization/po_file_tests.py
@@ -11,7 +11,7 @@ from arches.app.models.system_settings import settings
 from unittest.mock import Mock, MagicMock
 
 # these tests can be run from the command line via
-# python manage.py test tests/localization/po_file_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/localization/po_file_tests.py --settings="tests.test_settings"
 
 
 class PoFileTests(TestCase):

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/models --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models --settings="tests.test_settings"

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/models --settings="tests.test_settings"
+# python manage.py test tests.models --settings="tests.test_settings"

--- a/tests/models/concept_model_tests.py
+++ b/tests/models/concept_model_tests.py
@@ -23,7 +23,7 @@ from arches.app.models.concept import Concept
 from arches.app.models.concept import ConceptValue
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/concept_model_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models/concept_model_tests.py --settings="tests.test_settings"
 
 
 class ConceptModelTests(ArchesTestCase):

--- a/tests/models/concept_model_tests.py
+++ b/tests/models/concept_model_tests.py
@@ -23,7 +23,7 @@ from arches.app.models.concept import Concept
 from arches.app.models.concept import ConceptValue
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/concept_model_tests.py --settings="tests.test_settings"
+# python manage.py test tests.models.concept_model_tests --settings="tests.test_settings"
 
 
 class ConceptModelTests(ArchesTestCase):

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -27,7 +27,7 @@ from arches.app.models.card import Card
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/graph_tests.py --settings="tests.test_settings"
+# python manage.py test tests.models.graph_tests --settings="tests.test_settings"
 
 
 class GraphTests(ArchesTestCase):

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -27,7 +27,7 @@ from arches.app.models.card import Card
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/graph_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models/graph_tests.py --settings="tests.test_settings"
 
 
 class GraphTests(ArchesTestCase):

--- a/tests/models/mapped_archesjson_import_tests.py
+++ b/tests/models/mapped_archesjson_import_tests.py
@@ -29,7 +29,7 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/mapped_archesjson_import_tests.py --settings="tests.test_settings"
+# python manage.py test tests.models.mapped_archesjson_import_tests --settings="tests.test_settings"
 
 
 class mappedArchesJSONImportTests(ArchesTestCase):

--- a/tests/models/mapped_archesjson_import_tests.py
+++ b/tests/models/mapped_archesjson_import_tests.py
@@ -29,7 +29,7 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/mapped_archesjson_import_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models/mapped_archesjson_import_tests.py --settings="tests.test_settings"
 
 
 class mappedArchesJSONImportTests(ArchesTestCase):

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -31,7 +31,7 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/mapped_csv_import_tests.py --settings="tests.test_settings"
+# python manage.py test tests.models.mapped_csv_import_tests --settings="tests.test_settings"
 
 
 class mappedCSVFileImportTests(ArchesTestCase):

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -31,7 +31,7 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/mapped_csv_import_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models/mapped_csv_import_tests.py --settings="tests.test_settings"
 
 
 class mappedCSVFileImportTests(ArchesTestCase):

--- a/tests/models/relational_data_model_tests.py
+++ b/tests/models/relational_data_model_tests.py
@@ -34,7 +34,7 @@ from django.db import connection
 
 
 # these tests can be run from the command line via
-# python manage.py test tests.views.resource_tests --settings="tests.test_settings"
+# python manage.py test tests.models.relational_data_model_tests --settings="tests.test_settings"
 
 
 class RelationalDataModelTests(ArchesTestCase):

--- a/tests/models/relational_data_model_tests.py
+++ b/tests/models/relational_data_model_tests.py
@@ -34,7 +34,7 @@ from django.db import connection
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/resource_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/resource_tests.py --settings="tests.test_settings"
 
 
 class RelationalDataModelTests(ArchesTestCase):

--- a/tests/models/relational_data_model_tests.py
+++ b/tests/models/relational_data_model_tests.py
@@ -34,7 +34,7 @@ from django.db import connection
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/resource_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.resource_tests --settings="tests.test_settings"
 
 
 class RelationalDataModelTests(ArchesTestCase):

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -41,7 +41,7 @@ from tests.base_test import ArchesTestCase
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/resource_test.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models/resource_test.py --settings="tests.test_settings"
 
 
 class ResourceTests(ArchesTestCase):

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -41,7 +41,7 @@ from tests.base_test import ArchesTestCase
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/resource_test.py --settings="tests.test_settings"
+# python manage.py test tests.models.resource_test --settings="tests.test_settings"
 
 
 class ResourceTests(ArchesTestCase):

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -37,7 +37,7 @@ from arches.app.models.models import CardModel, CardXNodeXWidget, Node, NodeGrou
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/tile_model_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/models/tile_model_tests.py --settings="tests.test_settings"
 
 
 class TileTests(ArchesTestCase):

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -37,7 +37,7 @@ from arches.app.models.models import CardModel, CardXNodeXWidget, Node, NodeGrou
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/models/tile_model_tests.py --settings="tests.test_settings"
+# python manage.py test tests.models.tile_model_tests --settings="tests.test_settings"
 
 
 class TileTests(ArchesTestCase):

--- a/tests/permissions/__init__.py
+++ b/tests/permissions/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/importer --settings="tests.test_settings"
+# python manage.py test tests.importer --settings="tests.test_settings"

--- a/tests/permissions/__init__.py
+++ b/tests/permissions/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests.importer --settings="tests.test_settings"
+# python manage.py test tests.permissions --settings="tests.test_settings"

--- a/tests/permissions/__init__.py
+++ b/tests/permissions/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/importer --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/importer --settings="tests.test_settings"

--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -41,7 +41,7 @@ from arches.app.utils.permission_backend import user_has_resource_model_permissi
 from arches.app.utils.permission_backend import get_restricted_users
 
 # these tests can be run from the command line via
-# python manage.py test tests/permissions/permission_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/permissions/permission_tests.py --settings="tests.test_settings"
 
 
 class PermissionTests(ArchesTestCase):

--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -41,7 +41,7 @@ from arches.app.utils.permission_backend import user_has_resource_model_permissi
 from arches.app.utils.permission_backend import get_restricted_users
 
 # these tests can be run from the command line via
-# python manage.py test tests/permissions/permission_tests.py --settings="tests.test_settings"
+# python manage.py test tests.permissions.permission_tests --settings="tests.test_settings"
 
 
 class PermissionTests(ArchesTestCase):

--- a/tests/search/__init__.py
+++ b/tests/search/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/search --settings="tests.test_settings"
+# python manage.py test tests.search --settings="tests.test_settings"

--- a/tests/search/__init__.py
+++ b/tests/search/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/search --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/search --settings="tests.test_settings"

--- a/tests/search/search_tests.py
+++ b/tests/search/search_tests.py
@@ -23,7 +23,7 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Query, Nested, Terms, GeoShape, Range
 
 # these tests can be run from the command line via
-# python manage.py test tests/search/search_tests.py --settings="tests.test_settings"
+# python manage.py test tests.search.search_tests --settings="tests.test_settings"
 
 
 class SearchTests(ArchesTestCase):

--- a/tests/search/search_tests.py
+++ b/tests/search/search_tests.py
@@ -23,7 +23,7 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Query, Nested, Terms, GeoShape, Range
 
 # these tests can be run from the command line via
-# python manage.py test tests/search/search_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/search/search_tests.py --settings="tests.test_settings"
 
 
 class SearchTests(ArchesTestCase):

--- a/tests/utils/compatibility_tests.py
+++ b/tests/utils/compatibility_tests.py
@@ -22,7 +22,7 @@ from arches import VERSION
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/compatibility_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/utils/compatibility_tests.py --settings="tests.test_settings"
 
 
 class CompatibilityTests(ArchesTestCase):

--- a/tests/utils/compatibility_tests.py
+++ b/tests/utils/compatibility_tests.py
@@ -22,7 +22,7 @@ from arches import VERSION
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/compatibility_tests.py --settings="tests.test_settings"
+# python manage.py test tests.utils.compatibility_tests --settings="tests.test_settings"
 
 
 class CompatibilityTests(ArchesTestCase):

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -23,7 +23,7 @@ from tests.base_test import ArchesTestCase
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/datatype_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/utils/datatype_tests.py --settings="tests.test_settings"
 
 
 class BooleanDataTypeTests(ArchesTestCase):

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -23,7 +23,7 @@ from tests.base_test import ArchesTestCase
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/datatype_tests.py --settings="tests.test_settings"
+# python manage.py test tests.utils.datatype_tests --settings="tests.test_settings"
 
 
 class BooleanDataTypeTests(ArchesTestCase):

--- a/tests/utils/date_utils_tests.py
+++ b/tests/utils/date_utils_tests.py
@@ -21,7 +21,7 @@ from tests.base_test import ArchesTestCase
 from arches.app.utils.date_utils import ExtendedDateFormat
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/date_utils_tests.py --settings="tests.test_settings"
+# python manage.py test tests.utils.date_utils_tests --settings="tests.test_settings"
 
 EDTF_DATES = (
     # ******************************* LEVEL 0 *********************************

--- a/tests/utils/date_utils_tests.py
+++ b/tests/utils/date_utils_tests.py
@@ -21,7 +21,7 @@ from tests.base_test import ArchesTestCase
 from arches.app.utils.date_utils import ExtendedDateFormat
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/date_utils_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/utils/date_utils_tests.py --settings="tests.test_settings"
 
 EDTF_DATES = (
     # ******************************* LEVEL 0 *********************************

--- a/tests/utils/i18n.py
+++ b/tests/utils/i18n.py
@@ -5,7 +5,7 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.i18n import rank_label
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/i18n.py --settings="tests.test_settings"
+# python manage.py test tests.utils.i18n --settings="tests.test_settings"
 
 class I18nTests(SimpleTestCase):
     def test_rank_label(self):

--- a/tests/utils/i18n.py
+++ b/tests/utils/i18n.py
@@ -5,7 +5,7 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.i18n import rank_label
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/i18n.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/utils/i18n.py --settings="tests.test_settings"
 
 class I18nTests(SimpleTestCase):
     def test_rank_label(self):

--- a/tests/utils/label_based_graph_test.py
+++ b/tests/utils/label_based_graph_test.py
@@ -16,7 +16,7 @@ from arches.app.utils.label_based_graph import (
 )
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/label_based_graph_test.py --settings="tests.test_settings"
+# python manage.py test tests.utils.label_based_graph_test --settings="tests.test_settings"
 
 class LabelBasedNodeTests(TestCase):
     @classmethod

--- a/tests/utils/label_based_graph_test.py
+++ b/tests/utils/label_based_graph_test.py
@@ -16,7 +16,7 @@ from arches.app.utils.label_based_graph import (
 )
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/label_based_graph_test.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/utils/label_based_graph_test.py --settings="tests.test_settings"
 
 class LabelBasedNodeTests(TestCase):
     @classmethod

--- a/tests/utils/label_based_graph_test_v2.py
+++ b/tests/utils/label_based_graph_test_v2.py
@@ -12,7 +12,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/label_based_graph_test_v2.py --settings="tests.test_settings"
+# python manage.py test tests.utils.label_based_graph_test_v2 --settings="tests.test_settings"
 
 
 class LabelBasedNodeTests(TestCase):

--- a/tests/utils/label_based_graph_test_v2.py
+++ b/tests/utils/label_based_graph_test_v2.py
@@ -12,7 +12,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 
 
 # these tests can be run from the command line via
-# python manage.py test tests/utils/label_based_graph_test_v2.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/utils/label_based_graph_test_v2.py --settings="tests.test_settings"
 
 
 class LabelBasedNodeTests(TestCase):

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/views --settings="tests.test_settings"
+# python manage.py test tests.views --settings="tests.test_settings"

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/views --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views --settings="tests.test_settings"

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -39,7 +39,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from django.contrib.auth.models import User, Group, AnonymousUser
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/api_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/api_tests.py --settings="tests.test_settings"
 
 
 class APITests(ArchesTestCase):

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -39,7 +39,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from django.contrib.auth.models import User, Group, AnonymousUser
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/api_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.api_tests --settings="tests.test_settings"
 
 
 class APITests(ArchesTestCase):

--- a/tests/views/auth_tests.py
+++ b/tests/views/auth_tests.py
@@ -41,7 +41,7 @@ from arches.app.views.concept import RDMView
 from arches.app.utils.middleware import SetAnonymousUser
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/auth_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.auth_tests --settings="tests.test_settings"
 
 class AuthTests(ArchesTestCase):
     @classmethod

--- a/tests/views/auth_tests.py
+++ b/tests/views/auth_tests.py
@@ -41,7 +41,7 @@ from arches.app.views.concept import RDMView
 from arches.app.utils.middleware import SetAnonymousUser
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/auth_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/auth_tests.py --settings="tests.test_settings"
 
 class AuthTests(ArchesTestCase):
     @classmethod

--- a/tests/views/command_line_tests.py
+++ b/tests/views/command_line_tests.py
@@ -34,7 +34,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from django.test.client import Client
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/command_line_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/command_line_tests.py --settings="tests.test_settings"
 
 
 class CommandLineTests(TestCase):

--- a/tests/views/command_line_tests.py
+++ b/tests/views/command_line_tests.py
@@ -34,7 +34,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 from django.test.client import Client
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/command_line_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.command_line_tests --settings="tests.test_settings"
 
 
 class CommandLineTests(TestCase):

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -30,7 +30,7 @@ from arches.app.models.models import Node, NodeGroup, GraphModel, CardModel, Edg
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/graph_manager_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.graph_manager_tests --settings="tests.test_settings"
 
 
 class GraphManagerViewTests(ArchesTestCase):

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -30,7 +30,7 @@ from arches.app.models.models import Node, NodeGroup, GraphModel, CardModel, Edg
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/graph_manager_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/graph_manager_tests.py --settings="tests.test_settings"
 
 
 class GraphManagerViewTests(ArchesTestCase):

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -37,7 +37,7 @@ from django.contrib.auth.models import Group
 from guardian.shortcuts import assign_perm, get_perms, remove_perm, get_group_perms, get_user_perms
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/resource_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.resource_tests --settings="tests.test_settings"
 
 
 def add_users():

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -37,7 +37,7 @@ from django.contrib.auth.models import Group
 from guardian.shortcuts import assign_perm, get_perms, remove_perm, get_group_perms, get_user_perms
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/resource_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/resource_tests.py --settings="tests.test_settings"
 
 
 def add_users():

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -42,7 +42,7 @@ from arches.app.search.elasticsearch_dsl_builder import Query, Term
 from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/search_tests.py --settings="tests.test_settings"
+# python manage.py test tests.views.search_tests --settings="tests.test_settings"
 
 
 class SearchTests(ArchesTestCase):

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -42,7 +42,7 @@ from arches.app.search.elasticsearch_dsl_builder import Query, Term
 from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX
 
 # these tests can be run from the command line via
-# python manage.py test tests/views/search_tests.py --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests/views/search_tests.py --settings="tests.test_settings"
 
 
 class SearchTests(ArchesTestCase):


### PR DESCRIPTION
Fix test invocation hint to use module names.

(File paths were only supported by `nose`, which was removed in #9260 for lack of maintenance and lack of compatibility with recent python versions.)