### PR TITLE
Fix language switcher CSRF error when interacting before login #11528

### DIFF
--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -362,6 +362,7 @@
                         {% endif %}
 
                         {% if show_language_swtich %}
+                        {% csrf_token %}
                         {% get_current_language as LANGUAGE_CODE %}
                         <li aria-label="{% trans 'Choose your language' %}">
                             <div class="lang-switch ep-tools ep-tools-right" style="max-width: none;" data-bind='component: {

--- a/arches/app/templates/index.htm
+++ b/arches/app/templates/index.htm
@@ -114,6 +114,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             </li>
                         {% endif %}
                         {% if show_language_swtich %}
+                        {% csrf_token %}
                             <li>
                                 {% get_current_language as LANGUAGE_CODE %}
                                 <div class="lang-switch" style="max-width: none;" data-bind='component: {

--- a/arches/install/arches-templates/project_name/templates/index.htm
+++ b/arches/install/arches-templates/project_name/templates/index.htm
@@ -113,6 +113,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                             </li>
                         {% endif %}
                         {% if show_language_swtich %}
+                        {% csrf_token %}
                             <li>
                                 {% get_current_language as LANGUAGE_CODE %}
                                 <div class="lang-switch" style="max-width: none;" data-bind='component: {

--- a/releases/7.6.2.md
+++ b/releases/7.6.2.md
@@ -3,7 +3,6 @@
 ### Bug Fixes and Enhancements
 
 -   Fix language switcher CSRF error when interacting before login #[11528](https://github.com/archesproject/arches/issues/11528)
--   Fixes bug in which resource relationships fail to appear in visualize mode if using default deny as a non-superuser #[11539](https://github.com/archesproject/arches/pull/11539)
 -   Fixes failure to serialize non-editable Django fields (e.g. auto-date fields) #[11272](https://github.com/archesproject/arches/issues/11272)
 -   Fixes bug in which resource relationships fail to appear in visualize mode if using default deny as a non-superuser #[11539](https://github.com/archesproject/arches/pull/11539)
 -   Fixes bypassing of display logic of details table in search results for client-cached resources #[11537](https://github.com/archesproject/arches/issues/11537)

--- a/releases/7.6.2.md
+++ b/releases/7.6.2.md
@@ -1,4 +1,4 @@
-Arches 7.6.2 Release Notes
+## Arches 7.6.2 Release Notes
 --------------------------
 
 ### Bug Fixes and Enhancements

--- a/releases/7.6.2.md
+++ b/releases/7.6.2.md
@@ -1,5 +1,4 @@
 ## Arches 7.6.2 Release Notes
---------------------------
 
 ### Bug Fixes and Enhancements
 

--- a/releases/7.6.2.md
+++ b/releases/7.6.2.md
@@ -1,9 +1,9 @@
-Arches 7.6.1 Release Notes
+Arches 7.6.2 Release Notes
 --------------------------
 
 ### Bug Fixes and Enhancements
 
-- Fixes bug causing the map layer manager to fail if a system uses DEFAULT_PERMISSIONS setting #[11522](https://github.com/archesproject/arches/issues/11522)
+- Fix language switcher CSRF error when interacting before login #[11528](https://github.com/archesproject/arches/issues/11528)
 
 ### Dependency changes:
 ```
@@ -20,9 +20,9 @@ JavaScript:
 
 1. Upgrade to version 7.6.0 before proceeding by following the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md)
 
-2. Upgrade to Arches 7.6.1
+2. Upgrade to Arches 7.6.2
     ```
-    pip install --upgrade arches==7.6.1
+    pip install --upgrade arches==7.6.2
     ```
 
 3. If you are running Arches on Apache, restart your server:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The language switcher component assumes there is a CSRF token set already, but we weren't setting it before login. This PR now sets the csrf token when we render the language switcher.

To reproduce the problem without this patch:
- delete cookies
- enable multiple languages, rebuild frontend
- load the arches homepage
- navigate to search (it's an unrelated bug that the switcher is not rendering on the index page, see console errors)
- switch the language
- result: csrf error

### Issues Solved
Closes #11528

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/7.6.x (main support): crash (unexpected exception)
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ads04r
*   Tested by: @jacobtylerwalls
*   Designed by: @ <!--- Who designed this new feature-->