### PR TITLE
Avoid JSONDecodeError in querystring fallbacks, fix noisy test re #11443

### DIFF
--- a/arches/app/search/components/advanced_search.py
+++ b/arches/app/search/components/advanced_search.py
@@ -26,7 +26,7 @@ details = {
 
 class AdvancedSearch(BaseSearchFilter):
     def append_dsl(self, search_query_object, **kwargs):
-        querystring_params = kwargs.get("querystring", "")
+        querystring_params = kwargs.get("querystring", "[]")
         advanced_filters = JSONDeserializer().deserialize(querystring_params)
         datatype_factory = DataTypeFactory()
         search_query = Bool()

--- a/arches/app/search/components/resource_type_filter.py
+++ b/arches/app/search/components/resource_type_filter.py
@@ -28,7 +28,7 @@ class ResourceTypeFilter(BaseSearchFilter):
     def append_dsl(self, search_query_object, **kwargs):
         permitted_nodegroups = kwargs.get("permitted_nodegroups")
         search_query = Bool()
-        querystring_params = kwargs.get("querystring", "")
+        querystring_params = kwargs.get("querystring", "[]")
         graph_ids = []
         permitted_graphids = get_permitted_graphids(permitted_nodegroups)
 

--- a/arches/app/search/components/time_filter.py
+++ b/arches/app/search/components/time_filter.py
@@ -22,7 +22,7 @@ class TimeFilter(BaseSearchFilter):
         permitted_nodegroups = kwargs.get("permitted_nodegroups")
         include_provisional = kwargs.get("include_provisional")
         search_query = Bool()
-        querystring_params = kwargs.get("querystring", "")
+        querystring_params = kwargs.get("querystring", "[]")
         temporal_filter = JSONDeserializer().deserialize(querystring_params)
         if "fromDate" in temporal_filter and "toDate" in temporal_filter:
             # now = str(datetime.utcnow())

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -881,7 +881,8 @@ class SearchTests(ArchesTestCase):
         request.method = "GET"
         request.user = User.objects.get(username="anonymous")
         request.GET.__setitem__("term-filter", '{"key": "value",}')
-        resp = search_results(request)
+        with self.assertLogs("arches.app.search.components", level="WARNING"):
+            resp = search_results(request)
         self.assertEqual(resp.status_code, 500)
 
     def test_custom_resource_index(self):


### PR DESCRIPTION
[Avoid JSONDecodeError for querystring fallback](https://github.com/archesproject/arches/commit/79df33611e191456501af20b3022eb62d0a87403)
follow-up to 46f8d0f.

[Suppress logged error from test re #11443](https://github.com/archesproject/arches/commit/4d652874926eadb8f42a5b46366d510d6bcd9ce7)