### PR TITLE
Speed up test suite by 15% and fix blocking issue #11418 and issue #10719

### DIFF
--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -663,6 +663,11 @@ class Command(BaseCommand):
                 print("Could not save system settings")
             self.export_package_settings(dest_dir, "true")
 
+    @staticmethod
+    def update_resource_geojson_geometries():
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT * FROM refresh_geojson_geometries();")
+
     def load_package(
         self,
         source,
@@ -1177,10 +1182,6 @@ class Command(BaseCommand):
         def load_etl_modules(package_dir):
             load_extensions(package_dir, "etl_modules", "etl_module")
 
-        def update_resource_geojson_geometries():
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT * FROM refresh_geojson_geometries();")
-
         def load_apps(package_dir):
             package_apps = glob.glob(os.path.join(package_dir, "apps", "*"))
             for app in package_apps:
@@ -1299,7 +1300,7 @@ class Command(BaseCommand):
             for css_file in css_files:
                 shutil.copy(css_file, css_dest)
         print("Refreshing the resource view")
-        update_resource_geojson_geometries()
+        self.update_resource_geojson_geometries()
         print("loading post sql")
         load_sql(package_location, "post_sql")
         print("loading templates")

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -115,6 +115,8 @@ class ArchesTestCase(TestCase):
     def setUpTestData(cls):
         LanguageSynchronizer.synchronize_settings_with_db(update_published_graphs=False)
         cls.loadOntology()
+        if not cls.graph_fixtures:
+            return
         for path in test_settings.RESOURCE_GRAPH_LOCATIONS:
             file_paths = [
                 file_path

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -88,9 +88,7 @@ class ArchesTestCase(TestCase):
             )
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
+    def setUpTestData(cls):
         sql = """
             INSERT INTO public.oauth2_provider_application(
                 id, client_id, redirect_uris, client_type, authorization_grant_type,

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -135,6 +135,14 @@ class ArchesTestCase(TestCase):
     @classmethod
     def legacy_load_testing_package(cls):
         """Do not write new tests with this method."""
+        test_concepts_path = (
+            Path(test_settings.REFERENCE_DATA_FIXTURE_LOCATION) / "concepts"
+        )
+        test_collections_path = (
+            Path(test_settings.REFERENCE_DATA_FIXTURE_LOCATION) / "collections"
+        )
+        test_package_path = Path(test_settings.REFERENCE_DATA_FIXTURE_LOCATION).parent
+
         with (
             captured_stdout(),
             mock.patch(
@@ -143,7 +151,12 @@ class ArchesTestCase(TestCase):
         ):
             management.call_command(
                 "packages",
-                "-o import_reference_data -s tests/fixtures/testing_prj/testing_prj/pkg/reference_data/concepts/Test-scheme.xml".split(),
+                [
+                    "-o",
+                    "import_reference_data",
+                    "-s",
+                    test_concepts_path / "Test-scheme.xml",
+                ],
             )
             management.call_command(
                 "packages",
@@ -151,12 +164,8 @@ class ArchesTestCase(TestCase):
                     "-o",
                     "import_reference_data",
                     "-s",
-                    "tests/fixtures/testing_prj/testing_prj/pkg/reference_data/concepts/4.3 Test RDM Thesaurus.xml",
+                    test_concepts_path / "4.3 Test RDM Thesaurus.xml",
                 ],
-            )
-            management.call_command(
-                "packages",
-                "-o import_reference_data -s tests/fixtures/testing_prj/testing_prj/pkg/reference_data/collections/Test-scheme-collections.xml".split(),
             )
             management.call_command(
                 "packages",
@@ -164,12 +173,29 @@ class ArchesTestCase(TestCase):
                     "-o",
                     "import_reference_data",
                     "-s",
-                    "tests/fixtures/testing_prj/testing_prj/pkg/reference_data/collections/4.3 Test RDM Collections.xml",
+                    test_collections_path / "Test-scheme-collections.xml",
                 ],
             )
             management.call_command(
                 "packages",
-                "-o load_package -s tests/fixtures/testing_prj/testing_prj/pkg -ow True -y".split(),
+                [
+                    "-o",
+                    "import_reference_data",
+                    "-s",
+                    test_collections_path / "4.3 Test RDM collections.xml",
+                ],
+            )
+            management.call_command(
+                "packages",
+                [
+                    "-o",
+                    "load_package",
+                    "-s",
+                    test_package_path,
+                    "-ow",
+                    "True",
+                    "-y",
+                ],
             )
 
         path_to_cheesy_image = Path(settings.MEDIA_ROOT) / "uploadedfiles" / "test.png"

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -178,8 +178,3 @@ class ArchesTestCase(TestCase):
         sql = "DELETE FROM public.oauth2_provider_application WHERE id = 44;"
         cursor.execute(sql)
         super().tearDownClass()
-
-    @classmethod
-    def deleteGraph(cls, root):
-        graph = Graph.objects.get(graphid=str(root))
-        graph.delete()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -88,7 +88,8 @@ class ArchesTestCase(TestCase):
             )
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpClass(cls):
+        super().setUpClass()
         sql = """
             INSERT INTO public.oauth2_provider_application(
                 id, client_id, redirect_uris, client_type, authorization_grant_type,
@@ -110,6 +111,8 @@ class ArchesTestCase(TestCase):
         with connection.cursor() as cursor:
             cursor.execute(sql)
 
+    @classmethod
+    def setUpTestData(cls):
         LanguageSynchronizer.synchronize_settings_with_db(update_published_graphs=False)
         cls.loadOntology()
         for path in test_settings.RESOURCE_GRAPH_LOCATIONS:
@@ -172,7 +175,7 @@ class ArchesTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cursor = connection.cursor()
         sql = "DELETE FROM public.oauth2_provider_application WHERE id = 44;"
-        cursor.execute(sql)
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
         super().tearDownClass()

--- a/tests/bulkdata/bulk_data_delete_tests.py
+++ b/tests/bulkdata/bulk_data_delete_tests.py
@@ -2,7 +2,6 @@ import uuid
 from django.contrib.auth.models import User
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
-from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.etl_modules.bulk_data_deletion import BulkDataDeletion
 from tests.base_test import ArchesTestCase
 
@@ -11,6 +10,7 @@ from tests.base_test import ArchesTestCase
 
 
 class BulkDataDeletionTests(ArchesTestCase):
+    graph_fixtures = ["Search Test Model"]
 
     @classmethod
     def setUpClass(self):
@@ -18,13 +18,10 @@ class BulkDataDeletionTests(ArchesTestCase):
         self.search_model_graphid = "d291a445-fa5f-11e6-afa8-14109fd34195"
         self.search_model_name_nodeid = "2fe14de3-fa61-11e6-897b-14109fd34195"
         self.user = User.objects.create(username="testuser", password="securepassword")
-        LanguageSynchronizer.synchronize_settings_with_db()
         self.bulk_deleter = BulkDataDeletion()
-        self.loadOntology()
-        self.ensure_test_resource_models_are_loaded()
 
     def test_get_number_of_deletions_with_no_resourceids(self):
-        loadid = str(uuid.uuid4())
+        loadid = uuid.uuid4()
         resourceids, tile_ct = create_test_resources_and_tiles(
             self.search_model_graphid, self.search_model_name_nodeid, loadid
         )
@@ -35,7 +32,7 @@ class BulkDataDeletionTests(ArchesTestCase):
         self.assertEqual(number_of_resource, len(resourceids))
 
     def test_delete_resources(self):
-        loadid = str(uuid.uuid4())
+        loadid = uuid.uuid4()
         resourceids, tile_ct = create_test_resources_and_tiles(
             self.search_model_graphid, self.search_model_name_nodeid, loadid
         )
@@ -50,7 +47,7 @@ class BulkDataDeletionTests(ArchesTestCase):
         self.assertEqual(result["deleted_count"], len(resourceids))
 
     def test_delete_tiles(self):
-        loadid = str(uuid.uuid4())
+        loadid = uuid.uuid4()
         resourceids, tile_ct = create_test_resources_and_tiles(
             self.search_model_graphid, self.search_model_name_nodeid, loadid
         )
@@ -67,7 +64,7 @@ class BulkDataDeletionTests(ArchesTestCase):
 
 def create_test_resources_and_tiles(graphid, nodeid, transaction_id):
     count = 10
-    test_resourceids = [str(uuid.uuid4()) for x in range(count)]
+    test_resourceids = [uuid.uuid4() for x in range(count)]
     for x in range(count):
         r = Resource(graph_id=graphid, resourceinstanceid=test_resourceids[x])
         t = Tile.get_blank_tile(nodeid, resourceid=test_resourceids[x])

--- a/tests/bulkdata/bulk_data_delete_tests.py
+++ b/tests/bulkdata/bulk_data_delete_tests.py
@@ -13,12 +13,12 @@ class BulkDataDeletionTests(ArchesTestCase):
     graph_fixtures = ["Search Test Model"]
 
     @classmethod
-    def setUpClass(self):
-        super().setUpClass()
-        self.search_model_graphid = "d291a445-fa5f-11e6-afa8-14109fd34195"
-        self.search_model_name_nodeid = "2fe14de3-fa61-11e6-897b-14109fd34195"
-        self.user = User.objects.create(username="testuser", password="securepassword")
-        self.bulk_deleter = BulkDataDeletion()
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.search_model_graphid = "d291a445-fa5f-11e6-afa8-14109fd34195"
+        cls.search_model_name_nodeid = "2fe14de3-fa61-11e6-897b-14109fd34195"
+        cls.user = User.objects.create(username="testuser", password="securepassword")
+        cls.bulk_deleter = BulkDataDeletion()
 
     def test_get_number_of_deletions_with_no_resourceids(self):
         loadid = uuid.uuid4()

--- a/tests/bulkdata/single_csv_tests.py
+++ b/tests/bulkdata/single_csv_tests.py
@@ -41,7 +41,6 @@ class SingleCSVTests(TransactionTestCase):
     serialized_rollback = True
 
     def setUp(self):
-        LanguageSynchronizer.synchronize_settings_with_db()
         with open(
             os.path.join("tests/fixtures/single_csv_bulk_manager_test_model.json"), "r"
         ) as f:

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -47,11 +47,6 @@ class RDFExportUnitTests(ArchesTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.loadOntology()
-        LanguageSynchronizer.synchronize_settings_with_db()
-
-        ResourceInstance.objects.all().delete()
-
         for skospath in [
             "tests/fixtures/data/rdf_export_thesaurus.xml",
             "tests/fixtures/data/rdf_export_collections.xml",

--- a/tests/exporter/datatype_to_rdf_tests.py
+++ b/tests/exporter/datatype_to_rdf_tests.py
@@ -24,12 +24,10 @@ from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
-from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.utils.skos import SKOSReader
-from arches.app.models.models import ResourceInstance
 from arches.app.datatypes.datatypes import DataTypeFactory
 from rdflib import Namespace, URIRef, Literal
-from rdflib.namespace import RDF, RDFS, XSD
+from rdflib.namespace import RDFS, XSD
 from django.utils import translation
 
 # these tests can be run from the command line via
@@ -45,8 +43,8 @@ class RDFExportUnitTests(ArchesTestCase):
     """
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
         for skospath in [
             "tests/fixtures/data/rdf_export_thesaurus.xml",
             "tests/fixtures/data/rdf_export_collections.xml",

--- a/tests/exporter/jsonld_export_tests.py
+++ b/tests/exporter/jsonld_export_tests.py
@@ -11,7 +11,6 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
-from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.utils.skos import SKOSReader
 
 # these tests can be run from the command line via
@@ -20,8 +19,8 @@ from arches.app.utils.skos import SKOSReader
 
 class JsonLDExportTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         cls.factory = RequestFactory()
 

--- a/tests/exporter/jsonld_export_tests.py
+++ b/tests/exporter/jsonld_export_tests.py
@@ -23,14 +23,7 @@ class JsonLDExportTests(ArchesTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        # This runs once per instantiation
-        cls.loadOntology()
         cls.factory = RequestFactory()
-        cls.client = Client()
-
-        # cls.client.login(username='admin', password='admin')
-        # cls.user = User.objects.get(username='anonymous')
-        LanguageSynchronizer.synchronize_settings_with_db()
 
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/jsonld_base/rdm/jsonld_test_thesaurus.xml")

--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -24,7 +24,6 @@ from arches.app.utils.data_management.resources.formats.csvfile import (
     CsvWriter,
     MissingConfigException,
 )
-from arches.app.utils.i18n import LanguageSynchronizer
 from operator import itemgetter
 from tests.base_test import ArchesTestCase
 from arches.app.utils.skos import SKOSReader
@@ -44,8 +43,8 @@ from arches.app.utils.data_management.resource_graphs.importer import (
 
 class BusinessDataExportTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_scheme.xml")

--- a/tests/exporter/resource_export_tests.py
+++ b/tests/exporter/resource_export_tests.py
@@ -47,7 +47,6 @@ class BusinessDataExportTests(ArchesTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.loadOntology()
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_scheme.xml")
         ret = skos.save_concepts_from_skos(rdf)
@@ -61,7 +60,6 @@ class BusinessDataExportTests(ArchesTestCase):
             "r",
         ) as f:
             archesfile = JSONDeserializer().deserialize(f)
-        LanguageSynchronizer.synchronize_settings_with_db()
         ResourceGraphImporter(archesfile["graph"])
 
     def test_invalid_writer_config(self):

--- a/tests/importer/concept_import_tests.py
+++ b/tests/importer/concept_import_tests.py
@@ -35,8 +35,8 @@ from arches.app.search.search_engine_factory import SearchEngineFactory
 
 class ConceptImportTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         se = SearchEngineFactory().create()
         with captured_stdout():

--- a/tests/importer/datatype_from_rdf_tests.py
+++ b/tests/importer/datatype_from_rdf_tests.py
@@ -48,10 +48,6 @@ class RDFImportUnitTests(ArchesTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.loadOntology()
-        LanguageSynchronizer.synchronize_settings_with_db()
-        ResourceInstance.objects.all().delete()
-
         for skospath in [
             "tests/fixtures/data/rdf_export_thesaurus.xml",
             "tests/fixtures/data/rdf_export_collections.xml",

--- a/tests/importer/datatype_from_rdf_tests.py
+++ b/tests/importer/datatype_from_rdf_tests.py
@@ -23,15 +23,10 @@ from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
-from arches.app.models.models import ResourceInstance
 from tests.base_test import ArchesTestCase
 from arches.app.utils.skos import SKOSReader
-from arches.app.utils.i18n import LanguageSynchronizer
-from arches.app.models.concept import Concept
 from arches.app.datatypes.datatypes import DataTypeFactory
-from rdflib import Namespace, URIRef, Literal, Graph
-from rdflib.namespace import RDF, RDFS, XSD
-from arches.app.utils.data_management.resources.formats.rdffile import RdfWriter
+from rdflib import Namespace
 
 # these tests can be run from the command line via
 # python manage.py test tests.importer.datatype_from_rdf_tests --settings="tests.test_settings"
@@ -46,8 +41,8 @@ class RDFImportUnitTests(ArchesTestCase):
     """
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
         for skospath in [
             "tests/fixtures/data/rdf_export_thesaurus.xml",
             "tests/fixtures/data/rdf_export_collections.xml",

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -33,8 +33,6 @@ class JsonLDImportTests(ArchesTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        # This runs once per instantiation
-        cls.loadOntology()
         cls.factory = RequestFactory()
         cls.token = "abc123"
         cls.client = Client(HTTP_AUTHORIZATION="Bearer %s" % cls.token)
@@ -42,7 +40,6 @@ class JsonLDImportTests(ArchesTestCase):
         sql_str = CREATE_TOKEN_SQL.format(token=cls.token, user_id=1)
         cursor = connection.cursor()
         cursor.execute(sql_str)
-        LanguageSynchronizer.synchronize_settings_with_db()
 
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/jsonld_base/rdm/jsonld_test_thesaurus.xml")

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -34,8 +34,8 @@ class JsonLDImportTests(ArchesTestCase):
         cls.client = Client(HTTP_AUTHORIZATION="Bearer %s" % cls.token)
 
         sql_str = CREATE_TOKEN_SQL.format(token=cls.token, user_id=1)
-        cursor = connection.cursor()
-        cursor.execute(sql_str)
+        with connection.cursor() as cursor:
+            cursor.execute(sql_str)
 
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/jsonld_base/rdm/jsonld_test_thesaurus.xml")
@@ -185,8 +185,8 @@ class JsonLDImportTests(ArchesTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cursor = connection.cursor()
-        cursor.execute(DELETE_TOKEN_SQL)
+        with connection.cursor() as cursor:
+            cursor.execute(DELETE_TOKEN_SQL)
 
         super().tearDownClass()
 

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -7,16 +7,12 @@ from django.test.client import RequestFactory, Client
 from django.test.utils import captured_stdout
 from django.urls import reverse
 from django.db import connection
-from arches.app.utils.i18n import LanguageSynchronizer
 from tests.base_test import ArchesTestCase, CREATE_TOKEN_SQL, DELETE_TOKEN_SQL
 from arches.app.utils.skos import SKOSReader
 from arches.app.models.graph import Graph
 from arches.app.models.models import TileModel
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resources.importer import BusinessDataImporter
-from arches.app.utils.data_management.resources.exporter import (
-    ResourceExporter as BusinessDataExporter,
-)
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
@@ -30,8 +26,8 @@ from pyld.jsonld import expand
 
 class JsonLDImportTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         cls.factory = RequestFactory()
         cls.token = "abc123"

--- a/tests/importer/ontology_import_tests.py
+++ b/tests/importer/ontology_import_tests.py
@@ -36,14 +36,6 @@ class OntologyModelTests(ArchesTestCase):
             "load_ontology", source=test_settings.ONTOLOGY_FIXTURES, verbosity=0
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        ontology = models.Ontology.objects.get(
-            pk="11111111-0000-0000-0000-000000000000"
-        )
-        ontology.delete()
-        super().tearDownClass()
-
     def test_load_ontology(self):
         ontology_class = models.OntologyClass.objects.get(
             ontology__pk="11111111-0000-0000-0000-000000000000",

--- a/tests/importer/ontology_import_tests.py
+++ b/tests/importer/ontology_import_tests.py
@@ -30,8 +30,8 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer
 
 class OntologyModelTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
         management.call_command(
             "load_ontology", source=test_settings.ONTOLOGY_FIXTURES, verbosity=0
         )

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -44,13 +44,13 @@ class Customi18nTextFieldTests(ArchesTestCase):
             OWNER to postgres;
         """
 
-        cursor = connection.cursor()
-        cursor.execute(sql)
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
 
     @classmethod
     def tearDownClass(cls):
-        cursor = connection.cursor()
-        cursor.execute("DROP TABLE public._localization_test_model")
+        with connection.cursor() as cursor:
+            cursor.execute("DROP TABLE public._localization_test_model")
         super().tearDownClass()
 
     class LocalizationTestModel(models.Model):
@@ -246,13 +246,13 @@ class Customi18nJSONFieldTests(ArchesTestCase):
             OWNER to postgres;
         """
 
-        cursor = connection.cursor()
-        cursor.execute(sql)
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
 
     @classmethod
     def tearDownClass(cls):
-        cursor = connection.cursor()
-        cursor.execute("DROP TABLE public._localization_test_json_model")
+        with connection.cursor() as cursor:
+            cursor.execute("DROP TABLE public._localization_test_json_model")
         super().tearDownClass()
 
     class LocalizationTestJsonModel(models.Model):

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -19,8 +19,8 @@ from django.db import connection
 
 class Customi18nTextFieldTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         sql = """
         CREATE TABLE public._localization_test_model
@@ -231,8 +231,8 @@ class Customi18nTextFieldTests(ArchesTestCase):
 
 class Customi18nJSONFieldTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         sql = """
         CREATE TABLE public._localization_test_json_model

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -32,6 +32,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 class GraphTests(ArchesTestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.NODE_NODETYPE_GRAPHID = "22000000-0000-0000-0000-000000000001"
         cls.SINGLE_NODE_GRAPHID = "22000000-0000-0000-0000-000000000000"
 

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -16,7 +16,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os, json, uuid
+import uuid
+
 from django.contrib.auth.models import User
 from tests.base_test import ArchesTestCase
 from arches.app.models import models
@@ -150,7 +151,6 @@ class GraphTests(ArchesTestCase):
         }
         models.Edge.objects.create(**edges_dict).save()
 
-    def setUp(self):
         graph = Graph.new()
         graph.name = "TEST GRAPH"
         graph.subtitle = "ARCHES TEST GRAPH"
@@ -168,10 +168,7 @@ class GraphTests(ArchesTestCase):
         graph.root.datatype = "semantic"
         graph.root.save()
 
-        self.rootNode = graph.root
-
-    def tearDown(self):
-        self.deleteGraph(self.rootNode.graph_id)
+        cls.rootNode = graph.root
 
     def test_new_graph(self):
         name = "TEST NEW GRAPH"

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -30,12 +30,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 
 class GraphTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.loadOntology()
-        cls.ensure_test_resource_models_are_loaded()
-
+    def setUpTestData(cls):
         cls.NODE_NODETYPE_GRAPHID = "22000000-0000-0000-0000-000000000001"
         cls.SINGLE_NODE_GRAPHID = "22000000-0000-0000-0000-000000000000"
 

--- a/tests/models/mapped_archesjson_import_tests.py
+++ b/tests/models/mapped_archesjson_import_tests.py
@@ -19,9 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import os
 from tests.base_test import ArchesTestCase
 from django.test.utils import captured_stdout
-from arches.app.models.models import TileModel, ResourceInstance
-from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
-from arches.app.search.search_engine_factory import SearchEngineFactory
+from arches.app.models.models import TileModel
+from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
@@ -36,13 +35,10 @@ from arches.app.utils.data_management.resources.importer import (
 
 class mappedArchesJSONImportTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
         cls.loadOntology()
         cls.ensure_test_resource_models_are_loaded()
 
-    def setUp(self):
-        ResourceInstance.objects.all().delete()
         with open(
             os.path.join("tests/fixtures/data/json/cardinality_test_data/target.json"),
             "r",

--- a/tests/models/mapped_archesjson_import_tests.py
+++ b/tests/models/mapped_archesjson_import_tests.py
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
 from tests.base_test import ArchesTestCase
 from django.test.utils import captured_stdout
 from arches.app.models.models import TileModel
@@ -36,13 +35,8 @@ from arches.app.utils.data_management.resources.importer import (
 class mappedArchesJSONImportTests(ArchesTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.loadOntology()
-        cls.ensure_test_resource_models_are_loaded()
-
-        with open(
-            os.path.join("tests/fixtures/data/json/cardinality_test_data/target.json"),
-            "r",
-        ) as f:
+        path = "tests/fixtures/data/json/cardinality_test_data/target.json"
+        with open(path, "r") as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
 

--- a/tests/models/mapped_archesjson_import_tests.py
+++ b/tests/models/mapped_archesjson_import_tests.py
@@ -35,6 +35,7 @@ from arches.app.utils.data_management.resources.importer import (
 class mappedArchesJSONImportTests(ArchesTestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         path = "tests/fixtures/data/json/cardinality_test_data/target.json"
         with open(path, "r") as f:
             archesfile = JSONDeserializer().deserialize(f)

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -17,14 +17,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-from operator import itemgetter
 from tests.base_test import ArchesTestCase
 from django.test.utils import captured_stdout
-from arches.app.models.models import Language, TileModel, ResourceInstance
-from arches.app.models.concept import Concept
-from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+from arches.app.models.models import Language, TileModel
+from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.skos import SKOSReader
-from arches.app.search.search_engine_factory import SearchEngineFactory
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
@@ -37,13 +34,9 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 
 class mappedCSVFileImportTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
         cls.loadOntology()
         cls.ensure_test_resource_models_are_loaded()
-
-    def setUp(self):
-        ResourceInstance.objects.all().delete()
 
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_scheme.xml")

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -33,11 +33,10 @@ from arches.app.utils.data_management.resources.importer import BusinessDataImpo
 
 
 class mappedCSVFileImportTests(ArchesTestCase):
+    graph_fixtures = ["Cardinality Test Model"]
+
     @classmethod
     def setUpTestData(cls):
-        cls.loadOntology()
-        cls.ensure_test_resource_models_are_loaded()
-
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_scheme.xml")
         ret = skos.save_concepts_from_skos(rdf)

--- a/tests/models/mapped_csv_import_tests.py
+++ b/tests/models/mapped_csv_import_tests.py
@@ -37,6 +37,7 @@ class mappedCSVFileImportTests(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         skos = SKOSReader()
         rdf = skos.read_file("tests/fixtures/data/concept_label_test_scheme.xml")
         ret = skos.save_concepts_from_skos(rdf)

--- a/tests/models/relational_data_model_tests.py
+++ b/tests/models/relational_data_model_tests.py
@@ -85,10 +85,8 @@ class RelationalDataModelTests(ArchesTestCase):
             f"select public.__arches_create_resource_model_views('%s'::uuid);"
             % RelationalDataModelTests.custom_data_type_graphid
         )
-        cursor = connection.cursor()
-        cursor.execute(sql)
-        # row = cursor.fetchone()
-        # print("Result: %s" % str(row))
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
 
         schema_name = "relational_data_model_tests"
         view_name = "custom_datatypes"
@@ -106,7 +104,8 @@ class RelationalDataModelTests(ArchesTestCase):
             column_name,
         )
 
-        cursor.execute(validation_sql)
-        row = cursor.fetchone()
+        with connection.cursor() as cursor:
+            cursor.execute(validation_sql)
+            row = cursor.fetchone()
 
         assert row is not None and row[0] == expected_datatype

--- a/tests/models/relational_data_model_tests.py
+++ b/tests/models/relational_data_model_tests.py
@@ -37,21 +37,9 @@ class RelationalDataModelTests(ArchesTestCase):
     datatype_filename = None
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        # Create the Datatype Graph if it doesn't exist
-        if not Graph.objects.filter(graphid=cls.custom_data_type_graphid).exists():
-            with captured_stdout():
-                management.call_command(
-                    "packages",
-                    operation="import_graphs",
-                    source=cls.custom_datatype_graph_filename,
-                    verbosity=0,
-                )
-
-    @classmethod
     def setUpTestData(cls):
-        super().loadOntology()
+        super().setUpTestData()
+
         cls.custom_data_type_graphid = "ceed156d-aadf-4a13-b383-c044624c64bb"
         cls.custom_datatype_graph_filename = os.path.join(
             test_settings.TEST_ROOT,
@@ -77,6 +65,16 @@ class RelationalDataModelTests(ArchesTestCase):
                 source=cls.custom_string_datatype_filename,
                 verbosity=0,
             )
+
+        # Create the Datatype Graph if it doesn't exist
+        if not Graph.objects.filter(graphid=cls.custom_data_type_graphid).exists():
+            with captured_stdout():
+                management.call_command(
+                    "packages",
+                    operation="import_graphs",
+                    source=cls.custom_datatype_graph_filename,
+                    verbosity=0,
+                )
 
     def test_extended_string_postgres_datatype(self):
         """

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -193,13 +193,6 @@ class ResourceTests(ArchesTestCase):
         # add delay to allow for indexes to be updated
         time.sleep(1)
 
-    @classmethod
-    def tearDownClass(cls):
-        Resource.objects.filter(graph_id=cls.search_model_graphid).delete()
-        models.GraphModel.objects.filter(pk=cls.search_model_graphid).delete()
-        cls.user.delete()
-        super().tearDownClass()
-
     def test_get_node_value_string(self):
         """
         Query a string value

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -56,10 +56,6 @@ class ResourceTests(ArchesTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        LanguageSynchronizer.synchronize_settings_with_db()
-
-        models.ResourceInstance.objects.all().delete()
-
         cls.client = Client()
         cls.client.login(username="admin", password="admin")
 

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import json
-import os
 import time
 import uuid
 
@@ -31,15 +30,11 @@ from arches.app.models import models
 from arches.app.models.graph import Graph
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
-from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
-from arches.app.utils.data_management.resource_graphs.importer import (
-    import_graph as resource_graph_importer,
-)
+from arches.app.utils.betterJSONSerializer import JSONSerializer
 from arches.app.utils.exceptions import (
     InvalidNodeNameException,
     MultipleNodesFoundException,
 )
-from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.utils.index_database import (
     index_resources_by_type,
     index_resources_using_singleprocessing,

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -291,24 +291,13 @@ class ResourceTests(ArchesTestCase):
         """
         If a resource lacks a graph publication, it is restored by a call to save().
         """
-
-        publication = self.test_resource.graph_publication
-        cursor = connection.cursor()
-        # Hack out the graph publication
-        sql = """
-            UPDATE resource_instances
-            SET graphpublicationid = NULL
-            WHERE resourceinstanceid = '{resource_pk}';
-        """.format(
-            resource_pk=self.test_resource.pk
+        # Hack out the graph publication (bypass the guard in save())
+        models.ResourceInstance.objects.filter(pk=self.test_resource.pk).update(
+            graph_publication=None
         )
-        cursor.execute(sql)
-        self.addCleanup(setattr, self.test_resource, "graph_publication", publication)
-        self.addCleanup(self.test_resource.save)
         self.test_resource.refresh_from_db()
-        self.assertIsNone(
-            self.test_resource.graph_publication
-        )  # ensure test setup is good
+        # Ensure test setup is good
+        self.assertIsNone(self.test_resource.graph_publication)
 
         # update_or_create() delegates to save()
         obj, created = models.ResourceInstance.objects.filter(

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -50,8 +50,8 @@ class ResourceTests(ArchesTestCase):
     graph_fixtures = ["Resource Test Model"]
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         cls.client = Client()
         cls.client.login(username="admin", password="admin")

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -52,18 +52,14 @@ from tests.base_test import ArchesTestCase
 
 
 class ResourceTests(ArchesTestCase):
+    graph_fixtures = ["Resource Test Model"]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
         cls.client = Client()
         cls.client.login(username="admin", password="admin")
-
-        with open(
-            os.path.join("tests/fixtures/resource_graphs/Resource Test Model.json"), "r"
-        ) as f:
-            archesfile = JSONDeserializer().deserialize(f)
-        resource_graph_importer(archesfile["graph"])
 
         cls.search_model_graphid = uuid.UUID("c9b37a14-17b3-11eb-a708-acde48001122")
         cls.search_model_cultural_period_nodeid = "c9b3882e-17b3-11eb-a708-acde48001122"

--- a/tests/models/spatialview_model_tests.py
+++ b/tests/models/spatialview_model_tests.py
@@ -43,8 +43,6 @@ class SpatialViewTests(ArchesTestCase):
     def setUpClass(self):
         super().setUpClass()
 
-        LanguageSynchronizer.synchronize_settings_with_db()
-
         spatialviews_other_test_model_path = os.path.join(
             test_settings.TEST_ROOT,
             "fixtures",

--- a/tests/models/spatialview_model_tests.py
+++ b/tests/models/spatialview_model_tests.py
@@ -25,14 +25,8 @@ from django.core import management
 from tests.base_test import ArchesTestCase
 from arches.app.models import models
 from arches.app.models.models import SpatialView
-from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resources.importer import BusinessDataImporter
-from arches.app.utils.data_management.resource_graphs.importer import (
-    import_graph as resource_graph_importer,
-)
-from arches.app.utils.i18n import LanguageSynchronizer
 from tests import test_settings
-from django.conf import settings
 
 # these tests can be run from the command line via
 # python manage.py test tests.models.spatialview_model_tests --settings="tests.test_settings"
@@ -40,8 +34,8 @@ from django.conf import settings
 
 class SpatialViewTests(ArchesTestCase):
     @classmethod
-    def setUpClass(self):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         spatialviews_other_test_model_path = os.path.join(
             test_settings.TEST_ROOT,
@@ -295,8 +289,6 @@ class SpatialViewTriggerTests(TransactionTestCase):
     serialized_rollback = True
 
     def setUp(self):
-        LanguageSynchronizer.synchronize_settings_with_db()
-
         spatialviews_other_test_model_path = os.path.join(
             test_settings.TEST_ROOT,
             "fixtures",

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -70,8 +70,8 @@ class TileTests(ArchesTestCase):
             VALUES ('41111111-0000-0000-0000-000000000000', '', 'n');
         """
 
-        cursor = connection.cursor()
-        cursor.execute(sql)
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
 
     def test_load_from_python_dict(self):
         """

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -41,11 +41,11 @@ from arches.app.models.models import (
 
 
 class TileTests(ArchesTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loadOntology()
-        cls.ensure_test_resource_models_are_loaded()
+    graph_fixtures = [
+        "rdf_export_document_model",
+        "rdf_export_object_model",
+        "Cardinality Test Model",
+    ]
 
     @classmethod
     def setUpTestData(cls):

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -49,6 +49,7 @@ class TileTests(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         sql = """
         INSERT INTO public.resource_instances(resourceinstanceid, legacyid, graphid, createdtime)
             VALUES ('40000000-0000-0000-0000-000000000000', '40000000-0000-0000-0000-000000000000', '2f7f8e40-adbc-11e6-ac7f-14109fd34195', '1/1/2000');

--- a/tests/permissions/base_permissions_framework_test.py
+++ b/tests/permissions/base_permissions_framework_test.py
@@ -31,6 +31,7 @@ class ArchesPermissionFrameworkTestCase(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         add_users()
         cls.expected_resource_count = 2
         cls.user = User.objects.get(username="ben")

--- a/tests/permissions/base_permissions_framework_test.py
+++ b/tests/permissions/base_permissions_framework_test.py
@@ -14,16 +14,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from tests.base_test import ArchesTestCase
-
-import os
-from tests import test_settings
-from tests.base_test import ArchesTestCase
 from tests.utils.permission_test_utils import add_users
-from django.core import management
-from django.test.utils import captured_stdout
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
-from arches.app.models.models import GraphModel
 from arches.app.models.resource import Resource
 
 
@@ -32,39 +25,18 @@ from arches.app.models.resource import Resource
 
 
 class ArchesPermissionFrameworkTestCase(ArchesTestCase):
+    graph_fixtures = ["Data_Type_Model"]
+    data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
+    resource_instance_id = "f562c2fa-48d3-4798-a723-10209806c068"
+
     @classmethod
     def setUpTestData(cls):
         add_users()
         cls.expected_resource_count = 2
-        cls.data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
-        cls.resource_instance_id = "f562c2fa-48d3-4798-a723-10209806c068"
         cls.user = User.objects.get(username="ben")
         cls.group = Group.objects.get(pk=2)
+        cls.legacy_load_testing_package()
         cls.framework = cls.FRAMEWORK()
         resource = Resource.objects.get(pk=cls.resource_instance_id)
         resource.graph_id = cls.data_type_graphid
         resource.remove_resource_instance_permissions()
-
-    @classmethod
-    def setUpClass(cls):
-        cls.data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
-        if not GraphModel.objects.filter(pk=cls.data_type_graphid).exists():
-            # TODO: Fix this to run inside transaction, i.e. after super().setUpClass()
-            # https://github.com/archesproject/arches/issues/10719
-            test_pkg_path = os.path.join(
-                test_settings.TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg"
-            )
-            path_to_cheesy_image = os.path.join(
-                test_pkg_path, "uploadedfiles", "test.png"
-            )
-            cls.addClassCleanup(os.unlink, path_to_cheesy_image)
-            with captured_stdout():
-                management.call_command(
-                    "packages",
-                    operation="load_package",
-                    source=test_pkg_path,
-                    yes=True,
-                    verbosity=0,
-                )
-
-        super().setUpClass()

--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -44,10 +44,6 @@ class PermissionTests(ArchesTestCase):
         resource.graph_id = cls.data_type_graphid
         resource.remove_resource_instance_permissions()
 
-    def setUp(self):
-        resource = Resource.objects.get(pk=self.resource_instance_id)
-        resource.index()
-
     @classmethod
     def add_users(cls):
         profiles = (

--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -17,26 +17,13 @@ import os
 from tests import test_settings
 from tests.base_test import ArchesTestCase
 from django.core import management
-from django.urls import reverse
-from django.test.client import RequestFactory, Client
 from django.test.utils import captured_stdout
-from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
-from guardian.shortcuts import (
-    assign_perm,
-    get_perms,
-    remove_perm,
-    get_group_perms,
-    get_user_perms,
-)
+from guardian.shortcuts import assign_perm
 from arches.app.models.models import GraphModel, ResourceInstance, Node
 from arches.app.models.resource import Resource
-from arches.app.utils.permission_backend import get_editable_resource_types
-from arches.app.utils.permission_backend import get_resource_types_by_perm
 from arches.app.utils.permission_backend import user_can_read_resource
-from arches.app.utils.permission_backend import user_can_edit_resource
-from arches.app.utils.permission_backend import user_can_read_concepts
 from arches.app.utils.permission_backend import user_has_resource_model_permissions
 from arches.app.utils.permission_backend import get_restricted_users
 
@@ -54,9 +41,6 @@ class PermissionTests(ArchesTestCase):
         resource = Resource.objects.get(pk=self.resource_instance_id)
         resource.graph_id = self.data_type_graphid
         resource.remove_resource_instance_permissions()
-
-    def tearDown(self):
-        ResourceInstance.objects.filter(graph_id=self.data_type_graphid).delete()
 
     @classmethod
     def add_users(cls):

--- a/tests/permissions/permission_tests.py
+++ b/tests/permissions/permission_tests.py
@@ -34,6 +34,7 @@ class PermissionTests(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.add_users()
         cls.expected_resource_count = 2
         cls.user = User.objects.get(username="ben")

--- a/tests/permissions/permissions_arches_default_deny_tests.py
+++ b/tests/permissions/permissions_arches_default_deny_tests.py
@@ -13,27 +13,17 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
 from unittest.mock import MagicMock, Mock, patch
-from tests import test_settings
 from tests.permissions.base_permissions_framework_test import (
     ArchesPermissionFrameworkTestCase,
 )
-from django.core import management
-from django.urls import reverse
-from django.test.client import RequestFactory, Client
-from django.test.utils import captured_stdout
-from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
-from django.contrib.auth.models import User
-from django.contrib.auth.models import Group
-from arches.app.models.models import GraphModel, ResourceInstance, Node
-from arches.app.models.resource import Resource
+from arches.app.models.models import Node, ResourceInstance
 from arches.app.permissions.arches_default_deny import (
     ArchesDefaultDenyPermissionFramework,
 )
 
 # these tests can be run from the command line via
-# python manage.py test tests.permissions.permission_tests --settings="tests.test_settings"
+# python manage.py test tests.permissions.permissions_arches_default_deny_tests --settings="tests.test_settings"
 
 
 class ArchesDefaultDenyPermissionTests(ArchesPermissionFrameworkTestCase):

--- a/tests/search/search_export_tests.py
+++ b/tests/search/search_export_tests.py
@@ -37,8 +37,8 @@ class SearchExportTests(ArchesTestCase):
         sync_es(se)
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
         se = SearchEngineFactory().create()
         q = Query(se=se)
         for indexname in [TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX]:

--- a/tests/search/search_export_tests.py
+++ b/tests/search/search_export_tests.py
@@ -88,6 +88,7 @@ class SearchExportTests(ArchesTestCase):
         q = Query(se=se)
         for indexname in [TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX]:
             q.delete(index=indexname, refresh=True)
+        super().tearDownClass()
 
     def test_search_export_no_request(self):
         """Test SearchResultsExporter without search request"""

--- a/tests/search/search_export_tests.py
+++ b/tests/search/search_export_tests.py
@@ -31,6 +31,13 @@ from tests.utils.search_test_utils import sync_es
 
 
 class SearchExportTests(ArchesTestCase):
+    graph_fixtures = ["Search Test Model"]
+
+    search_model_graphid = "d291a445-fa5f-11e6-afa8-14109fd34195"
+    search_model_cultural_period_nodeid = "7a182580-fa60-11e6-96d1-14109fd34195"
+    search_model_cultural_period_nodename = "Cultural Period Concept"
+    search_model_name_nodeid = "2fe14de3-fa61-11e6-897b-14109fd34195"
+
     def setUp(self):
         super().setUp()
         se = SearchEngineFactory().create()
@@ -44,17 +51,11 @@ class SearchExportTests(ArchesTestCase):
             q.delete(index=indexname, refresh=True)
         cls.factory = RequestFactory()
 
-        LanguageSynchronizer.synchronize_settings_with_db()
         with open(
             os.path.join("tests/fixtures/resource_graphs/Search Test Model.json"), "r"
         ) as f:
             archesfile = JSONDeserializer().deserialize(f)
         ResourceGraphImporter(archesfile["graph"])
-
-        cls.search_model_graphid = "d291a445-fa5f-11e6-afa8-14109fd34195"
-        cls.search_model_cultural_period_nodeid = "7a182580-fa60-11e6-96d1-14109fd34195"
-        cls.search_model_cultural_period_nodename = "Cultural Period Concept"
-        cls.search_model_name_nodeid = "2fe14de3-fa61-11e6-897b-14109fd34195"
 
         cls.user = User.objects.create_user(
             "unprivileged_user", "unprivileged_user@test.com", "test"
@@ -62,8 +63,6 @@ class SearchExportTests(ArchesTestCase):
 
         cls.test_resourceinstanceid = uuid.uuid4()
 
-        cls.loadOntology()
-        cls.ensure_test_resource_models_are_loaded()
         models.ResourceInstance.objects.get_or_create(
             graph_id=cls.search_model_graphid,
             resourceinstanceid=cls.test_resourceinstanceid,

--- a/tests/search/search_tests.py
+++ b/tests/search/search_tests.py
@@ -67,7 +67,7 @@ class SearchTests(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        User.objects.create_user(
+        cls.tester = User.objects.create_user(
             username="Tester", email="test@test.com", password="test12345!"
         )
 
@@ -146,9 +146,8 @@ class SearchTests(ArchesTestCase):
         tileid = "bebffbea-daf6-414e-80c2-530ec88d2705"
         resourceinstanceid = "745f5e4a-d645-4c50-bafc-c677ea95f060"
         resource = Resource(uuid.UUID(resourceinstanceid))
-        user = User.objects.get(username="Tester")
         resource.graph_id = "c9b37a14-17b3-11eb-a708-acde48001122"
-        resource.save(user=user, transaction_id=uuid.uuid4())
+        resource.save(user=self.tester, transaction_id=uuid.uuid4())
         tile_data = {}
         tile_data[nodeid] = {
             "en": {"value": "Etiwanda Avenue Street Trees", "direction": "ltr"}
@@ -168,7 +167,7 @@ class SearchTests(ArchesTestCase):
         request.GET.__setitem__("lang", "en")
         request.GET.__setitem__("q", "Etiwanda")
         request.LANGUAGE_CODE = "en"
-        request.user = user
+        request.user = self.tester
         response = search_terms(request)
         result = {}
         try:

--- a/tests/search/search_tests.py
+++ b/tests/search/search_tests.py
@@ -46,15 +46,12 @@ class SearchTests(ArchesTestCase):
         se = search_engine if search_engine else SearchEngineFactory().create()
         se.refresh(index=index)
 
-    def setUp(self):
-        super().setUp()
-        self.delete_resources()
-
-    def delete_resources(self):
-        se = SearchEngineFactory().create()
-        q = {"query": {"match_all": {}}}
-        se.delete(index="resources", query=q)
-        self.sync_es(se)
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.tester = User.objects.create_user(
+            username="Tester", email="test@test.com", password="test12345!"
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -64,11 +61,15 @@ class SearchTests(ArchesTestCase):
             se.delete_index(index="bulk")
         super().tearDownClass()
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.tester = User.objects.create_user(
-            username="Tester", email="test@test.com", password="test12345!"
-        )
+    def setUp(self):
+        super().setUp()
+        self.delete_resources()
+
+    def delete_resources(self):
+        se = SearchEngineFactory().create()
+        q = {"query": {"match_all": {}}}
+        se.delete(index="resources", query=q)
+        self.sync_es(se)
 
     def test_delete_by_query(self):
         """

--- a/tests/search/search_tests.py
+++ b/tests/search/search_tests.py
@@ -33,7 +33,6 @@ from django.http import HttpRequest
 from django.contrib.auth.models import User
 from django.test.utils import captured_stdout
 from tests.base_test import ArchesTestCase
-from tests.utils.search_test_utils import sync_es
 
 # these tests can be run from the command line via
 # python manage.py test tests.search.search_tests --settings="tests.test_settings"
@@ -85,7 +84,7 @@ class SearchTests(ArchesTestCase):
             y = {"id": i + 100, "type": "altLabel", "value": "test alt label"}
             se.index_data(index="test", body=y, idfield="id", refresh=True)
 
-        sync_es(se)
+        self.sync_es(se)
 
         query = Query(se, start=0, limit=100)
         match = Match(field="type", query="altLabel")
@@ -141,7 +140,6 @@ class SearchTests(ArchesTestCase):
         Test finding a resource by a term
 
         """
-
         nodeid = "c9b37b7c-17b3-11eb-a708-acde48001122"
         tileid = "bebffbea-daf6-414e-80c2-530ec88d2705"
         resourceinstanceid = "745f5e4a-d645-4c50-bafc-c677ea95f060"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,10 +20,7 @@ import os
 
 from arches.settings import *
 
-try:
-    from django.utils.translation import gettext_lazy as _
-except ImportError:  # unable to import prior to installing requirements
-    pass
+from django.utils.translation import gettext_lazy as _
 
 PACKAGE_NAME = "arches"
 TEST_ROOT = os.path.normpath(os.path.join(ROOT_DIR, "..", "tests"))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,7 @@ except ImportError:  # unable to import prior to installing requirements
 PACKAGE_NAME = "arches"
 TEST_ROOT = os.path.normpath(os.path.join(ROOT_DIR, "..", "tests"))
 APP_ROOT = ""
+STATICFILES_DIRS = []
 
 # LOAD_V3_DATA_DURING_TESTS = True will engage the most extensive the of the v3
 # data migration tests, which could add over a minute to the test process. It's

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -45,6 +45,9 @@ RESOURCE_GRAPH_LOCATIONS = [
         "resource_models",
     ),
 ]
+REFERENCE_DATA_FIXTURE_LOCATION = os.path.join(
+    TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg", "reference_data"
+)
 
 ONTOLOGY_FIXTURES = os.path.join(TEST_ROOT, "fixtures", "ontologies", "test_ontology")
 ONTOLOGY_PATH = os.path.join(TEST_ROOT, "fixtures", "ontologies", "cidoc_crm")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,7 +35,18 @@ APP_ROOT = ""
 # and run in specific cases at the discretion of the developer.
 LOAD_V3_DATA_DURING_TESTS = False
 
-RESOURCE_GRAPH_LOCATIONS = (os.path.join(TEST_ROOT, "fixtures", "resource_graphs"),)
+RESOURCE_GRAPH_LOCATIONS = [
+    os.path.join(TEST_ROOT, "fixtures", "resource_graphs"),
+    os.path.join(
+        TEST_ROOT,
+        "fixtures",
+        "testing_prj",
+        "testing_prj",
+        "pkg",
+        "graphs",
+        "resource_models",
+    ),
+]
 
 ONTOLOGY_FIXTURES = os.path.join(TEST_ROOT, "fixtures", "ontologies", "test_ontology")
 ONTOLOGY_PATH = os.path.join(TEST_ROOT, "fixtures", "ontologies", "cidoc_crm")

--- a/tests/utils/activitystream.py
+++ b/tests/utils/activitystream.py
@@ -20,16 +20,12 @@ import os
 from unittest.mock import Mock
 from tests.base_test import ArchesTestCase
 from rdflib import Namespace
-from arches.app.utils.activity_stream_jsonld import (
-    ActivityStreamCollection,
-    ActivityStreamCollectionPage,
-)
+from arches.app.utils.activity_stream_jsonld import ActivityStreamCollection
 
 from arches.app.utils.betterJSONSerializer import JSONDeserializer
 from arches.app.utils.data_management.resource_graphs.importer import (
     import_graph as ResourceGraphImporter,
 )
-from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.models.models import ResourceInstance
 from arches.app.utils.skos import SKOSReader
 from uuid import uuid4
@@ -122,8 +118,8 @@ class ActivityStreamCollectionTests(ArchesTestCase):
     """
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
         for skospath in [
             "tests/fixtures/data/rdf_export_thesaurus.xml",
             "tests/fixtures/data/rdf_export_collections.xml",

--- a/tests/utils/activitystream.py
+++ b/tests/utils/activitystream.py
@@ -124,11 +124,6 @@ class ActivityStreamCollectionTests(ArchesTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.loadOntology()
-        LanguageSynchronizer.synchronize_settings_with_db()
-
-        ResourceInstance.objects.all().delete()
-
         for skospath in [
             "tests/fixtures/data/rdf_export_thesaurus.xml",
             "tests/fixtures/data/rdf_export_collections.xml",

--- a/tests/v3migration/v3_migration_cli_tests.py
+++ b/tests/v3migration/v3_migration_cli_tests.py
@@ -31,8 +31,8 @@ class v3MigrationTests(ArchesTestCase):
     pkg = os.path.join(test_settings.TEST_ROOT, "v3migration", "pkg")
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         cls.loadOntology()
         with captured_stdout():

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -40,6 +40,7 @@ class ResourceAPITests(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.legacy_load_testing_package()
         with open(
             os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "r"

--- a/tests/views/api_tests.py
+++ b/tests/views/api_tests.py
@@ -19,8 +19,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import json
 import os
 
-from arches.app.utils.i18n import LanguageSynchronizer
-from tests import test_settings
 from tests.base_test import ArchesTestCase
 from django.urls import reverse
 from django.core import management
@@ -36,28 +34,13 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 # python manage.py test tests.views.api_tests --settings="tests.test_settings"
 
 
-class APITests(ArchesTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
-        if not models.GraphModel.objects.filter(pk=cls.data_type_graphid).exists():
-            # TODO: Fix this to run inside transaction, i.e. after super().setUpClass()
-            # https://github.com/archesproject/arches/issues/10719
-            test_pkg_path = os.path.join(
-                test_settings.TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg"
-            )
-            with captured_stdout():
-                management.call_command(
-                    "packages",
-                    operation="load_package",
-                    source=test_pkg_path,
-                    yes=True,
-                    verbosity=0,
-                )
+class ResourceAPITests(ArchesTestCase):
+    graph_fixtures = ["Data_Type_Model"]
+    data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
 
-        super().setUpClass()
-        cls.loadOntology()
-        LanguageSynchronizer.synchronize_settings_with_db()
+    @classmethod
+    def setUpTestData(cls):
+        cls.legacy_load_testing_package()
         with open(
             os.path.join("tests/fixtures/resource_graphs/unique_graph_shape.json"), "r"
         ) as f:

--- a/tests/views/auth_tests.py
+++ b/tests/views/auth_tests.py
@@ -46,6 +46,7 @@ from arches.app.utils.middleware import SetAnonymousUser
 class AuthTests(ArchesTestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.factory = RequestFactory()
         cls.client = Client()
 

--- a/tests/views/auth_tests.py
+++ b/tests/views/auth_tests.py
@@ -63,8 +63,8 @@ class AuthTests(ArchesTestCase):
         cls.oauth_client_secret = OAUTH_CLIENT_SECRET
 
         sql_str = CREATE_TOKEN_SQL.format(token=cls.token, user_id=cls.user.pk)
-        cursor = connection.cursor()
-        cursor.execute(sql_str)
+        with connection.cursor() as cursor:
+            cursor.execute(sql_str)
 
     def tearDown(self):
         settings.ENABLE_TWO_FACTOR_AUTHENTICATION = False

--- a/tests/views/command_line_tests.py
+++ b/tests/views/command_line_tests.py
@@ -18,49 +18,28 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 from pathlib import Path
+from unittest import mock
 
-from tests import test_settings
 from django.test.utils import captured_stdout
 from django.conf import settings
-from django.core import management
+from django.core.management import call_command
 from arches.app.models import models
 from tests.base_test import ArchesTestCase
-from django.test.client import Client
 
 # these tests can be run from the command line via
 # python manage.py test tests.views.command_line_tests --settings="tests.test_settings"
 
 
 class CommandLineTests(ArchesTestCase):
-    def setUp(self):
-        self.expected_resource_count = 2
-        self.client = Client()
+    data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
 
     @classmethod
-    def setUpClass(cls):
-        cls.data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
-        if not models.GraphModel.objects.filter(pk=cls.data_type_graphid).exists():
-            # TODO: Fix this to run inside transaction, i.e. after super().setUpClass()
-            # https://github.com/archesproject/arches/issues/10719
-            test_pkg_path = os.path.join(
-                test_settings.TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg"
-            )
-            with captured_stdout():
-                management.call_command(
-                    "packages",
-                    operation="load_package",
-                    source=test_pkg_path,
-                    yes=True,
-                    verbosity=0,
-                )
-
-        path_to_cheesy_image = Path(settings.MEDIA_ROOT) / "uploadedfiles" / "test.png"
-        cls.addClassCleanup(os.unlink, path_to_cheesy_image)
-
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.legacy_load_testing_package()
 
     def test_load_package(self):
         resources = models.ResourceInstance.objects.filter(
             graph_id=self.data_type_graphid
         )
-        self.assertEqual(len(list(resources)), self.expected_resource_count)
+        self.assertEqual(len(resources), 2)

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -34,6 +34,7 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 class GraphManagerViewTests(ArchesTestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.loadOntology()
         cls.NODE_NODETYPE_GRAPHID = "22000000-0000-0000-0000-000000000001"
 

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -18,12 +18,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import json
-from arches.app.utils.i18n import LanguageSynchronizer
 from tests import test_settings
 from arches.app.models.system_settings import settings
 from tests.base_test import ArchesTestCase
 from django.contrib.auth import get_user_model
-from django.test import Client
 from django.urls import reverse
 from arches.app.models.graph import Graph
 from arches.app.models.models import Node, NodeGroup, GraphModel, CardModel, Edge
@@ -35,15 +33,11 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 
 class GraphManagerViewTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
+    def setUpTestData(cls):
         cls.loadOntology()
+        cls.NODE_NODETYPE_GRAPHID = "22000000-0000-0000-0000-000000000001"
 
-    def setUp(self):
-        self.NODE_NODETYPE_GRAPHID = "22000000-0000-0000-0000-000000000001"
-
-        if len(Graph.objects.filter(graphid=self.NODE_NODETYPE_GRAPHID)) == 0:
+        if not Graph.objects.filter(graphid=cls.NODE_NODETYPE_GRAPHID).exists():
             # Node Branch
             graph_dict = {
                 "author": "Arches",
@@ -177,30 +171,21 @@ class GraphManagerViewTests(ArchesTestCase):
         graph.root.datatype = "semantic"
         graph.root.save()
         graph = Graph.objects.get(graphid=graph.pk)
-        self.appended_branch_1 = graph.append_branch(
+        cls.appended_branch_1 = graph.append_branch(
             "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
-            graphid=self.NODE_NODETYPE_GRAPHID,
+            graphid=cls.NODE_NODETYPE_GRAPHID,
         )
-        self.appended_branch_2 = graph.append_branch(
+        cls.appended_branch_2 = graph.append_branch(
             "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
-            graphid=self.NODE_NODETYPE_GRAPHID,
+            graphid=cls.NODE_NODETYPE_GRAPHID,
         )
         graph.save()
 
-        self.ROOT_ID = graph.root.nodeid
-        self.GRAPH_ID = str(graph.pk)
-        self.NODE_COUNT = 5
+        cls.ROOT_ID = graph.root.nodeid
+        cls.GRAPH_ID = str(graph.pk)
+        cls.NODE_COUNT = 5
 
-        self.graph = graph
-
-        self.client = Client()
-        LanguageSynchronizer.synchronize_settings_with_db()
-
-    def tearDown(self):
-        try:
-            self.deleteGraph(self.GRAPH_ID)
-        except:
-            pass
+        cls.graph = graph
 
     def test_graph_manager(self):
         """

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -42,6 +42,7 @@ class CommandLineTests(ArchesTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         add_users()
         cls.legacy_load_testing_package()
         cls.expected_resource_count = 2

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -16,16 +16,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
 from unittest.mock import MagicMock, patch
-from arches.app.views.resource import ResourceEditorView, ResourcePermissionDataView
-from tests import test_settings
+from arches.app.views.resource import ResourcePermissionDataView
 from tests.base_test import ArchesTestCase
-from django.core import management
-from django.test.utils import captured_stdout
 from django.urls import reverse
-from arches.app.models.models import GraphModel, ResourceInstance, EditLog
-from django.test.client import Client
+from arches.app.models.models import EditLog, ResourceInstance
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
@@ -41,45 +36,22 @@ from tests.utils.permission_test_utils import add_users
 
 
 class CommandLineTests(ArchesTestCase):
-    def setUp(self):
-        self.expected_resource_count = 2
-        self.client = Client()
+    graph_fixtures = ["Data_Type_Model"]
+    data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
+    resource_instance_id = "f562c2fa-48d3-4798-a723-10209806c068"
+
+    @classmethod
+    def setUpTestData(cls):
+        add_users()
+        cls.legacy_load_testing_package()
+        cls.expected_resource_count = 2
         user = User.objects.get(username="ben")
         edit_records = EditLog.objects.filter(
-            resourceinstanceid=self.resource_instance_id
+            resourceinstanceid=cls.resource_instance_id
         ).filter(edittype="create")
         for edit in edit_records:
             edit.userid = user.id
             edit.save()
-
-    def tearDown(self):
-        ResourceInstance.objects.filter(graph_id=self.data_type_graphid).delete()
-        EditLog.objects.filter(resourceinstanceid=self.resource_instance_id).filter(
-            edittype="create"
-        ).delete()
-
-    @classmethod
-    def setUpClass(cls):
-        cls.data_type_graphid = "330802c5-95bd-11e8-b7ac-acde48001122"
-        cls.resource_instance_id = "f562c2fa-48d3-4798-a723-10209806c068"
-
-        if not GraphModel.objects.filter(pk=cls.data_type_graphid).exists():
-            # TODO: Fix this to run inside transaction, i.e. after super().setUpClass()
-            # https://github.com/archesproject/arches/issues/10719
-            test_pkg_path = os.path.join(
-                test_settings.TEST_ROOT, "fixtures", "testing_prj", "testing_prj", "pkg"
-            )
-            with captured_stdout():
-                management.call_command(
-                    "packages",
-                    operation="load_package",
-                    source=test_pkg_path,
-                    yes=True,
-                    verbosity=0,
-                )
-
-        super().setUpClass()
-        add_users()
 
     def test_resource_instance_permission_assignment(self):
         """

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -57,8 +57,6 @@ class SearchTests(ArchesTestCase):
         cls.client = Client()
         cls.client.login(username="admin", password="admin")
 
-        LanguageSynchronizer.synchronize_settings_with_db()
-        models.ResourceInstance.objects.all().delete()
         with open(
             os.path.join("tests/fixtures/resource_graphs/Search Test Model.json"), "r"
         ) as f:

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -43,8 +43,8 @@ class SearchTests(ArchesTestCase):
     graph_fixtures = ["Search Test Model"]
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         se = SearchEngineFactory().create()
         q = Query(se=se)

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -16,9 +16,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
 import json
-import time
+
 from tests.base_test import ArchesTestCase
 from tests.utils.search_test_utils import sync_es
 from django.http import HttpRequest
@@ -28,16 +27,12 @@ from django.test.client import Client
 from arches.app.models import models
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
-from arches.app.utils.i18n import LanguageSynchronizer
-from arches.app.utils.data_management.resource_graphs.importer import (
-    import_graph as ResourceGraphImporter,
-)
-from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+from arches.app.utils.betterJSONSerializer import JSONSerializer
 from arches.app.views.search import search_results
 from guardian.shortcuts import assign_perm
 from arches.app.search.components.base import SearchFilterFactory
 from arches.app.search.search_engine_factory import SearchEngineFactory
-from arches.app.search.elasticsearch_dsl_builder import Query, Term
+from arches.app.search.elasticsearch_dsl_builder import Query
 from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX
 
 # these tests can be run from the command line via
@@ -45,6 +40,8 @@ from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_IN
 
 
 class SearchTests(ArchesTestCase):
+    graph_fixtures = ["Search Test Model"]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -56,12 +53,6 @@ class SearchTests(ArchesTestCase):
 
         cls.client = Client()
         cls.client.login(username="admin", password="admin")
-
-        with open(
-            os.path.join("tests/fixtures/resource_graphs/Search Test Model.json"), "r"
-        ) as f:
-            archesfile = JSONDeserializer().deserialize(f)
-        ResourceGraphImporter(archesfile["graph"])
 
         cls.search_model_graphid = "d291a445-fa5f-11e6-afa8-14109fd34195"
         cls.search_model_cultural_period_nodeid = "7a182580-fa60-11e6-96d1-14109fd34195"

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -219,13 +219,6 @@ class SearchTests(ArchesTestCase):
 
         sync_es(se)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete()
-        Resource.objects.filter(graph_id=cls.search_model_graphid).delete()
-        models.GraphModel.objects.filter(pk=cls.search_model_graphid).delete()
-        super().tearDownClass()
-
     def test_temporal_only_search_1(self):
         """
         Search for resources that fall between 1940 and 1960

--- a/tests/views/spatialview_api_tests.py
+++ b/tests/views/spatialview_api_tests.py
@@ -1,19 +1,14 @@
 import json
 import random
 import os, uuid
-from django.test import TestCase, RequestFactory, TransactionTestCase
+from django.test import TransactionTestCase
 from django.urls import reverse
-from tests.base_test import ArchesTestCase
 from django.test.utils import captured_stdout
-from django.contrib.auth.models import User
 from django.core import management
-from django.db import connection, connections
 from arches.app.models.models import SpatialView as SpatialViewModel
-from arches.app.views.api import SpatialView
 from arches.app.utils.data_management.resources.importer import BusinessDataImporter
 from arches.app.utils.i18n import LanguageSynchronizer
 from arches.app.models import models
-from uuid import uuid4
 from tests import test_settings
 
 

--- a/tests/views/workflow_tests.py
+++ b/tests/views/workflow_tests.py
@@ -14,7 +14,8 @@ from tests.base_test import ArchesTestCase
 
 class WorkflowHistoryTests(ArchesTestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
+        super().setUpTestData()
         cls.client = Client()
         cls.admin = User.objects.get(username="admin")
         cls.anonymous = User.objects.get(username="anonymous")
@@ -23,10 +24,7 @@ class WorkflowHistoryTests(ArchesTestCase):
         )
         group = Group.objects.get(name="Resource Editor")
         group.user_set.add(cls.editor)
-        super().setUpClass()
 
-    @classmethod
-    def setUpTestData(cls):
         cls.history = WorkflowHistory.objects.create(
             workflowid=str(uuid.uuid1()),
             workflowname="test-name",


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
A couple recent developments made it worth refactoring some things in the test suite.

1 -- #11270 changed how test packages are loaded, now every test graph is loaded for every test case whether test case needs it or not, which added overhead
2 -- #11418 describes a hanging test that was preventing running the whole suite, it's likely due to the above

All of this was faster to solve by just biting the bullet and fixing #10719. The only blocker was refactoring `refresh_geojson_geometries()` in the packages command from a nested function to a staticmethod that could be more easily patched.

### Benchmark
**PR**
```
----------------------------------------------------------------------
Ran 401 tests in 213.807s
```

**dev/7.6.x** if you hack out the failing input() call
```
----------------------------------------------------------------------
Ran 401 tests in 252.148s
```

### Issues Solved
Fixes #11418
Fixes #10719

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Farallon


### Further comments
To load graph data now in a test, I basically cribbed the interface from Django, which lets you declare a `fixtures` class attribute on your test. But instead of using that, since we (for now) want to continue dogfooding our own graph importers, I called it `graph_fixtures` and hooked it into the same interface @apeters added in #11270.

So in the future to use sample graphs, you would:
- subclass ArchesTestCase
- add graph_fixtures attribute
- not depend on it until after `super().setUpTestData()`

