### PR TITLE
Fix typescript pre-commit hook file inclusion #11249

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 ---
 repos:
 
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
@@ -22,9 +26,9 @@ repos:
         files: arches/app/src
       - id: typescript
         name: typescript
-        entry: npm run ts:check
+        entry: bash -c 'npm run ts:check'
         language: system
-        types: [
+        types_or: [
           "ts",
           "vue",
         ]

--- a/arches/install/arches-templates/.pre-commit-config.yaml
+++ b/arches/install/arches-templates/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 ---
 repos:
 
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
@@ -22,9 +26,9 @@ repos:
         files: {{ project_name }}/src
       - id: typescript
         name: typescript
-        entry: npm run ts:check
+        entry: bash -c 'npm run ts:check'
         language: system
-        types: [
+        types_or: [
           "ts",
           "vue",
         ]

--- a/arches/install/arches-templates/pyproject.toml
+++ b/arches/install/arches-templates/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "sst",
     "coverage",
     "django-silk==5.1.0",
-    "pre-commit",
+    "pre-commit==3.8.0",
     "black==24.4.2",
 ]
 

--- a/arches/install/arches-templates/tests/search_indexes/__init__.py
+++ b/arches/install/arches-templates/tests/search_indexes/__init__.py
@@ -1,2 +1,2 @@
 # these tests can be run from the command line via
-# python manage.py test tests/views --pattern="*.py" --settings="tests.test_settings"
+# python manage.py test tests.search_indexes --pattern="*.py" --settings="tests.test_settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
     "coverage",
     "django-silk==5.1.0",
     "livereload",
-    "pre-commit",
+    "pre-commit==3.8.0",
     "sst",
 ]
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the ts pre-commit hook had trouble finding files for two reasons:
- [types_or](https://pre-commit.com/#config-types_or) was needed instead of types
- pre-commit provides a list of staged files to check, which [causes typescript to ignore your .tsconfig.json](https://github.com/microsoft/TypeScript/issues/27379) (!)

This second issue was worked around by using bash to bail out of the pre-commit context that provides a list of staged files only.

Now, also add the [check-hooks-apply](https://pre-commit.com/#meta-check_hooks_apply) meta hook to ensure the checks are operative.

### Issues Solved
Closes #11249