### PR TITLE
Adjust APITests setup to work on both v7.6 and v8

### DIFF
--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -66,7 +66,7 @@ class APITests(ArchesTestCase):
             cls.phase_type_assignment_graph.publish(user=None)
             cls.phase_type_assignment_graph.save()
 
-        cls.data_type_graph = Graph.objects.get(name="Data Type Testing Model")
+        cls.data_type_graph = Graph.objects.get(pk=cls.data_type_graphid)
         cls.test_prj_user = (
             models.ResourceInstance.objects.filter(graph=cls.data_type_graph).first()
         )


### PR DESCRIPTION
Fixes test failure in #10948 due to graph names/slugs (I tried slugifying first...) no longer being strictly unique on v8 (unique only to themselves and their partners-in-history):
```py
ERROR: setUpClass (tests.views.api_tests.APITests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/arches/arches/tests/views/api_tests.py", line 69, in setUpClass
    cls.data_type_graph = Graph.objects.get(name="Data Type Testing Model")
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/django/db/models/query.py", line 640, in get
    raise self.model.MultipleObjectsReturned(
arches.app.models.graph.Graph.MultipleObjectsReturned: get() returned more than one Graph -- it returned 2!
```

This should work on both 7.6 and 8.