### PR TITLE
Fix  any value and no value complements in advanced search

### DIFF
--- a/arches/app/search/components/advanced_search.py
+++ b/arches/app/search/components/advanced_search.py
@@ -1,15 +1,15 @@
+from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models.models import (
-    Node,
-    DDataType,
-    GraphModel,
     CardModel,
     CardXNodeXWidget,
+    DDataType,
+    GraphModel,
+    Node,
 )
 from arches.app.models.system_settings import settings
-from arches.app.datatypes.datatypes import DataTypeFactory
-from arches.app.utils.betterJSONSerializer import JSONDeserializer
-from arches.app.search.elasticsearch_dsl_builder import Bool, Nested
 from arches.app.search.components.base import BaseSearchFilter
+from arches.app.search.elasticsearch_dsl_builder import Bool
+from arches.app.utils.betterJSONSerializer import JSONDeserializer
 
 details = {
     "searchcomponentid": "",
@@ -61,11 +61,9 @@ class AdvancedSearch(BaseSearchFilter):
                             datatype.append_search_filters(
                                 val, node, tile_query, self.request
                             )
-            nested_query = Nested(path="tiles", query=tile_query)
             if advanced_filter["op"] == "or" and index != 0:
                 grouped_query = Bool()
                 grouped_queries.append(grouped_query)
-            grouped_query.must(nested_query)
             grouped_query.must(null_query)
         for grouped_query in grouped_queries:
             advanced_query.should(grouped_query)

--- a/releases/7.6.5.md
+++ b/releases/7.6.5.md
@@ -4,6 +4,7 @@
 
 - Fix Activity Stream id value [#11727](https://github.com/archesproject/arches/issues/11727)
 - Prevent Arches templates from overriding App templates [#11731]https://github.com/archesproject/arches/pull/11731
+- Fix the complement of "Has Any Value" and "Has No Value" in advanced search [#11424](https://github.com/archesproject/arches/issues/11424)
 
 
 ### Dependency changes:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
In some cases when indexing resources, a resource might not have tiles. This results in ES indexing an empty list for the tiles of that resource. The nested query for the tiles ensures that at least one indexed tile must be present. This was the issue where the "Has any value" and "Has no value" did not complement each other. By removing the at least one indexed tile requirement, the two options complement each other and sum up to the correct count.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11424 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch