### PR TITLE
Deprecate `-o install` operation

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -7,6 +7,7 @@ import uuid
 import sys
 import urllib.request, urllib.parse, urllib.error
 import os
+import warnings
 import logging
 from arches.management.commands import utils
 from arches.app.utils.i18n import LanguageSynchronizer
@@ -335,7 +336,11 @@ class Command(BaseCommand):
             self.setup(package_name, es_install_location=options["dest_dir"])
 
         if options["operation"] == "install":
-            self.install(package_name)
+            warnings.warn(
+                "The install operation does nothing since Arches 7.6. "
+                "In Arches 8.0, calling this operation will raise an exception.",
+                DeprecationWarning,
+            )
 
         if options["operation"] == "setup_indexes":
             self.setup_indexes()
@@ -1318,15 +1323,6 @@ class Command(BaseCommand):
         """
 
         self.setup_db(package_name)
-
-    def install(self, package_name):
-        """
-        Runs the setup.py file found in the package root
-
-        """
-
-        install = import_string("%s.setup.install" % package_name)
-        install()
 
     def setup_db(self, package_name):
         """

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -339,7 +339,7 @@ class Command(BaseCommand):
             warnings.warn(
                 "The install operation does nothing since Arches 7.6. "
                 "In Arches 8.0, calling this operation will raise an exception.",
-                DeprecationWarning,
+                UserWarning,
             )
 
         if options["operation"] == "setup_indexes":

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -182,6 +182,8 @@ Minor incompatibilities:
 
     For more, see the [documentation](https://arches.readthedocs.io/en/stable/configuring/settings-beyond-the-ui/#file-type-checking) for this setting. 
 
+- As a consequence of migrating from `setup.py` to `pyproject.toml`, the `-o install` argument to `manage.py packages` (previously used to execute a project's `setup.py`) does nothing and has been deprecated. In Arches 8.0, it will raise an exception.
+
 ### Upgrading Arches
 
 1. You must be upgraded to at least version 7.5.0 before proceeding. If you are on an earlier version, please refer to the upgrade process in the [Version 7.5.0 release notes](https://github.com/archesproject/arches/blob/dev/7.5.x/releases/7.5.0.md)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Follow-up to 4d2f4f5. Unreleased bugfix in 7.6. Projects no longer have a setup.install.
