### PR TITLE
performance improvements for indexing with default deny

### DIFF
--- a/arches/app/permissions/arches_permission_base.py
+++ b/arches/app/permissions/arches_permission_base.py
@@ -234,12 +234,17 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         obj -- the model instance to check
 
         """
+        default_permissions = [
+            permission["id"]
+            for permission in self.get_all_default_permissions(obj)
+            if permission["type"] == "group" and perm in permission["permissions"]
+        ]
 
-        ret = []
-        for group in Group.objects.all():
-            if self.has_group_perm(group, perm, obj):  # type: ignore
-                ret.append(group)
-        return ret
+        default_permissions = Group.objects.filter(id__in=default_permissions)
+        groups = gsc.get_groups_with_perms(obj=obj).filter(
+            permissions__codename__in=[perm]
+        )
+        return QuerySet.union(default_permissions, groups)
 
     def get_users_with_permission_for_object(self, perm: str, obj: Model) -> list[User]:
         """
@@ -250,17 +255,20 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         obj -- the model instance to check
 
         """
+        default_permissions = [
+            permission["id"]
+            for permission in self.get_all_default_permissions(obj)
+            if permission["type"] == "user" and perm in permission["permissions"]
+        ]
 
-        ret = []
-        for user in User.objects.all():
-            default_perms = self.get_default_permissions(user, obj)
-            if (
-                perm
-                in self.get_user_perms(user, obj).values_list("codename", flat=True)
-                or perm in default_perms
-            ):
-                ret.append(user)
-        return ret
+        default_permissions = User.objects.filter(id__in=default_permissions)
+        users = gsc.get_users_with_perms(obj=obj, only_with_perms_in=[perm])
+        return QuerySet.union(default_permissions, users)
+
+        # for user in User.objects.all():
+        #     if perm in self.get_user_perms(user, obj).values_list("codename", flat=True):
+        #         ret.append(user)
+        # return ret
 
     def get_restricted_instances(
         self,
@@ -594,18 +602,14 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         """
         Gets default permissions (if any) for a resource instance.
         """
-        default_permissions_settings = settings.PERMISSION_DEFAULTS
-        if not default_permissions_settings or model is None:
-            return []
-
+        default_permissions_for_graph = []
         if isinstance(model, ResourceInstance):
-            default_permissions_for_graph = (
-                default_permissions_settings[str(model.graph_id)]
-                if str(model.graph_id) in default_permissions_settings
-                else None
-            )
-        else:
-            return []  # default permissions for nodegroups not currently supported
+            default_permissions_for_graph = self.get_all_default_permissions(
+                model
+            )  # default permissions for nodegroups not currently supported
+
+        if not len(default_permissions_for_graph):
+            return []
 
         if default_permissions_for_graph is None:
             return []
@@ -631,6 +635,17 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
             for item in sub_list
         ]
         return default_permissions
+
+    def get_all_default_permissions(self, model: Model = None):
+        default_permissions_settings = settings.PERMISSION_DEFAULTS
+        if not default_permissions_settings or model is None:
+            return []
+
+        return (
+            default_permissions_settings[str(model.graph_id)]
+            if str(model.graph_id) in default_permissions_settings
+            else None
+        )
 
     def get_default_permissions_objects(
         self,

--- a/arches/app/permissions/arches_permission_base.py
+++ b/arches/app/permissions/arches_permission_base.py
@@ -265,11 +265,6 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         users = gsc.get_users_with_perms(obj=obj, only_with_perms_in=[perm])
         return QuerySet.union(default_permissions, users)
 
-        # for user in User.objects.all():
-        #     if perm in self.get_user_perms(user, obj).values_list("codename", flat=True):
-        #         ret.append(user)
-        # return ret
-
     def get_restricted_instances(
         self,
         user: User,


### PR DESCRIPTION
There are some issues with indexing performance using default deny for large datasets.  These seem to be tied to the number of resources, but in all cases there is a 10x difference between default allow and default deny performance.  This change attempts to improve that discrepancy, which is largely a result of querying for object permissions for users and groups - a set of four groups of queries that must occur for each object.  Default Allow has a much faster implementation here.  This PR (instead of starting with the user and getting their permissions on a given object) gets all of the permissions that exist for a particular object and uses that (complete) set of permissions.  