### PR TITLE
Sync app template treatment of ignored system checks setting

### DIFF
--- a/tests/fixtures/testing_prj/testing_prj/settings.py
+++ b/tests/fixtures/testing_prj/testing_prj/settings.py
@@ -160,7 +160,7 @@ ENABLE_CAPTCHA = False
 NOCAPTCHA = True
 # RECAPTCHA_PROXY = 'http://127.0.0.1:8000'
 if DEBUG is True:
-    SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
+    SILENCED_SYSTEM_CHECKS += ["captcha.recaptcha_test_key_error"]
 
 # EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_USE_TLS = True


### PR DESCRIPTION
Follow-up to a1ecddc.

This setting already exists when imported from arches, so prefer extending to overwriting.

Was getting this check at the project level:
```sh
?: (guardian.W001) Guardian authentication backend is not hooked. You can add this in settings as eg: `AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend', 'guardian.backends.ObjectPermissionBackend')`.
```