### PR TITLE
Pick out useful changes from controlled list work

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,6 +6,8 @@ eea27d316c5ff975556e15ccd4c11d7c393dd95c
 8de09526329685ee4d80c816c3475a66b19d46e9
 9740c846eda0cc067f49d7abffdcb1a93fe3e0a9
 eff6710e8b44faef5a628b0ea1373cd99cb47e9e
+# Reformatting of 7.6 features under dev (2024)
+9740c846eda0cc067f49d7abffdcb1a93fe3e0a9
 # Relevant subset of git log --grep black
 9b7e30d4499cb02dec6d17c7c99f9a7087fcdd47
 b959f1139a1d789e6c116d43d8be7daa0baa6075

--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -517,3 +517,11 @@ class BaseDataType(object):
         Adds properties to a tile necessary for some clients, but not essential to the tile
         """
         pass
+
+    def validate_node(self, node):
+        """
+        Confirms a node is properly configured to collect data.
+        If improperly configured, this method should raise
+        a GraphValidationError
+        """
+        pass

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2423,7 +2423,7 @@ class BaseDomainDataType(BaseDataType):
                 return get_localized_value(option["text"], return_lang=return_lang)
         raise Exception(
             _(
-                "No domain option found for option id {0}, in node conifg: {1}".format(
+                "No domain option found for option id {0}, in node config: {1}".format(
                     option_id, node.config["options"]
                 )
             )

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1968,8 +1968,12 @@ class Graph(models.GraphModel):
             return fieldname
 
         fieldnames = {}
-        for node_id, node in self.nodes.items():
+        datatype_factory = DataTypeFactory()
+
+        for node in self.nodes.values():
             self._validate_node_name(node)
+            datatype = datatype_factory.get_instance(node.datatype)
+            datatype.validate_node(node)
             if node.exportable is True:
                 if node.fieldname is not None:
                     validated_fieldname = validate_fieldname(node.fieldname, fieldnames)

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -22,6 +22,7 @@ from arches.app.const import ExtensionType
 from arches.app.utils.module_importer import get_class_from_modulename
 from arches.app.utils.thumbnail_factory import ThumbnailGeneratorInstance
 from arches.app.models.fields.i18n import I18n_TextField, I18n_JSONField
+from arches.app.models.utils import add_to_update_fields
 from arches.app.utils import import_class_from_string
 from django.contrib.gis.db import models
 from django.db.models import JSONField
@@ -34,7 +35,7 @@ from django.db.models import Q, Max
 from django.db.models.signals import post_delete, pre_save, post_save, m2m_changed
 from django.dispatch import receiver
 from django.utils import translation
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
 from django.core.validators import validate_slug
@@ -45,22 +46,6 @@ from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
-
-
-def add_to_update_fields(kwargs, field_name):
-    """
-    Update the `update_field` arg inside `kwargs` (if present) in-place
-    with `field_name`.
-    """
-    if (update_fields := kwargs.get("update_fields")) is not None:
-        # Django sends a set from update_or_create()
-        if isinstance(update_fields, set):
-            update_fields.add(field_name)
-        # Arches sends a list from tile POST view
-        else:
-            new = set(update_fields)
-            new.add(field_name)
-            kwargs["update_fields"] = new
 
 
 class BulkIndexQueue(models.Model):

--- a/arches/app/models/utils.py
+++ b/arches/app/models/utils.py
@@ -15,4 +15,4 @@ def add_to_update_fields(kwargs, field_name):
 
 
 def field_names(instance):
-    return {f.name for f in instance.__class__._meta.fields}
+    return {f.name for f in instance._meta.fields}

--- a/arches/app/models/utils.py
+++ b/arches/app/models/utils.py
@@ -1,0 +1,18 @@
+def add_to_update_fields(kwargs, field_name):
+    """
+    Update the `update_field` arg inside `kwargs` (if present) in-place
+    with `field_name`.
+    """
+    if (update_fields := kwargs.get("update_fields")) is not None:
+        if isinstance(update_fields, set):
+            # Django sends a set from update_or_create()
+            update_fields.add(field_name)
+        else:
+            # Arches sends a list from tile POST view
+            new = set(update_fields)
+            new.add(field_name)
+            kwargs["update_fields"] = new
+
+
+def field_names(instance):
+    return {f.name for f in instance.__class__._meta.fields}

--- a/arches/app/src/arches/types.ts
+++ b/arches/app/src/arches/types.ts
@@ -1,0 +1,8 @@
+export type Language = {
+    code: string;
+    default_direction: "ltr" | "rtl";
+    id: number;
+    isdefault: boolean;
+    name: string;
+    scope: string;
+};

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -170,6 +170,7 @@ Minor incompatibilities:
     is now a more attractive target for overriding than `run_load_task()`.
 -   `unzip_file()` moved from `arches.setup` to `arches.app.utils.zip`
 -   Version-related utils moved from `arches.setup` to `arches.version`
+-   `add_to_update_fields()` moved from `arches.app.models.models` to `arches.app.models.utils`.
 
 
 ### Deprecations


### PR DESCRIPTION
As described in https://github.com/archesproject/arches/pull/11209#issue-2417288140, there were a few useful changes mixed in with the controlled list work that we should preserve in core, ranging from trivial typo fixes to a new hook for datatype validation.

Adding this to 7.6 preserves the ability for the (separately maintained) Controlled List Manager & Reference Datatype to be compatible with 7.6 if it chooses. See #11201. 