### PR TITLE
Reduce queries for published graphs when indexing

### DIFF
--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -422,18 +422,15 @@ class ResourceTests(ArchesTestCase):
             self.assertFalse(result)
 
     def test_recalculate_descriptors_prefetch_related_objects(self):
+        other_graph = Graph.new(name="Other graph", is_resource=True)
+        other_graph.publish()
         r1 = Resource(graph_id=self.search_model_graphid)
-        r2 = Resource(graph_id=self.search_model_graphid)
+        r2 = Resource(graph_id=other_graph.pk)
         r1_tile = Tile(
             data={self.search_model_creation_date_nodeid: "1941-01-01"},
             nodegroup_id=self.search_model_creation_date_nodeid,
         )
         r1.tiles.append(r1_tile)
-        r2_tile = Tile(
-            data={self.search_model_creation_date_nodeid: "1941-01-01"},
-            nodegroup_id=self.search_model_creation_date_nodeid,
-        )
-        r2.tiles.append(r2_tile)
         r1.save(index=False)
         r2.save(index=False)
 
@@ -464,6 +461,13 @@ class ResourceTests(ArchesTestCase):
                     q for q in queries if q["sql"].startswith('SELECT "tiles"."tileid"')
                 ]
                 self.assertEqual(len(tile_selects), 1)
+
+                published_graph_selects = [
+                    q
+                    for q in queries
+                    if q["sql"].startswith('SELECT "published_graphs"."id"')
+                ]
+                self.assertEqual(len(published_graph_selects), 1)
 
     def test_self_referring_resource_instance_descriptor(self):
         # Create a nodegroup with a string node and a resource-instance node.


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, when indexing resources there were 2 queries per graph to get the published graph in the active language. One for the GraphXPublishedGraph row, one for the PublishedGraph row. This was then cached in memory, persisting either for a short period (on the CLI) or potentially forever for server-side operations, which could lead to retrieving stale data.

Now, these are prefetched during `optimize_resource_iteration`, so that it takes 2 queries total per chunk, no matter how many graphs are involved. A typical chunk size is 500 (2000 // 8), so if two adjacent chunks each contain 500 resources of the same graph, then this might _slightly_ increase queries, because we are no longer perpetually caching, but with a benefit of less memory overhead and better correctness for server-side operations--_but in all other cases this should reduce queries by avoiding repetitive published graph queries._

### Checklist
-   I targeted one of these branches:
    - [x] dev/8
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @chiatt
*   Tested by: @jacobtylerwalls