### PR TITLE
Fix flaky test_json_export()

### DIFF
--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -110,10 +110,19 @@ class BusinessDataExportTests(ArchesTestCase):
                 new_list = []
                 for val in obj:
                     new_list.append(deep_sort(val))
-                try:
-                    _sorted = sorted(new_list, key=itemgetter("tileid"))
-                except:
-                    _sorted = new_list
+                if all(
+                    isinstance(item, dict) and "resourceinstance" in item
+                    for item in new_list
+                ):
+                    _sorted = sorted(
+                        new_list,
+                        key=lambda item: item["resourceinstance"]["resourceinstanceid"],
+                    )
+                else:
+                    try:
+                        _sorted = sorted(new_list, key=itemgetter("tileid"))
+                    except:
+                        _sorted = new_list
 
             else:
                 _sorted = obj


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
In this test we had indeterminate sorting of lists holding dictionaries. To sort a list of dictionaries consistently, we need to define a sort key. We had a sort key for the innermost array of tiles (tileid), but not the outer array of resources.

### Testing instructions

With this diff applied:
```diff
diff --git a/tests/exporter/resource_export_tests.py b/tests/exporter/resource_export_tests.py
index 764829e9f5..51799cab88 100644
--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -95,6 +95,7 @@ class BusinessDataExportTests(ArchesTestCase):
         self.assertDictEqual(dict(csv_input), dict(csv_output))
 
     def test_json_export(self):
+        import random
         def deep_sort(obj):
             """
             Recursively sort list or dict nested lists. Taken from
@@ -117,6 +118,7 @@ class BusinessDataExportTests(ArchesTestCase):
                     _sorted = sorted(
                         new_list,
                         key=lambda item: item["resourceinstance"]["resourceinstanceid"],
+                        reverse=random.random() > 0.5,
                     )
                 else:
                     try:
```
you can run `python3 manage.py test tests -k test_json_export --settings=tests.test_settings --keepdb` and see the [failure](https://github.com/archesproject/arches/actions/runs/9585820836/job/26432543378) occasionally seen on CI.