### PR TITLE
Prevent failed popup when clicking search result marker in default deny

### DIFF
--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -343,8 +343,9 @@ define([
             const popupFeatures = features.map(feature => {
                 var data = feature.properties;
                 var id = data.resourceinstanceid;
+                const userid = ko.unwrap(self.userid);
                 data.showFilterByFeatureButton = !!params.search;
-                data.showEditButton = self.canEdit;
+                data.showEditButton = false;
                 data.sendFeatureToMapFilter = mapPopupProvider.sendFeatureToMapFilter.bind(mapPopupProvider);
                 data.showFilterByFeature = mapPopupProvider.showFilterByFeature.bind(mapPopupProvider);
                 const descriptionProperties = ['displayname', 'graph_name', 'map_popup', 'geometries'];
@@ -364,8 +365,13 @@ define([
                             } catch (err) {
                                 data.permissions = koMapping.toJS(ko.unwrap(data.permissions));
                             }
-                            if (data.permissions.users_without_edit_perm.indexOf(ko.unwrap(self.userid)) > 0) {
-                                data.showEditButton = false;
+
+                            const hasInstanceEditPermission = data.permissions.users_without_edit_perm?.includes(userid) === false || 
+                                data.permissions.principal_user?.includes(userid) || 
+                                data.permissions.users_edit?.includes(userid);
+
+                            if (self.canEdit && hasInstanceEditPermission) {
+                                data.showEditButton = true;
                             }
                         }
                         descriptionProperties.forEach(prop => data[prop] = ko.observable(data[prop]));


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Prevent the marker popup from failing when clicking a search result while using the default deny permission framework. Hard-coded permission types are still in the map.js viewmodel. This could be avoided with an instance permission endpoint as described [here](https://github.com/archesproject/arches/issues/11502)

### Issues Solved
Closes #11501

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
