### PR TITLE
Preserve tile sortorder in `import_business_data` (JSON format)

### DIFF
--- a/arches/app/utils/data_management/resources/formats/archesfile.py
+++ b/arches/app/utils/data_management/resources/formats/archesfile.py
@@ -162,6 +162,7 @@ class ArchesFileReader(Reader):
                                 "resourceinstance": resourceinstance,
                                 "parenttile_id": str(src_tile["parenttile_id"]) if src_tile["parenttile_id"] else None,
                                 "nodegroup_id": str(src_tile["nodegroup_id"]) if src_tile["nodegroup_id"] else None,
+                                "sortorder": str(src_tile["sortorder"]) if src_tile["sortorder"] else 0,
                                 "data": src_tile["data"],
                             }
                             new_values = {"tileid": uuid.UUID(str(src_tile["tileid"]))}

--- a/arches/app/utils/data_management/resources/formats/archesfile.py
+++ b/arches/app/utils/data_management/resources/formats/archesfile.py
@@ -162,7 +162,7 @@ class ArchesFileReader(Reader):
                                 "resourceinstance": resourceinstance,
                                 "parenttile_id": str(src_tile["parenttile_id"]) if src_tile["parenttile_id"] else None,
                                 "nodegroup_id": str(src_tile["nodegroup_id"]) if src_tile["nodegroup_id"] else None,
-                                "sortorder": str(src_tile["sortorder"]) if src_tile["sortorder"] else 0,
+                                "sortorder": int(src_tile["sortorder"]) if src_tile["sortorder"] else 0,
                                 "data": src_tile["data"],
                             }
                             new_values = {"tileid": uuid.UUID(str(src_tile["tileid"]))}

--- a/releases/6.2.8.md
+++ b/releases/6.2.8.md
@@ -2,6 +2,7 @@ Arches 6.2.8 release notes
 --------------------------
 ### Bug Fixes and Enhancements
 
+- Preserve tile sortorder during `import_business_data` (from JSON) #10874
 
 ### Dependency changes:
 ```


### PR DESCRIPTION
Backport of #10874.

Targeting 6.2 as a "data loss" fix.