### PR TITLE
Replace deprecated workbook method

### DIFF
--- a/arches/app/etl_modules/branch_excel_importer.py
+++ b/arches/app/etl_modules/branch_excel_importer.py
@@ -218,13 +218,13 @@ class BranchExcelImporter(BaseImportModule):
 
     def validate_uploaded_file(self, workbook):
         try:
-            graphid = workbook.get_sheet_by_name("metadata")["B1"].value
+            graphid = workbook["metadata"]["B1"].value
             uuid.UUID(graphid)
         except:
             raise FileValidationError()
 
     def get_graphid(self, workbook):
-        graphid = workbook.get_sheet_by_name("metadata")["B1"].value
+        graphid = workbook["metadata"]["B1"].value
         return graphid
 
     def stage_files(self, files, summary, cursor):


### PR DESCRIPTION
Address deprecation warnings in test suite:

```py
/home/runner/work/arches/arches/arches/app/etl_modules/branch_excel_importer.py:227: DeprecationWarning: Call to deprecated function get_sheet_by_name (Use wb[sheetname]).
[2259](https://github.com/archesproject/arches/actions/runs/10406926722/job/28821082656?pr=11101#step:6:2275)
  graphid = workbook.get_sheet_by_name("metadata")["B1"].value
[2260](https://github.com/archesproject/arches/actions/runs/10406926722/job/28821082656?pr=11101#step:6:2276)
./home/runner/work/arches/arches/arches/app/etl_modules/branch_excel_importer.py:227: DeprecationWarning: Call to deprecated function get_sheet_by_name (Use wb[sheetname]).
[2261](https://github.com/archesproject/arches/actions/runs/10406926722/job/28821082656?pr=11101#step:6:2277)
  graphid = workbook.get_sheet_by_name("metadata")["B1"].value
```