### PR TITLE
Fix error preventing widget changes

### DIFF
--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -308,7 +308,9 @@ define([
                         }
                         else {
                             viewModel.cardTree.updateCards(viewModel.selectedNode().nodeGroupId(), data.responseJSON);
-                            viewModel.permissionTree.updateCards(viewModel.selectedNode().nodeGroupId(), data.responseJSON);
+                            setTimeout(function () {
+                                viewModel.permissionTree.updateCards(viewModel.selectedNode().nodeGroupId(), data.responseJSON);
+                            }, 50);
                             viewModel.updatedCardinalityData([data.responseJSON, viewModel.graphSettingsViewModel]);
                         }
 

--- a/arches/app/media/js/views/graph-designer.js
+++ b/arches/app/media/js/views/graph-designer.js
@@ -308,9 +308,7 @@ define([
                         }
                         else {
                             viewModel.cardTree.updateCards(viewModel.selectedNode().nodeGroupId(), data.responseJSON);
-                            setTimeout(function () {
-                                viewModel.permissionTree.updateCards(viewModel.selectedNode().nodeGroupId(), data.responseJSON);
-                            }, 50);
+                            viewModel.permissionTree.updateCards(viewModel.selectedNode().nodeGroupId(), data.responseJSON);
                             viewModel.updatedCardinalityData([data.responseJSON, viewModel.graphSettingsViewModel]);
                         }
 

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -154,28 +154,18 @@ class Card(models.CardModel):
 
                 if "widgets" in args[0]:
                     for widget in args[0]["widgets"]:
-                        cardxnodexwidgetid = widget.get("id", None)
                         node_id = widget.get("node_id", None)
                         card_id = widget.get("card_id", None)
                         widget_id = widget.get("widget_id", None)
-                        if cardxnodexwidgetid is None and (
-                            node_id is not None
-                            and card_id is not None
-                            and widget_id is not None
-                        ):
-                            widget_model, _ = (
-                                models.CardXNodeXWidget.objects.get_or_create(
-                                    node_id=node_id,
-                                    card_id=card_id,
-                                    widget_id=widget_id,
-                                )
-                            )
-                        else:
+ 
+                        try:
+                            widget_model = models.CardXNodeXWidget.objects.get(node_id=node_id, card_id=card_id)
+                        except models.CardXNodeXWidget.DoesNotExist:
                             widget_model = models.CardXNodeXWidget()
-                            widget_model.pk = cardxnodexwidgetid
                             widget_model.node_id = node_id
                             widget_model.card_id = card_id
-                            widget_model.widget_id = widget_id
+
+                        widget_model.widget_id = widget_id
                         widget_model.config = widget.get("config", {})
                         widget_model.label = widget.get("label", "")
                         widget_model.visible = widget.get("visible", None)

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -157,9 +157,11 @@ class Card(models.CardModel):
                         node_id = widget.get("node_id", None)
                         card_id = widget.get("card_id", None)
                         widget_id = widget.get("widget_id", None)
- 
+
                         try:
-                            widget_model = models.CardXNodeXWidget.objects.get(node_id=node_id, card_id=card_id)
+                            widget_model = models.CardXNodeXWidget.objects.get(
+                                node_id=node_id, card_id=card_id
+                            )
                         except models.CardXNodeXWidget.DoesNotExist:
                             widget_model = models.CardXNodeXWidget()
                             widget_model.node_id = node_id

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -157,17 +157,13 @@ class Card(models.CardModel):
                         node_id = widget.get("node_id", None)
                         card_id = widget.get("card_id", None)
                         widget_id = widget.get("widget_id", None)
-
-                        try:
-                            widget_model = models.CardXNodeXWidget.objects.get(
-                                node_id=node_id, card_id=card_id
+                        widget_model, _ = (
+                            models.CardXNodeXWidget.objects.update_or_create(
+                                node_id=node_id,
+                                card_id=card_id,
+                                defaults={"widget_id": uuid.UUID(widget_id)},
                             )
-                        except models.CardXNodeXWidget.DoesNotExist:
-                            widget_model = models.CardXNodeXWidget()
-                            widget_model.node_id = node_id
-                            widget_model.card_id = card_id
-
-                        widget_model.widget_id = widget_id
+                        )
                         widget_model.config = widget.get("config", {})
                         widget_model.label = widget.get("label", "")
                         widget_model.visible = widget.get("visible", None)

--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -180,9 +180,6 @@ class Card(models.CardModel):
                         widget_model.label = widget.get("label", "")
                         widget_model.visible = widget.get("visible", None)
                         widget_model.sortorder = widget.get("sortorder", None)
-                        if widget_model.pk is None:
-                            widget_model.pk = uuid.uuid4()
-                            widget_model.save()
                         self.widgets.append(widget_model)
 
                 if "nodes" in args[0]:

--- a/releases/7.6.0.md
+++ b/releases/7.6.0.md
@@ -68,6 +68,7 @@ Arches 7.6.0 Release Notes
 - 10754 Move the i18n/ url outside of the i18n_patterns function
 - Fixes hard coded Polygon geometry type in geo_utils.convert_multipart_to_singlepart #11218
 - Fixes geocoder placeholder #11173
+- Fixes error preventing user from changing a node's widget #10899
 - 11274 Raise limit of editable installs of arches applications from 3 to 9
 - Allow minzoom and maxzoom to be applied to a resource map source from a geojson node config #10929
 - Avoid retrieving full user information in the bulk data manager task status page.


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Replaced `get_or_create` because it was taking widget_id as an argument. This worked well for newly created records, but if a record already existed and the widget was being changed to a different widget, this would create a second cardsxnodesxwidget record for the node.

This change reintroduces #9858, however, that error was due in part to making two immediate calls to the CardView endpoint to update the card and permissions trees [here](https://github.com/archesproject/arches/blob/96051bb2d3fc1edd45b24071c53e2004a6313070/arches/app/media/js/views/graph-designer.js#L310-L311). Throttling the second call by 50ms prevents the issue, however, a better long term solution would be to avoid the second call and find a better way of ensuring the trees stay in sync.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #10899

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
