### PR TITLE
Fix noisy test

### DIFF
--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -151,10 +151,13 @@ class PermissionTests(ArchesTestCase):
         resource = ResourceInstance.objects.get(
             resourceinstanceid=self.resource_instance_id
         )
-        nodes = Node.objects.filter(graph_id=resource.graph_id)
+        nodes = (
+            Node.objects.filter(graph_id=resource.graph_id)
+            .exclude(nodegroup__isnull=True)
+            .select_related("nodegroup")
+        )
         for node in nodes:
-            if node.nodegroup:
-                assign_perm("no_access_to_nodegroup", self.group, node.nodegroup)
+            assign_perm("no_access_to_nodegroup", self.group, node.nodegroup)
         hasperms = user_has_resource_model_permissions(
             self.user, ["models.read_nodegroup"], resource
         )

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -804,7 +804,8 @@ class SearchTests(ArchesTestCase):
 
         """
         query = {"search-view": "unavailable-search-view"}
-        response_json = get_response_json(self.client, query=query)
+        with self.assertLogs("django.request", level="WARNING"):
+            response_json = get_response_json(self.client, query=query)
         self.assertFalse(response_json["success"])
 
     def test_searchview_searchview_component_from_admin(self):


### PR DESCRIPTION
Fix noisy output from recently merged test:

```py
.......Not Acceptable: /search/resources..........
```

While re-running tests, noticed a relatively slow test (unrelated) with a straightforward fix.