### PR TITLE
Consume core arches types in projects #11234

### DIFF
--- a/arches/install/arches-templates/tsconfig.json
+++ b/arches/install/arches-templates/tsconfig.json
@@ -14,11 +14,14 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "baseUrl": "{{ project_name }}/src/",
     "paths": {
+      "@/arches/*": [
+        "./node_modules/arches/arches/app/src/arches/*.ts",
+        "./node_modules/arches/arches/app/src/arches/*.vue"
+      ],
       "@/*": [
-        "*.ts",
-        "*.vue"
+        "./{{ project_name }}/src/*.ts",
+        "./{{ project_name }}/src/*.vue"
       ]
     }
   },


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Addresses unreleased issue in new 7.6 feature.

As described in #11234, the ts linter at the project level cannot resolve a core-arches import aliased with `@` without these changes. See below for an alternative I ruled out.

[Docs](https://www.typescriptlang.org/tsconfig/#baseUrl) for the `baseUrl` field advise removing it anyway:
> This feature was designed for use in conjunction with AMD module loaders in the browser, and is not recommended in any other context. As of TypeScript 4.1, baseUrl is no longer required to be set when using [paths](https://www.typescriptlang.org/tsconfig/#paths).

@chrabyrd I'm totally open to other solutions here; this was just what got things working for me and I wanted to volley it over to you to get your opinion.

@johnatawnclementawn let me know if making the adjustment suggested here to tsconfig.json at the project level resolves it for you also 🙏 

### Issues Solved
Closes #11234

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by:  Getty Conservation Institute

### Further comments
An alternative I considered was changing the imports to end in `.ts`. That moved the error from the import to the usage, showing errors at the usage sites like:
```ts
arches_references/src/arches-references/utils.ts:76:23 - error TS2709: Cannot use namespace 'Language' as a type.

76     selectedLanguage: Language,
                         ~~~~~~~~

[6:11:18 PM] Found 16 errors. Watching for file changes.
```

Fine, even though Language _is_ a type, you can surrender to the linter and pretend it's not a type by taking `typeof`. So let's say you change every use of `Language` to `typeof Language`. Now you have 0 warnings, but now you have no useful type-checking. Try to access `.garbage` on a `Language` object, and notice typescript doesn't complain. Whereas with this change you retain useful type-checking.