### PR TITLE
also catch type error for userid being None

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1166,7 +1166,7 @@ class ResourceInstance(models.Model):
         if create_record:
             try:
                 creatorid = int(create_record.userid)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
         if creatorid is None:


### PR DESCRIPTION
userid can be of NoneType, which will return a TypeError.  pass on this to invoke the DEFAULT_RESOURCE_IMPORT_USER setting.