### PR TITLE
Prevent TooManyFieldsSent error in graph designer #11615

### DIFF
--- a/arches/app/media/js/viewmodels/graph-settings.js
+++ b/arches/app/media/js/viewmodels/graph-settings.js
@@ -90,6 +90,7 @@ define([
             $.ajax({
                 type: "POST",
                 url: arches.urls.graph_settings(self.graph.graphid()),
+                contentType: 'application/json',
                 data: self.jsonData()})
                 .done(function(response) {
                     self.jsonCache(self.jsonData());

--- a/releases/7.6.3.md
+++ b/releases/7.6.3.md
@@ -6,7 +6,7 @@
 - Fix issue in which search results do not load if a saved search has no title or description #[11603](https://github.com/archesproject/arches/pull/11603) 
 - Fix issue with JSON-LD export failing when geojson features have no "id". #[11587](https://github.com/archesproject/arches/issues/11587)
 - Reduce permissions query to 1 query for all related resources in `get_related_resources` to prevent reports from failing to load #[11575](https://github.com/archesproject/arches/issues/11575)
-- Fix webpack build for Windows instances #[#11606](https://github.com/archesproject/arches/pull/11606)
+- Fix webpack build for Windows instances #[11606](https://github.com/archesproject/arches/pull/11606)
 
 
 ### Dependency changes:

--- a/releases/7.6.4.md
+++ b/releases/7.6.4.md
@@ -1,0 +1,32 @@
+## Arches 7.6.4 Release Notes
+
+### Bug Fixes and Enhancements
+
+- Fix Graph Designer failure when editing large graphs #[11615](https://github.com/archesproject/arches/issues/11615)
+
+
+### Dependency changes:
+
+```
+Python:
+    Upgraded:
+        None
+JavaScript:
+    Upgraded:
+        none
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 7.6.0 before proceeding by following the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md)
+
+2. Upgrade to Arches 7.6.4
+
+    ```
+    pip install --upgrade arches==7.6.4
+    ```
+
+3. If you are running Arches on Apache, restart your server:
+    ```
+    sudo service apache2 reload
+    ```


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, editing a large graph (e.g. Person model in Lingo) would fail with `TooManyFieldsError`, because django/python has handling to prevent DDoS vectors from very large numbers of parameters. We were getting a false positive for too many fields because our graph payloads include the string `&` many times. Whereas `&` is a field separator for the default `application/x-www-form-urlencoded` content type, here we just want to send json. The issue goes away if we send the correct content type with the request.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11615

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute