### PR TITLE
Persist dirty state of string widget #11092

### DIFF
--- a/arches/app/media/js/viewmodels/widget.js
+++ b/arches/app/media/js/viewmodels/widget.js
@@ -96,7 +96,7 @@ define([
 
         if (ko.isObservable(this.value) && ko.isObservable(this.defaultValue)) {
             var defaultValue = this.defaultValue();
-            if (this.tile && !this.tile.noDefaults && ko.unwrap(this.tile.tileid) == "" && defaultValue != null && defaultValue != "") {
+            if (this.tile && !this.tile.noDefaults && !ko.unwrap(this.tile.dirty) && ko.unwrap(this.tile.tileid) == "" && defaultValue != null && defaultValue != "") {
                 this.value(defaultValue);
             }
 

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -180,10 +180,6 @@ define([
 
         });
 
-        if (self.currentDefaultText() === "") {
-            self.defaultValue("");
-        }
-
     };
 
     return ko.components.register('text-widget', {

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -34,6 +34,7 @@ Arches 7.6.0 Release Notes
 - 9769 Ensure resource creation edit log timestamps precede resource update timestamps
 - 10738 Adds Github action for comparing test coverage between branches and rejecting branches that lower test coverage
 - Ensure search facets have widget label on advanced search restore #11046
+- Persists unsaved value in string widget if a user switches between cards in the card tree #11092 
 - 10842 Adds project-level testing and GitHub test runners
 - 10862 Lenient file-type checking mode
 - 10699 Allow overriding search_results view


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Persists unsaved value in widget if a user switches between cards in the card tree.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11092

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
