### PR TITLE
Forbid malicious keys in node configs

### DIFF
--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -297,6 +297,8 @@ class I18n_JSON(NothingNode):
             # Forbid dangerous values.
             sanitizer = Query(model=None)
             for prop in self.raw_value:
+                if "%" in prop:
+                    raise ValueError
                 sanitizer.check_alias(prop)
 
             params = []

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -506,7 +506,7 @@ class Graph(models.GraphModel):
 
     def save(self, validate=True, nodeid=None):
         """
-        Saves an a graph and its nodes, edges, and nodegroups back to the db
+        Saves a graph and its nodes, edges, and nodegroups back to the db
         creates associated card objects if any of the nodegroups don't already have a card
 
         Arguments:
@@ -533,6 +533,8 @@ class Graph(models.GraphModel):
                 try:
                     node.sourcebranchpublication_id = None
                     node.save()
+                except ValueError as ve:
+                    raise GraphValidationError(ve.args[0])
                 except IntegrityError as err:
                     if "unique_alias_graph" in str(err):
                         message = _(

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -40,6 +40,7 @@ Arches 7.6.0 Release Notes
 - 11166 Invalid API routes now respond with JSON instead of HTML
 - 10710 Workflow history API: return 400 (instead of 401) for attempts to update completed workflows
 - 10083 Fix whatisthis command
+- Forbid malicious keys in node configs
 - Updates Google Analytics syntax supporting Google Analytics 4 #11132
 - 9768 Filter out tiles created during resource creation from activity stream API
 - 9769 Ensure resource creation edit log timestamps precede resource update timestamps


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Forbid potentially malicious node and plugin config keys. No known SQL injection vulnerability exists, see test case which (after fiddling with the payload quite a bit) always fails on target branch with ProgrammingError, due to its being used in two places.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @jacobtylerwalls