### PR TITLE
Remove workaround in optimize_resource_iteration() that caused N+1 queries

### DIFF
--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -218,8 +218,7 @@ def optimize_resource_iteration(resources: Iterable[Resource], chunk_size: int):
         )
     else:  # public API that arches itself does not currently use
         for r in resources:
-            # retrieve graph -- better for this to have been selected already
-            r.graph
+            r.clean_fields()  # ensure strings become UUIDs
 
         prefetch_related_objects(resources, tiles_prefetch, descriptor_prefetch)
         return resources

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import json
 import os
 import time
+import uuid
 
 from django.contrib.auth.models import User, Group
 from django.db import connection
@@ -58,7 +59,7 @@ class ResourceTests(ArchesTestCase):
             archesfile = JSONDeserializer().deserialize(f)
         resource_graph_importer(archesfile["graph"])
 
-        cls.search_model_graphid = "c9b37a14-17b3-11eb-a708-acde48001122"
+        cls.search_model_graphid = uuid.UUID("c9b37a14-17b3-11eb-a708-acde48001122")
         cls.search_model_cultural_period_nodeid = "c9b3882e-17b3-11eb-a708-acde48001122"
         cls.search_model_creation_date_nodeid = "c9b38568-17b3-11eb-a708-acde48001122"
         cls.search_model_destruction_date_nodeid = "c9b3828e-17b3-11eb-a708-acde48001122"


### PR DESCRIPTION
Follow-up to https://github.com/archesproject/arches/commit/f2861f22a34e7bb096bbc95bfcf9188d70611ccf.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
@bferguso loosened the type annotation of `index_resources_using_singleprocessing` to take an iterable of resources, so in f2861f22a34e7bb096bbc95bfcf9188d70611ccf I made sure to handle that. But in doing so I hit the footgun described in #10877. I found a workaround that gave up on n+1 queries at the graph level, but the better fix is to just clean the fields to ensure graph ids are UUIDs.

For more information, see #10877.
