### PR TITLE
Return JSON response in GET calls to api/concepts #11519

### DIFF
--- a/arches/app/views/api/__init__.py
+++ b/arches/app/views/api/__init__.py
@@ -910,7 +910,7 @@ class Concepts(APIBase):
             allowed_formats = ["json", "json-ld"]
             format = request.GET.get("format", "json-ld")
             if format not in allowed_formats:
-                return JSONResponse(
+                return JSONErrorResponse(
                     status=406,
                     reason="incorrect format specified, only %s formats allowed"
                     % allowed_formats,
@@ -948,13 +948,15 @@ class Concepts(APIBase):
 
                     ret.append(concept_graph)
                 except models.Concept.DoesNotExist:
-                    return JSONResponse(status=404)
+                    return JSONErrorResponse(status=404)
                 except Exception as e:
-                    return JSONResponse(status=500, reason=e)
+                    return JSONErrorResponse(status=500, reason=e)
             else:
-                return JSONResponse(status=500)
+                return JSONErrorResponse(status=400)
         else:
-            return JSONResponse(status=500)
+            return JSONErrorResponse(
+                status=401 if request.user.username == "anonymous" else 403
+            )
 
         if format == "json-ld":
             try:
@@ -971,7 +973,7 @@ class Concepts(APIBase):
 
                 ret = compact(js, context)
             except Exception as e:
-                return JSONResponse(status=500, reason=e)
+                return JSONErrorResponse(status=500, reason=e)
 
         return JSONResponse(ret, indent=indent)
 

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -10,6 +10,7 @@ Arches 8.0.0 Release Notes
 - Add session-based REST APIs for login, logout [#11261](https://github.com/archesproject/arches/issues/11261)
 - Improve handling of longer model names [#11317](https://github.com/archesproject/arches/issues/11317)
 - Support more expressive plugin URLs [#11320](https://github.com/archesproject/arches/issues/11320)
+- Concepts API no longer responds with empty body for error conditions [#11519](https://github.com/archesproject/arches/issues/11519)
 
 ### Dependency changes
 ```


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the concepts api would respond to error conditions with an empty body. This might frustrate a vue frontend that expects to be able to parse the response body as json.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11519

### Checklist
-   I targeted one of these branches:
    - [x] dev/8
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: CA Dept of Parks and Rec
*   Found by: @jacobtylerwalls