### PR TITLE
Add `ARCHES_APPLICATIONS` to core settings #10714

### DIFF
--- a/arches/settings.py
+++ b/arches/settings.py
@@ -356,6 +356,8 @@ INSTALLED_APPS = (
     "django_celery_results",
 )
 
+ARCHES_APPLICATIONS = ()
+
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Add `ARCHES_APPLICATIONS` to core settings so that the test suite can be run on core arches after running `setup_db`. We weren't seeing this failure on CI because (AFAICT) it uses a postgres service that bootstraps a database called "arches". It's reasonable to expect an individual contributor to do this via `setup_db` instead.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10714