### PR TITLE
Automate the changes to the github action template re #10079

### DIFF
--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -51,3 +51,30 @@ class Command(BaseCommand):  # pragma: no cover
             os.remove(declarations_test_file_path)
 
         self.stdout.write("Done!")
+
+        # Update certain lines in GitHub Actions workflows.
+        self.stdout.write("Updating GitHub Actions...")
+        action_path = os.path.join(
+            settings.APP_ROOT,
+            "..",
+            ".github",
+            "actions",
+            "build-and-test-branch",
+            "action.yml",
+        )
+        if os.path.exists(action_path):
+            first_find = "python manage.py check\n"
+            first_replace = "python manage.py check --tag=compatibility\n"
+            second_find = "python manage.py makemigrations --check\n"
+            second_replace = "python manage.py makemigrations --check --skip-checks\n"
+            with open(action_path, "r") as f:
+                content = f.readlines()
+            for i, line in enumerate(content):
+                if line.endswith(first_find):
+                    content[i] = line.replace(first_find, first_replace)
+                elif line.endswith(second_find):
+                    content[i] = line.replace(second_find, second_replace)
+            with open(action_path, "w") as f:
+                f.writelines(content)
+
+        self.stdout.write("Done!")


### PR DESCRIPTION
Follow-up to #10079.

The github actions only setup a test database, not a default database. The system check in #10079 runs against the default database. We need to make one conscious of the other, either introspect the database connection in the system check, which seems a little intense, or just simplify the github action to skip unnecessary checks, which is what #10079 did for core arches without adding any automation to `updateproject`.

This adds that automation to `updateproject` to reduce friction on upgrade.