### PR TITLE
#11111 Adds workaround to load widgets into workflow if missing.

### DIFF
--- a/arches/app/media/js/models/card-widget.js
+++ b/arches/app/media/js/models/card-widget.js
@@ -27,6 +27,16 @@ define([
                 'sortorder': null,
                 'disabled': false
             };
+
+            // Workaround to issue with widgets not being loaded in workflow (https://community.archesproject.org/t/issue-with-workflows-in-7-5/2270)
+            // This is a temporary fix until we can figure out why widgets are not being loaded.
+            if (!document.widgets) {
+                document.widgets = require('widgets');
+            }
+
+            const widgets = document.widgets;
+            //-----------------------------------------------
+            
             var self = this;
             this.disposables = [];
             this.widgetLookup = widgets;

--- a/arches/app/media/js/models/card-widget.js
+++ b/arches/app/media/js/models/card-widget.js
@@ -30,11 +30,9 @@ define([
 
             // Workaround to issue with widgets not being loaded in workflow (https://community.archesproject.org/t/issue-with-workflows-in-7-5/2270)
             // This is a temporary fix until we can figure out why widgets are not being loaded.
-            if (!document.widgets) {
-                document.widgets = require('widgets');
+            if (!widgets) {
+                widgets = require('widgets');
             }
-
-            const widgets = document.widgets;
             //-----------------------------------------------
             
             var self = this;


### PR DESCRIPTION

### Types of changes

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

The card-widget looks to see if widgets have been loaded into the workflow; if not, widgets are required so they load in the workflow


### Issues Solved
#11111 



### Checklist

-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [X] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @aj-he 
*   Tested by: @csmith-he 
*   Designed by: @chrabyrd 

### Further comments

Originally added as a hotfix to fix https://github.com/archesproject/arches-her/issues/1104 but we're asking for it to be put in Core Arches unless another solution has been found to this problem

For background, read discussion here: https://community.archesproject.org/t/issue-with-workflows-in-7-5/2270
