### PR TITLE
10767 enforce search filter sortorder

### DIFF
--- a/arches/app/media/js/views/search.js
+++ b/arches/app/media/js/views/search.js
@@ -140,6 +140,21 @@ define([
         doQuery: function() {
             var queryObj = JSON.parse(this.queryString());
 
+            let sortOrderDict = {}, sortedQueryObj = {};
+            for (let filter of Object.values(SearchComponents)) {
+                sortOrderDict[filter.componentname] = filter.sortorder;
+            }
+            const sortedKeys = Object.keys(queryObj).sort((a, b) => {
+                // Utilizing sortOrderDict for sorting. If a key is not found in sortOrderDict, assign a default sort order
+                const orderA = sortOrderDict[a] || Infinity; // Using Infinity to place unknown items at the end
+                const orderB = sortOrderDict[b] || Infinity;
+                return orderA - orderB;
+            });
+            sortedKeys.forEach(key => {
+                sortedQueryObj[key] = queryObj[key];
+            });
+            queryObj = JSON.parse(JSON.stringify(sortedQueryObj));
+
             if (this.updateRequest) {
                 this.updateRequest.abort();
             }

--- a/arches/app/media/js/views/search.js
+++ b/arches/app/media/js/views/search.js
@@ -138,7 +138,7 @@ define([
         },
 
         doQuery: function() {
-            var queryString = JSON.parse(this.queryString());
+            var queryObj = JSON.parse(this.queryString());
 
             if (this.updateRequest) {
                 this.updateRequest.abort();
@@ -147,7 +147,7 @@ define([
             this.updateRequest = $.ajax({
                 type: "GET",
                 url: arches.urls.search_results,
-                data: queryString,
+                data: queryObj,
                 context: this,
                 success: function(response) {
                     _.each(this.viewModel.sharedStateObject.searchResults, function(value, key, results) {
@@ -175,7 +175,7 @@ define([
                 },
                 complete: function(request, status) {
                     this.updateRequest = undefined;
-                    window.history.pushState({}, '', '?' + $.param(queryString).split('+').join('%20'));
+                    window.history.pushState({}, '', '?' + $.param(queryObj).split('+').join('%20'));
                 }
             });
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The sortorder of search filters is preserved on search load when a new queryObject gets created. However as soon as it is mutated, search filter order per each's `search_component.sortorder` is no longer maintained. This PR ensures that the queryObject (renamed so since that's what it is in the ajax request) enforces search filter sortorder prior to sending to the backend.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10767 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: @scholiumtech
*   Found by: @whatisgalen 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
