### PR TITLE
Remove underscores from AppConfig class name #11195

### DIFF
--- a/arches/install/arches-templates/project_name/apps.py-tpl
+++ b/arches/install/arches-templates/project_name/apps.py-tpl
@@ -3,5 +3,4 @@ from django.apps import AppConfig
 
 class {{ project_name_title_case }}Config(AppConfig):
     name = "{{ project_name }}"
-    verbose_name = "{{ project_name_title_case }}"
     is_arches_application = True

--- a/arches/install/arches_admin.py
+++ b/arches/install/arches_admin.py
@@ -121,7 +121,7 @@ class ArchesProjectCommand(TemplateCommand):
         options["arches_next_minor_version"] = ".".join(
             [str(arches.VERSION[0]), str(arches.VERSION[1] + 1), "0"]
         )
-        options["project_name_title_case"] = project_name.title()
+        options["project_name_title_case"] = project_name.title().replace("_", "")
 
         super(ArchesProjectCommand, self).handle(
             "project", project_name, target, **options
@@ -144,7 +144,10 @@ class ArchesProjectCommand(TemplateCommand):
             file.close()
 
             updated_file_data = (
-                file_data.replace("{{ project_name_title_case }}", project_name.title())
+                file_data.replace(
+                    "{{ project_name_title_case }}",
+                    options["project_name_title_case"],
+                )
                 .replace("{{ project_name }}", project_name)
                 .replace(
                     "{{ arches_semantic_version }}", options["arches_semantic_version"]

--- a/arches/install/arches_project.py
+++ b/arches/install/arches_project.py
@@ -51,7 +51,7 @@ class ArchesCommand(TemplateCommand):
         options["arches_next_minor_version"] = ".".join(
             [str(arches.VERSION[0]), str(arches.VERSION[1] + 1), "0"]
         )
-        options["project_name_title_case"] = project_name.title()
+        options["project_name_title_case"] = project_name.title().replace("_", "")
 
         super(ArchesCommand, self).handle("project", project_name, target, **options)
 
@@ -72,7 +72,9 @@ class ArchesCommand(TemplateCommand):
             file.close()
 
             updated_file_data = (
-                file_data.replace("{{ project_name_title_case }}", project_name.title())
+                file_data.replace(
+                    "{{ project_name_title_case }}", options["project_name_title_case"]
+                )
                 .replace("{{ project_name }}", project_name)
                 .replace(
                     "{{ arches_semantic_version }}", options["arches_semantic_version"]

--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -330,7 +330,8 @@ class Command(BaseCommand):  # pragma: no cover
 
                 updated_file_data = (
                     file_data.replace(
-                        "{{ project_name_title_case }}", settings.APP_NAME.title()
+                        "{{ project_name_title_case }}",
+                        settings.APP_NAME.title().replace("_", ""),
                     )
                     .replace("{{ project_name }}", settings.APP_NAME)
                     .replace("{{ arches_semantic_version }}", arches_semantic_version)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Remove underscores from the templated class name for the AppConfig subclass in apps.py provided with 7.6.

### Issues Solved
Closes #11195

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @chrabyrd 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments
Removed the `verbose_name` templating, since all it did was default to the [Django default](https://docs.djangoproject.com/en/4.2/ref/applications/#django.apps.AppConfig.verbose_name) anyway.