### PR TITLE
Update nonlocalized string search to correct the null search performance issue

### DIFF
--- a/arches/app/datatypes/core/__init__.py
+++ b/arches/app/datatypes/core/__init__.py
@@ -1,1 +1,2 @@
 from .geojson_feature_collection import *
+from .non_localized_string import *

--- a/arches/app/datatypes/core/non_localized_string.py
+++ b/arches/app/datatypes/core/non_localized_string.py
@@ -1,0 +1,146 @@
+from django.utils.translation import gettext as _
+from rdflib import URIRef, Literal, ConjunctiveGraph as Graph
+from rdflib.namespace import RDF
+
+from arches.app.datatypes.base import BaseDataType
+from arches.app.datatypes.core.util import get_value_from_jsonld
+from arches.app.models.system_settings import settings
+from arches.app.search.elasticsearch_dsl_builder import (
+    Bool,
+    Exists,
+    Match,
+    Term,
+    Terms,
+    Wildcard,
+    Nested,
+)
+from arches.app.models.system_settings import settings
+from arches.app.search.search_term import SearchTerm
+
+
+class NonLocalizedStringDataType(BaseDataType):
+    def validate(
+        self,
+        value,
+        row_number=None,
+        source=None,
+        node=None,
+        nodeid=None,
+        strict=False,
+        **kwargs,
+    ):
+        errors = []
+        try:
+            if value is not None:
+                value.upper()
+        except:
+            message = _("This is not a string")
+            error_message = self.create_error_message(
+                value, source, row_number, message
+            )
+            errors.append(error_message)
+        return errors
+
+    def clean(self, tile, nodeid):
+        if tile.data[nodeid] in ["", "''"]:
+            tile.data[nodeid] = None
+
+    def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
+        if nodevalue is not None:
+            val = {
+                "string": nodevalue,
+                "language": "",
+                "nodegroup_id": tile.nodegroup_id,
+                "provisional": provisional,
+            }
+            document["strings"].append(val)
+
+    def transform_export_values(self, value, *args, **kwargs):
+        if value is not None:
+            return value
+
+    def get_search_terms(self, nodevalue, nodeid=None):
+        terms = []
+
+        if nodevalue is not None:
+            if settings.WORDS_PER_SEARCH_TERM is None or (
+                len(nodevalue.split(" ")) < settings.WORDS_PER_SEARCH_TERM
+            ):
+                terms.append(SearchTerm(value=nodevalue, lang=""))
+        return terms
+
+    def append_null_search_filters(self, value, node, query, request):
+        """
+        Appends the search query dsl to search for fields that have not been populated or are empty strings
+        """
+
+        query.filter(Terms(field="graph_id", terms=[str(node.graph_id)]))
+
+        data_exists_query = Exists(field=f"tiles.data.{str(node.pk)}")
+        tiles_w_node_exists = Nested(path="tiles", query=data_exists_query)
+
+        if value["op"] == "not_null":
+            query.must(tiles_w_node_exists)
+            non_blank_string_query = Wildcard(
+                field=f"tiles.data.{str(node.pk)}", query="?*"
+            )
+            query.must(Nested(path="tiles", query=non_blank_string_query))
+
+        elif value["op"] == "null":
+            # search for tiles that don't exist
+            not_exists_query = Bool()
+            not_exists_query.must_not(tiles_w_node_exists)
+            query.should(not_exists_query)
+
+            # search for tiles that do exist, but have empty strings
+            non_blank_string_query = Term(
+                field=f"tiles.data.{str(node.pk)}.keyword",
+                query="",
+            )
+            query.should(Nested(path="tiles", query=non_blank_string_query))
+
+    def append_search_filters(self, value, node, query, request):
+        try:
+            if value["op"] == "null" or value["op"] == "not_null":
+                self.append_null_search_filters(value, node, query, request)
+            elif value["val"] != "":
+                match_type = "phrase_prefix" if "~" in value["op"] else "phrase"
+                match_query = Match(
+                    field="tiles.data.%s" % (str(node.pk)),
+                    query=value["val"],
+                    type=match_type,
+                )
+                if "!" in value["op"]:
+                    query.must_not(match_query)
+                    query.filter(Exists(field="tiles.data.%s" % (str(node.pk))))
+                else:
+                    query.must(match_query)
+        except KeyError as e:
+            pass
+
+    def is_a_literal_in_rdf(self):
+        return True
+
+    def to_rdf(self, edge_info, edge):
+        # returns an in-memory graph object, containing the domain resource, its
+        # type and the string as a string literal
+        g = Graph()
+        if edge_info["range_tile_data"] is not None:
+            g.add((edge_info["d_uri"], RDF.type, URIRef(edge.domainnode.ontologyclass)))
+            g.add(
+                (
+                    edge_info["d_uri"],
+                    URIRef(edge.ontologyproperty),
+                    Literal(edge_info["range_tile_data"]),
+                )
+            )
+        return g
+
+    def from_rdf(self, json_ld_node):
+        # returns the string value only
+        # FIXME: Language?
+        value = get_value_from_jsonld(json_ld_node)
+        try:
+            return value[0]
+        except (AttributeError, KeyError) as e:
+            pass

