### PR TITLE
Reenable type-checking in vue templates

### DIFF
--- a/arches/install/arches-templates/tsconfig.json
+++ b/arches/install/arches-templates/tsconfig.json
@@ -25,8 +25,5 @@
   "include": [
     "**/*.ts",
     "**/*.vue"
-  ],
-  "vueCompilerOptions": {
-    "skipTemplateCodegen": true
-  }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,8 +25,5 @@
   "include": [
     "**/*.ts",
     "**/*.vue"
-  ],
-  "vueCompilerOptions": {
-    "skipTemplateCodegen": true
-  }
+  ]
 }


### PR DESCRIPTION
In fca355c we fixed the root cause for why we couldn't get type-checking in vue templates, so reenabling that functionality (that was temporarily turned off in 92123cd).

See example output with templates checked:
```ts
...
arches/app/src/components/ControlledListManager/TreeRow.vue:237:27 - error TS18048: '__VLS_ctx.node.key' is possibly 'undefined'.

237                     v-if="node.key in selectedKeys"
                              ~~~~~~~~

arches/app/src/components/ControlledListManager/TreeRow.vue:246:27 - error TS18048: '__VLS_ctx.node.key' is possibly 'undefined'.

246                     v-if="node.key in selectedKeys"
                              ~~~~~~~~

arches/app/src/components/ControlledListManager/TreeRow.vue:256:42 - error TS18048: '__VLS_ctx.node.key' is possibly 'undefined'.

256                 v-if="!node.data.name && node.key in selectedKeys"
                                             ~~~~~~~~


Found 19 errors in 6 files.
```