### PR TITLE
Bump Django to 4.2.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "arcgis2geojson==2.0.0",
     "celery==5.3.6",
     "defusedxml==0.7.1",
-    "Django>=4.2.16,<5.0.0",
+    "Django>=4.2.17,<5.0.0",
     "django-celery-results==2.5.1",
     "django-cors-headers==4.2.0",
     "django-guardian==2.4.0",

--- a/releases/7.6.4.md
+++ b/releases/7.6.4.md
@@ -12,7 +12,7 @@
 ```
 Python:
     Upgraded:
-        None
+        Django == 4.2.17 (or <5.0.0)
 JavaScript:
     Upgraded:
         none


### PR DESCRIPTION
Ensure the next 7.6 patch has the latest django security release as the floor.