### PR TITLE
Use resource id rather than url in ActivityStreams #10665

### DIFF
--- a/arches/app/utils/activity_stream_jsonld.py
+++ b/arches/app/utils/activity_stream_jsonld.py
@@ -136,7 +136,7 @@ class ActivityStreamCollectionPage(object):
                 # Tombstone instead.
                 obj["formerType"] = obj["type"]
                 obj["type"] = "Tombstone"
-            obj["url"] = self.base_uri_for_arches + reverse("resources", args=(editlog_object.resourceinstanceid,))
+            obj["id"] = editlog_object.resourceinstanceid
 
             return obj
 

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -21,6 +21,7 @@ Arches 7.6.0 Release Notes
 - 10699 Allow overriding search_results view
 - 10726 Upgrade openpyxl package to 3.1.2 and fixes ETL modules
 - 9191 Adds unlocalized string datatype
+- 10665 Return resourceid in ActivityStream rather than resource url
 
 ### Dependency changes
 ```

--- a/tests/utils/activitystream.py
+++ b/tests/utils/activitystream.py
@@ -130,4 +130,5 @@ class ActivityStreamCollectionTests(ArchesTestCase):
 
     def test_generate_page(self):
         collection_page = self.C.generate_page(page_1_uris, reversed([x for x in self.EF.get_events(10)]))
-        outtxt = collection_page.to_jsonld()
+        obj = collection_page.to_obj()
+        self.assertIn("id", obj["orderedItems"][0]["object"])


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Configure ActivityStreams objects to return resource id's rather than resource url.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10665 