### PR TITLE
Bump versions in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@ Closes #
 ### Checklist
 <!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
 -   I targeted one of these branches:
-    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
-    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
+    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
+    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
     - [ ] dev/6.2.x (extended support): major security issues, data loss issues
 -   [ ] I added a changelog in arches/releases
 -   [ ] I submitted a PR to arches-docs (if appropriate)


### PR DESCRIPTION
dev/8.0.x is now the target for new features, so update the PR template to reflect this.

(Technically 7.5 also has two more months of main support, but it may take almost that much time to merge this up to master anyway.)