--- a/arches/app/datatypes/core/non_localized_string.py
+++ b/arches/app/datatypes/core/non_localized_string.py
@@ -4,7 +4,7 @@ from rdflib.namespace import RDF
 
 from arches.app.datatypes.base import BaseDataType
 from arches.app.datatypes.core.util import get_value_from_jsonld
-from arches.app.models.system_settings import settings
+from django.conf import settings
 from arches.app.search.elasticsearch_dsl_builder import (
     Bool,
     Exists,
@@ -14,7 +14,6 @@ from arches.app.search.elasticsearch_dsl_builder import (
     Wildcard,
     Nested,
 )
-from arches.app.models.system_settings import settings
 from arches.app.search.search_term import SearchTerm
 
 
@@ -69,11 +68,10 @@ class NonLocalizedStringDataType(BaseDataType):
                 terms.append(SearchTerm(value=nodevalue, lang=""))
         return terms
 
-    def append_null_search_filters(self, value, node, query, request):
+    def append_null_search_filters(self, value, node, query: Bool, request):
         """
         Appends the search query dsl to search for fields that have not been populated or are empty strings
         """
-
         query.filter(Terms(field="graph_id", terms=[str(node.graph_id)]))
 
         data_exists_query = Exists(field=f"tiles.data.{str(node.pk)}")

--- a/arches/app/datatypes/core/util.py
+++ b/arches/app/datatypes/core/util.py
@@ -1,0 +1,19 @@
+from django.utils.translation import get_language, gettext as _
+
+
+def get_value_from_jsonld(json_ld_node):
+    try:
+        language = json_ld_node[0].get("@language")
+        if language is None:
+            language = get_language()
+        return (json_ld_node[0].get("@value"), language)
+    except KeyError as e:
+        try:
+            language = json_ld_node.get("@language")
+            if language is None:
+                language = get_language()
+            return (json_ld_node.get("@value"), language)
+        except AttributeError as e:
+            return
+    except IndexError as e:
+        return

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2,6 +2,7 @@ import copy
 import uuid
 import json
 import decimal
+from arches.app.datatypes.core.util import get_value_from_jsonld
 from arches.app.utils.file_validator import FileValidator
 import filetype
 import base64
@@ -453,104 +454,6 @@ class StringDataType(BaseDataType):
         tile_language_codes = set(tile.data[nodeid].keys())
         for code in all_language_codes - tile_language_codes:
             tile.data[nodeid][code] = {"value": "", "direction": direction_lookup[code]}
-
-
-class NonLocalizedStringDataType(BaseDataType):
-    def validate(
-        self,
-        value,
-        row_number=None,
-        source=None,
-        node=None,
-        nodeid=None,
-        strict=False,
-        **kwargs,
-    ):
-        errors = []
-        try:
-            if value is not None:
-                value.upper()
-        except:
-            message = _("This is not a string")
-            error_message = self.create_error_message(
-                value, source, row_number, message
-            )
-            errors.append(error_message)
-        return errors
-
-    def clean(self, tile, nodeid):
-        if tile.data[nodeid] in ["", "''"]:
-            tile.data[nodeid] = None
-
-    def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
-        if nodevalue is not None:
-            val = {
-                "string": nodevalue,
-                "language": "",
-                "nodegroup_id": tile.nodegroup_id,
-                "provisional": provisional,
-            }
-            document["strings"].append(val)
-
-    def transform_export_values(self, value, *args, **kwargs):
-        if value is not None:
-            return value
-
-    def get_search_terms(self, nodevalue, nodeid=None):
-        terms = []
-
-        if nodevalue is not None:
-            if settings.WORDS_PER_SEARCH_TERM is None or (
-                len(nodevalue.split(" ")) < settings.WORDS_PER_SEARCH_TERM
-            ):
-                terms.append(SearchTerm(value=nodevalue, lang=""))
-        return terms
-
-    def append_search_filters(self, value, node, query, request):
-        try:
-            if value["op"] == "null" or value["op"] == "not_null":
-                self.append_null_search_filters(value, node, query, request)
-            elif value["val"] != "":
-                match_type = "phrase_prefix" if "~" in value["op"] else "phrase"
-                match_query = Match(
-                    field="tiles.data.%s" % (str(node.pk)),
-                    query=value["val"],
-                    type=match_type,
-                )
-                if "!" in value["op"]:
-                    query.must_not(match_query)
-                    query.filter(Exists(field="tiles.data.%s" % (str(node.pk))))
-                else:
-                    query.must(match_query)
-        except KeyError as e:
-            pass
-
-    def is_a_literal_in_rdf(self):
-        return True
-
-    def to_rdf(self, edge_info, edge):
-        # returns an in-memory graph object, containing the domain resource, its
-        # type and the string as a string literal
-        g = Graph()
-        if edge_info["range_tile_data"] is not None:
-            g.add((edge_info["d_uri"], RDF.type, URIRef(edge.domainnode.ontologyclass)))
-            g.add(
-                (
-                    edge_info["d_uri"],
-                    URIRef(edge.ontologyproperty),
-                    Literal(edge_info["range_tile_data"]),
-                )
-            )
-        return g
-
-    def from_rdf(self, json_ld_node):
-        # returns the string value only
-        # FIXME: Language?
-        value = get_value_from_jsonld(json_ld_node)
-        try:
-            return value[0]
-        except (AttributeError, KeyError) as e:
-            pass
 
 
 class NumberDataType(BaseDataType):
@@ -2522,21 +2425,3 @@ class AnnotationDataType(BaseDataType):
             }
         }
         return mapping
