### PR TITLE
Fix for search panel height scrolling issues

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -9154,10 +9154,9 @@ a.clear-geojson-button:hover {
 }
 
 .saved-search-grid {
-    height: calc(100vh - 105px);
+    height: auto;
     width: 100%;
     min-height: 400px;
-    overflow-y: scroll;
 }
 
 .ss-grid-item:last-child {
@@ -10175,6 +10174,7 @@ table.table.dataTable {
     height: calc(100vh - 100px);
     border-left: solid 1px #dcdcdc;
     padding: 20px;
+    overflow-y: auto;
 }
 
 .rr-splash-img-container .fa {

--- a/arches/app/templates/views/components/search/saved-searches.htm
+++ b/arches/app/templates/views/components/search/saved-searches.htm
@@ -2,7 +2,7 @@
 {% load static %}
 {% load webpack_static from webpack_loader %}
 
-<div class="saved-search-container relative" style="overflow-y: scroll;">
+<div class="saved-search-container relative">
     <div class="close-popup-panel-container">
         <span class="close-popup-panel" tabindex="0" role="button" id="saved-searches-close-btn" 
             data-bind="onEnterkeyClick, onSpaceClick,

--- a/arches/app/templates/views/components/search/search-export.htm
+++ b/arches/app/templates/views/components/search/search-export.htm
@@ -1,7 +1,7 @@
 {% load template_tags %}
 {% load i18n %}
 
-<div class="relative" style="overflow-y: scroll;">
+<div class="relative">
     <div class="close-popup-panel-container">
         <span class="close-popup-panel" tabindex="0" role="button" id="search-export-close-btn" 
             data-bind="onEnterkeyClick, onSpaceClick, 

--- a/arches/app/templates/views/components/search/time-filter.htm
+++ b/arches/app/templates/views/components/search/time-filter.htm
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="time-search-container relative" style="overflow-y: scroll;">
+<div class="time-search-container relative">
     <div class="close-popup-panel-container time-filter-title">
         <span class="close-popup-panel" tabindex="0" role="button" id="time-filter-close-btn"
             data-bind="onEnterkeyClick, onSpaceClick, 


### PR DESCRIPTION
### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fixes search panel height/scrolling/overflow issue when viewing on devices with smaller screen heights. I wasn't sure if this should be for 7.5 or 7.6, so for now I targeted 7.5.

### Issues Solved
Closes #11019 

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he 
*   Tested by: @phudson-he 
*   Designed by: @phudson-he 
