### PR TITLE
Return blank tiles from get_tile_data() #10829

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -202,6 +202,8 @@ class BaseDataType(object):
             return provisionaledits[userid]["value"]
         elif not data:
             logger.exception(_("Tile has no authoritative or provisional data"))
+        else:
+            return data
 
 
     def get_display_value(self, tile, node, **kwargs):

--- a/releases/7.5.3.md
+++ b/releases/7.5.3.md
@@ -1,0 +1,52 @@
+Arches 7.5.3 Release Notes
+--------------------------
+
+### Bug Fixes and Enhancements
+
+- Prevent get_tile_data() from returning None for tiles holding only None, #10829
+
+
+### Upgrading Arches
+
+1. Upgrade to version 7.5.0 before proceeding. If upgrading from an earlier version, refer to the upgrade process in the [Version 7.5.0 release notes](https://github.com/archesproject/arches/blob/dev/7.5.x/releases/7.5.0.md)
+
+2. Upgrade to Arches 7.5.3
+    ```
+    pip install --upgrade arches==7.5.3
+    ```
+
+3. Update the JavaScript dependencies and devDependencies:
+    In the project's `package.json` file change arches from `stable/7.5.0` to `stable/7.5.3`:
+    ```    
+        "dependencies": {
+            "arches": "archesproject/arches#stable/7.5.3",
+        },
+        "devDependencies": {
+            "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/7.5.3"
+        }
+    ```
+    In in your terminal navigate to the directory with your project's package.json file. Then run:
+
+        yarn install
+
+
+4. Start your application server in a separate terminal if it's not already running. Your webpack build will not complete without your application server running.
+
+5. In a different terminal navigate to the directory with your project's package.json file, run `yarn start` or `yarn build_development`. This will generate your `media/build` directory.
+   - If running your project in development:
+     -  `yarn start` will build the frontend of the application and then start a webpack development server
+      - `yarn build_development` will build a development bundle for the frontend assests of the application -- this should complete in less than 2 minutes
+    - If running your project in production:
+      - `yarn build_production` This builds a production bundle. **takes up to 2hrs depending on resources**
+      - Alternatively you can `cd ..` up a directory and run `python manage.py build_production`. This will create a production bundle of frontend assessts and also call `collectstatic`.
+
+
+6. If you are running Arches on Apache, be sure to run:
+
+    ```
+    collectstatic
+    ```
+    and restart your server:
+    ```
+    sudo service apache2 reload
+    ```

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -16,6 +16,9 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import uuid
+
+from arches.app.datatypes.base import BaseDataType
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models.models import Language
 from arches.app.models.tile import Tile
@@ -24,6 +27,22 @@ from tests.base_test import ArchesTestCase
 
 # these tests can be run from the command line via
 # python manage.py test tests/utils/datatype_tests.py --pattern="*.py" --settings="tests.test_settings"
+
+class BaseDataTypeTests(ArchesTestCase):
+    def test_get_tile_data_only_none(self):
+        base = BaseDataType()
+        node_id = str(uuid.uuid4())
+        resourceinstance_id = str(uuid.uuid4())
+        tile_data = {node_id: None}
+        tile_holding_only_none = Tile({
+            "resourceinstance_id": resourceinstance_id,
+            "parenttile_id": "",
+            "nodegroup_id": node_id,
+            "tileid": "",
+            "data": tile_data,
+        })
+
+        self.assertEqual(base.get_tile_data(tile_holding_only_none), tile_data)
 
 
 class StringDataTypeTests(ArchesTestCase):


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Return blank tiles (holding only None values) from `get_tile_data()` rather than returning an implicit None. For example, return `{node_id: None}` rather than `None`.

Datatypes often drill into the result of `get_type_data()` expecting a dict, and do not check for `None`. (Perhaps they should, since there is still a code path that could return None after logging an exception. Or, we could elevate that logged exception to a runtime exception, but that's outside the scope here.)

Tiles might hold only None if a tile is added for a resource and then edited to remove all values. Or they might have been created in a data migration (#9704, 7.5.0).

Refs 4b02d35

### History
https://github.com/archesproject/arches/commit/4b02d35d097230f273d34e8aac86204efe5d2057 changed the if/else logic so that tiles with only falsy values log an exception and return None implicitly (7.5.0)
https://github.com/archesproject/arches/commit/e4a519e531aae9e31b3671a116fdfb72a6d8e62e tightened that up to "only None values" to exempt falsy values like [] in the file-list datatype. (7.5.0)
be7a130284f5aa955bbfa73ad10051eb1333d1e2 removed the logged exception for blank tiles but kept the implicit None return (7.5.2)

Targeting dev/7.5.x as this is a regression in 7.5.0.

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
Closes #10829

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @aj-he
*   Tested by: @jacobtylerwalls