### PR TITLE
Fix webpack failure for project names containing "js" #10791

### DIFF
--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,7 +17,7 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/css(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/css(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,7 +17,8 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/css(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}css(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,9 +17,8 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}css(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}css${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             const parsedPath = Path.parse(subPath);
 
             let pathName = parsedPath['name'];

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,7 +17,7 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/css(.*)/s)[1];  // splits only on first occurrence
+            let subPath = Path.join(path, name).split(/\/css(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-image-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-image-filepath-lookup.js
@@ -18,7 +18,8 @@ const buildImageFilePathLookup = function(publicPath, path, outerAcc, imageDirec
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/img(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}img(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             
             const parsedPath = Path.parse(subPath);

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-image-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-image-filepath-lookup.js
@@ -18,7 +18,7 @@ const buildImageFilePathLookup = function(publicPath, path, outerAcc, imageDirec
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/img(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/\/img(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             
             const parsedPath = Path.parse(subPath);

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-image-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-image-filepath-lookup.js
@@ -18,9 +18,8 @@ const buildImageFilePathLookup = function(publicPath, path, outerAcc, imageDirec
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}img(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}img${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             
             const parsedPath = Path.parse(subPath);
             const filename = parsedPath['dir'] ? Path.join(parsedPath['dir'], parsedPath['base']) : parsedPath['base'];

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,9 +17,8 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}js(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}js${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             const parsedPath = Path.parse(subPath);
 
             let pathName = parsedPath['name'];

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,7 +17,7 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/js(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/\/js(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,7 +17,8 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/js(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}js(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-template-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-template-filepath-lookup.js
@@ -17,7 +17,7 @@ const buildTemplateFilePathLookup = function(path, outerAcc, templateDirectoryPa
             );
         }
         else {
-            let subPath = (Path.join(path, name)).split(/templates(.*)/s)[1];  // splits only on first occurance
+            let subPath = (Path.join(path, name)).split(/\/templates(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
 
             const parsedPath = Path.parse(subPath);

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-template-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-template-filepath-lookup.js
@@ -17,9 +17,8 @@ const buildTemplateFilePathLookup = function(path, outerAcc, templateDirectoryPa
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}templates(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}templates${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
 
             const parsedPath = Path.parse(subPath);
             const filename = parsedPath['dir'] ? Path.join(parsedPath['dir'], parsedPath['base']) : parsedPath['base'];

--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-template-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-template-filepath-lookup.js
@@ -17,7 +17,8 @@ const buildTemplateFilePathLookup = function(path, outerAcc, templateDirectoryPa
             );
         }
         else {
-            let subPath = (Path.join(path, name)).split(/\/templates(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}templates(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
 
             const parsedPath = Path.parse(subPath);

--- a/arches/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,7 +17,8 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/css(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}css(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,9 +17,8 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}css(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}css${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             const parsedPath = Path.parse(subPath);
 
             let pathName = parsedPath['name'];

--- a/arches/webpack/webpack-utils/build-css-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-css-filepath-lookup.js
@@ -17,7 +17,7 @@ function buildCSSFilepathLookup(path, outerAcc, cssDirectoryPath) {
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/css(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/\/css(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/webpack/webpack-utils/build-image-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-image-filepath-lookup.js
@@ -18,7 +18,8 @@ const buildImageFilePathLookup = function(publicPath, path, outerAcc, imageDirec
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/img(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}img(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             
             const parsedPath = Path.parse(subPath);

--- a/arches/webpack/webpack-utils/build-image-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-image-filepath-lookup.js
@@ -18,10 +18,9 @@ const buildImageFilePathLookup = function(publicPath, path, outerAcc, imageDirec
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}img(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
-            
+            const regex = new RegExp(`${Path.sep}img${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
+
             const parsedPath = Path.parse(subPath);
             const filename = parsedPath['dir'] ? Path.join(parsedPath['dir'], parsedPath['base']) : parsedPath['base'];
 

--- a/arches/webpack/webpack-utils/build-image-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-image-filepath-lookup.js
@@ -18,7 +18,7 @@ const buildImageFilePathLookup = function(publicPath, path, outerAcc, imageDirec
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/img(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/\/img(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             
             const parsedPath = Path.parse(subPath);

--- a/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,9 +17,8 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}js(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}js${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             const parsedPath = Path.parse(subPath);
 
             let pathName = parsedPath['name'];

--- a/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,7 +17,8 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/js(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}js(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,7 +17,7 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/js(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/\/js(.*)/s)[1];  // splits only on first occurance
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-javascript-filepath-lookup.js
@@ -17,7 +17,7 @@ function buildJavascriptFilepathLookup(path, outerAcc, javascriptDirectoryPath) 
             );
         }
         else {
-            let subPath = Path.join(path, name).split(/\/js(.*)/s)[1];  // splits only on first occurance
+            let subPath = Path.join(path, name).split(/\/js(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
             const parsedPath = Path.parse(subPath);
 

--- a/arches/webpack/webpack-utils/build-template-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-template-filepath-lookup.js
@@ -17,7 +17,7 @@ const buildTemplateFilePathLookup = function(path, outerAcc, templateDirectoryPa
             );
         }
         else {
-            let subPath = (Path.join(path, name)).split(/templates(.*)/s)[1];  // splits only on first occurance
+            let subPath = (Path.join(path, name)).split(/\/templates(.*)/s)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
 
             const parsedPath = Path.parse(subPath);

--- a/arches/webpack/webpack-utils/build-template-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-template-filepath-lookup.js
@@ -17,9 +17,8 @@ const buildTemplateFilePathLookup = function(path, outerAcc, templateDirectoryPa
             );
         }
         else {
-            const regex = new RegExp(`${Path.sep}templates(.*)`, 's');
-            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
-            subPath = subPath.substring(1);
+            const regex = new RegExp(`${Path.sep}templates${Path.sep}(.*)`, 's');
+            const subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
 
             const parsedPath = Path.parse(subPath);
             const filename = parsedPath['dir'] ? Path.join(parsedPath['dir'], parsedPath['base']) : parsedPath['base'];

--- a/arches/webpack/webpack-utils/build-template-filepath-lookup.js
+++ b/arches/webpack/webpack-utils/build-template-filepath-lookup.js
@@ -17,7 +17,8 @@ const buildTemplateFilePathLookup = function(path, outerAcc, templateDirectoryPa
             );
         }
         else {
-            let subPath = (Path.join(path, name)).split(/\/templates(.*)/s)[1];  // splits only on first occurrence
+            const regex = new RegExp(`${Path.sep}templates(.*)`, 's');
+            let subPath = Path.join(path, name).split(regex)[1];  // splits only on first occurrence
             subPath = subPath.substring(1);
 
             const parsedPath = Path.parse(subPath);


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Prevents webpack failure seen when project name contains the substring "js"

### Issues Solved
Closes #10791

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
To test:
```
arches-project create projs
cd projs
yarn build_development // with a django dev server running
```