-
-
-def get_value_from_jsonld(json_ld_node):
-    try:
-        language = json_ld_node[0].get("@language")
-        if language is None:
-            language = get_language()
-        return (json_ld_node[0].get("@value"), language)
-    except KeyError as e:
-        try:
-            language = json_ld_node.get("@language")
-            if language is None:
-                language = get_language()
-            return (json_ld_node.get("@value"), language)
-        except AttributeError as e:
-            return
-    except IndexError as e:
-        return

--- a/tests/utils/datatype_tests.py
+++ b/tests/utils/datatype_tests.py
@@ -292,34 +292,6 @@ class StringDataTypeTests(ArchesTestCase):
         self.assertIsNotNone(tile2.data[nodeid])
 
 
-class NonLocalizedStringDataTypeTests(ArchesTestCase):
-    def test_string_validate(self):
-        string = DataTypeFactory().get_instance("non-localized-string")
-        some_errors = string.validate(float(1.2))
-        self.assertGreater(len(some_errors), 0)
-        no_errors = string.validate("Hello World")
-        self.assertEqual(len(no_errors), 0)
-
-    def test_string_clean(self):
-        string = DataTypeFactory().get_instance("non-localized-string")
-        nodeid1 = "72048cb3-adbc-11e6-9ccf-14109fd34195"
-        nodeid2 = "72048cb3-adbc-11e6-9ccf-14109fd34196"
-        resourceinstanceid = "40000000-0000-0000-0000-000000000000"
-
-        json_empty_strings = {
-            "resourceinstance_id": resourceinstanceid,
-            "parenttile_id": "",
-            "nodegroup_id": nodeid1,
-            "tileid": "",
-            "data": {nodeid1: "''", nodeid2: ""},
-        }
-        tile1 = Tile(json_empty_strings)
-        string.clean(tile1, nodeid1)
-        self.assertIsNone(tile1.data[nodeid1])
-        string.clean(tile1, nodeid2)
-        self.assertIsNone(tile1.data[nodeid2])
-
-
 class URLDataTypeTests(ArchesTestCase):
     def test_validate(self):
         url = DataTypeFactory().get_instance("url")

