### PR TITLE
Reraise ImproperlyConfigured in SystemSettings #11118

### DIFF
--- a/arches/app/models/system_settings.py
+++ b/arches/app/models/system_settings.py
@@ -17,8 +17,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from django.conf import LazySettings
-from django.db import ProgrammingError, OperationalError
-from django.utils.functional import empty
+from django.core.exceptions import ImproperlyConfigured
+
 from arches.app.models import models
 
 
@@ -42,7 +42,6 @@ class SystemSettings(LazySettings):
 
     def __init__(self, *args, **kwargs):
         super(SystemSettings, self).__init__(*args, **kwargs)
-        # print self
 
     def __str__(self):
         ret = []
@@ -65,6 +64,8 @@ class SystemSettings(LazySettings):
 
         try:
             return super(SystemSettings, self).__getattr__(name)
+        except ImproperlyConfigured:
+            raise
         except:
             self.update_from_db()
             return super(SystemSettings, self).__getattr__(
@@ -79,6 +80,8 @@ class SystemSettings(LazySettings):
         try:
             super(SystemSettings, self).__getattr__(name)
             return True
+        except ImproperlyConfigured:
+            raise
         except:
             return False
 

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -39,6 +39,7 @@ Arches 7.6.0 Release Notes
 - 10862 Lenient file-type checking mode
 - 10699 Allow overriding search_results view
 - 10911 Styling fix in resource model manage menu
+- 11118 Harden SystemSettings model against too-early access #11118
 - 10726 Upgrade openpyxl package to 3.1.2 and fixes ETL modules
 - 9191 Adds unlocalized string datatype
 - 10121 Prevent language code duplication during concept import; avoid creating Language objects other than English in new projects

--- a/tests/models/system_settings_tests.py
+++ b/tests/models/system_settings_tests.py
@@ -1,0 +1,39 @@
+"""
+ARCHES - a program developed to inventory and manage immovable cultural heritage.
+Copyright (C) 2013 J. Paul Getty Trust and World Monuments Fund
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import os
+from unittest import mock
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+
+from arches.app.models.system_settings import SystemSettings
+
+# these tests can be run from the command line via
+# python manage.py test tests.models.system_settings_tests --settings="tests.test_settings"
+
+
+class SystemSettingsTests(SimpleTestCase):
+    @mock.patch.dict(os.environ, {"DJANGO_SETTINGS_MODULE": ""})
+    def test_improper_access(self):
+        """Accessing settings during the Django startup phase fails loudly."""
+        settings_obj = SystemSettings()
+        with self.assertRaises(ImproperlyConfigured):
+            settings_obj.ARBITRARY_KEY
+        with self.assertRaises(ImproperlyConfigured):
+            settings_obj.setting_exists("ARBITRARY_KEY")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Protects against silent failure shown in issue

### Issues Solved
Closes #11118

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls

### Testing considerations
A 'real life' scenario for testing:

Edit the `if __name__ ...` block of settings.py in core arches to include this (along the lines of #11009):
```py
    import django
    from django.conf import global_settings, settings

    settings_defined_here = {k: v for k, v in locals().items() if k.isupper()}
    settings.configure(default_settings=global_settings, **settings_defined_here)
    django.setup()
```

Then cd to the directory containing settings.py and attempt to `python settings.py`. With this change you should get a more appropriate failure instead of a red herring circular import error (emanating because we went to fetch from the database, which doesn't seem correct, and which won't necessarily always fail in future similar situations).

(Then, in #11016, we're going to address the underlying issue with the thumbnail factory by using django.conf settings, not ours)