### PR TITLE
Loosen line endings check to ignore ontology (.xml) files

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -61,9 +61,9 @@ runs:
         black . --check --exclude=node_modules
       shell: bash
 
-    - name: Check line endings
+    - name: Check line endings on all but ontology (.xml) files
       run: |
-        ! git ls-files --eol | grep 'w/crlf\|w/mixed'
+        ! git ls-files --eol | grep -v '.xml' | grep 'w/crlf\|w/mixed'
       shell: bash
 
     - name: Run frontend tests

--- a/arches/install/arches-templates/.github/actions/build-and-test-branch/action.yml
+++ b/arches/install/arches-templates/.github/actions/build-and-test-branch/action.yml
@@ -61,9 +61,9 @@ runs:
         black . --check --exclude=node_modules
       shell: bash
 
-    - name: Check line endings
+    - name: Check line endings on all but ontology (.xml) files
       run: |
-        ! git ls-files --eol | grep 'w/crlf\|w/mixed'
+        ! git ls-files --eol | grep -v '.xml' | grep 'w/crlf\|w/mixed'
       shell: bash
 
     - name: Run frontend tests


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
A unix line endings check was added in 7.6 to improve collaboration and prevent checking in code files with mixed line endings. It might be a bit overkill to enforce this for data files like ontology files, however, which we noticed when upgrading Arches for Science and discussed [here](https://github.com/archesproject/arches-for-science/pull/1576#issuecomment-2266277859).