### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/arches/app/search/components/sort_results.py
+++ b/arches/app/search/components/sort_results.py
@@ -22,7 +22,7 @@ class SortResults(BaseSearchFilter):
     ):
         sort_param = self.request.GET.get(details["componentname"], None)
 
-        if sort_param is not None and sort_param is not "":
+        if sort_param is not None and sort_param != "":
             search_results_object["query"].sort(
                 field="displayname.value",
                 dsl={


### PR DESCRIPTION
See recent GitHub actions logs with this warning emitted:
```py
/home/runner/work/arches/arches/arches/app/search/components/sort_results.py:25: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if sort_param is not None and sort_param is not "":
```

Could possibly be simplified even further to `if sort_param:`, but would rather keep this scoped smaller / easier to review.