### PR TITLE
Factor out a helper for calculating next tile sort order

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -30,6 +30,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import get_language
 from arches.app.models import models
 from arches.app.models.models import EditLog, TileModel
+from arches.app.models.utils import add_to_update_fields
 from arches.app.models.concept import get_preflabel_from_valueid
 from arches.app.models.system_settings import settings
 from arches.app.search.search_engine_factory import SearchEngineInstance as se
@@ -280,8 +281,7 @@ class Resource(models.ResourceInstance):
 
         if not self.principaluser_id and user:
             self.principaluser_id = user.id
-            # TODO: this is not updating update_fields in kwargs
-            # Fix when adding user argument to Resource.save().
+            add_to_update_fields(kwargs, "principaluser_id")
 
         super(Resource, self).save(**kwargs)
 

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -29,8 +29,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.utils.translation import gettext as _
 from django.utils.translation import get_language
 from arches.app.models import models
-from arches.app.models.models import EditLog
-from arches.app.models.models import TileModel
+from arches.app.models.models import EditLog, TileModel
 from arches.app.models.concept import get_preflabel_from_valueid
 from arches.app.models.system_settings import settings
 from arches.app.search.search_engine_factory import SearchEngineInstance as se


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This allows access to the calculation for tile sort order without having to call `Tile.save()`, e.g. if planning to call `TileModel.objects.create(**data)` instead.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Designed by: @jacobtylerwalls