### PR TITLE
10778 - Fixed Slick image slider path, added shim for jQuery

### DIFF
--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -89,6 +89,9 @@
             'leaflet-draw': {
                 deps: ['leaflet']
             },
+            'slick': {
+                deps: ['jquery']
+            },
             'leaflet-fullscreen': {
                 deps: ['leaflet']
             }
@@ -611,7 +614,7 @@
         provisional='{% trans "Provisional" as provisional %} "{{ provisional|escapejs }}"'
         card-name='{% trans "Card Name" as cardName %} "{{ cardName|escapejs }}"'
         add-tab='{% trans "Add Tab" as addTab %} "{{ addTab|escapejs }}"'
-        tab-name='{% trans "Tab Name" as tabName %} "{{ tabName|escapejs }}"' 
+        tab-name='{% trans "Tab Name" as tabName %} "{{ tabName|escapejs }}"'
         find-a-resource='{% trans "Find a resource..." as findAResource %} "{{ findAResource|escapejs }}"'
         find-an-icon='{% trans "Find an icon" as findAnIcon %} "{{ findAnIcon|escapejs }}"'
         select-tab-icon='{% trans "Select Tab icon" as selectTabIcon %} "{{ selectTabIcon|escapejs }}"'

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "leaflet-side-by-side": "plugins/leaflet-side-by-side/index",
         "themepunch-tools": "plugins/revolution-slider/rs-plugin/js/jquery.themepunch.tools.min",
         "revolution-slider": "plugins/revolution-slider",
-        "slick": "plugins/slick",
+        "slick": "plugins/slick/slick.min",
         "async": "node_modules/requirejs-plugins/src/async",
         "text": "node_modules/requirejs-text/text",
         "jquery": "node_modules/jquery/dist/jquery.min",

--- a/releases/7.5.2.md
+++ b/releases/7.5.2.md
@@ -6,6 +6,7 @@ Arches 7.5.2 Release Notes
 1. Fix bug where a Django auth group with no member causes 500 error in some views, #10702
 2. Fix page break when domain value has apostrophe
 3. Add missing required asterisk to string widget #10749
+4. Fix Slick carousel plugin path so it can be used in the application #10778
 
 
 ### Dependency changes:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Updated path to Slick image slider so it can be used in the application. The existing path was causing webpack build errors. Added a shim for Slick's jQuery dependency.


### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10778

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments
CSS files in core Arches need to be referenced by the project to be able to use the plugin.