--- a/tests/utils/non_localized_string_tests.py
+++ b/tests/utils/non_localized_string_tests.py
@@ -1,0 +1,82 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from rdflib import ConjunctiveGraph
+
+from arches.app.datatypes.core.non_localized_string import NonLocalizedStringDataType
+from arches.app.datatypes.datatypes import DataTypeFactory
+from arches.app.models.models import Node
+from arches.app.models.tile import Tile
+from arches.app.search.elasticsearch_dsl_builder import Bool
+from tests.exporter.datatype_to_rdf_tests import ARCHES_NS, CIDOC_NS
+
+
+class NonLocalizedStringDataTypeTests(TestCase):
+    def test_string_validate(self):
+        string = NonLocalizedStringDataType()
+        some_errors = string.validate(float(1.2))
+        self.assertGreater(len(some_errors), 0)
+        no_errors = string.validate("Hello World")
+        self.assertEqual(len(no_errors), 0)
+
+    def test_string_clean(self):
+        string = NonLocalizedStringDataType()
+        nodeid1 = "72048cb3-adbc-11e6-9ccf-14109fd34195"
+        nodeid2 = "72048cb3-adbc-11e6-9ccf-14109fd34196"
+
+        tile_mock = Mock()
+        tile_mock.data = {}
+        tile_mock.data[nodeid1] = "''"
+        tile_mock.data[nodeid2] = ""
+        string.clean(tile_mock, nodeid1)
+        self.assertIsNone(tile_mock.data[nodeid1])
+        string.clean(tile_mock, nodeid2)
+        self.assertIsNone(tile_mock.data[nodeid2])
+
+    def test_append_null_search_filters(self):
+        mock_node = Mock(Node)
+        mock_query = Mock(Bool)
+        mock_query.filter = Mock()
+        mock_value = {"op": "null"}
+        nonlocalized_string_dt = NonLocalizedStringDataType()
+        nonlocalized_string_dt.append_null_search_filters(
+            mock_value, mock_node, mock_query, Mock()
+        )
+
+        mock_query.filter.assert_called()
+
+    def test_to_rdf(self):
+        nonlocalized_string_dt = NonLocalizedStringDataType()
+        edge_info, edge = mock_edge(1, CIDOC_NS["name"], None, "", "bob")
+        result = nonlocalized_string_dt.to_rdf(edge_info, edge)
+        self.assertIsInstance(result, ConjunctiveGraph)
+
+
+def mock_edge(
+    s_id,
+    p_uri_str,
+    o_id,
+    domain_tile_data,
+    range_tile_data,
+    s_type_str=CIDOC_NS["E22_Man-Made_Object"],
+    o_type_str=None,
+    s_pref="resources",
+    o_pref="resources",
+):
+    # (S, P, O triple, tiledata for domainnode, td for rangenode, S's type, O's type)
+    edge = Mock()
+    edge_info = {}
+    edge.domainnode_id = edge.domainnode.pk = s_id
+    edge_info["d_uri"] = ARCHES_NS["{0}/{1}".format(s_pref, s_id)]
+    edge_info["r_uri"] = None
+    edge_info["d_datatype"] = None
+    edge_info["r_datatype"] = None
+    edge.rangenode_id = edge.rangenode.pk = o_id
+    if o_id:
+        edge_info["r_uri"] = ARCHES_NS["{0}/{1}".format(o_pref, o_id)]
+    edge.ontologyproperty = p_uri_str
+    edge.domainnode.ontologyclass = s_type_str
+    edge.rangenode.ontologyclass = o_type_str
+    edge_info["range_tile_data"] = range_tile_data
+    edge_info["domain_tile_data"] = domain_tile_data
+    return edge_info, edge


### PR DESCRIPTION
There's an issue with the null/empty search performance for non-localized string nodes in very large datasets.  Performance is dramatically slower because of the base painless script.  This bypasses that problem only for this datatype. 

Also extracting nonlocalized string (similar to geojson feature collection datatype).  