### PR TITLE
Fix user_can_* checks handling of resource kwarg

### DIFF
--- a/arches/app/permissions/arches_default_allow.py
+++ b/arches/app/permissions/arches_default_allow.py
@@ -261,11 +261,6 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
         """
         result = ResourceInstancePermissions()
         try:
-            if resourceid == settings.SYSTEM_SETTINGS_RESOURCE_ID:
-                if not user.groups.filter(name="System Administrator").exists():
-                    result["permitted"] = False
-                    return result
-
             if not resource:
                 resource = ResourceInstance.objects.select_related(
                     "resource_instance_lifecycle_state"
@@ -273,6 +268,11 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
             elif resourceid:
                 raise ValueError("resourceid and resource are mutually incompatible")
             result["resource"] = resource
+
+            if str(resource.pk) == settings.SYSTEM_SETTINGS_RESOURCE_ID:
+                if not user.groups.filter(name="System Administrator").exists():
+                    result["permitted"] = False
+                    return result
 
             all_perms = self.get_perms(user, resource)
 

--- a/arches/app/permissions/arches_default_deny.py
+++ b/arches/app/permissions/arches_default_deny.py
@@ -119,7 +119,7 @@ class ArchesDefaultDenyPermissionFramework(ArchesPermissionBase):
             resource = ResourceInstance.objects.get(resourceinstanceid=resourceid)
         elif resourceid:
             raise ValueError("resourceid and resource are mutually incompatible")
-        if resourceid == settings.SYSTEM_SETTINGS_RESOURCE_ID:
+        if str(resource.pk) == settings.SYSTEM_SETTINGS_RESOURCE_ID:
             result["resource"] = resource
             if not user.groups.filter(name="System Administrator").exists():
                 result["permitted"] = False

--- a/arches/app/permissions/arches_permission_base.py
+++ b/arches/app/permissions/arches_permission_base.py
@@ -310,7 +310,7 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         if user.is_authenticated:
             if user.is_superuser:
                 return True
-            if resourceid is not None and resourceid != "":
+            if resourceid or resource:
                 result = self.check_resource_instance_permissions(
                     user, resourceid, "view_resourceinstance", resource=resource
                 )
@@ -363,7 +363,7 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         if user.is_authenticated:
             if user.is_superuser:
                 return True
-            if resourceid:
+            if resourceid or resource:
                 result = self.check_resource_instance_permissions(
                     user, resourceid, "change_resourceinstance", resource=resource
                 )
@@ -399,7 +399,7 @@ class ArchesPermissionBase(PermissionFramework, metaclass=ABCMeta):
         if user.is_authenticated:
             if user.is_superuser:
                 return True
-            if resourceid:
+            if resourceid or resource:
                 result = self.check_resource_instance_permissions(
                     user, resourceid, "delete_resourceinstance", resource=resource
                 )

--- a/tests/permissions/permissions_arches_default_allow_tests.py
+++ b/tests/permissions/permissions_arches_default_allow_tests.py
@@ -15,7 +15,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from unittest.mock import MagicMock, Mock, patch
 
-from django.test import override_settings
 from arches.app.models.resource import Resource
 from tests.permissions.base_permissions_framework_test import (
     ArchesPermissionFrameworkTestCase,

--- a/tests/views/api/test_permissions.py
+++ b/tests/views/api/test_permissions.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.contrib.auth.models import Group, User
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
@@ -15,9 +17,14 @@ class InstancePermissionsAPITest(TestCase):
     def setUpTestData(cls):
         cls.graph = Graph.new(
             name="INSTANCE_PERMISSIONS_TEST_GRAPH",
-            is_resource=True,
+            is_resource=False,  # creates a nodegroup, will undo this below.
             author="ARCHES TEST",
         )
+        cls.graph.isresource = True
+        cls.graph.resource_instance_lifecycle_id = (
+            settings.DEFAULT_RESOURCE_INSTANCE_LIFECYCLE_ID
+        )
+        cls.graph.save(validate=False)
 
     def test_get(self):
         resource = ResourceInstance.objects.create(graph=self.graph)
@@ -32,4 +39,20 @@ class InstancePermissionsAPITest(TestCase):
         self.assertEqual(len(resource_selects), 1, list(queries))
         self.assertEqual(
             response.content.decode(), '{"delete": false, "edit": false, "read": false}'
+        )
+
+    def test_get_with_resource_editor_role(self):
+        resource = ResourceInstance.objects.create(graph=self.graph)
+        editor_group = Group.objects.get(name="Resource Editor")
+        test_user = User.objects.create()
+        test_user.groups.add(editor_group)
+        self.client.force_login(test_user)
+
+        response = self.client.get(
+            reverse("api_instance_permissions"),
+            QUERY_STRING=f"resourceinstanceid={resource.pk}",
+        )
+
+        self.assertEqual(
+            response.content.decode(), '{"delete": true, "edit": true, "read": true}'
         )

--- a/tests/views/api/test_permissions.py
+++ b/tests/views/api/test_permissions.py
@@ -26,7 +26,7 @@ class InstancePermissionsAPITest(TestCase):
         )
         cls.graph.save(validate=False)
 
-    def test_get(self):
+    def test_get_with_anonymous_user(self):
         resource = ResourceInstance.objects.create(graph=self.graph)
         with CaptureQueriesContext(connection) as queries:
             response = self.client.get(
@@ -38,7 +38,7 @@ class InstancePermissionsAPITest(TestCase):
         ]
         self.assertEqual(len(resource_selects), 1, list(queries))
         self.assertEqual(
-            response.content.decode(), '{"delete": false, "edit": false, "read": false}'
+            response.content.decode(), '{"delete": true, "edit": true, "read": true}'
         )
 
     def test_get_with_resource_editor_role(self):


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Fixes a regression in c86d4d9 -- we need to allow passing either a resource model instance or a resource id string after that change.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls
*   Tested by: @jacobtylerwalls