### PR TITLE
11537 - Ensure subscribe is called before observable is updated

### DIFF
--- a/arches/app/media/js/views/components/search/search-results.js
+++ b/arches/app/media/js/views/components/search/search-results.js
@@ -54,7 +54,7 @@ define([
 
                 this.searchFilterVms[componentName](this);
                 this.restoreState();
-                
+
                 this.mapFilter = this.getFilterByType("map-filter-type", false);
                 this.mapFilter.subscribe(mapFilter => {
                     if (mapFilter) {
@@ -124,6 +124,15 @@ define([
 
                 return function () {
                     reportDataLoaded(false);
+                    reportDataLoaded.subscribe((loaded) => {
+                        if (loaded) {
+                            self.details.setupReport(
+                                result._source,
+                                self.bulkResourceReportCache,
+                                self.bulkDisambiguatedResourceInstanceCache,
+                            );
+                        }
+                    });
 
                     if (
                         !self.bulkDisambiguatedResourceInstanceCache()[
@@ -154,16 +163,6 @@ define([
                         reportDataLoaded(true);
                         self.shiftFocus(".resource-report");
                     }
-
-                    reportDataLoaded.subscribe((loaded) => {
-                        if (loaded) {
-                            self.details.setupReport(
-                                result._source,
-                                self.bulkResourceReportCache,
-                                self.bulkDisambiguatedResourceInstanceCache,
-                            );
-                        }
-                    });
 
                     if (self.selectedTab() !== "search-result-details-type") {
                         self.selectedTab("search-result-details-type");

--- a/releases/7.6.2.md
+++ b/releases/7.6.2.md
@@ -1,0 +1,34 @@
+## Arches 7.6.2 Release Notes
+
+### Bug Fixes and Enhancements
+
+-   Fixes failure to serialize non-editable Django fields (e.g. auto-date fields) #[11272](https://github.com/archesproject/arches/issues/11272)
+-   Fixes bug in which resource relationships fail to appear in visualize mode if using default deny as a non-superuser #[11539](https://github.com/archesproject/arches/pull/11539)
+-   Fixes bypassing of display logic of details table in search results for client-cached resources #[11537](https://github.com/archesproject/arches/issues/11537)
+
+### Dependency changes:
+
+```
+Python:
+    Upgraded:
+        None
+
+JavaScript:
+    Upgraded:
+        none
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 7.6.0 before proceeding by following the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md)
+
+2. Upgrade to Arches 7.6.2
+
+    ```
+    pip install --upgrade arches==7.6.2
+    ```
+
+3. If you are running Arches on Apache, restart your server:
+    ```
+    sudo service apache2 reload
+    ```


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
In some circumstances, the observable that controls the setup and display of the Details tab is updated before the subscribe call is made. This can happen if a client-cached version of the resource is used.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11537

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
n/a - No UI changes


#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This was found when making the call to show the deatils card from the map popup.
