### PR TITLE
Fix frontend build issue for Arches installed with pipenv, poetry or uv

### DIFF
--- a/webpack/webpack-utils/build-filepath-lookup.js
+++ b/webpack/webpack-utils/build-filepath-lookup.js
@@ -27,7 +27,7 @@ function buildFilepathLookup(path, staticUrlPrefix) {
 
     return getFileList(path).reduce((lookup, file) => {
         // Ignore dotfiles
-        if (file.match(new RegExp(Path.sep + '\\.')) || file.match(/^\./)) {
+        if (Path.basename(file).startsWith('.')) {
             return lookup;
         }
         const extension = file.match(/[^.]+$/).toString();


### PR DESCRIPTION
The convention of naming a virtual environment "`.venv`" appears to have been adopted by the above package managers.

The fix addresses the issue of templates in directories that contain a dot (specifically for Arches installed with the above package managers) while ensuring that dotfiles, such as macOS' .DS_Store, are ignored.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
