### PR TITLE
Remove references to postgres user in migration

### DIFF
--- a/arches/app/models/migrations/10709_refresh_geos_by_transaction.py
+++ b/arches/app/models/migrations/10709_refresh_geos_by_transaction.py
@@ -56,10 +56,7 @@ class Migration(migrations.Migration):
                     
         $BODY$;
 
-        ALTER FUNCTION public.refresh_transaction_geojson_geometries(uuid)
-            OWNER TO postgres;
-
-
+        
         CREATE OR REPLACE FUNCTION public.__arches_staging_to_tile(
             load_id uuid)
             RETURNS boolean
@@ -176,9 +173,6 @@ class Migration(migrations.Migration):
                 RETURN status;
             END;
         $BODY$;
-
-        ALTER FUNCTION public.__arches_staging_to_tile(uuid)
-            OWNER TO postgres;
         """
 
     reverse = """


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Removes references to postgres users so that Arches can be installed using postgres without the postgres user

### Issues Solved
<!--- If this Pull Request solves any issues, please list them here  -->
#10944 
