### PR TITLE
Fix display and update of provisional edits

### DIFF
--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -103,6 +103,16 @@ define([
                 self.selectedProvisionalEdit(val);
                 koMapping.fromJS(val['value'], self.selectedTile().data);
                 self.selectedTile().parent.params.handlers['tile-reset'].forEach(handler => handler(self.selectedTile()));
+                self.selectedTile().parent.widgets().forEach(
+                    function(w){
+                        var defaultconfig = w.widgetLookup[w.widget_id()].defaultconfig;
+                        if (defaultconfig.rerender === true && self.selectedTile().parent.allowProvisionalEditRerender() === true) {
+                            w.label.valueHasMutated();
+                        } 
+                    });
+                if (self.selectedTile().parent.triggerUpdate) {
+                    self.selectedTile().parent.triggerUpdate();
+                }
             }
         };
 

--- a/arches/app/media/js/viewmodels/provisional-tile.js
+++ b/arches/app/media/js/viewmodels/provisional-tile.js
@@ -102,17 +102,7 @@ define([
             if (self.selectedProvisionalEdit() != val) {
                 self.selectedProvisionalEdit(val);
                 koMapping.fromJS(val['value'], self.selectedTile().data);
-                self.selectedTile()._tileData.valueHasMutated();
-                self.selectedTile().parent.widgets().forEach(
-                    function(w){
-                        var defaultconfig = w.widgetLookup[w.widget_id()].defaultconfig;
-                        if (JSON.parse(defaultconfig).rerender === true && self.selectedTile().parent.allowProvisionalEditRerender() === true) {
-                            self.selectedTile().parent.widgets()[0].label.valueHasMutated();
-                        } 
-                        if (self.selectedTile().parent.triggerUpdate) {
-                            self.selectedTile().parent.triggerUpdate();
-                        }
-                    });
+                self.selectedTile().parent.params.handlers['tile-reset'].forEach(handler => handler(self.selectedTile()));
             }
         };
 

--- a/arches/app/media/js/viewmodels/tile.js
+++ b/arches/app/media/js/viewmodels/tile.js
@@ -84,6 +84,7 @@ define([
         _.extend(this, {
             filter: filter,
             parent: params.card,
+            handlers: params.handlers,
             userisreviewer: params.userisreviewer,
             cards: _.filter(params.cards, function(card) {
                 var nodegroup = _.find(ko.unwrap(params.graphModel.get('nodegroups')), function(group) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fixes the display and updating of provisional edits in the default card

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10633, #10360
