### PR TITLE
Restore custom error views (but return JSON where desired) #11722

### DIFF
--- a/arches/app/templates/errors/400.htm
+++ b/arches/app/templates/errors/400.htm
@@ -16,10 +16,10 @@
 	<!-- CONTENT -->
 	<!--===================================================-->
 	<div class="cls-content">
-	    <h1 class="error-code text-mint">{% trans "Oops!" %}</h1>
-	    <p class="h3 text-uppercase">{% trans "Page Not Found!" %}</p>
+	    <h1 class="error-code text-primary">{% trans "Oops!" %}</h1>
+	    <p class="h3 text-uppercase">{% trans "Bad Request" %}</p>
 	    <div class="pad-btm">
-			{% trans "Sorry, but the page you are looking for has not been found on our server." %}
+	        {% trans "Something went wrong and we couldn't process your request." %}"
 	    </div>
 
 	    <hr class="new-section-sm bord-no">

--- a/arches/app/templates/errors/403.htm
+++ b/arches/app/templates/errors/403.htm
@@ -16,10 +16,10 @@
 	<!-- CONTENT -->
 	<!--===================================================-->
 	<div class="cls-content">
-	    <h1 class="error-code text-mint">{% trans "Oops!" %}</h1>
-	    <p class="h3 text-uppercase">{% trans "Page Not Found!" %}</p>
+	    <h1 class="error-code text-primary">{% trans "Oops!" %}</h1>
+	    <p class="h3 text-uppercase">{% trans "Access Denied" %}</p>
 	    <div class="pad-btm">
-			{% trans "Sorry, but the page you are looking for has not been found on our server." %}
+	        {% trans "You don't have permission to access this resource." %}"
 	    </div>
 
 	    <hr class="new-section-sm bord-no">

--- a/arches/app/templates/errors/500.htm
+++ b/arches/app/templates/errors/500.htm
@@ -15,7 +15,7 @@
 
 	<!-- CONTENT -->
 	<!--===================================================-->
-	<div class="cls-content" >
+	<div class="cls-content">
 	    <h1 class="error-code text-primary">{% trans "Oops!" %}</h1>
 	    <p class="h3 text-uppercase">{% trans "Internal Server Error!" %}</p>
 	    <div class="pad-btm">

--- a/arches/app/utils/request.py
+++ b/arches/app/utils/request.py
@@ -7,7 +7,7 @@ def looks_like_api_call(request):
         return True
     if not request.resolver_match:
         return False
-    if "api." in request.resolver_match.func.__module__:
+    if ".api." in request.resolver_match.func.__module__:
         return True
     if (
         request.resolver_match.func.__module__

--- a/arches/app/utils/request.py
+++ b/arches/app/utils/request.py
@@ -1,0 +1,17 @@
+def looks_like_api_call(request):
+    known_api_paths_without_api_signposting = [
+        # Until these are renamed for consistency, just list them.
+        "arches.app.views.workflow_history",
+    ]
+    if "/api/" in request.path:
+        return True
+    if not request.resolver_match:
+        return False
+    if "api." in request.resolver_match.func.__module__:
+        return True
+    if (
+        request.resolver_match.func.__module__
+        in known_api_paths_without_api_signposting
+    ):
+        return True
+    return False

--- a/arches/install/arches-templates/project_name/urls.py-tpl
+++ b/arches/install/arches-templates/project_name/urls.py-tpl
@@ -7,6 +7,11 @@ urlpatterns = [
     # project-level urls
 ]
 
+handler400 = "arches.app.views.main.custom_400"
+handler403 = "arches.app.views.main.custom_403"
+handler404 = "arches.app.views.main.custom_404"
+handler500 = "arches.app.views.main.custom_500"
+
 # Ensure Arches core urls are superseded by project-level urls
 urlpatterns.append(path('', include('arches.urls')))
 

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -781,8 +781,12 @@ urlpatterns = [
         api.SpatialView.as_view(),
         name="spatialview_api",
     ),
-    re_path("^api", api.API404.as_view(), name="api_404"),
 ]
