### PR TITLE
added required backslash changes for windows compatibility

### DIFF
--- a/arches/install/arches-templates/webpack/webpack-utils/build-filepath-lookup.js
+++ b/arches/install/arches-templates/webpack/webpack-utils/build-filepath-lookup.js
@@ -4,6 +4,7 @@ const Path = require('path');
 const fs = require('fs');
 
 function buildFilepathLookup(path, staticUrlPrefix) {
+    path = path.replace(/\\/g, '/')
     if (!fs.existsSync(path)) {
         return;
     }
@@ -13,7 +14,7 @@ function buildFilepathLookup(path, staticUrlPrefix) {
 
     const getFileList = function (dirPath) {
         return fs.readdirSync(dirPath, { withFileTypes: true }).reduce((fileList,entries) => {
-            const childPath = Path.join(dirPath, entries.name);
+            const childPath = Path.join(dirPath, entries.name).replace(/\\/g, '/');
 
             if (entries.isDirectory()) {
                 fileList.push(...getFileList(childPath, fileList));
@@ -37,7 +38,7 @@ function buildFilepathLookup(path, staticUrlPrefix) {
             lookup[file.replace(path,'').replace(/\\/g, '/').replace(extensionReplacementRegex,'').replace(/^\//,'')] = {"import": file, "filename": `${prefix}/[name].${extension}`};
         }
         else if (extension === 'css' || extension === 'scss') {
-            lookup[Path.join('css', file.replace(path,'').replace(/\\/g, '/')).replace(extensionReplacementRegex,'').replace(/^\//,'')] = { 'import': file };
+            lookup[Path.join('css', file.replace(path,'')).replace(/\\/g, '/').replace(extensionReplacementRegex,'').replace(/^\//,'')] = { 'import': file };
         }
         else {
             // staticUrl used for images

--- a/webpack/webpack-utils/build-filepath-lookup.js
+++ b/webpack/webpack-utils/build-filepath-lookup.js
@@ -4,6 +4,7 @@ const Path = require('path');
 const fs = require('fs');
 
 function buildFilepathLookup(path, staticUrlPrefix) {
+    path = path.replace(/\\/g, '/')
     if (!fs.existsSync(path)) {
         return;
     }
@@ -13,7 +14,7 @@ function buildFilepathLookup(path, staticUrlPrefix) {
 
     const getFileList = function (dirPath) {
         return fs.readdirSync(dirPath, { withFileTypes: true }).reduce((fileList,entries) => {
-            const childPath = Path.join(dirPath, entries.name);
+            const childPath = Path.join(dirPath, entries.name).replace(/\\/g, '/');
 
             if (entries.isDirectory()) {
                 fileList.push(...getFileList(childPath, fileList));
@@ -37,7 +38,7 @@ function buildFilepathLookup(path, staticUrlPrefix) {
             lookup[file.replace(path,'').replace(/\\/g, '/').replace(extensionReplacementRegex,'').replace(/^\//,'')] = {"import": file, "filename": `${prefix}/[name].${extension}`};
         }
         else if (extension === 'css' || extension === 'scss') {
-            lookup[Path.join('css', file.replace(path,'').replace(/\\/g, '/')).replace(extensionReplacementRegex,'').replace(/^\//,'')] = { 'import': file };
+            lookup[Path.join('css', file.replace(path,'')).replace(/\\/g, '/').replace(extensionReplacementRegex,'').replace(/^\//,'')] = { 'import': file };
         }
         else {
             // staticUrl used for images


### PR DESCRIPTION
This is based on the changes that we needed to get v7.6.2 running on our Windows environment after upgrading from v7.5

[Forum discussion](https://community.archesproject.org/t/lessons-from-arches-7-6-upgrade-on-a-windows-server/2604)

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
As done previously in another PR, the webpack code can get strings wrong when running on a Windows environment due to the use of backslashes rather than forward slashes in Unix environments. This change replaces the backslashes with forward slashes where it is required.


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Parks Canada<!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @jkemper-pca  <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @jkemper-pca  <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @jkemper-pca  <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
