### PR TITLE
Fix page break when domain values contain apostrophes

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2047,7 +2047,7 @@ class DomainDataType(BaseDomainDataType):
 
         sql = i18n_json_field.attname
         for prop, value in i18n_json_field.raw_value.items():
-            escaped_value = json.dumps(value).replace("%", "%%")
+            escaped_value = json.dumps(value).replace("%", "%%").replace("'", "''")
             if prop == "options":
                 sql = f"""
                     __arches_i18n_update_jsonb_array('options.text', '{{"options": {escaped_value}}}', {sql}, '{i18n_json_field.lang}')

--- a/releases/7.5.2.md
+++ b/releases/7.5.2.md
@@ -4,6 +4,8 @@ Arches 7.5.2 Release Notes
 ### Bug Fixes and Enhancements
 
 1. Fix bug where a Django auth group with no member causes 500 error in some views, #10702
+2. Fix page break when domain value has apostrophe
+
 
 ### Dependency changes:
 ```

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -1,4 +1,6 @@
 import json
+
+from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models.fields.i18n import I18n_String, I18n_TextField, I18n_JSON, I18n_JSONField
 from tests.base_test import ArchesTestCase
 from django.contrib.gis.db import models
@@ -355,3 +357,13 @@ class Customi18nJSONFieldTests(ArchesTestCase):
         m.save()
         m = self.LocalizationTestJsonModel.objects.get(pk=3)
         self.assertEqual(m.config.raw_value, expected_output_json)
+
+
+class AsSqlTests(ArchesTestCase):
+    def test_domain_datatype(self):
+        datatype = DataTypeFactory().get_instance("domain-value")
+        domain_value = I18n_JSON({"en": "it's a bird"})
+
+        # Apostrophe in "it's" is doubly-escaped so it doesn't close the string
+        expected = "jsonb_set(None, array[\'en\'], \'\"it\'\'s a bird\"\')"
+        self.assertEqual(datatype.i18n_as_sql(domain_value, None, None), expected)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, attempting to save a domain value containing an apostrophe would raise a 500 and break the page.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @jacobtylerwalls
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->
