### PR TITLE
Measure coverage on untested files re #10738

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+source = arches
+
 [report]
 omit =
     */python?.?/*


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Without the `--source` option, coverage.py doesn't discover python files that aren't exercised in your tests. For instance, the entire etl_modules directory was untested, and so wasn't included in the coverage denominator. (Also, that directory needed an `__init__.py` to be discovered.)

[Docs](https://coverage.readthedocs.io/en/7.5.0/source.html)


See [example coverage artifact](https://github.com/archesproject/arches/actions/runs/8923012808) without etl_modules coverage listed.

### Testing instructions
```sh
coverage run manage.py test tests --settings=tests.test_settings && coverage report
```
Ensure etl_modules and management commands are listed.