### PR TITLE
Fix mis-aligned buttons in photo editing workflow step

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -692,6 +692,7 @@ dl.inline-flex dd {
     padding: 10px;
     background-color: #ececec;
     border-top: solid 1px #ddd;
+    display: flex;
 }
 
 .tabbed-workflow-step-body .display-in-workflow-step.install-buttons {

--- a/releases/7.5.3.md
+++ b/releases/7.5.3.md
@@ -7,6 +7,7 @@ Arches 7.5.3 Release Notes
 - Fix child concepts not being deleted when a thesaurus is deleted #9444
 - Prevent get_tile_data() from returning None for tiles holding only None, #10829
 - Updates select dropdown to fix broken SPARQL import of concepts #10856
+- Fixes mis-aligned buttons in photo editing workflow step #11052
 - Fixes breaking error when cloning published graphs #10839
 - Fixes branch exports of published graphs #10973
 - Fixes print from resource manager #11035


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Fixes an issue where buttons are mis-aligned when editing photo meta-data in a workflow

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11051 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [x] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he 
*   Tested by: @phudson-he 
*   Designed by: @phudson-he 