### PR TITLE
search export history with default storages

### DIFF
--- a/arches/app/search/search_export.py
+++ b/arches/app/search/search_export.py
@@ -25,6 +25,7 @@ from io import BytesIO
 import re
 from django.contrib.gis.geos import GeometryCollection, GEOSGeometry
 from django.core.files import File
+from django.core.files.storage import default_storage
 from django.utils.translation import gettext as _
 from django.urls import reverse, resolve
 from arches.app.models import models
@@ -321,9 +322,12 @@ class SearchResultsExporter(object):
         search_history_obj = models.SearchExportHistory.objects.get(
             pk=export_info.searchexportid
         )
+        search_history_obj.downloadfile.name = name
         f = BytesIO(zip_stream)
         download = File(f)
-        search_history_obj.downloadfile.save(name, download)
+        storage = default_storage
+        storage.save(search_history_obj.downloadfile.name, download)
+        search_history_obj.save()
         return search_history_obj.searchexportid
 
     def get_node(self, nodeid):

--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -109,7 +109,7 @@ def export_search_results(self, userid, request_values, format, report_link):
             "name": export_name,
             "email_link": str(settings.PUBLIC_SERVER_ADDRESS).rstrip("/")
             + "/files/"
-            + str(search_history_obj.downloadfile),
+            + str(exportid),
             "username": _user.first_name or _user.username,
         },
     )

--- a/releases/7.6.4.md
+++ b/releases/7.6.4.md
@@ -2,8 +2,8 @@
 
 ### Bug Fixes and Enhancements
 
-- Fix Graph Designer failure when editing large graphs #[11615](https://github.com/archesproject/arches/issues/11615)
-
+-   Fix Graph Designer failure when editing large graphs #[11615](https://github.com/archesproject/arches/issues/11615)
+-   Fix failure to download exported search results when using non file-system based storages #[11620](https://github.com/archesproject/arches/issues/11620)
 
 ### Dependency changes:
 

--- a/tests/search/search_export_tests.py
+++ b/tests/search/search_export_tests.py
@@ -118,6 +118,14 @@ class SearchExportTests(ArchesTestCase):
         result, _ = exporter.export(format="tilecsv", report_link="false")
         self.assertIn(".csv", result[0]["name"])
 
+    def test_write_export_to_zip(self):
+        request = self.factory.get("/search?tiles=True&export=True&format=tilecsv")
+        request.user = self.user
+        exporter = SearchResultsExporter(search_request=request)
+        result, info = exporter.export(format="tilecsv", report_link="false")
+        uuid = exporter.write_export_zipfile(result, info, "test")
+        self.assertIsNotNone(uuid)
+
     # def test_export_to_shp(self):
     #     """Test exporting search results to SHP format"""
     #     request = self.factory.get('/search?tiles=True&export=True&format=shp&compact=True')


### PR DESCRIPTION
This PR patches search export history to use default storages.  

To test, 

1. Have celery running.  
2. Do an export of an adequate number of search export records.  
3. Email/context should contain a new link pointing to the arches file view, which will proxy through django storages.  This should work for both files and any storage based configuration (including s3).

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Patches search export history to use default storages.  In order to be able to download the file, I also needed to patch the file view to look through the search export history table if uuid is not a base file uuid

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11620

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
