### PR TITLE
Scrolling fix for many items in search qa/resource filter dropdowns

### DIFF
--- a/arches/app/media/css/components/_buttons.scss
+++ b/arches/app/media/css/components/_buttons.scss
@@ -4,6 +4,10 @@
 			.btn {
 				padding: 2px 10px;
 			}
+			.dropdown-menu {
+				max-height: 60vh;
+				overflow-y: auto;
+			}
 		}
 	}
 }
@@ -13,6 +17,10 @@
 		div {
 			.btn {
 				padding: 2px 10px;
+			}
+			.dropdown-menu {
+				max-height: 60vh;
+				overflow-y: auto;
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
On the search page, if there are many items to select when using the QA Type or Resource Type dropdowns, users are unable to scroll to the bottom. This fix will ensure users can scroll down to view all of the content if needed.


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11077 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [x] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he 
*   Tested by: @phudson-he 
*   Designed by: @phudson-he 