+
+handler400 = "arches.app.views.main.custom_400"
+handler403 = "arches.app.views.main.custom_403"
+handler404 = "arches.app.views.main.custom_404"
+handler500 = "arches.app.views.main.custom_500"
 
 # This must be included in core to keep webpack happy, but cannot be appended when running a project.
 # See https://github.com/archesproject/arches/pull/10754

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -31,6 +31,7 @@ Arches 8.0.0 Release Notes
 - Add system dark mode detection for Vue apps [#11624](https://github.com/archesproject/arches/issues/11624)
 - Make number datatype node values searchable in the main search [#11619](https://github.com/archesproject/arches/issues/11619)
 - Prevent navigation to a new browser tab when clicking Manage link in index.htm [#11635](https://github.com/archesproject/arches/issues/11635)
+- Mitigate the tendency of JSON APIs to respond with HTML under error conditions [#11722](https://github.com/archesproject/arches/pull/11722)
 - Add support for tile sort order to the bulk data manager [#11638](https://github.com/archesproject/arches/pull/11638)
 - Fix issue that produced an error when cycling between the dropdown options in Advanced search [#11442](https://github.com/archesproject/arches/issues/11442)
 
@@ -129,6 +130,15 @@ JavaScript:
 1. Then run:
     ```
     python manage.py updateproject
+    ```
+
+1. Update your urls.py to include generic error handlers:
+
+    ```
+    handler400 = "arches.app.views.main.custom_400"
+    handler403 = "arches.app.views.main.custom_403"
+    handler404 = "arches.app.views.main.custom_404"
+    handler500 = "arches.app.views.main.custom_500"
     ```
 
 3. Create editable_future_graphs for your Resource Models using the command `python manage.py graph create_editable_future_graphs`. This will publish new versions of each Graph.

--- a/tests/views/api/test_resources.py
+++ b/tests/views/api/test_resources.py
@@ -26,7 +26,7 @@ from tests.base_test import ArchesTestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
 from django.test.client import RequestFactory
-from django.test.utils import captured_stdout
+from django.test.utils import captured_stdout, override_settings
 from unittest.mock import patch, MagicMock
 
 from arches.app.views.api import APIBase
@@ -120,11 +120,14 @@ class ResourceAPITests(ArchesTestCase):
             response = view(request)
         self.assertEqual(request.GET.get("ver"), "2.1")
 
-    def test_api_404(self):
+    @override_settings(DEBUG=False)
+    def test_api_404_returns_json(self):
         with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(reverse("api_404"))
-        self.assertEqual(
-            set(json.loads(response.content)), {"message", "status", "success", "title"}
+            response = self.client.get("/api/doesnotexist")
+        self.assertContains(
+            response,
+            "Not Found",
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_api_resources_archesjson(self):

--- a/tests/views/workflow_tests.py
+++ b/tests/views/workflow_tests.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+from http import HTTPStatus
 
 from django.contrib.auth.models import Group, User
 from django.urls import reverse
@@ -83,8 +84,9 @@ class WorkflowHistoryTests(ArchesTestCase):
                 )
             )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertIn(b"Forbidden", response.content)
+        self.assertContains(
+            response, "Permission Denied", status_code=HTTPStatus.FORBIDDEN
+        )
 
         self.client.force_login(self.admin)
         response = self.client.get(
@@ -93,8 +95,7 @@ class WorkflowHistoryTests(ArchesTestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b"sample name", response.content)
+        self.assertContains(response, "sample name", status_code=HTTPStatus.OK)
 
     def test_post_workflow_history(self):
         """Partial updates of componentdata and stepdata are allowed."""
@@ -148,8 +149,9 @@ class WorkflowHistoryTests(ArchesTestCase):
                 content_type="application/json",
             )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertIn(b"Forbidden", response.content)
+        self.assertContains(
+            response, "Permission Denied", status_code=HTTPStatus.FORBIDDEN
+        )
 
         self.client.force_login(self.admin)
         response = self.client.post(


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This PR addresses two issues:
- Arches used to have generic error views, but they were removed from the core URL config in [f8a5045](https://github.com/archesproject/arches/commit/f8a50459340cc9ff98b12b4b792685e070a30a56). This PR restores them to the config and models in the release notes how to make sure your project uses them.
- Not every view that is supposed to return JSON returns JSON in every single error circumstance. One scenario with a view decorator is described in #11722, but there is no bulletproof way to catch every error without leveraging Django's built-in error views. If we do this, then front-end parsers that expect to call `.json()` on a response body won't throw when they get an HTML response from the generic (or customized) error view.

### Issues Solved
Closes #11722

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute