### PR TITLE
Ensure search facets have widget label on restore #11046

### DIFF
--- a/arches/app/media/js/views/components/search/advanced-search.js
+++ b/arches/app/media/js/views/components/search/advanced-search.js
@@ -236,8 +236,9 @@ define([
                         return _.contains(cardNodeIds, nodeIds[0]);
                     }, this);
                     if (card) {
-                        _.each(card.nodes, function(node) {
+                        card.nodes.forEach(node => {
                             facet[node.nodeid] = ko.observable(facet[node.nodeid]);
+                            node.label = this.widgetLookup[node.nodeid]?.label;  
                         });
                         facet.op = ko.observable(facet.op);
                         this.filter.facets.push({

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -33,6 +33,7 @@ Arches 7.6.0 Release Notes
 - 9768 Filter out tiles created during resource creation from activity stream API
 - 9769 Ensure resource creation edit log timestamps precede resource update timestamps
 - 10738 Adds Github action for comparing test coverage between branches and rejecting branches that lower test coverage
+- Ensure search facets have widget label on advanced search restore #11046
 - 10842 Adds project-level testing and GitHub test runners
 - 10699 Allow overriding search_results view
 - 10911 Styling fix in resource model manage menu


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Ensures advanced search facets have widget labels when the search is restored #11046

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11046

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
