### PR TITLE
Fix enabling multiple languages if the `APP_NAME` in the db was "Arches" #11660

### DIFF
--- a/arches/app/models/system_settings.py
+++ b/arches/app/models/system_settings.py
@@ -22,9 +22,6 @@ from django.core.exceptions import ImproperlyConfigured
 from arches.app.models import models
 
 
-tiles_loaded = False
-
-
 class SystemSettings(LazySettings):
     """
     This class can be used just like you would use settings.py
@@ -36,12 +33,15 @@ class SystemSettings(LazySettings):
         settings.SEARCH_ITEMS_PER_PAGE
 
         # will list all settings
-        print(settings)
+        print settings
 
     """
 
     SYSTEM_SETTINGS_RESOURCE_MODEL_ID = "ff623370-fa12-11e6-b98b-6c4008b05c4c"
     RESOURCE_INSTANCE_ID = "a106c400-260c-11e7-a604-14109fd34195"
+
+    def __init__(self, *args, **kwargs):
+        super(SystemSettings, self).__init__(*args, **kwargs)
 
     def __str__(self):
         ret = []
@@ -53,21 +53,24 @@ class SystemSettings(LazySettings):
 
     def __getattr__(self, name):
         """
-        Defer loading of system settings tiles until first access.
-        An effort toward avoiding module-level queries, which are discouraged:
-        https://docs.djangoproject.com/stable/ref/applications/#troubleshooting
-        """
-        global tiles_loaded
-        if not tiles_loaded:
-            # Optimistically set this True to avoid concurrent queries.
-            tiles_loaded = True
-            try:
-                self.update_from_db()
-            except ImportError:
-                # Circular imports. Try again later.
-                tiles_loaded = False
+        By default get settings from this class which is initially populated from the settings.py filter
+        If a setting is requested that isn't found, assume it's saved in the database and try and retrieve it from there
+        by calling update_from_db first which populates this class with any settings from the database
 
-        return super().__getattr__(name)
+        What this means is that update_from_db will only be called once a setting is requested that isn't initially in the settings.py file
+        Only then will settings from the database be applied (and potentially overwrite settings found in settings.py)
+
+        """
+
+        try:
+            return super(SystemSettings, self).__getattr__(name)
+        except ImproperlyConfigured:
+            raise
+        except:
+            self.update_from_db()
+            return super(SystemSettings, self).__getattr__(
+                name
+            )  # getattr(self, name, True)
 
     def setting_exists(self, name):
         """

--- a/arches/app/models/system_settings.py
+++ b/arches/app/models/system_settings.py
@@ -22,6 +22,9 @@ from django.core.exceptions import ImproperlyConfigured
 from arches.app.models import models
 
 
+tiles_loaded = False
+
+
 class SystemSettings(LazySettings):
     """
     This class can be used just like you would use settings.py
@@ -33,15 +36,12 @@ class SystemSettings(LazySettings):
         settings.SEARCH_ITEMS_PER_PAGE
 
         # will list all settings
-        print settings
+        print(settings)
 
     """
 
     SYSTEM_SETTINGS_RESOURCE_MODEL_ID = "ff623370-fa12-11e6-b98b-6c4008b05c4c"
     RESOURCE_INSTANCE_ID = "a106c400-260c-11e7-a604-14109fd34195"
-
-    def __init__(self, *args, **kwargs):
-        super(SystemSettings, self).__init__(*args, **kwargs)
 
     def __str__(self):
         ret = []
@@ -53,24 +53,21 @@ class SystemSettings(LazySettings):
 
     def __getattr__(self, name):
         """
-        By default get settings from this class which is initially populated from the settings.py filter
-        If a setting is requested that isn't found, assume it's saved in the database and try and retrieve it from there
-        by calling update_from_db first which populates this class with any settings from the database
-
-        What this means is that update_from_db will only be called once a setting is requested that isn't initially in the settings.py file
-        Only then will settings from the database be applied (and potentially overwrite settings found in settings.py)
-
+        Defer loading of system settings tiles until first access.
+        An effort toward avoiding module-level queries, which are discouraged:
+        https://docs.djangoproject.com/stable/ref/applications/#troubleshooting
         """
+        global tiles_loaded
+        if not tiles_loaded:
+            # Optimistically set this True to avoid concurrent queries.
+            tiles_loaded = True
+            try:
+                self.update_from_db()
+            except ImportError:
+                # Circular imports. Try again later.
+                tiles_loaded = False
 
-        try:
-            return super(SystemSettings, self).__getattr__(name)
-        except ImproperlyConfigured:
-            raise
-        except:
-            self.update_from_db()
-            return super(SystemSettings, self).__getattr__(
-                name
-            )  # getattr(self, name, True)
+        return super().__getattr__(name)
 
     def setting_exists(self, name):
         """

--- a/arches/settings_utils.py
+++ b/arches/settings_utils.py
@@ -164,7 +164,10 @@ def generate_frontend_configuration():
             "WEBPACK_DEVELOPMENT_SERVER_PORT": settings.WEBPACK_DEVELOPMENT_SERVER_PORT,
         }
 
-        if settings.APP_NAME == "Arches":
+        if str(Path(app_root_path).parent) == root_dir_path:
+            # Running core arches directly without a project, e.g.:
+            # app_root_path: arches/app
+            # root_dir_path: arches
             base_path = root_dir_path
         else:
             base_path = app_root_path

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -736,7 +736,7 @@ urlpatterns = [
 
 # This must be included in core to keep webpack happy, but cannot be appended when running a project.
 # See https://github.com/archesproject/arches/pull/10754
-if settings.APP_NAME == "Arches":
+if settings.ROOT_URLCONF == __name__:
     if settings.SHOW_LANGUAGE_SWITCH is True:
         urlpatterns = i18n_patterns(*urlpatterns)
 

--- a/releases/7.6.4.md
+++ b/releases/7.6.4.md
@@ -9,6 +9,7 @@
 - Cache resource relationship preflabels to improve report load time #[11583](https://github.com/archesproject/arches/issues/11583)
 - Fix regression where Arches is no longer overriding Django admin templates #[11668](https://github.com/archesproject/arches/issues/11668)
 - Fix bug causing the Edit button to not display in the map popup #[11679](https://github.com/archesproject/arches/issues/11679)
+- Fix enabling multiple languages if the `APP_NAME` system settings tile had never been updated #[11660](https://github.com/archesproject/arches/issues/11660)
 
 ### Dependency changes:
 


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
setup_db creates a tile for the system setting `APP_NAME` with a value of "Arches". If the application was running under wsgi.py, then it's likely that the arches system settings object fetched tiles, thus merging the APP_NAME setting tile into the django settings, causing the check against the django settings in urls.py to unexpectedly evaluate True, breaking the ability of a project to enable multiple languages. This wasn't caught in development because the dev workflow doesn't run wsgi.py and thus update_from_db() never ran.

#### Two fixes:
- avoid checking `APP_NAME` in core urls.py. Instead use the same check that's working well in projects to determine "is this project the project being served"
- ~merge system settings into the django settings in more cases, not just under wsgi.py but also during development. This was discussed at a recent standup. Fix the docstring that implies that this is not wanted.~ EDIT: will defer this fix, caused issues with `setup_db`.

#### Testing instructions
- To reproduce the original issue, checkout the first commit (or undo its reversion, since it's no longer part of this PR), and you should be able to reproduce #11660 by adjusting your project level settings to enable the language switcher.
- Then, checkout the second commit, the issue should be fixed.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11660

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @ekansa
