### PR TITLE
10770 bulk_save_edits method for saving Tiles en masse

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -305,16 +305,6 @@ class Resource(models.ResourceInstance):
 
         print(f"Time to bulk create tiles and resources: {datetime.timedelta(seconds=time() - start)}")
 
-        start = time()
-        for resource in resources:
-            resource.save_edit(edit_type="create", transaction_id=transaction_id)
-
-        resources[0].tiles[0].save_edit(
-            note=f"Bulk created: {len(tiles)} for {len(resources)} resources.", edit_type="bulk_create", transaction_id=transaction_id
-        )
-
-        print("Time to save resource edits: %s" % datetime.timedelta(seconds=time() - start))
-
         for resource in resources:
             start = time()
             document, terms = resource.get_documents_to_index(

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -278,6 +278,7 @@ class Resource(models.ResourceInstance):
         transaction_id -- a uuid identifing the save of these instances as belonging to a collective load or process
 
         """
+        from arches.app.models.tile import Tile
 
         datatype_factory = DataTypeFactory()
         node_datatypes = {str(nodeid): datatype for nodeid, datatype in models.Node.objects.values_list("nodeid", "datatype")}
@@ -293,6 +294,14 @@ class Resource(models.ResourceInstance):
         start = time()
         Resource.objects.bulk_create(resources)
         TileModel.objects.bulk_create(tiles)
+
+        Tile.bulk_save_edits(
+            tiles=tiles,
+            note=f"Bulk created in Resource.bulk_save",
+            edit_type="bulk_create",
+            transaction_id=transaction_id,
+            new_resource_created=True
+        )
 
         print(f"Time to bulk create tiles and resources: {datetime.timedelta(seconds=time() - start)}")
 

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -176,6 +176,67 @@ class Tile(models.TileModel):
             edit.transactionid = transaction_id
         edit.save()
 
+    @staticmethod
+    def bulk_save_edits(
+        tiles=[],
+        user={},
+        note="",
+        edit_type="",
+        transaction_id=None,
+        new_resource_created=False
+    ):
+        """
+        Accepts a list of Tile objects to save edits for each
+        as well as associated resources
+        Does not support provisional edits
+        """
+        bulk_edits = []
+        resourceids = set()
+        timestamp = datetime.datetime.now()
+        for tile in tiles:
+            if str(tile.resourceinstance.resourceinstanceid) not in resourceids:
+                resourceids.add(str(tile.resourceinstance.resourceinstanceid))
+                resource_edit = EditLog()
+                resource_edit.resourceclassid = tile.resourceinstance.graph_id
+                resource_edit.resourceinstanceid = tile.resourceinstance.resourceinstanceid
+                if new_resource_created:
+                    resource_edit.edittype = "create"
+                else:
+                    resource_edit.edittype = "append"
+                resource_edit.timestamp = timestamp
+                resource_edit.userid = getattr(user, "id", "")
+                resource_edit.user_email = getattr(user, "email", "")
+                resource_edit.user_firstname = getattr(user, "first_name", "")
+                resource_edit.user_lastname = getattr(user, "last_name", "")
+                resource_edit.user_username = getattr(user, "username", "")
+                if transaction_id is not None:
+                    resource_edit.transactionid = transaction_id
+                bulk_edits.append(resource_edit)
+
+            edit = EditLog()
+            edit.resourceclassid = tile.resourceinstance.graph_id
+            edit.resourceinstanceid = tile.resourceinstance.resourceinstanceid
+            edit.resourcedisplayname = tile.resourceinstance.displayname()
+            edit.nodegroupid = tile.nodegroup_id
+            edit.tileinstanceid = tile.tileid
+            edit.userid = getattr(user, "id", "")
+            edit.user_email = getattr(user, "email", "")
+            edit.user_firstname = getattr(user, "first_name", "")
+            edit.user_lastname = getattr(user, "last_name", "")
+            edit.user_username = getattr(user, "username", "")
+            if "delete" in edit_type:
+                edit.old_value = tile.data
+            else:
+                edit.newvalue = tile.data
+            edit.timestamp = timestamp
+            edit.note = note
+            edit.edittype = edit_type
+            if transaction_id is not None:
+                edit.transactionid = transaction_id
+            bulk_edits.append(edit)
+        if len(bulk_edits):
+            models.EditLog.objects.bulk_create(bulk_edits)
+
     def tile_collects_data(self):
         result = True
         if self.tiles is not None and len(self.tiles) > 0:

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -216,7 +216,7 @@ class Tile(models.TileModel):
             edit = EditLog()
             edit.resourceclassid = tile.resourceinstance.graph_id
             edit.resourceinstanceid = tile.resourceinstance.resourceinstanceid
-            edit.resourcedisplayname = tile.resourceinstance.displayname()
+            # edit.resourcedisplayname = Resource.objects.get(pk=tile.resourceinstance_id).displayname() # commented for performance
             edit.nodegroupid = tile.nodegroup_id
             edit.tileinstanceid = tile.tileid
             edit.userid = getattr(user, "id", "")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This PR creates a method inside the Tile Proxy Model to create instances of `EditLog` en masse given a list of Tiles, `bulk_save_edits`. The implementation presented in this PR is via the Resource proxy model `bulk_save` method, which creates Tiles en masse via `bulk_create` and naturally should create edits en masse as well.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10770 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: @scholiumtech
*   Found by: @whatisgalen 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @whatisgalen 
### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
