### PR TITLE
Omit `SESSION_COOKIE_SECURE` in development

### DIFF
--- a/arches/settings.py
+++ b/arches/settings.py
@@ -200,7 +200,6 @@ RESOURCE_EDITOR_GROUPS = ("Resource Editor", "Crowdsource Editor")
 # Unique session cookie ensures that logins are treated separately for each app
 SESSION_COOKIE_NAME = "arches"
 SESSION_COOKIE_SAMESITE = "Strict"
-SESSION_COOKIE_SECURE = True
 
 # EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  #<-- Only need to uncomment this for testing without an actual email server
 # EMAIL_USE_TLS = True


### PR DESCRIPTION
Refs archesproject/arches-lingo#59
Follow-up to f8076a3.

This should be set True in production, but the development server doesn't run over HTTPS, so this is too aggressive for our default dev settings.

[Reference](https://docs.djangoproject.com/en/5.0/ref/settings/#session-cookie-secure)