### PR TITLE
Fix path to arches declarations file in project template

### DIFF
--- a/arches/install/arches-templates/project_name/src/project_name/declarations.d.ts
+++ b/arches/install/arches-templates/project_name/src/project_name/declarations.d.ts
@@ -1,4 +1,4 @@
 // declare untyped modules that have been added to your project in `package.json`
 // Module homepage on npmjs.com uses logos "TS" or "DT" to indicate if typed
 
-import("@/arches/declarations.d.ts");
+import("@/arches/arches/declarations.d.ts");


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Was getting this with a project-level typescript watcher:
```ts
error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file '@/arches/declarations.ts' instead?
```

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: CA Dept of Parks and Rec
*   Found by: @jacobtylerwalls
