### PR TITLE
Remove fixed height from search listing footers

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -9672,9 +9672,9 @@ ul.pagination {
 
 .search-listing-footer {
     display: flex;
-    height: 40px;
+    min-height: 40px;
     font-size: 1.1rem;
-    padding: 10px 10px 0px 10px;
+    padding: 10px;
     background: #f5f5f5;
     border-top: 1px solid #ddd;
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The search listing footers were a fixed height, and these changes ensure that if any extra height is required, it will render correctly and not break the container.

### Issues Solved
Closes #11078 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [x] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he 
*   Tested by: @phudson-he 
*   Designed by: @phudson-he 

### Further comments

Tested fine on iOS and Android, images attached
![11078_Android](https://github.com/archesproject/arches/assets/52997281/891fd452-6362-429c-9ce9-29933553ddef)
![11078_iOS](https://github.com/archesproject/arches/assets/52997281/a18bce88-2997-4fe0-a5ce-799271d11c00)
