### PR TITLE
Rewrite model check as validation check re #10079

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Ensure frontend configuration files exist
       run: |
-          python manage.py check --tag=compatibility
+          python manage.py check
       shell: bash
 
     - name: Install Arches applications
@@ -74,7 +74,7 @@ runs:
 
     - name: Check for missing migrations
       run: |
-        python manage.py makemigrations --check --skip-checks
+        python manage.py makemigrations --check
       shell: bash
 
     - name: Ensure previous Python coverage data is erased

--- a/arches/app/const.py
+++ b/arches/app/const.py
@@ -4,6 +4,7 @@ from enum import Enum, unique
 IntegrityCheckDescriptions = {
     1005: "Nodes with ontologies found in graphs without ontologies",
     1012: "Node Groups without matching nodes",
+    1014: "Publication missing for language",
 }
 
 
@@ -11,6 +12,7 @@ IntegrityCheckDescriptions = {
 class IntegrityCheck(Enum):
     NODE_HAS_ONTOLOGY_GRAPH_DOES_NOT = 1005
     NODELESS_NODE_GROUP = 1012
+    PUBLICATION_MISSING_FOR_LANGUAGE = 1014
 
     def __str__(self):
         return IntegrityCheckDescriptions[self.value]

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -613,39 +613,6 @@ class GraphModel(models.Model):
 
         super(GraphModel, self).save(*args, **kwargs)
 
-    @classmethod
-    def check(cls, **kwargs):
-        errors = super().check(**kwargs)
-        errors.extend(cls._check_publication_in_every_language())
-        return errors
-
-    @classmethod
-    def _check_publication_in_every_language(cls):
-        errors = []
-        system_languages = {lang[0] for lang in settings.LANGUAGES}
-
-        for graph in (
-            cls.objects.filter(publication__isnull=False)
-            .select_related("publication")
-            .prefetch_related("publication__publishedgraph_set")
-        ):
-            languages_with_a_publication = {
-                published_graph.language_id
-                for published_graph in graph.publication.publishedgraph_set.all()
-            }
-            missing_languages = system_languages - languages_with_a_publication
-            if missing_languages:
-                errors.append(
-                    checks.Error(
-                        "This graph is not published in all enabled languages.",
-                        hint="Run python manage.py graph publish --update",
-                        obj=graph,
-                        id="arches.E004",  # TODO: enum in arches 8
-                    )
-                )
-
-        return errors
-
     def __str__(self):
         return str(self.name)
 

--- a/arches/install/arches-templates/.github/actions/build-and-test-branch/action.yml
+++ b/arches/install/arches-templates/.github/actions/build-and-test-branch/action.yml
@@ -33,7 +33,7 @@ runs:
     
     - name: Ensure frontend configuration files exist
       run: |
-          python manage.py check --tag=compatibility
+          python manage.py check
       shell: bash
 
     - name: Install Arches applications
@@ -74,7 +74,7 @@ runs:
 
     - name: Check for missing migrations
       run: |
-        python manage.py makemigrations --check --skip-checks
+        python manage.py makemigrations --check
       shell: bash
 
     - name: Ensure previous Python coverage data is erased

--- a/arches/management/commands/graph.py
+++ b/arches/management/commands/graph.py
@@ -23,14 +23,7 @@ from django.db import connection, transaction
 
 
 class Command(BaseCommand):
-    """
-    Commands for adding arches test users
-
-    """
-
-    # Silence system checks since this command is the cure for
-    # one of the system checks (arches.E004)
-    requires_system_checks = []
+    """Commands for updating graphs."""
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/arches/management/commands/packages.py
+++ b/arches/management/commands/packages.py
@@ -73,9 +73,6 @@ class Command(BaseCommand):
 
     """
 
-    # Silence system checks: if run with -db, should always succeed.
-    requires_system_checks = []
-
     def add_arguments(self, parser):
         parser.add_argument(
             "-o",

--- a/arches/management/commands/setup_db.py
+++ b/arches/management/commands/setup_db.py
@@ -36,9 +36,6 @@ class Command(BaseCommand):
     during development.
     """
 
-    # Silence system checks: this command should always succeed.
-    requires_system_checks = []
-
     def add_arguments(self, parser):
 
         parser.add_argument(

--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -51,30 +51,3 @@ class Command(BaseCommand):  # pragma: no cover
             os.remove(declarations_test_file_path)
 
         self.stdout.write("Done!")
-
-        # Update certain lines in GitHub Actions workflows.
-        self.stdout.write("Updating GitHub Actions...")
-        action_path = os.path.join(
-            settings.APP_ROOT,
-            "..",
-            ".github",
-            "actions",
-            "build-and-test-branch",
-            "action.yml",
-        )
-        if os.path.exists(action_path):
-            first_find = "python manage.py check\n"
-            first_replace = "python manage.py check --tag=compatibility\n"
-            second_find = "python manage.py makemigrations --check\n"
-            second_replace = "python manage.py makemigrations --check --skip-checks\n"
-            with open(action_path, "r") as f:
-                content = f.readlines()
-            for i, line in enumerate(content):
-                if line.endswith(first_find):
-                    content[i] = line.replace(first_find, first_replace)
-                elif line.endswith(second_find):
-                    content[i] = line.replace(second_find, second_replace)
-            with open(action_path, "w") as f:
-                f.writelines(content)
-
-        self.stdout.write("Done!")

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -106,6 +106,12 @@ JavaScript:
 
 4. Update your Graph publications and Resource instances to point to the newly published Graphs by running `python manage.py graph publish --update -ui`
 
+1. Also consider running validation checks:
+    ```
+    python manage.py validate
+    python manage.py validate --fix [error]
+    ```
+
 5. Within your project with your Python 3 virtual environment activated:
     ```
     python manage.py es reindex_database

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -19,7 +19,6 @@ Arches 8.0.0 Release Notes
 
 ### Additional highlights
 - Add session-based REST APIs for login, logout [#11261](https://github.com/archesproject/arches/issues/11261)
-- Add system check advising next action when enabling additional languages without updating graphs [#10079](https://github.com/archesproject/arches/issues/10079)
 - Improve handling of longer model names [#11317](https://github.com/archesproject/arches/issues/11317)
 - Support more expressive plugin URLs [#11320](https://github.com/archesproject/arches/issues/11320)
 - Make node aliases not nullable [#10437](https://github.com/archesproject/arches/issues/10437)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When trying my hand at writing a django system check in #10079, I missed a pretty major [caveat](https://docs.djangoproject.com/en/5.1/topics/checks/#writing-your-own-checks), which is that if you use the database, you need to do something like:

https://github.com/archesproject/arches/blob/0f23a6cbc78a093e5a08cf2ab2abf2c542915df4/arches/app/models/models.py#L619-L620

... to avoid db hits during commands that don't generally expect a database to be configured. (My earlier workaround was was to run subsets of checks in different places, but that was kind of a code smell. This PR removes some of those workarounds.)

But to start observing `kwargs["databases"]` means that these checks only run on:
```
- manage.py migrate
- manage.py check --database default
```

So, given how infrequently this would be run, better to just implement this in our validation framework and call it out in the release notes?


#### Testing instructions
- Create and publish a graph
- Enable an additional system language, without republishing any graphs
- manage.py validate
- expect errros
- manage.py validate --fix
- expect errrors fixed
- ensure branches do not trigger the check
- ensure languages for which a publication exists but is not currently in settings.LANGUAGES doesn't alter the comparison and cause the check to unexpectedly pass