### PR TITLE
Allow min & maxzoom to be applied to a resource map source

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -109,6 +109,11 @@ class BaseDataType(object):
         if node is None:
             return None
         source_config = {"type": "vector", "tiles": [tileserver_url]}
+        node_config = json.loads(node.config.value)
+        for prop in ("minzoom", "maxzoom"):
+            if prop in node_config:
+                source_config[prop] = node_config[prop]
+
         count = None
         if preview == True:
             count = models.TileModel.objects.filter(nodegroup_id=node.nodegroup_id, data__has_key=str(node.nodeid)).count()

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -36,6 +36,7 @@ Arches 7.6.0 Release Notes
 - 10781 Graph.delete_instances() now uses BulkDataDeletion
 - 10665 Return resourceid in ActivityStream rather than resource url
 - 10754 Move the i18n/ url outside of the i18n_patterns function
+- Allow minzoom and maxzoom to be applied to a resource map source from a geojson node config #10929
 
 ### Dependency changes
 ```

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -17,13 +17,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import json
+import os
 import uuid
 
 from arches.app.datatypes.base import BaseDataType
 from arches.app.datatypes.datatypes import DataTypeFactory
+from arches.app.models import models
 from arches.app.models.models import Language
 from arches.app.models.tile import Tile
-from arches.app.models.system_settings import settings
+from arches.app.utils.betterJSONSerializer import JSONDeserializer
+from arches.app.utils.data_management.resource_graphs.importer import import_graph as resource_graph_importer
+from arches.app.utils.i18n import LanguageSynchronizer
 from tests.base_test import ArchesTestCase, sync_overridden_test_settings_to_arches
 from django.test import override_settings
 
@@ -62,6 +66,22 @@ class BooleanDataTypeTests(ArchesTestCase):
             boolean.transform_value_for_tile(None)
 
 class GeoJsonDataTypeTest(ArchesTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        LanguageSynchronizer.synchronize_settings_with_db()
+
+        with open(os.path.join("tests/fixtures/resource_graphs/Resource Test Model.json"), "r") as f:
+            archesfile = JSONDeserializer().deserialize(f)
+            
+        resource_graph_importer(archesfile["graph"])
+        cls.search_model_graphid = uuid.UUID("c9b37a14-17b3-11eb-a708-acde48001122")
+
+    @classmethod
+    def tearDownClass(cls):
+        models.GraphModel.objects.filter(pk=cls.search_model_graphid).delete()
+        super().tearDownClass()
 
     def test_validate_reduce_byte_size(self):
         with open("tests/fixtures/problematic_excessive_vertices.geojson") as f:
@@ -105,6 +125,27 @@ class GeoJsonDataTypeTest(ArchesTestCase):
                 geom = json.loads('{"type": "FeatureCollection","features": [{"type": "Feature","properties": {},"geometry": {"coordinates": [13.400257324930152,52.50578474077699],"type": "Point"}}]}')
                 errors = geom_datatype.validate(geom)
                 self.assertEqual(len(errors), 0)
+    
+    def test_get_map_source(self):
+        geom_datatype = DataTypeFactory().get_instance("geojson-feature-collection")
+        node = models.Node.objects.get(pk='c9b37f96-17b3-11eb-a708-acde48001122')
+        nodeconfig = json.loads(node.config.value)
+        nodeconfig["minzoom"] = 12
+        nodeconfig["maxzoom"] = 15
+        node.config.value = json.dumps(nodeconfig)
+        node.save()
+        result = geom_datatype.get_map_source(node)
+        map_source = json.loads(result["source"])
+
+        with self.subTest(input=result):
+            self.assertEqual(result["name"], 'resources-c9b37f96-17b3-11eb-a708-acde48001122')
+
+        with self.subTest(input=map_source):
+            self.assertEqual(map_source["tiles"][0], "/mvt/c9b37f96-17b3-11eb-a708-acde48001122/{z}/{x}/{y}.pbf")
+
+        with self.subTest(input=map_source):
+            self.assertTrue("minzoom" in map_source and "maxzoom" in map_source)
+
 
 class BaseDataTypeTests(ArchesTestCase):
     def test_get_tile_data_only_none(self):


### PR DESCRIPTION

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Allows minzoom and maxzoom properties to be added to the map source of a resource so that geometry requests can be limited to a specific range. 

Currently zoom properties must be added using sql:
```
update nodes set config = config || '{"minzoom": 10}' where nodeid = 'some geojson node id';
```

The ability to modify these properties in the UI will be addressed here: #10931

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10929

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   [x] Unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
