### PR TITLE
#11120 - File Widget: Indicate clearly All formats are allowed if no specific format is defined

### DIFF
--- a/arches/app/templates/views/components/widgets/file.htm
+++ b/arches/app/templates/views/components/widgets/file.htm
@@ -41,7 +41,7 @@
                 <div class="file-upload-footer">
                     <span>
                         <span data-bind="text: $root.translations.allowedDocumentFormats"></span>
-                        <span data-bind="text: (acceptedFiles() || $root.translations.any) + '. '"></span>
+                        <span data-bind="text: (acceptedFiles() || $root.translations.allFormatsAccepted) + '. '"></span>
                     </span>
                 </div>
             </div>

--- a/releases/7.5.4.md
+++ b/releases/7.5.4.md
@@ -5,6 +5,8 @@ Arches 7.5.4 Release Notes
 
 - Fix regression in 7.5.3 where webpack fails to build if dotfiles are present #11094
 - Ensure search result pagination is visible on small screens #11191
+- File widget uses allFormatsAccepted translations value when no particular file format 
+is specified #11120
 - Allow main (left) nav to scroll to content height when expanded #11243
 - Ensure resource type search filter dropdown is not displayed beneath search filter buttons #11188
 


### PR DESCRIPTION

### Types of changes

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

Allowed document formats text indicates all formats are acceptable if no specific format is defined - uses the allFormatsAccepted value in translatons


### Issues Solved

#11120 

### Checklist

-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [X] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [X] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch



#### Ticket Background

*   Sponsored by: Historic England
*   Found by: @csmith-he 
*   Tested by: @csmith-he 
*   Designed by: @csmith-he 

### Further comments

Targetting dev/7.5.x as requested for Arches for HERs
