### PR TITLE
uuid type conversion error to fix #11536

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -887,8 +887,8 @@ class Resource(models.ResourceInstance):
             )
             filtered_instances = filtered_instances if user is not None else []
 
-            resourceid_to_permission = resourceid_to not in filtered_instances
-            resourceid_from_permission = resourceid_from not in filtered_instances
+            resourceid_to_permission = str(resourceid_to) not in filtered_instances
+            resourceid_from_permission = str(resourceid_from) not in filtered_instances
 
             if exclusive_set:
                 resourceid_to_permission = not (resourceid_to_permission)

--- a/releases/7.6.2.md
+++ b/releases/7.6.2.md
@@ -1,0 +1,32 @@
+## Arches 7.6.2 Release Notes
+
+### Bug Fixes and Enhancements
+
+-   Fixes bug in which resource relationships fail to appear in visualize mode if using default deny as a non-superuser #[11539](https://github.com/archesproject/arches/pull/11539)
+
+### Dependency changes:
+
+```
+Python:
+    Upgraded:
+        None
+
+JavaScript:
+    Upgraded:
+        none
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 7.6.0 before proceeding by following the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md)
+
+2. Upgrade to Arches 7.6.2
+
+    ```
+    pip install --upgrade arches==7.6.2
+    ```
+
+3. If you are running Arches on Apache, be restart your server:
+    ```
+    sudo service apache2 reload
+    ```


### PR DESCRIPTION
closes #11536 - resourceid_to and from are uuids, and will never be in filtered instances (strings)