### PR TITLE
Add vitest globals to tsconfig

### DIFF
--- a/arches/install/arches-templates/tsconfig.json
+++ b/arches/install/arches-templates/tsconfig.json
@@ -15,6 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
+    "types": ["vitest/globals"],
     "allowImportingTsExtensions": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
+    "types": ["vitest/globals"],
     "allowImportingTsExtensions": true
   }
 }


### PR DESCRIPTION
Without this change, notice failure in archesproject/arches-lingo#86 in the ts linter:

```ts
arches_lingo/src/arches_lingo/utils.spec.ts:12:1 - error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.

12 describe("Build scheme hierarchy", () => {
   ~~~~~~~~

arches_lingo/src/arches_lingo/utils.spec.ts:13:5 - error TS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.

13     it("Should shape schemes into TreeNodes", () => {
       ~~

arches_lingo/src/arches_lingo/utils.spec.ts:21:9 - error TS2304: Cannot find name 'expect'.

21         expect(schemeNode.label).toEqual("Test Scheme");
           ~~~~~~

arches_lingo/src/arches_lingo/utils.spec.ts:22:9 - error TS2304: Cannot find name 'expect'.

22         expect(schemeNode.iconLabel).toEqual("Scheme");
           ~~~~~~

arches_lingo/src/arches_lingo/utils.spec.ts:23:9 - error TS2304: Cannot find name 'expect'.

23         expect(schemeNode.data.top_concepts.length).toEqual(1);
           ~~~~~~

arches_lingo/src/arches_lingo/utils.spec.ts:26:9 - error TS2304: Cannot find name 'expect'.

26         expect(topConcept.labels[0].value).toEqual("Concept 1");
           ~~~~~~

arches_lingo/src/arches_lingo/utils.spec.ts:27:9 - error TS2304: Cannot find name 'expect'.

27         expect(topConcept.narrower.length).toEqual(4);
           ~~~~~~

[1:38:04 PM] Found 9 errors. Watching for file changes.
```