### PR TITLE
Adds Vue style reset #11333

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -21,7 +21,6 @@
 @import url(node_modules/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css);
 @import url(node_modules/leaflet.fullscreen/Control.FullScreen.css);
 @import url(../css/base-manager.css);
-@import url(vue-style-base.css);
 @import "abstracts";
 @import "sidenav";
 @import "edit-history";
@@ -29,13 +28,8 @@
 @import "jqtree";
 @import "rdm";
 
-
-html {
-    font-size: 0.62rem;
-}
-
-body {
-    font-size: 1.4rem;
+html {  // font size _must_ be reverted to web-standard to retain parity for `rem`-based elements in standalone applications
+    font-size: 16px;
 }
 
 img {

--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -3615,7 +3615,6 @@ div.dropdown-menu.open {
 }
 
 .loading-mask {
-    display: none;
     position: fixed;
     background-color: #fafafa;
     top: 0;

--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -21,12 +21,14 @@
 @import url(node_modules/@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css);
 @import url(node_modules/leaflet.fullscreen/Control.FullScreen.css);
 @import url(../css/base-manager.css);
+@import url(vue-style-base.css);
 @import "abstracts";
 @import "sidenav";
 @import "edit-history";
 @import "tree";
 @import "jqtree";
 @import "rdm";
+
 
 html {
     font-size: 0.62rem;
@@ -3613,6 +3615,7 @@ div.dropdown-menu.open {
 }
 
 .loading-mask {
+    display: none;
     position: fixed;
     background-color: #fafafa;
     top: 0;

--- a/arches/app/media/css/vue-style-base.css
+++ b/arches/app/media/css/vue-style-base.css
@@ -1,9 +1,13 @@
+.vue-style-base {
+    background-color: white;
+    color: black;
+    font-size: 16px;
+}
+
 .vue-style-base * {
     /* reset */
     margin: 0;
     padding: 0;
-    background: white;
-    color: black;
     border: none;
     bottom: auto;
     clear: none;
@@ -35,7 +39,7 @@
     z-index: auto;
 
     /* standardized in Arches */
-    font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: unset;
     -webkit-font-smoothing: antialiased;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
@@ -241,36 +245,6 @@
     rt {
         display: ruby-text;
     }
-
-    :link {
-        color: #0000EE;
-    }
-
-    :visited {
-        color: #551A8B;
-    }
-
-    :link:active,
-    :visited:active {
-        color: #FF0000;
-    }
-
-    :link,
-    :visited {
-        text-decoration: underline;
-        cursor: pointer;
-    }
-
-    :focus-visible {
-        outline: auto;
-    }
-
-    mark {
-        background: yellow;
-        color: black;
-    }
-
-    /* this color is just a suggestion and can be changed based on implementation feedback */
 
     abbr[title],
     acronym[title] {

--- a/arches/app/media/css/vue-style-base.css
+++ b/arches/app/media/css/vue-style-base.css
@@ -1,0 +1,805 @@
+.vue-style-base * {
+    /* reset */
+    margin: 0;
+    padding: 0;
+    background: white;
+    color: black;
+    border: none;
+    bottom: auto;
+    clear: none;
+    cursor: default;
+    float: none;
+    font-size: medium;
+    font-style: normal;
+    font-weight: normal;
+    height: unset;
+    left: auto;
+    letter-spacing: normal;
+    line-height: normal;
+    max-height: none;
+    max-width: none;
+    min-height: 0;
+    min-width: 0;
+    overflow: visible;
+    position: static;
+    right: auto;
+    text-align: left;
+    text-decoration: none;
+    text-indent: 0;
+    text-size-adjust: auto;
+    text-transform: none;
+    top: auto;
+    visibility: visible;
+    white-space: normal;
+    width: auto;
+    z-index: auto;
+
+    /* standardized in Arches */
+    font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+    /* w3c standards see: https://html.spec.whatwg.org/multipage/rendering.html */
+    area,
+    base,
+    basefont,
+    datalist,
+    head,
+    link,
+    meta,
+    noembed,
+    noframes,
+    param,
+    rp,
+    script,
+    style,
+    template,
+    title {
+        display: none;
+    }
+
+    [hidden]:not([hidden=until-found i]):not(embed) {
+        display: none;
+    }
+
+    [hidden=until-found i]:not(embed) {
+        content-visibility: hidden;
+    }
+
+    embed[hidden] {
+        display: inline;
+        height: 0;
+        width: 0;
+    }
+
+    input[type=hidden i] {
+        display: none !important;
+    }
+
+    @media (scripting) {
+        noscript {
+            display: none !important;
+        }
+    }
+
+    address,
+    blockquote,
+    center,
+    dialog,
+    div,
+    figure,
+    figcaption,
+    footer,
+    form,
+    header,
+    hr,
+    legend,
+    listing,
+    main,
+    p,
+    plaintext,
+    pre,
+    search,
+    xmp {
+        display: block;
+    }
+
+    blockquote,
+    figure,
+    listing,
+    p,
+    plaintext,
+    pre,
+    xmp {
+        margin-block: 1em;
+    }
+
+    blockquote,
+    figure {
+        margin-inline: 40px;
+    }
+
+    address {
+        font-style: italic;
+    }
+
+    listing,
+    plaintext,
+    pre,
+    xmp {
+        font-family: monospace;
+        white-space: pre;
+    }
+
+    dialog:not([open]) {
+        display: none;
+    }
+
+    dialog {
+        position: absolute;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
+        width: fit-content;
+        height: fit-content;
+        margin: auto;
+        border: solid;
+        padding: 1em;
+        background-color: Canvas;
+        color: CanvasText;
+    }
+
+    dialog:modal {
+        position: fixed;
+        overflow: auto;
+        inset-block: 0;
+        max-width: calc(100% - 6px - 2em);
+        max-height: calc(100% - 6px - 2em);
+    }
+
+    dialog::backdrop {
+        background: rgba(0, 0, 0, 0.1);
+    }
+
+    [popover]:not(:popover-open):not(dialog[open]) {
+        display: none;
+    }
+
+    dialog:popover-open {
+        display: block;
+    }
+
+    [popover] {
+        position: fixed;
+        inset: 0;
+        width: fit-content;
+        height: fit-content;
+        margin: auto;
+        border: solid;
+        padding: 0.25em;
+        overflow: auto;
+        color: CanvasText;
+        background-color: Canvas;
+    }
+
+    :popover-open::backdrop {
+        position: fixed;
+        inset: 0;
+        pointer-events: none !important;
+        background-color: transparent;
+    }
+
+    slot {
+        display: contents;
+    }
+
+    cite,
+    dfn,
+    em,
+    i,
+    var {
+        font-style: italic;
+    }
+
+    b,
+    strong {
+        font-weight: bolder;
+    }
+
+    code,
+    kbd,
+    samp,
+    tt {
+        font-family: monospace;
+    }
+
+    big {
+        font-size: larger;
+    }
+
+    small {
+        font-size: smaller;
+    }
+
+    sub {
+        vertical-align: sub;
+    }
+
+    sup {
+        vertical-align: super;
+    }
+
+    sub,
+    sup {
+        line-height: normal;
+        font-size: smaller;
+    }
+
+    ruby {
+        display: ruby;
+    }
+
+    rt {
+        display: ruby-text;
+    }
+
+    :link {
+        color: #0000EE;
+    }
+
+    :visited {
+        color: #551A8B;
+    }
+
+    :link:active,
+    :visited:active {
+        color: #FF0000;
+    }
+
+    :link,
+    :visited {
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    :focus-visible {
+        outline: auto;
+    }
+
+    mark {
+        background: yellow;
+        color: black;
+    }
+
+    /* this color is just a suggestion and can be changed based on implementation feedback */
+
+    abbr[title],
+    acronym[title] {
+        text-decoration: dotted underline;
+    }
+
+    ins,
+    u {
+        text-decoration: underline;
+    }
+
+    del,
+    s,
+    strike {
+        text-decoration: line-through;
+    }
+
+    q::before {
+        content: open-quote;
+    }
+
+    q::after {
+        content: close-quote;
+    }
+
+    br {
+        display-outside: newline;
+    }
+
+    /* this also has bidi implications */
+    nobr {
+        white-space: nowrap;
+    }
+
+    wbr {
+        display-outside: break-opportunity;
+    }
+
+    /* this also has bidi implications */
+    nobr wbr {
+        white-space: normal;
+    }
+
+    [dir]:dir(ltr),
+    bdi:dir(ltr),
+    input[type=tel i]:dir(ltr) {
+        direction: ltr;
+    }
+
+    [dir]:dir(rtl),
+    bdi:dir(rtl) {
+        direction: rtl;
+    }
+
+    address,
+    blockquote,
+    center,
+    div,
+    figure,
+    figcaption,
+    footer,
+    form,
+    header,
+    hr,
+    legend,
+    listing,
+    main,
+    p,
+    plaintext,
+    pre,
+    summary,
+    xmp,
+    article,
+    aside,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    hgroup,
+    nav,
+    section,
+    search,
+    table,
+    caption,
+    colgroup,
+    col,
+    thead,
+    tbody,
+    tfoot,
+    tr,
+    td,
+    th,
+    dir,
+    dd,
+    dl,
+    dt,
+    menu,
+    ol,
+    ul,
+    li,
+    bdi,
+    output,
+    [dir=ltr i],
+    [dir=rtl i],
+    [dir=auto i] {
+        unicode-bidi: isolate;
+    }
+
+    bdo,
+    bdo[dir] {
+        unicode-bidi: isolate-override;
+    }
+
+    input[dir=auto i]:is([type=search i], [type=tel i], [type=url i],
+        [type=email i]),
+    textarea[dir=auto i],
+    pre[dir=auto i] {
+        unicode-bidi: plaintext;
+    }
+
+    address,
+    blockquote,
+    center,
+    div,
+    figure,
+    figcaption,
+    footer,
+    form,
+    header,
+    hr,
+    legend,
+    listing,
+    main,
+    p,
+    plaintext,
+    pre,
+    summary,
+    xmp,
+    article,
+    aside,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    hgroup,
+    nav,
+    section,
+    search,
+    table,
+    caption,
+    colgroup,
+    col,
+    thead,
+    tbody,
+    tfoot,
+    tr,
+    td,
+    th,
+    dir,
+    dd,
+    dl,
+    dt,
+    menu,
+    ol,
+    ul,
+    li,
+    [dir=ltr i],
+    [dir=rtl i],
+    [dir=auto i],
+    *|* {
+        unicode-bidi: bidi-override;
+    }
+
+    input:not([type=submit i]):not([type=reset i]):not([type=button i]),
+    textarea {
+        unicode-bidi: normal;
+    }
+
+    article,
+    aside,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    hgroup,
+    nav,
+    section {
+        display: block;
+    }
+
+    h1 {
+        margin-block: 0.67em;
+        font-size: 2.00em;
+        font-weight: bold;
+    }
+
+    h2 {
+        margin-block: 0.83em;
+        font-size: 1.50em;
+        font-weight: bold;
+    }
+
+    h3 {
+        margin-block: 1.00em;
+        font-size: 1.17em;
+        font-weight: bold;
+    }
+
+    h4 {
+        margin-block: 1.33em;
+        font-size: 1.00em;
+        font-weight: bold;
+    }
+
+    h5 {
+        margin-block: 1.67em;
+        font-size: 0.83em;
+        font-weight: bold;
+    }
+
+    h6 {
+        margin-block: 2.33em;
+        font-size: 0.67em;
+        font-weight: bold;
+    }
+
+    dir,
+    dd,
+    dl,
+    dt,
+    menu,
+    ol,
+    ul {
+        display: block;
+    }
+
+    li {
+        display: list-item;
+        text-align: match-parent;
+    }
+
+    dir,
+    dl,
+    menu,
+    ol,
+    ul {
+        margin-block: 1em;
+    }
+
+    :is(dir, dl, menu, ol, ul) :is(dir, dl, menu, ol, ul) {
+        margin-block: 0;
+    }
+
+    dd {
+        margin-inline-start: 40px;
+    }
+
+    dir,
+    menu,
+    ol,
+    ul {
+        padding-inline-start: 40px;
+    }
+
+    ol,
+    ul,
+    menu {
+        counter-reset: list-item;
+    }
+
+    ol {
+        list-style-type: decimal;
+    }
+
+    dir,
+    menu,
+    ul {
+        list-style-type: disc;
+    }
+
+    :is(dir, menu, ol, ul) :is(dir, menu, ul) {
+        list-style-type: circle;
+    }
+
+    :is(dir, menu, ol, ul) :is(dir, menu, ol, ul) :is(dir, menu, ul) {
+        list-style-type: square;
+    }
+
+    table {
+        display: table;
+    }
+
+    caption {
+        display: table-caption;
+    }
+
+    colgroup,
+    colgroup[hidden] {
+        display: table-column-group;
+    }
+
+    col,
+    col[hidden] {
+        display: table-column;
+    }
+
+    thead,
+    thead[hidden] {
+        display: table-header-group;
+    }
+
+    tbody,
+    tbody[hidden] {
+        display: table-row-group;
+    }
+
+    tfoot,
+    tfoot[hidden] {
+        display: table-footer-group;
+    }
+
+    tr,
+    tr[hidden] {
+        display: table-row;
+    }
+
+    td,
+    th {
+        display: table-cell;
+    }
+
+    colgroup[hidden],
+    col[hidden],
+    thead[hidden],
+    tbody[hidden],
+    tfoot[hidden],
+    tr[hidden] {
+        visibility: collapse;
+    }
+
+    table {
+        box-sizing: border-box;
+        border-spacing: 2px;
+        border-collapse: separate;
+        text-indent: initial;
+    }
+
+    td,
+    th {
+        padding: 1px;
+    }
+
+    th {
+        font-weight: bold;
+    }
+
+    caption {
+        text-align: center;
+    }
+
+    thead,
+    tbody,
+    tfoot,
+    table>tr {
+        vertical-align: middle;
+    }
+
+    tr,
+    td,
+    th {
+        vertical-align: inherit;
+    }
+
+    thead,
+    tbody,
+    tfoot,
+    tr {
+        border-color: inherit;
+    }
+
+    table[rules=none i],
+    table[rules=groups i],
+    table[rules=rows i],
+    table[rules=cols i],
+    table[rules=all i],
+    table[frame=void i],
+    table[frame=above i],
+    table[frame=below i],
+    table[frame=hsides i],
+    table[frame=lhs i],
+    table[frame=rhs i],
+    table[frame=vsides i],
+    table[frame=box i],
+    table[frame=border i],
+    table[rules=none i]>tr>td,
+    table[rules=none i]>tr>th,
+    table[rules=groups i]>tr>td,
+    table[rules=groups i]>tr>th,
+    table[rules=rows i]>tr>td,
+    table[rules=rows i]>tr>th,
+    table[rules=cols i]>tr>td,
+    table[rules=cols i]>tr>th,
+    table[rules=all i]>tr>td,
+    table[rules=all i]>tr>th,
+    table[rules=none i]>thead>tr>td,
+    table[rules=none i]>thead>tr>th,
+    table[rules=groups i]>thead>tr>td,
+    table[rules=groups i]>thead>tr>th,
+    table[rules=rows i]>thead>tr>td,
+    table[rules=rows i]>thead>tr>th,
+    table[rules=cols i]>thead>tr>td,
+    table[rules=cols i]>thead>tr>th,
+    table[rules=all i]>thead>tr>td,
+    table[rules=all i]>thead>tr>th,
+    table[rules=none i]>tbody>tr>td,
+    table[rules=none i]>tbody>tr>th,
+    table[rules=groups i]>tbody>tr>td,
+    table[rules=groups i]>tbody>tr>th,
+    table[rules=rows i]>tbody>tr>td,
+    table[rules=rows i]>tbody>tr>th,
+    table[rules=cols i]>tbody>tr>td,
+    table[rules=cols i]>tbody>tr>th,
+    table[rules=all i]>tbody>tr>td,
+    table[rules=all i]>tbody>tr>th,
+    table[rules=none i]>tfoot>tr>td,
+    table[rules=none i]>tfoot>tr>th,
+    table[rules=groups i]>tfoot>tr>td,
+    table[rules=groups i]>tfoot>tr>th,
+    table[rules=rows i]>tfoot>tr>td,
+    table[rules=rows i]>tfoot>tr>th,
+    table[rules=cols i]>tfoot>tr>td,
+    table[rules=cols i]>tfoot>tr>th,
+    table[rules=all i]>tfoot>tr>td,
+    table[rules=all i]>tfoot>tr>th {
+        border-color: black;
+    }
+
+    input,
+    select,
+    button,
+    textarea {
+        letter-spacing: initial;
+        word-spacing: initial;
+        line-height: initial;
+        text-transform: initial;
+        text-indent: initial;
+        text-shadow: initial;
+        appearance: auto;
+    }
+
+    input:not([type=image i], [type=range i], [type=checkbox i], [type=radio i]) {
+        overflow: clip !important;
+        overflow-clip-margin: 0 !important;
+    }
+
+    input,
+    select,
+    textarea {
+        text-align: initial;
+    }
+
+    :autofill {
+        field-sizing: fixed !important;
+    }
+
+    input:is([type=reset i], [type=button i], [type=submit i]),
+    button {
+        text-align: center;
+    }
+
+    input,
+    button {
+        display: inline-block;
+    }
+
+    input[type=hidden i],
+    input[type=file i],
+    input[type=image i] {
+        appearance: none;
+    }
+
+    input:is([type=radio i], [type=checkbox i], [type=reset i], [type=button i],
+        [type=submit i], [type=color i], [type=search i]),
+    select,
+    button {
+        box-sizing: border-box;
+    }
+
+    textarea {
+        white-space: pre-wrap;
+    }
+
+    hr {
+        color: gray;
+        border-style: inset;
+        border-width: 1px;
+        margin-block: 0.5em;
+        margin-inline: auto;
+        overflow: hidden;
+    }
+
+    fieldset {
+        display: block;
+        margin-inline: 2px;
+        border: groove 2px ThreeDFace;
+        padding-block: 0.35em 0.625em;
+        padding-inline: 0.75em;
+        min-inline-size: min-content;
+    }
+
+    legend {
+        padding-inline: 2px;
+    }
+
+    legend[align=left i] {
+        justify-self: left;
+    }
+
+    legend[align=center i] {
+        justify-self: center;
+    }
+
+    legend[align=right i] {
+        justify-self: right;
+    }
+}

--- a/arches/app/templates/base-root.htm
+++ b/arches/app/templates/base-root.htm
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 {% load static %}
 {% load webpack_static from webpack_loader %}
+{% load render_bundle from webpack_loader %}
 
 
 <!DOCTYPE html>
@@ -53,6 +54,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <link rel="apple-touch-icon" sizes="180x180" href="{% webpack_static 'favicons/apple-touch-icon-180x180.png' %}" />
 
     {% block css %}
+        {% render_bundle 'css/vue-style-base' 'css' %}
         <link rel="stylesheet" href="{% webpack_static 'node_modules/font-awesome/css/font-awesome.min.css' %}" />
     {% endblock css %}
 </head>

--- a/arches/app/templates/base.htm
+++ b/arches/app/templates/base.htm
@@ -34,6 +34,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% block title %}{{ app_settings.APP_NAME }} - {% endblock title %}
 
 {% block css %}
+    {% render_bundle 'css/vue-style-base' 'css' %}
     {% render_bundle 'css/arches' 'css' %}
     {% render_bundle 'css/core' 'css' %}
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This adds a style reset so that components can be expected to look the same whether rendered as an Arches component or a standalone compnent.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11333 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

There isn't a good solution for this.

https://meyerweb.com/eric/tools/css/reset/
https://necolas.github.io/normalize.css/
https://github.com/sindresorhus/modern-normalize
https://github.com/elad2412/the-new-css-reset
https://github.com/master-co/normal.css
https://github.com/kkrishguptaa/reseter.css
https://gist.github.com/devinschumacher/59c2456ec421084a867a9fea8575f763

Are all focused on green-field development. The issue here is that we're not looking to reset basic styles attributed by different browsers, but undo a large amount of style pollution provided by `arches.scss`.

In the end I've rolled my own. It's not a great solution, and admittedly there's a good amount of hack. However, this _should_ give a good starting point for normalization of Vue components, and _should_ be easy to get rid of once we're able to move entirely to Vue. It's largely based on https://html.spec.whatwg.org/multipage/rendering.html

To test this create a basic vue plugin.  Ensure the mounting point has the classname `vue-style-base`. Have it inherit from `base.htm`. Then change the inheritance to `base-root.htm` . Notice the difference in the page surrounding the Vue component, but not within the component.

Contingent on approval, we'll need to update the documentation [here](https://github.com/archesproject/arches-docs/issues/446)
