### PR TITLE
Allow import of modules with unspecified js/mjs extensions #10992

### DIFF
--- a/arches/install/arches-templates/webpack/webpack.common.js
+++ b/arches/install/arches-templates/webpack/webpack.common.js
@@ -316,9 +316,12 @@ module.exports = () => {
                             loader: Path.join(PROJECT_RELATIVE_NODE_MODULES_PATH, 'vue-loader'),
                         },
                         {
-                            test: /\.mjs$/,
+                            test: /\.m?js$/,
                             include: /node_modules/,
                             type: 'javascript/auto',
+                            resolve: {
+                              fullySpecified: false,
+                            }
                         },
                         {
                             test: /\.js$/,

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -41,6 +41,7 @@ Arches 7.6.0 Release Notes
 - 10726 Upgrade openpyxl package to 3.1.2 and fixes ETL modules
 - 9191 Adds unlocalized string datatype
 - 10575 Add pre-commit hooks for formatting
+- Allow import of JavaScript modules with unspecified .js or .mjs extensions #10992 
 - 10781 Graph.delete_instances() now uses BulkDataDeletion
 - 10665 Return resourceid in ActivityStream rather than resource url
 - 10754 Move the i18n/ url outside of the i18n_patterns function

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -316,9 +316,12 @@ module.exports = () => {
                             loader: Path.join(PROJECT_RELATIVE_NODE_MODULES_PATH, 'vue-loader'),
                         },
                         {
-                            test: /\.mjs$/,
+                            test: /\.m?js$/,
                             include: /node_modules/,
                             type: 'javascript/auto',
+                            resolve: {
+                              fullySpecified: false,
+                            }
                         },
                         {
                             test: /\.js$/,


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Allows import of js dependencies even if their import statements don't declare a file extension (.js or .mjs) when their type is set to 'module'. 
https://github.com/webpack/webpack/issues/11467#issuecomment-691702706
https://webpack.js.org/configuration/module/#resolvefullyspecified

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #10992

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
