### PR TITLE
Add CSS to overwrite and prevent extra scroll bar caused by CKEditor screen reader

### DIFF
--- a/arches/app/media/css/arches.scss
+++ b/arches/app/media/css/arches.scss
@@ -12914,3 +12914,7 @@ table.csv-mapping-table td {
         width: auto;
     }
 }
+
+.cke_screen_reader_only {
+    position: fixed !important;
+}

--- a/releases/7.6.7.md
+++ b/releases/7.6.7.md
@@ -5,6 +5,7 @@
 -   ANALYSIS_COORDINATE_SYSTEM_SRID string compatibility [#11714](https://github.com/archesproject/arches/issues/11714)
 -   Removes need for required cantaloupe directory [#10289](https://github.com/archesproject/arches/issues/10289)
 -   Fixes frontend build for systems using poetry or uv [#11764](https://github.com/archesproject/arches/issues/11764)
+-   Fixes accessibility issues from extra scroll bar caused by CKEditor screen reader css class [#11713](https://github.com/archesproject/arches/issues/11713)
 
 ### Dependency changes:
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
CKEditor includes a CSS class called `cke_screen_reader_only` which adds a component with 1px height and width.  In Arches, this appears with an extra, unnecessary scrollbar on the right side of the page, moving only one pixel.

This fix overwrites the position of the CSS class from `absolute` to `fixed`, which prevents the scroll bar from showing.  

@phudson-he - I tested this addition with the NVDA screen reader and it still read out the rich-text widget as intended, but please could you double check it works with this addition?
It's also possible that we change the height/width values rather than the position?  Though I think they both solve the issue.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11713 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    | x | x |


#### Ticket Background
*   Sponsored by: Knowledge Integration<!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @CWDamm-Kint + @SDScandrettKint  <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @CWDamm-Kint + @SDScandrettKint  <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @CWDamm-Kint + @SDScandrettKint <!--- Who designed this new feature-->

### Further comments

Note, I have targeted 7.6.x, as this is a bug to Arches version 7 and a regression as it was not present in version 6.