### PR TITLE
Support more expressive plugin URLs #11320

### DIFF
--- a/arches/app/views/plugin.py
+++ b/arches/app/views/plugin.py
@@ -28,17 +28,14 @@ from arches.app.views.base import MapBaseManagerView
 class PluginView(MapBaseManagerView):
     action = None
 
-    def get(self, request, pluginid=None, slug=None):
+    def get(self, request, pluginid=None, slug=None, path=None):
         if slug is not None:
             plugin = models.Plugin.objects.get(slug=slug)
         else:
             plugin = models.Plugin.objects.get(pk=pluginid)
 
         if not request.user.has_perm("view_plugin", plugin):
-            if slug is not None:
-                return redirect("/auth?next=/plugins/{}".format(slug))
-            if slug is not None:
-                return redirect("/auth?next=/plugins/{}".format(pluginid))
+            return redirect("/auth/?next=" + request.path)
 
         if request.GET.get("json"):
             return JSONResponse(plugin)

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -648,10 +648,10 @@ urlpatterns = [
         api.Concepts.as_view(),
         name="concepts",
     ),
-    re_path(
-        r"^plugins/(?P<pluginid>%s)$" % uuid_regex, PluginView.as_view(), name="plugins"
-    ),
-    re_path(r"^plugins/(?P<slug>[-\w]+)$", PluginView.as_view(), name="plugins"),
+    path("plugins/<uuid:pluginid>", PluginView.as_view(), name="plugins"),
+    path("plugins/<uuid:pluginid>/<path:path>", PluginView.as_view(), name="plugins"),
+    path("plugins/<slug:slug>", PluginView.as_view(), name="plugins"),
+    path("plugins/<slug:slug>/<path:path>", PluginView.as_view(), name="plugins"),
     re_path(
         r"^workflow_history/(?P<workflowid>%s|())$" % uuid_regex,
         WorkflowHistoryView.as_view(),

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -9,6 +9,7 @@ Arches 8.0.0 Release Notes
 
 - Add session-based REST APIs for login, logout [#11261](https://github.com/archesproject/arches/issues/11261)
 - Improve handling of longer model names [#11317](https://github.com/archesproject/arches/issues/11317)
+- Support more expressive plugin URLs [#11320](https://github.com/archesproject/arches/issues/11320)
 
 ### Dependency changes
 ```

--- a/tests/views/plugin_tests.py
+++ b/tests/views/plugin_tests.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+
+# these tests can be run from the command line via
+# python manage.py test tests.views.plugin_tests --settings="tests.test_settings"
+
+
+class PluginViewTests(TestCase):
+    def test_post_auth_redirect_preserves_full_path(self):
+        response = self.client.get("/plugins/bulk-data-manager/full-path")
+        self.assertRedirects(
+            response, "/auth/?next=/plugins/bulk-data-manager/full-path"
+        )


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, plugin routes couldn't be more expressive than just /plugins/slug or /plugins/pluginid. Further, if an arches application tried to add more expressive routes to its plugins itself, the core arches PluginView would just drop the full route when redirecting post-auth.

Now, these issues are solved in a backward-compatible way. Needed for archesproject/arches-references#19

### Issues Solved
Closes #11320

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls

### Testing instructions
- [ ] ensure /plugins/bulk-data-manager still works
- [ ] ensure /plugins/bulk-data-manager/ still doesn't work
- [ ] ensure /plugins/bulk-data-manager/full-path newly works
- [ ] and redirects to auth if logged out
- [ ] and redirects to full path once logged in
