### PR TITLE
Handle custom selectors in dark mode query re #11624

### DIFF
--- a/arches/app/media/js/utils/create-vue-application.js
+++ b/arches/app/media/js/utils/create-vue-application.js
@@ -13,7 +13,7 @@ import { createGettext } from "vue3-gettext";
 import arches from 'arches';
 import { DEFAULT_THEME } from "@/arches/themes/default.ts";
 
-export default async function createVueApplication(vueComponent, themeConfiguration) {
+export default async function createVueApplication(vueComponent, themeConfiguration = DEFAULT_THEME) {
     /**
      * This wrapper allows us to maintain a level of control inside arches-core
      * over Vue apps. For instance this allows us to abstract i18n setup/config
@@ -40,8 +40,19 @@ export default async function createVueApplication(vueComponent, themeConfigurat
         });
 
         const app = createApp(vueComponent);
+        const darkModeClass = themeConfiguration.theme.options.darkModeSelector.substring(1);
+        const darkModeStorageKey = `arches.${darkModeClass}`;
 
-        app.use(PrimeVue, themeConfiguration || DEFAULT_THEME);
+        const darkModeToggleState = localStorage.getItem(darkModeStorageKey);
+        if (
+            darkModeToggleState === "true" ||
+            (darkModeToggleState === null &&
+                window.matchMedia("(prefers-color-scheme: dark)").matches)
+        ) {
+            document.documentElement.classList.add(darkModeClass);
+        }
+
+        app.use(PrimeVue, themeConfiguration);
         app.use(gettext);
         app.use(ConfirmationService);
         app.use(DialogService);

--- a/arches/app/templates/base-root.htm
+++ b/arches/app/templates/base-root.htm
@@ -35,16 +35,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         gtag('config', '{{app_settings.GOOGLE_ANALYTICS_TRACKING_ID}}');
     </script>
     {% endif %}
-    <script>
-        const darkModeToggleState = localStorage.getItem("arches-dark");
-        if (
-            darkModeToggleState === "true" ||
-            (darkModeToggleState === null &&
-                window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-            document.documentElement.classList.add("arches-dark");
-        }
-    </script>
     <title>
         {% block title %}{% endblock title %}
     </title>


### PR DESCRIPTION
Follow-up to #11667, see [suggestion](https://github.com/archesproject/arches-lingo/pull/91#pullrequestreview-2476580442) to liberalize this. Agree we should avoid hard-coding the selector.