### PR TITLE
Ensure longer model names can be used #11317

### DIFF
--- a/arches/app/models/migrations/0001_initial.py
+++ b/arches/app/models/migrations/0001_initial.py
@@ -112,6 +112,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0002_alter_permission_name_max_length"),
     ]
 
     initial = True

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -7,7 +7,8 @@ Arches 8.0.0 Release Notes
 
 ### Additional highlights
 
-- Add session-based REST APIs for login, logout [#11261]
+- Add session-based REST APIs for login, logout [#11261](https://github.com/archesproject/arches/issues/11261)
+- Improve handling of longer model names [#11317](https://github.com/archesproject/arches/issues/11317)
 
 ### Dependency changes
 ```


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, longer model names might fail (due to indeterminate inter-app ordering of migrations) if the initial migration for Arches ran before the migration from the Django admin app that lifts the length of the permission name field.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11317

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch