### PR TITLE
Indicate if user has no etl module permissions

### DIFF
--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -787,6 +787,7 @@
         etl-file-upload-message='{% trans "Use this workflow to upload a file with data that you want to use to create new data instances of a model." as etlFileUploadMessage %} "{{ etlFileUploadMessage|escapejs }}"'
         etl-single-csv-title='{% trans "Import Format: Single .csv file" as etlSingleCSVTitle %} "{{ etlSingleCSVTitle|escapejs }}"'
         bulk-data-edit-summary='{% trans "Bulk Data Edit Summary" as bulkDataEditSummary %} "{{ bulkDataEditSummary|escapejs }}"'
+        bulk-data-permission-notification='{% trans "You do not have permission to access any bulk data management tools" as bulkDataPermissionNotification %} "{{ bulkDataPermissionNotification|escapejs }}"'
         edit-details='{% trans "Edit Details" as editDetails %} "{{ editDetails|escapejs }}"'
         no-data-to-preview='{% trans "Nothing to update. Your data already meets your requirements." as noDataToPreview %} "{{ noDataToPreview|escapejs }}"'
         resource-model-edited='{% trans "Resource Model Edited" as resourceModelEdited %} "{{ resourceModelEdited|escapejs }}"'

--- a/arches/app/templates/views/components/plugins/etl-manager.htm
+++ b/arches/app/templates/views/components/plugins/etl-manager.htm
@@ -27,7 +27,7 @@
         <div class="workflow-select-plugin">
             <div class="workflow-select-card-container">
                 <!--ko if: etlModules.length === 0 -->
-                <div style="display: flex; justify-content: center; padding: 25px; width: 100%"><div data-bind="text: $parent.translations.bulkDataPermissionNotification" style="font-size: 1.9rem">TEST</div></div>
+                <div style="display: flex; justify-content: center; padding: 25px; width: 100%"><div data-bind="text: $parent.translations.bulkDataPermissionNotification" style="font-size: 1.9rem"></div></div>
                 <!--/ko-->
                 <!-- ko foreach: {data: etlModules, as: 'etlmodule', noChildContext: true} -->
                     <!-- ko if: activeModules() == 'import' && (!moduleSearchString() || !!moduleSearchString() && etlmodule.name.toLowerCase().includes(moduleSearchString().toLowerCase()) ) -->

--- a/arches/app/templates/views/components/plugins/etl-manager.htm
+++ b/arches/app/templates/views/components/plugins/etl-manager.htm
@@ -26,6 +26,9 @@
         <!-- ko ifnot: loading() -->
         <div class="workflow-select-plugin">
             <div class="workflow-select-card-container">
+                <!--ko if: etlModules.length === 0 -->
+                <div style="display: flex; justify-content: center; padding: 25px; width: 100%"><div data-bind="text: $parent.translations.bulkDataPermissionNotification" style="font-size: 1.9rem">TEST</div></div>
+                <!--/ko-->
                 <!-- ko foreach: {data: etlModules, as: 'etlmodule', noChildContext: true} -->
                     <!-- ko if: activeModules() == 'import' && (!moduleSearchString() || !!moduleSearchString() && etlmodule.name.toLowerCase().includes(moduleSearchString().toLowerCase()) ) -->
                     <a href="#" data-bind="if: etlmodule.etl_type === 'import', click: function() { selectModule(etlmodule) }">

--- a/arches/management/commands/permissions.py
+++ b/arches/management/commands/permissions.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
         try:
             permission_group = Group.objects.get(name=group)
         except Group.DoesNotExist:
-            print(f"{group} does not exist")
+            self.stderr.write(f"{group} group does not exist")
 
         permission_type = f"{permission}_{type}"
 

--- a/arches/management/commands/permissions.py
+++ b/arches/management/commands/permissions.py
@@ -24,7 +24,8 @@ import arches.app.utils.permission_backend as permission_backend
 
 class Command(BaseCommand):
     """
-    Commands for adding arches test users
+    Command for granting or revoking object permissions
+    Example: python manage.py permissions --permission view --action grant --group 'Resource Reviewer' --type etlmodule
 
     """
 

--- a/arches/management/commands/permissions.py
+++ b/arches/management/commands/permissions.py
@@ -67,12 +67,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        
+
         self.edit_permissions(
             permission=options["permission"],
             action=options["action"],
             group=options["group"],
-            type=options["type"]
+            type=options["type"],
         )
 
     def edit_permissions(self, permission, action, group, type):
@@ -85,7 +85,7 @@ class Command(BaseCommand):
             permission_action = getattr(permission_backend, "assign_perm")
         elif action == "revoke":
             permission_action = getattr(permission_backend, "remove_perm")
-        
+
         try:
             permission_group = Group.objects.get(name=group)
         except Group.DoesNotExist:

--- a/arches/management/commands/permissions.py
+++ b/arches/management/commands/permissions.py
@@ -1,0 +1,97 @@
+"""
+ARCHES - a program developed to inventory and manage immovable cultural heritage.
+Copyright (C) 2013 J. Paul Getty Trust and World Monuments Fund
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Group
+from arches.app.models import models
+import arches.app.utils.permission_backend as permission_backend
+
+
+class Command(BaseCommand):
+    """
+    Commands for adding arches test users
+
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("operation", nargs="?")
+
+        parser.add_argument(
+            "-p",
+            "--permission",
+            action="store",
+            dest="permission",
+            choices=["view", "add", "change", "delete"],
+            help="Permission to be added",
+        )
+
+        parser.add_argument(
+            "-a",
+            "--action",
+            action="store",
+            dest="action",
+            choices=["grant", "revoke"],
+            help="Indicate if you want to grant a permission or revoke it",
+        )
+
+        parser.add_argument(
+            "-g",
+            "--group",
+            action="store",
+            dest="group",
+            help="Indicate to which group permissions will be applied",
+        )
+
+        parser.add_argument(
+            "-t",
+            "--type",
+            action="store",
+            dest="type",
+            choices=["plugin", "etlmodule"],
+            help="Type of object to which permissions will be applied",
+        )
+
+    def handle(self, *args, **options):
+        
+        self.edit_permissions(
+            permission=options["permission"],
+            action=options["action"],
+            group=options["group"],
+            type=options["type"]
+        )
+
+    def edit_permissions(self, permission, action, group, type):
+        if type == "plugin":
+            objects = models.Plugin.objects.all()
+        elif type == "etlmodule":
+            objects = models.ETLModule.objects.all()
+
+        if action == "grant":
+            permission_action = getattr(permission_backend, "assign_perm")
+        elif action == "revoke":
+            permission_action = getattr(permission_backend, "remove_perm")
+        
+        try:
+            permission_group = Group.objects.get(name=group)
+        except Group.DoesNotExist:
+            print(f"{group} does not exist")
+
+        permission_type = f"{permission}_{type}"
+
+        for object in objects:
+            permission_action(permission_type, permission_group, object)

--- a/tests/commands/test_permissions.py
+++ b/tests/commands/test_permissions.py
@@ -19,12 +19,34 @@ class PermissionsCommandTet(ArchesTestCase):
         cls.permission_backend = PermissionBackend()
 
     def test_grant_perm(self):
-        call_command("permissions", permission="view", action="grant", group="Resource Reviewer", type="etlmodule")
-        has_perm = self.permission_backend.has_perm(self.user, "view_etlmodule", obj=self.etl_module)
+        call_command(
+            "permissions",
+            permission="view",
+            action="grant",
+            group="Resource Reviewer",
+            type="etlmodule",
+        )
+        has_perm = self.permission_backend.has_perm(
+            self.user, "view_etlmodule", obj=self.etl_module
+        )
         self.assertTrue(has_perm)
 
     def test_revoke_perm(self):
-        call_command("permissions", permission="view", action="grant", group="Resource Reviewer", type="etlmodule")
-        call_command("permissions", permission="view", action="revoke", group="Resource Reviewer", type="etlmodule")
-        has_perm = self.permission_backend.has_perm(self.user, "view_etlmodule", obj=self.etl_module)
+        call_command(
+            "permissions",
+            permission="view",
+            action="grant",
+            group="Resource Reviewer",
+            type="etlmodule",
+        )
+        call_command(
+            "permissions",
+            permission="view",
+            action="revoke",
+            group="Resource Reviewer",
+            type="etlmodule",
+        )
+        has_perm = self.permission_backend.has_perm(
+            self.user, "view_etlmodule", obj=self.etl_module
+        )
         self.assertFalse(has_perm)

--- a/tests/commands/test_permissions.py
+++ b/tests/commands/test_permissions.py
@@ -9,7 +9,7 @@ from arches.app.utils.permission_backend import PermissionBackend
 from arches.app.models import models
 
 
-class PermissionsCommandTet(ArchesTestCase):
+class PermissionsCommandTest(ArchesTestCase):
 
     def setUp(cls):
         resource_reviewer_group = Group.objects.get(name="Resource Reviewer")

--- a/tests/commands/test_permissions.py
+++ b/tests/commands/test_permissions.py
@@ -1,0 +1,30 @@
+# these tests can be run from the command line via
+# python manage.py test tests.commands.test_permissions --settings="tests.test_settings"
+
+
+from django.core.management import call_command
+from tests.base_test import ArchesTestCase
+from django.contrib.auth.models import Group, User
+from arches.app.utils.permission_backend import PermissionBackend
+from arches.app.models import models
+
+
+class PermissionsCommandTet(ArchesTestCase):
+
+    def setUp(cls):
+        resource_reviewer_group = Group.objects.get(name="Resource Reviewer")
+        cls.user = User.objects.create_user(username="test_user")
+        cls.user.groups.add(resource_reviewer_group)
+        cls.etl_module = models.ETLModule.objects.all()[0]
+        cls.permission_backend = PermissionBackend()
+
+    def test_grant_perm(self):
+        call_command("permissions", permission="view", action="grant", group="Resource Reviewer", type="etlmodule")
+        has_perm = self.permission_backend.has_perm(self.user, "view_etlmodule", obj=self.etl_module)
+        self.assertTrue(has_perm)
+
+    def test_revoke_perm(self):
+        call_command("permissions", permission="view", action="grant", group="Resource Reviewer", type="etlmodule")
+        call_command("permissions", permission="view", action="revoke", group="Resource Reviewer", type="etlmodule")
+        has_perm = self.permission_backend.has_perm(self.user, "view_etlmodule", obj=self.etl_module)
+        self.assertFalse(has_perm)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Indicates to user that they have no permissions to any bulk modules if they do not find any etl modules on the Bulk Data Manager page. This is because permissions were not enforced in 7.5, however, that issue is fixed in 7.6, so users accustomed to seeing modules may now find that that they can't see any in 7.6. Additionally, this PR adds a management command to allow an admin to grant or revoke permissions to etl modules in bulk.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11450

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (under development): features, bugfixes not covered below
    - [ ] dev/7.5.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
