### PR TITLE
Remove memory leaks from GetFrontendI18NData

### DIFF
--- a/arches/app/views/api/__init__.py
+++ b/arches/app/views/api/__init__.py
@@ -136,9 +136,8 @@ class GetFrontendI18NData(APIBase):
         localized_strings = {}
         for lang_file in language_file_path:
             try:
-                localized_strings = (
-                    json.load(open(lang_file))[user_language] | localized_strings
-                )
+                with open(lang_file, "r", encoding="utf-8") as f:
+                    localized_strings = json.load(f)[user_language] | localized_strings
             except FileNotFoundError:
                 pass
 


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Avoid leaving file handles open (increases memory usage).

Noticed while profiling the report view for a client that is prioritizing performance.

We may want to consider caching this view (by requested language) in the future, since this data is very unlikely to change often in a mature deployment, and file I/O can really add drag.