### PR TITLE
Fix text widget dirty state calculation w/r/t localized placeholder #10873

### DIFF
--- a/arches/app/media/js/models/card-widget.js
+++ b/arches/app/media/js/models/card-widget.js
@@ -74,6 +74,20 @@ define([
 
             AbstractModel.prototype.constructor.call(this, attributes, options);
 
+            // Wrap I18n_JSON field values (signified as i18n_properties)
+            // in a shape like: { "en": "some value" }.
+            for (const [key, val] of Object.entries(this.config)) {
+                if (
+                    // Limit to string datatype for now.
+                    this.datatype.datatype === 'string'
+                    && ko.unwrap(this.config.i18n_properties)?.includes
+                    && ko.unwrap(this.config.i18n_properties).includes(key)
+                    && typeof ko.unwrap(val) === 'string'
+                ) {
+                    this.config[key]({ [arches.activeLanguage]: ko.unwrap(val) });
+                }
+            }
+
             this.configJSON = ko.computed({
                 read: function() {
                     var configJSON = {};

--- a/arches/app/media/js/views/components/widgets/rich-text.js
+++ b/arches/app/media/js/views/components/widgets/rich-text.js
@@ -29,6 +29,7 @@ define([
         const currentLanguage = {"code": arches.activeLanguage};
         let currentValue = koMapping.toJS(self.value) || initialCurrent;
         self.currentLanguage = ko.observable(currentLanguage);
+        self.currentPlaceholder = ko.observable();
         let updating = false;
 
         if(self.form){
@@ -53,6 +54,13 @@ define([
             self.currentText = ko.observable(currentValue?.[currentLanguage.code]?.value);
             self.currentDirection = ko.observable(ko.unwrap(currentValue?.[currentLanguage.code]?.direction));
         }
+
+        if (ko.unwrap(self.placeholder) && typeof ko.unwrap(self.placeholder) === 'string') {
+            self.placeholder({
+                [self.currentLanguage().code]: ko.unwrap(self.placeholder),
+            });
+        }
+        self.currentPlaceholder(self.placeholder()[self.currentLanguage().code]);
 
         self.strippedValue = ko.pureComputed(() => {
             return $(`<span>${self.currentText()}</span>`).text();
@@ -121,6 +129,19 @@ define([
 
             self.currentText(koMapping.toJS(self.value)[currentLanguage.code]?.value);
             self.currentDirection(koMapping.toJS(self.value)[currentLanguage.code]?.direction);
+            self.currentPlaceholder(koMapping.toJS(self.placeholder)[currentLanguage.code]);
+        });
+
+        self.currentPlaceholder.subscribe(newValue => {
+            if(!self.currentLanguage()){ return; }
+            const currentLanguage = self.currentLanguage();
+
+            if (ko.isObservable(self.placeholder)) {
+                const patchedPlaceholder = self.placeholder();
+                patchedPlaceholder[currentLanguage.code] = newValue;
+                self.placeholder(patchedPlaceholder);
+                self.card._card.valueHasMutated();
+            }
         });
 
         this.displayfullvalue(params.displayfullvalue);

--- a/arches/app/media/js/views/components/widgets/rich-text.js
+++ b/arches/app/media/js/views/components/widgets/rich-text.js
@@ -55,12 +55,14 @@ define([
             self.currentDirection = ko.observable(ko.unwrap(currentValue?.[currentLanguage.code]?.direction));
         }
 
-        if (ko.unwrap(self.placeholder) && typeof ko.unwrap(self.placeholder) === 'string') {
-            self.placeholder({
-                [self.currentLanguage().code]: ko.unwrap(self.placeholder),
-            });
+        if (ko.unwrap(self.placeholder)) {
+            if (typeof ko.unwrap(self.placeholder) === 'string') {
+                self.placeholder({
+                    [self.currentLanguage().code]: ko.unwrap(self.placeholder),
+                });
+            }
+            self.currentPlaceholder(self.placeholder()[self.currentLanguage().code]);
         }
-        self.currentPlaceholder(self.placeholder()[self.currentLanguage().code]);
 
         self.strippedValue = ko.pureComputed(() => {
             return $(`<span>${self.currentText()}</span>`).text();
@@ -136,7 +138,7 @@ define([
             if(!self.currentLanguage()){ return; }
             const currentLanguage = self.currentLanguage();
 
-            if (ko.isObservable(self.placeholder)) {
+            if (self.card && ko.isObservable(self.placeholder)) {
                 const patchedPlaceholder = self.placeholder();
                 patchedPlaceholder[currentLanguage.code] = newValue;
                 self.placeholder(patchedPlaceholder);

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -84,12 +84,14 @@ define([
                 currentDefaultValue[currentLanguage.code] = {value: '', direction: 'ltr'};
             }
 
-            if (ko.unwrap(self.placeholder) && typeof ko.unwrap(self.placeholder) === 'string') {
-                self.placeholder({
-                    [self.currentLanguage().code]: ko.unwrap(self.placeholder),
-                });
+            if (ko.unwrap(self.placeholder)) {
+                if (typeof ko.unwrap(self.placeholder) === 'string') {
+                    self.placeholder({
+                        [self.currentLanguage().code]: ko.unwrap(self.placeholder),
+                    });
+                }
+                self.currentPlaceholder(self.placeholder()[self.currentLanguage().code]);
             }
-            self.currentPlaceholder(self.placeholder()[self.currentLanguage().code]);
         };
 
         init();
@@ -189,7 +191,7 @@ define([
             if(!self.currentLanguage()){ return; }
             const currentLanguage = self.currentLanguage();
 
-            if (ko.isObservable(self.placeholder)) {
+            if (self.card && ko.isObservable(self.placeholder)) {
                 const patchedPlaceholder = self.placeholder();
                 patchedPlaceholder[currentLanguage.code] = newValue;
                 self.placeholder(patchedPlaceholder);

--- a/arches/app/media/js/views/components/widgets/text.js
+++ b/arches/app/media/js/views/components/widgets/text.js
@@ -34,6 +34,7 @@ define([
         self.currentDefaultText = ko.observable();
         self.currentDefaultDirection = ko.observable();
         self.currentDefaultLanguage = ko.observable({code: arches.activeLanguage});
+        self.currentPlaceholder = ko.observable();
 
         const initialCurrent = {};
         const initialDefault = {};
@@ -82,9 +83,13 @@ define([
                 self.currentDefaultDirection('ltr');
                 currentDefaultValue[currentLanguage.code] = {value: '', direction: 'ltr'};
             }
-            if (ko.unwrap(self.placeholder) && (typeof ko.unwrap(self.placeholder) !== "string")) {
-                self.placeholder(self.placeholder()[self.currentLanguage().code]);
+
+            if (ko.unwrap(self.placeholder) && typeof ko.unwrap(self.placeholder) === 'string') {
+                self.placeholder({
+                    [self.currentLanguage().code]: ko.unwrap(self.placeholder),
+                });
             }
+            self.currentPlaceholder(self.placeholder()[self.currentLanguage().code]);
         };
 
         init();
@@ -177,9 +182,20 @@ define([
 
             self.currentText(koMapping.toJS(self.value)[currentLanguage.code]?.value);
             self.currentDirection(koMapping.toJS(self.value)[currentLanguage.code]?.direction);
-
+            self.currentPlaceholder(koMapping.toJS(self.placeholder)[currentLanguage.code]);
         });
 
+        self.currentPlaceholder.subscribe(newValue => {
+            if(!self.currentLanguage()){ return; }
+            const currentLanguage = self.currentLanguage();
+
+            if (ko.isObservable(self.placeholder)) {
+                const patchedPlaceholder = self.placeholder();
+                patchedPlaceholder[currentLanguage.code] = newValue;
+                self.placeholder(patchedPlaceholder);
+                self.card._card.valueHasMutated();
+            }
+        });
     };
 
     return ko.components.register('text-widget', {

--- a/arches/app/templates/views/components/widgets/rich-text.htm
+++ b/arches/app/templates/views/components/widgets/rich-text.htm
@@ -61,7 +61,7 @@
                     ckeditor: currentText,
                     language: currentLanguage.code,
                     direction: currentDirection,
-                    placeholder: placeholder,
+                    placeholder: currentPlaceholder,
                     ckeditorOptions: {},
                     valueUpdate: 'afterkeydown',
                     attr: {disabled: disabled}
@@ -85,7 +85,7 @@
         isConfigForm: true,
         language: currentLanguage.code,
         direction: currentDirection,
-        placeholder: placeholder,
+        placeholder: currentPlaceholder,
         ckeditorOptions: {},
         valueUpdate: 'afterkeydown',
         attr: {disabled: disabled}

--- a/arches/app/templates/views/components/widgets/text.htm
+++ b/arches/app/templates/views/components/widgets/text.htm
@@ -69,7 +69,7 @@
             <div class="col-xs-12" style="display:flex;flex-wrap: wrap;flex-direction: column;">
                 <input type="text" style="flex:1" class="form-control input-lg widget-input"
                     data-bind="textInput: currentText,
-                        attr: {placeholder: placeholder, maxlength: maxLength, disabled: disable, 'aria-label': label, dir: currentDirection},
+                        attr: {placeholder: currentPlaceholder, maxlength: maxLength, disabled: disable, 'aria-label': label, dir: currentDirection},
                 ">
             </div>
         </div>
@@ -87,7 +87,7 @@
         class="form-control input-md widget-input"
         data-bind="
             attr: {placeholder: $root.translations.placeholder, 'aria-label': $root.translations.placeholder},
-            textInput: placeholder
+            textInput: currentPlaceholder
         "
     >
 </div>
@@ -164,7 +164,7 @@
     <div class="col-xs-12" style="display:flex;flex-wrap: wrap;flex-direction: column;">
         <input type="text" style="flex:1" id="input-default-value" class="form-control input-lg widget-input"
             data-bind="textInput: currentDefaultText,
-                attr: {placeholder: placeholder, maxlength: maxLength, disabled: disable, dir: currentDefaultDirection, 'aria-label': $root.translations.defaultValue}
+                attr: {placeholder: currentPlaceholder, maxlength: maxLength, disabled: disable, dir: currentDefaultDirection, 'aria-label': $root.translations.defaultValue}
         ">
     </div>
     </div>

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -58,6 +58,7 @@ Arches 7.6.0 Release Notes
 - 11114 Implement arches version compatibility check as a Django system check
 - 9191 Adds unlocalized string datatype
 - 10597 Fix internationalized string/json field entry problems in the Django admin
+- 10873 Fix text widget dirty state calculation for newly created nodes
 - 10787 Search Export: data exportable as "system values" (e.g. concept valueids) instead of "display values" (e.g. string preflabel)
 - 10121 Prevent language code duplication during concept import; avoid creating Language objects other than English in new projects
 - 10575 Add pre-commit hooks for formatting


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When a fresh string node is created in the graph designer, the Discard Card Edits button was malfunctioning. Now, the situation is improved, although there are still some related bugs.

More specifically:

    These issues are fixed for a new widget that has
    *just* been created in the graph designer.
    - after discarding edits to fields like widget name,
      there is no dirty state (good).
    - dirty state is correctly picked up for initial
      edits to placeholder.
    
    This issue remains:
    - after dismissing card edits, the placeholder
      field is not editable (dirty state not detected)
      and neither is max length (shows "[object Object]")

### Issues Solved
Closes #10873

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @chrabyrd
*   Tested by: @jacobtylerwalls