### PR TITLE
Soften compatibility check to warning in debug mode re #11114

### DIFF
--- a/arches/apps.py
+++ b/arches/apps.py
@@ -51,6 +51,7 @@ def check_cache_backend_for_production(app_configs, **kwargs):
         errors.append(
             Error(
                 "Using dummy cache in production",
+                obj=settings.APP_NAME,
                 id="arches.E001",
             )
         )
@@ -71,6 +72,7 @@ def check_cache_backend(app_configs, **kwargs):
             Warning(
                 "Cache backend does not support rate-limiting",
                 hint=f"Your cache: {your_cache}\n\tSupported caches: {supported_by_django_ratelimit}",
+                obj=settings.APP_NAME,
                 id="arches.W001",
             )
         )
@@ -127,8 +129,9 @@ def check_arches_compatibility(app_configs, **kwargs):
             break
         else:
             errors.append(
-                Error(
-                    f"Invalid or missing arches requirement",
+                CheckMessage(
+                    level=WARNING if settings.DEBUG else ERROR,
+                    msg="Arches requirement is invalid, missing, or given by a URL.",
                     obj=config.name,
                     hint=project_requirements,
                     id="arches.E002",
@@ -161,6 +164,7 @@ def warn_old_compatibility_settings(app_configs, **kwargs):
             Warning(
                 msg=f"MIN_ARCHES_VERSION and MAX_ARCHES_VERSION have no effect.",
                 hint="Migrate your version range to pyproject.toml.",
+                obj=settings.APP_NAME,
                 id="arches.W002",
             )
         )

--- a/tests/utils/test_checks.py
+++ b/tests/utils/test_checks.py
@@ -28,14 +28,16 @@ class SystemCheckTests(SimpleTestCase):
 
         # Test something pip-installed.
         with self.assertRaisesMessage(
-            SystemCheckError, "Invalid or missing arches requirement"
+            SystemCheckError,
+            "Arches requirement is invalid, missing, or given by a URL.",
         ):
             call_command("check")
 
         # Mock having to go to the pyproject.toml
         with mock.patch("arches.apps.requires", raise_package_not_found_error):
             with self.assertRaisesMessage(
-                SystemCheckError, "Invalid or missing arches requirement"
+                SystemCheckError,
+                "Arches requirement is invalid, missing, or given by a URL.",
             ):
                 call_command("check")
 


### PR DESCRIPTION
Improve the compatibility check from #11114 by softening it to a warning in debug mode. This allows people to continue to develop projects while their arches compatibility is in flux (perhaps with a URL reference to a branch).

Also clarify/standardize the message prefixes with application names, so that they appear like:


```
arches-references: (arches.W001) Cache backend does not support rate-limiting
```
instead of:
```
?: (arches.W001) Cache backend does not support rate-limiting
```