### PR TITLE
Fine-tune project template tooling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,12 @@ jobs:
             echo "package.json not found, skipping npm commands."
           fi
 
-      - name: Check formatting
+      - name: Check frontend formatting with prettier
         run: |
           npm run prettier:check
+
+      - name: Check backend formatting with black
+        run: |
           black . --check --exclude=node_modules
 
       - name: Run frontend tests

--- a/arches/install/arches-templates/.github/workflows/main.yml
+++ b/arches/install/arches-templates/.github/workflows/main.yml
@@ -61,9 +61,12 @@ jobs:
             echo "package.json not found, skipping npm commands."
           fi
 
-      - name: Check formatting
+      - name: Check frontend formatting with prettier
         run: |
           npm run prettier:check
+
+      - name: Check backend formatting with black
+        run: |
           black . --check --exclude=node_modules
 
       - name: Run frontend tests

--- a/arches/install/arches-templates/.prettierrc
+++ b/arches/install/arches-templates/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "singleAttributePerLine": true
+    "singleAttributePerLine": true,
+    "tabWidth": 4
 }

--- a/arches/install/arches-templates/project_name/install/requirements_dev.txt
+++ b/arches/install/arches-templates/project_name/install/requirements_dev.txt
@@ -1,7 +1,6 @@
 livereload
 sst
 coverage
-sauceclient
 django-silk==5.1.0
 pre-commit
 black==24.4.2

--- a/arches/install/arches-templates/tests/base_test.py-tpl
+++ b/arches/install/arches-templates/tests/base_test.py-tpl
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
 from contextlib import contextmanager
 
 from arches.app.models.system_settings import settings
@@ -34,16 +33,6 @@ from arches.app.search.mappings import (
 
 # these tests can be run from the command line via
 # python manage.py test tests --pattern="*.py" --settings="tests.test_settings"
-
-OAUTH_CLIENT_ID = "AAac4uRQSqybRiO6hu7sHT50C4wmDp9fAmsPlCj9"
-OAUTH_CLIENT_SECRET = "7fos0s7qIhFqUmalDI1QiiYj0rAtEdVMY4hYQDQjOxltbRCBW3dIydOeMD4MytDM9ogCPiYFiMBW6o6ye5bMh5dkeU7pg1cH86wF6B\
-        ap9Ke2aaAZaeMPejzafPSj96ID"
-CREATE_TOKEN_SQL = """
-        INSERT INTO public.oauth2_provider_accesstoken(
-            token, expires, scope, application_id, user_id, created, updated)
-            VALUES ('{token}', '1-1-2068', 'read write', 44, {user_id}, '1-1-2018', '1-1-2018');
-    """
-DELETE_TOKEN_SQL = "DELETE FROM public.oauth2_provider_accesstoken WHERE application_id = 44;"
 
 
 class ArchesTestRunner(DiscoverRunner):


### PR DESCRIPTION
Noticed in arches-lingo:
- these constants in base_test.py are only used in core.
- without specifying tab width, prettier defaulted to two spaces. we missed this in core because we use an .editorconfig
- separate formatting steps