### PR TITLE
Avoid refetching resource instances inside permissions framework

### DIFF
--- a/arches/app/permissions/arches_permission_base.py
+++ b/arches/app/permissions/arches_permission_base.py
@@ -207,7 +207,12 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
 
     @abstractmethod
     def check_resource_instance_permissions(
-        self, user: User, resourceid: str, permission: str
+        self,
+        user: User,
+        resourceid: str,
+        permission: str,
+        *,
+        resource: ResourceInstance | None,
     ): ...
 
     def get_groups_with_permission_for_object(
@@ -292,7 +297,11 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         return nodes.exists()
 
     def user_can_read_resource(
-        self, user: User, resourceid: str | None = None
+        self,
+        user: User,
+        resourceid: str | None = None,
+        *,
+        resource: ResourceInstance | None = None,
     ) -> bool | None:
         """
         Requires that a user be able to read an instance and read a single nodegroup of a resource
@@ -303,7 +312,7 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
                 return True
             if resourceid is not None and resourceid != "":
                 result = self.check_resource_instance_permissions(
-                    user, resourceid, "view_resourceinstance"
+                    user, resourceid, "view_resourceinstance", resource=resource
                 )
                 if result is not None:
                     if result["permitted"] == "unknown":
@@ -340,7 +349,13 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
 
         return list(str(graph) for graph in graphs)
 
-    def user_can_edit_resource(self, user: User, resourceid: str | None = None) -> bool:
+    def user_can_edit_resource(
+        self,
+        user: User,
+        resourceid: str | None = None,
+        *,
+        resource: ResourceInstance | None = None,
+    ) -> bool:
         """
         Requires that a user be able to edit an instance and delete a single nodegroup of a resource
 
@@ -348,9 +363,9 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         if user.is_authenticated:
             if user.is_superuser:
                 return True
-            if resourceid is not None and resourceid != "":
+            if resourceid:
                 result = self.check_resource_instance_permissions(
-                    user, resourceid, "change_resourceinstance"
+                    user, resourceid, "change_resourceinstance", resource=resource
                 )
                 if result is not None:
                     if result["permitted"] == "unknown":
@@ -371,7 +386,11 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         return False
 
     def user_can_delete_resource(
-        self, user: User, resourceid: str | None = None
+        self,
+        user: User,
+        resourceid: str | None = None,
+        *,
+        resource: ResourceInstance | None = None,
     ) -> bool | None:
         """
         Requires that a user be permitted to delete an instance
@@ -380,9 +399,9 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         if user.is_authenticated:
             if user.is_superuser:
                 return True
-            if resourceid is not None and resourceid != "":
+            if resourceid:
                 result = self.check_resource_instance_permissions(
-                    user, resourceid, "delete_resourceinstance"
+                    user, resourceid, "delete_resourceinstance", resource=resource
                 )
                 if result is not None:
                     if result["permitted"] == "unknown":

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -77,7 +77,9 @@ class PermissionFramework(metaclass=ABCMeta):
     def get_users_with_permission_for_object(self, perm, obj): ...
 
     @abstractmethod
-    def check_resource_instance_permissions(self, user, resourceid, permission): ...
+    def check_resource_instance_permissions(
+        self, user, resourceid, permission, *, resource=None
+    ): ...
 
     @abstractmethod
     def get_nodegroups_by_perm(self, user, perms, any_perm=True): ...
@@ -98,13 +100,13 @@ class PermissionFramework(metaclass=ABCMeta):
     def user_has_resource_model_permissions(self, user, perms, resource): ...
 
     @abstractmethod
-    def user_can_read_resource(self, user, resourceid=None): ...
+    def user_can_read_resource(self, user, resourceid=None, *, resource=None): ...
 
     @abstractmethod
-    def user_can_edit_resource(self, user, resourceid=None): ...
+    def user_can_edit_resource(self, user, resourceid=None, *, resource=None): ...
 
     @abstractmethod
-    def user_can_delete_resource(self, user, resourceid=None): ...
+    def user_can_delete_resource(self, user, resourceid=None, *, resource=None): ...
 
     @abstractmethod
     def user_can_read_concepts(self, user): ...
@@ -217,9 +219,9 @@ def get_users_with_permission_for_object(perm, obj):
     return _get_permission_framework().get_users_with_permission_for_object(perm, obj)
 
 
-def check_resource_instance_permissions(user, resourceid, permission):
+def check_resource_instance_permissions(user, resourceid, permission, *, resource=None):
     return _get_permission_framework().check_resource_instance_permissions(
-        user, resourceid, permission
+        user, resourceid, permission, resource=resource
     )
 
 
@@ -309,21 +311,21 @@ def user_has_resource_model_permissions(user, perms, resource):
     )
 
 
-def user_can_read_resource(user, resourceid=None):
+def user_can_read_resource(user, resourceid=None, *, resource=None):
     return _get_permission_framework().user_can_read_resource(
-        user, resourceid=resourceid
+        user, resourceid=resourceid, resource=resource
     )
 
 
-def user_can_edit_resource(user, resourceid=None):
+def user_can_edit_resource(user, resourceid=None, *, resource=None):
     return _get_permission_framework().user_can_edit_resource(
-        user, resourceid=resourceid
+        user, resourceid=resourceid, resource=resource
     )
 
 
-def user_can_delete_resource(user, resourceid=None):
+def user_can_delete_resource(user, resourceid=None, *, resource=None):
     return _get_permission_framework().user_can_delete_resource(
-        user, resourceid=resourceid
+        user, resourceid=resourceid, resource=resource
     )
 
 

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -945,9 +945,11 @@ class ResourceDescriptors(View):
 @method_decorator(can_read_resource_instance, name="dispatch")
 class ResourceReportView(MapBaseManagerView):
     def get(self, request, resourceid=None):
-        resource = Resource.objects.only(
-            "graph_id", "resource_instance_lifecycle_state"
-        ).get(pk=resourceid)
+        resource = (
+            models.ResourceInstance.objects.filter(pk=resourceid)
+            .select_related("resource_instance_lifecycle_state")
+            .get()
+        )
         graph = Graph.objects.get(graphid=resource.graph_id)
         graph_has_different_publication = bool(
             resource.graph_publication_id != graph.publication_id
@@ -985,7 +987,7 @@ class ResourceReportView(MapBaseManagerView):
         )
 
         context["user_can_edit_resource"] = user_can_edit_resource(
-            request.user, resourceid=resourceid
+            request.user, resource=resource
         )
 
         context["resource_instance_lifecycle_state_permits_editing"] = (

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -8,6 +8,11 @@ Arches 8.0.0 Release Notes
 
 ### Performance improvements
 - Improve indexing and bulk deletion performance [#11382](https://github.com/archesproject/arches/issues/11382)
+- The following methods or functions in the permissions framework now take an optional ``resource`` keyword argument to avoid refetching an instance that a caller may already have:
+    - `user_can_read_resource()`
+    - `user_can_edit_resource()`
+    - `user_can_delete_resource()`
+    - `check_resource_instance_permissions()`
 
 ### Additional highlights
 

--- a/tests/views/api/test_permissions.py
+++ b/tests/views/api/test_permissions.py
@@ -1,0 +1,35 @@
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from arches.app.models.graph import Graph
+from arches.app.models.models import ResourceInstance
+
+# these tests can be run from the command line via
+# python manage.py test tests.views.api.test_permissions --settings="tests.test_settings"
+
+
+class InstancePermissionsAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.graph = Graph.new(
+            name="INSTANCE_PERMISSIONS_TEST_GRAPH",
+            is_resource=True,
+            author="ARCHES TEST",
+        )
+
+    def test_get(self):
+        resource = ResourceInstance.objects.create(graph=self.graph)
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(
+                reverse("api_instance_permissions"),
+                QUERY_STRING=f"resourceinstanceid={resource.pk}",
+            )
+        resource_selects = [
+            q for q in queries if q["sql"].startswith('SELECT "resource_instances"')
+        ]
+        self.assertEqual(len(resource_selects), 1, list(queries))
+        self.assertEqual(
+            response.content.decode(), '{"delete": false, "edit": false, "read": false}'
+        )

--- a/tests/views/api/test_resources.py
+++ b/tests/views/api/test_resources.py
@@ -356,18 +356,22 @@ class ResourceAPITests(ArchesTestCase):
         # ==PUT=============================================================================================
 
         # ==Act : GET confirmation that resource does not exist in database=================================
-        with self.assertRaises(models.ResourceInstance.DoesNotExist) as context:
-            with self.assertLogs("django.request", level="ERROR"):
-                resp_get = self.client.get(
-                    reverse(
-                        "resources",
-                        kwargs={"resourceid": "075957c4-d97f-4986-8d27-c32b6dec8e62"},
-                    )
-                    + "?format=arches-json"
+        with (
+            self.assertLogs("django.request", level="WARNING"),
+            self.assertLogs("arches.app.views.api", level="ERROR"),
+        ):
+            resp_get = self.client.get(
+                reverse(
+                    "resources",
+                    kwargs={"resourceid": "075957c4-d97f-4986-8d27-c32b6dec8e62"},
                 )
+                + "?format=arches-json"
+            )
         # ==Assert==========================================================================================
-        self.assertTrue(
-            "Resource matching query does not exist." in str(context.exception)
+        self.assertContains(
+            resp_get,
+            "Resource matching query does not exist.",
+            status_code=HTTPStatus.NOT_FOUND,
         )  # Check exception message.
         # ==================================================================================================
 
@@ -488,18 +492,22 @@ class ResourceAPITests(ArchesTestCase):
         # ==================================================================================================
 
         # ==Act : GET confirmation that resource does not exist in database=================================
-        with self.assertRaises(models.ResourceInstance.DoesNotExist) as context_del:
-            with self.assertLogs("django.request", level="ERROR"):
-                resp_get_deleted = self.client.get(
-                    reverse(
-                        "resources",
-                        kwargs={"resourceid": my_resource_resourceinstanceid},
-                    )
-                    + "?format=arches-json"
+        with (
+            self.assertLogs("django.request", level="WARNING"),
+            self.assertLogs("arches.app.views.api", level="ERROR"),
+        ):
+            resp_get_deleted = self.client.get(
+                reverse(
+                    "resources",
+                    kwargs={"resourceid": my_resource_resourceinstanceid},
                 )
+                + "?format=arches-json"
+            )
         # ==Assert==========================================================================================
-        self.assertTrue(
-            "Resource matching query does not exist." in str(context_del.exception)
+        self.assertContains(
+            resp_get_deleted,
+            "Resource matching query does not exist.",
+            status_code=HTTPStatus.NOT_FOUND,
         )  # Check exception message.
         # ==================================================================================================
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The methods in the permissions framework mostly expect to be provided with a resource id. Each method then fetches an instance from the database. If the caller already has a model instance, they can't provide it to avoid the refetch. This PR now allows the caller to do that.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @jacobtylerwalls
