### PR TITLE
Fix i18n text/json field serialization in Django admin #10597

### DIFF
--- a/arches/app/utils/betterJSONSerializer.py
+++ b/arches/app/utils/betterJSONSerializer.py
@@ -53,7 +53,11 @@ class JSONSerializer(object):
         self.utf_encode = False
 
     def encode(self, obj):
-        return self.serializeToPython(obj, **self._options)
+        if isinstance(obj, (I18n_JSON, I18n_String)):
+            # Ensure raw JSON strings are re-encoded ("'" -> "\"")
+            # and non-active language values are preserved.
+            return DjangoJSONEncoder().encode(obj.raw_value)
+        return self.serialize(obj, **self._options)
 
     def serializeToPython(self, obj, **options):
         # allow users to override any kwargs passed into the __init__ method
@@ -71,7 +75,7 @@ class JSONSerializer(object):
 
     def serialize(self, obj, **options):
         obj = self.serializeToPython(obj, **options)
-        # prevent raw strings from begin re-encoded
+        # prevent raw strings from being re-encoded
         # this is especially important when doing bulk operations in elasticsearch
         if isinstance(obj, str):
             return obj

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -43,6 +43,7 @@ Arches 7.6.0 Release Notes
 - 10911 Styling fix in resource model manage menu
 - 10726 Upgrade openpyxl package to 3.1.2 and fixes ETL modules
 - 9191 Adds unlocalized string datatype
+- 10597 Fix internationalized string/json field entry problems in the Django admin
 - 10787 Search Export: data exportable as "system values" (e.g. concept valueids) instead of "display values" (e.g. string preflabel)
 - 10121 Prevent language code duplication during concept import; avoid creating Language objects other than English in new projects
 - 10575 Add pre-commit hooks for formatting

--- a/tests/utils/test_betterJSONSerializer.py
+++ b/tests/utils/test_betterJSONSerializer.py
@@ -1,5 +1,4 @@
 from django.test import SimpleTestCase
-from django.utils.translation import activate
 
 from arches.app.models.fields.i18n import I18n_JSON, I18n_String
 from arches.app.utils.betterJSONSerializer import JSONSerializer

--- a/tests/utils/test_betterJSONSerializer.py
+++ b/tests/utils/test_betterJSONSerializer.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+from django.utils.translation import activate
+
+from arches.app.models.fields.i18n import I18n_JSON, I18n_String
+from arches.app.utils.betterJSONSerializer import JSONSerializer
+
+# these tests can be run from the command line via
+# python manage.py test tests.utils.test_betterJSONSerializer --settings="tests.test_settings"
+
+
+class TestBetterJSONSerializer(SimpleTestCase):
+    def test_encode_i18n_json(self):
+        serializer = JSONSerializer()
+        json = I18n_JSON("{'trueLabel': {'en': 'Yes'}")
+        encoded = serializer.encode(json)
+        self.assertEqual(
+            encoded, "\"{'trueLabel': {'en': 'Yes'}\"", "JSON must be double-quoted"
+        )
+
+    def test_encode_i18n_string(self):
+        string = I18n_String()
+        string["de"] = "German label"
+        string["en"] = "English label"
+
+        serializer = JSONSerializer()
+        encoded = serializer.encode(string)
+        self.assertEqual(encoded, '{"en": "English label", "de": "German label"}')


### PR DESCRIPTION
Follow-up to 9334ae1.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
**Before**
Attempting to edit an internationalized field like `Plugin.name` (string) or `DDataType.defaultconfig` (json) would throw errors in the Django admin ("Enter a valid JSON"). Also, it's possible that if a user worked around this by hand-escaping the JSON, there was a possibility of data loss since not all saved language values (for strings) were populated into the form.

**After**
Now, these issues are fixed. Some testing notes below.

### Issues Solved
Closes #10597

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [x] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
The `encode()` method was added in 9334ae1d609338462a1743ca3c082a3b73c4b061, because it's what's called when  `json.dumps()` is [called in the Django forms layer](https://github.com/django/django/blob/e095c7612d49dbe371e9c7edd76ba99b6bc4f9f6/django/forms/fields.py#L1401) with this encoder as the `cls` keyword.

### Testing considerations
- [ ] Start with multiple saved values for internationalized string and json fields. The Plugin model has one of each (name, config).
- [ ] Ensure the form loads with all saved values, and can be saved back with or without edits
- [ ] Ensure when Plugin.icon is nulled out, and you attempt to save, then re-enter the missing icon and save back, that there is no "Enter a valid JSON" again on the string/json fields.