### PR TITLE
Ignore dotfiles in webpack file discovery #11094

### DIFF
--- a/arches/install/arches-templates/project_name/webpack/webpack-utils/build-filepath-lookup.js
+++ b/arches/install/arches-templates/project_name/webpack/webpack-utils/build-filepath-lookup.js
@@ -24,6 +24,10 @@ function buildFilepathLookup(path, staticUrlPrefix) {
     };
 
     return getFileList(path).reduce((lookup, file) => {
+        // Ignore dotfiles
+        if (file.match(new RegExp(Path.sep + '\\.')) || file.match(/^\./)) {
+            return lookup;
+        }
         const extension = file.match(/[^.]+$/).toString();
         if (extension === 'js') {
             lookup[file.replace(path,'').replace(/\\/g, '/').replace(/\.js$/,'').replace(/^\//,'')] = {"import": file, "filename": `${prefix}/[name].${extension}`};

--- a/releases/7.5.4.md
+++ b/releases/7.5.4.md
@@ -3,6 +3,7 @@ Arches 7.5.4 Release Notes
 
 ### Bug Fixes and Enhancements
 
+- Fix regression in 7.5.3 where webpack fails to build if dotfiles are present #11094
 
 ### Dependency changes:
 ```


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before 7.5.3, the webpack config special-cased a specific common dotfile created on mac systems (`.DS_Store`) that results from moving files using the Finder. Without that special case, node throws a TypeError (see issue). That special case was removed in bc0d79c.

Now, the special case is restored, but generalized to any dotfile, e.g. `.gitkeep` ([example](https://github.com/archesproject/arches-templating/pull/18#discussion_r1681727121)).

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11094

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [x] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch



#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls 
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->