### PR TITLE
Gracefully handle null card sortorders in resource report #10949

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,6 +9,8 @@ e3d8197d5a7d1f03ed125fe2f47d4fbef0913404
 eff6710e8b44faef5a628b0ea1373cd99cb47e9e
 # Reformatting of 7.6 features under dev (2024)
 9740c846eda0cc067f49d7abffdcb1a93fe3e0a9
+# Format with black on dev/8.0.x (2024)
+e218a8ab828fae79aaeaa4895e4c30c0ce8c96f1
 # Relevant subset of git log --grep black
 9b7e30d4499cb02dec6d17c7c99f9a7087fcdd47
 b959f1139a1d789e6c116d43d8be7daa0baa6075

--- a/arches/app/views/api.py
+++ b/arches/app/views/api.py
@@ -1555,14 +1555,14 @@ class ResourceReport(APIBase):
 
         if "cards" not in exclude:
             readable_nodegroup_ids = [
-                nodegroup.pk
-                for nodegroup in get_nodegroups_by_perm(
+                nodegroup_id
+                for nodegroup_id in get_nodegroups_by_perm(
                     request.user, perm, any_perm=True
                 )
             ]
             writable_nodegroup_ids = [
-                nodegroup.pk
-                for nodegroup in get_nodegroups_by_perm(
+                nodegroup_id
+                for nodegroup_id in get_nodegroups_by_perm(
                     request.user,
                     "write_nodegroup",
                     any_perm=True,
@@ -1576,7 +1576,7 @@ class ResourceReport(APIBase):
                     if card.nodegroup_id in readable_nodegroup_ids
                     and card.nodegroup_id in writable_nodegroup_ids
                 ],
-                key=lambda card: card.sortorder,
+                key=lambda card: card.sortorder or 0,
             )
 
             permitted_card_ids = [card.pk for card in permitted_cards]
@@ -1586,7 +1586,7 @@ class ResourceReport(APIBase):
                     for widget in graph.widgets
                     if widget["card_id"] in permitted_card_ids
                 ],
-                key=lambda widget: widget["sortorder"],
+                key=lambda widget: widget["sortorder"] or 0,
             )
 
             resp["cards"] = permitted_cards


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the API resource report would crash on cards with null sortorders.


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #10949

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
-   [ ] I added a changelog in arches/releases (no --> unreleased bug)
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institut
*   Found by: @jacobtylerwalls
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->