### PR TITLE
11139 Check value is geometry before proceeding with export to geojson

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -398,13 +398,14 @@ class SearchResultsExporter(object):
                             properties[header] = None
                 for key, value in instance.items():
                     if key == geometry_field:
-                        geometry = GEOSGeometry(value, srid=4326)
-                        for geom in geometry:
-                            feature = {}
-                            feature["geometry"] = JSONDeserializer().deserialize(GEOSGeometry(geom, srid=4326).json)
-                            feature["type"] = "Feature"
-                            feature["properties"] = properties
-                            features.append(feature)
+                        if isinstance(value, GeometryCollection):
+                            geometry = GEOSGeometry(value, srid=4326)
+                            for geom in geometry:
+                                feature = {}
+                                feature["geometry"] = JSONDeserializer().deserialize(GEOSGeometry(geom, srid=4326).json)
+                                feature["type"] = "Feature"
+                                feature["properties"] = properties
+                                features.append(feature)
 
         feature_collection = {"type": "FeatureCollection", "features": features}
         return feature_collection

--- a/releases/7.5.3.md
+++ b/releases/7.5.3.md
@@ -14,6 +14,7 @@ Arches 7.5.3 Release Notes
 - Fixes print from resource manager #11035
 - Displays configured maximum file size and accepted image file formats in photo gallery #11022
 - Alphabetically sort graphs by name in search Resource Type filter #10646
+- Adds check to GeoJSON export that value is a valid geometry # 11139
 
 ### Dependency changes:
 ```

--- a/releases/7.5.3.md
+++ b/releases/7.5.3.md
@@ -12,9 +12,9 @@ Arches 7.5.3 Release Notes
 - Fixes branch exports of published graphs #10973
 - Fix the issue of the semantic nodeid being added to the tiledata when tile sortorder is null #11011
 - Fixes print from resource manager #11035
+- Adds check to GeoJSON export that value is a valid geometry #11139
 - Displays configured maximum file size and accepted image file formats in photo gallery #11022
 - Alphabetically sort graphs by name in search Resource Type filter #10646
-- Adds check to GeoJSON export that value is a valid geometry # 11139
 
 ### Dependency changes:
 ```


### PR DESCRIPTION
### Types of changes

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

Puts an isinstance check on the geometry field value to make sure the following code is only run on values that whole valid geometry


### Issues Solved
#11139 

### Checklist

-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [X] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [X] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch




#### Ticket Background
*   Sponsored by: HistoricEngland
*   Found by: @csmith-he 
*   Tested by: @csmith-he


### Further comments

Required for Arches for HERs
