### PR TITLE
Bump arches to 7.6.5.b0

### DIFF
--- a/arches/__init__.py
+++ b/arches/__init__.py
@@ -11,6 +11,6 @@ except Exception as e:
     pass
 
 # VERSION[3] options = "alpha", "beta", "rc", or "final"
-VERSION = (7, 6, 4, "beta", 0)
+VERSION = (7, 6, 5, "beta", 0)
 
 __version__ = get_version(VERSION)


### PR DESCRIPTION
Bump version on dev/7.6.x following 7.6.4 release.

Allows installing the dev/7.6.x branch of arches in projects requiring 7.6.4 or higher. (7.6.4.b0 is lower than 7.6.4.)