### PR TITLE
Fix "sortorder" values are not being preserved during a JSON import

### DIFF
--- a/arches/app/utils/data_management/resources/formats/archesfile.py
+++ b/arches/app/utils/data_management/resources/formats/archesfile.py
@@ -176,6 +176,7 @@ class ArchesFileReader(Reader):
                                 "resourceinstance": resourceinstance,
                                 "parenttile_id": str(src_tile["parenttile_id"]) if src_tile["parenttile_id"] else None,
                                 "nodegroup_id": str(src_tile["nodegroup_id"]) if src_tile["nodegroup_id"] else None,
+                                "sortorder": str(src_tile["sortorder"]) if src_tile["sortorder"] else 0,
                                 "data": src_tile["data"],
                             }
                             new_values = {"tileid": uuid.UUID(str(src_tile["tileid"]))}

--- a/arches/app/utils/data_management/resources/formats/archesfile.py
+++ b/arches/app/utils/data_management/resources/formats/archesfile.py
@@ -176,7 +176,7 @@ class ArchesFileReader(Reader):
                                 "resourceinstance": resourceinstance,
                                 "parenttile_id": str(src_tile["parenttile_id"]) if src_tile["parenttile_id"] else None,
                                 "nodegroup_id": str(src_tile["nodegroup_id"]) if src_tile["nodegroup_id"] else None,
-                                "sortorder": str(src_tile["sortorder"]) if src_tile["sortorder"] else 0,
+                                "sortorder": int(src_tile["sortorder"]) if src_tile["sortorder"] else 0,
                                 "data": src_tile["data"],
                             }
                             new_values = {"tileid": uuid.UUID(str(src_tile["tileid"]))}


### PR DESCRIPTION
When a json file is used for the `import_business_data` command, the "sortorder" values are not being used and all tiles are resetting to all be "sortorder: 0".

### Example

1. Initial Manual Data Entry
*Note the order and the resource name at the top*
![Fixed_Report](https://github.com/archesproject/arches/assets/80784391/b5a6b851-d7bd-4f41-96c9-974ac0ba0127)
[Initial_Export.json which is used for all `import_business_data` commands](https://github.com/archesproject/arches/files/15204092/Initial_Export.json)
1. After using `export_business_data` followed by `import_business_data`
*Note the same areas as last step are now in an incorrect order (this is not a consistent order but is random each time)*
![Reimported_Report](https://github.com/archesproject/arches/assets/80784391/d133b4f9-9a96-4235-a7ee-abc6b8749846)
[Reimported_Export.json](https://github.com/archesproject/arches/files/15204094/Reimported_Export.json)
1. After adding the fix and running `import_business_data` on the same data file as the previous step
*This has the same order as the original data*
![Fixed_Report](https://github.com/archesproject/arches/assets/80784391/1323504d-d613-4946-beb2-3016b0126248)
[Fixed_Export.json](https://github.com/archesproject/arches/files/15204095/Fixed_Export.json)



### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This change adds one line to ingest code for a JSON import and gets the supplied "sortorder" value for a tile similar to how it gets values for "nodegroup_id", "parenttile_id", etc.


### Issues Solved
Now, JSON data that is imported will maintain its order.
#

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [ ] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: Parks Canada
*   Found by: @jkemper-pca 
*   Tested by: @jkemper-pca 
*   Designed by: @jkemper-pca 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
