### PR TITLE
Remove types.ts

### DIFF
--- a/arches/app/src/arches/types.ts
+++ b/arches/app/src/arches/types.ts
@@ -1,8 +1,0 @@
-export type Language = {
-    code: string;
-    default_direction: "ltr" | "rtl";
-    id: number;
-    isdefault: boolean;
-    name: string;
-    scope: string;
-};


### PR DESCRIPTION
Helpful typescript interfaces for vue development will be fleshed out further in archesproject/arches-vue-utils rather than core.