### PR TITLE
Transform tile trigger exception to ValidationError #11803

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1600,7 +1600,7 @@ class TileModel(models.Model):  # Tile
             self.tileid = uuid.uuid4()
 
     def __repr__(self):
-        return f"<{self.nodegroup_alias} ({self.pk})>"
+        return f"<{self.find_nodegroup_alias()} ({self.pk})>"
 
     def __str__(self):
         return repr(self)
@@ -1609,8 +1609,7 @@ class TileModel(models.Model):  # Tile
     def nodegroup(self):
         return NodeGroup.objects.filter(pk=self.nodegroup_id).first()
 
-    @property
-    def nodegroup_alias(self):
+    def find_nodegroup_alias(self):
         return (
             NodeGroup.objects.filter(pk=self.nodegroup_id)
             .values_list("grouping_node__alias", flat=True)
@@ -1635,7 +1634,7 @@ class TileModel(models.Model):  # Tile
             add_to_update_fields(kwargs, "tileid")
 
         # Query for this first instead of during a transaction rollback.
-        nodegroup_alias = self.nodegroup_alias
+        nodegroup_alias = self.find_nodegroup_alias()
         try:
             super(TileModel, self).save(**kwargs)  # Call the "real" save() method.
         except ProgrammingError as error:
@@ -1649,9 +1648,7 @@ class TileModel(models.Model):  # Tile
         ).aggregate(Max("sortorder"))["sortorder__max"]
         self.sortorder = sortorder_max + 1 if sortorder_max is not None else 0
 
-    def serialize(
-        self, fields=None, exclude=["nodegroup", "nodegroup_alias"], **kwargs
-    ):
+    def serialize(self, fields=None, exclude=["nodegroup"], **kwargs):
         return JSONSerializer().handle_model(
             self, fields=fields, exclude=exclude, **kwargs
         )

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1600,10 +1600,7 @@ class TileModel(models.Model):  # Tile
             self.tileid = uuid.uuid4()
 
     def __repr__(self):
-        alias = None
-        if self.nodegroup and self.nodegroup.grouping_node:
-            alias = self.nodegroup.grouping_node.alias
-        return f"<{alias} ({self.pk})>"
+        return f"<{self.nodegroup_alias} ({self.pk})>"
 
     def __str__(self):
         return repr(self)

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1659,7 +1659,7 @@ class TileModel(models.Model):  # Tile
             self, fields=fields, exclude=exclude, **kwargs
         )
 
-    def _handle_programming_error(error, nodegroup_alias=None):
+    def _handle_programming_error(self, error, nodegroup_alias=None):
         from arches.app.models.tile import TileCardinalityError
 
         if error.args and "excess_tiles" in error.args[0]:

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1663,7 +1663,7 @@ class TileModel(models.Model):  # Tile
         from arches.app.models.tile import TileCardinalityError
 
         if error.args and "excess_tiles" in error.args[0]:
-            message = _("Tile Cardinality Error")
+            message = error.args[0].split("\nCONTEXT")[0]
             if nodegroup_alias:
                 message = {nodegroup_alias: message}
             raise TileCardinalityError(message) from error

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -28,7 +28,7 @@ from django.contrib.auth.models import Group, User
 from django.contrib.gis.db import models
 from django.core import checks
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import connection
+from django.db import ProgrammingError, connection
 from django.db.models import JSONField
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
@@ -1612,6 +1612,14 @@ class TileModel(models.Model):  # Tile
     def nodegroup(self):
         return NodeGroup.objects.filter(pk=self.nodegroup_id).first()
 
+    @property
+    def nodegroup_alias(self):
+        return (
+            NodeGroup.objects.filter(pk=self.nodegroup_id)
+            .values_list("grouping_node__alias", flat=True)
+            .first()
+        )
+
     def is_fully_provisional(self):
         return bool(self.provisionaledits and not any(self.data.values()))
 
@@ -1628,7 +1636,14 @@ class TileModel(models.Model):  # Tile
         if not self.tileid:
             self.tileid = uuid.uuid4()
             add_to_update_fields(kwargs, "tileid")
-        super(TileModel, self).save(**kwargs)  # Call the "real" save() method.
+
+        # Query for this first instead of during a transaction rollback.
+        nodegroup_alias = self.nodegroup_alias
+        try:
+            super(TileModel, self).save(**kwargs)  # Call the "real" save() method.
+        except ProgrammingError as error:
+            self._handle_programming_error(error, nodegroup_alias)
+            raise
 
     def set_next_sort_order(self):
         sortorder_max = self.__class__.objects.filter(
@@ -1637,10 +1652,21 @@ class TileModel(models.Model):  # Tile
         ).aggregate(Max("sortorder"))["sortorder__max"]
         self.sortorder = sortorder_max + 1 if sortorder_max is not None else 0
 
-    def serialize(self, fields=None, exclude=["nodegroup"], **kwargs):
+    def serialize(
+        self, fields=None, exclude=["nodegroup", "nodegroup_alias"], **kwargs
+    ):
         return JSONSerializer().handle_model(
             self, fields=fields, exclude=exclude, **kwargs
         )
+
+    def _handle_programming_error(error, nodegroup_alias=None):
+        from arches.app.models.tile import TileCardinalityError
+
+        if error.args and "excess_tiles" in error.args[0]:
+            message = _("Tile Cardinality Error")
+            if nodegroup_alias:
+                message = {nodegroup_alias: message}
+            raise TileCardinalityError(message) from error
 
 
 class Value(models.Model):

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -884,6 +884,8 @@ class TileValidationError(ValidationError):
         self.code = code
 
     def __str__(self):
+        if hasattr(self, "messages"):
+            return repr(self.messages)
         return repr(self.message)
 
 

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -877,10 +877,10 @@ class Tile(models.TileModel):
         return ret
 
 
-class TileValidationError(Exception):
+class TileValidationError(ValidationError):
     def __init__(self, message, code=None):
+        super().__init__(message)
         self.title = _("Tile Validation Error")
-        self.message = message
         self.code = code
 
     def __str__(self):
@@ -889,5 +889,5 @@ class TileValidationError(Exception):
 
 class TileCardinalityError(TileValidationError):
     def __init__(self, message, code=None):
-        super(TileCardinalityError, self).__init__(message, code)
+        super().__init__(message, code)
         self.title = _("Tile Cardinality Error")

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -77,6 +77,8 @@ class TileData(View):
             message = type(e).__name__
             if hasattr(e, "message") and e.message:
                 message += ": {0}".format(e.message)
+            if hasattr(e, "messages") and e.messages:
+                message += ": {0}".format(e.messages[0])
         else:
             message = str(e)
         logger.error(

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -77,7 +77,7 @@ class TileData(View):
             message = type(e).__name__
             if hasattr(e, "message") and e.message:
                 message += ": {0}".format(e.message)
-            if hasattr(e, "messages") and e.messages:
+            elif hasattr(e, "messages") and e.messages:
                 message += ": {0}".format(e.messages[0])
         else:
             message = str(e)

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -21,6 +21,7 @@ import json as jsonparser
 import logging
 import traceback
 import uuid
+from http import HTTPStatus
 import arches.app.utils.zip as arches_zip
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models import models
@@ -90,8 +91,16 @@ class TileData(View):
             )
         )
 
+        if isinstance(e, ValidationError):
+            status = HTTPStatus.BAD_REQUEST
+        else:
+            status = HTTPStatus.INTERNAL_SERVER_ERROR
+
         return JSONErrorResponse(
-            _(title), _(str(message)), {"message": message, "title": title}
+            _(title),
+            _(str(message)),
+            {"message": message, "title": title},
+            status=status,
         )
 
     def post(self, request):

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -29,7 +29,7 @@ Arches 8.0.0 Release Notes
 - Make failed login alert message dismissible [#11767](https://github.com/archesproject/arches/issues/11767)
 - Concepts API no longer responds with empty body for error conditions [#11519](https://github.com/archesproject/arches/issues/11519)
 - Removes sample index from new projects, updates test coverage behavior [#11591](https://github.com/archesproject/arches/issues/11519)
-- Treat tile cardinality violations like validation errors [#11803](https://github.com/archesproject/arches/issues/11803)
+- Fix HTTP return code for tile validation and cardinality errors [#11803](https://github.com/archesproject/arches/issues/11803)
 - Add system dark mode detection for Vue apps [#11624](https://github.com/archesproject/arches/issues/11624)
 - Make number datatype node values searchable in the main search [#11619](https://github.com/archesproject/arches/issues/11619)
 - Prevent navigation to a new browser tab when clicking Manage link in index.htm [#11635](https://github.com/archesproject/arches/issues/11635)

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -29,6 +29,7 @@ Arches 8.0.0 Release Notes
 - Make failed login alert message dismissible [#11767](https://github.com/archesproject/arches/issues/11767)
 - Concepts API no longer responds with empty body for error conditions [#11519](https://github.com/archesproject/arches/issues/11519)
 - Removes sample index from new projects, updates test coverage behavior [#11591](https://github.com/archesproject/arches/issues/11519)
+- Treat tile cardinality violations like validation errors [#11803](https://github.com/archesproject/arches/issues/11803)
 - Add system dark mode detection for Vue apps [#11624](https://github.com/archesproject/arches/issues/11624)
 - Make number datatype node values searchable in the main search [#11619](https://github.com/archesproject/arches/issues/11619)
 - Prevent navigation to a new browser tab when clicking Manage link in index.htm [#11635](https://github.com/archesproject/arches/issues/11635)

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -106,6 +106,9 @@ JavaScript:
     - From TileModel, traversing a child tile: `tilemodel` -> `child`
     - From TileModel, collecting child tiles: `tilemodel_set` -> `children`
 
+- Tile cardinality errors raised when saving `TileModel` instances now raise `TileCardinalityError` rather than `ProgrammingError`.
+
+- `TileValidationError` and `TileCardinalityError` now subclass `django.core.exceptions.ValidationError`.
 
 ### Upgrading Arches
 

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -21,10 +21,9 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer
 from tests.base_test import ArchesTestCase
 from django.db import connection
 from django.contrib.auth.models import User
-from django.db.utils import ProgrammingError
 from django.http import HttpRequest
 from arches.app.models.graph import Graph
-from arches.app.models.tile import Tile, TileValidationError
+from arches.app.models.tile import Tile, TileCardinalityError, TileValidationError
 from arches.app.models.resource import Resource
 from arches.app.models.models import (
     CardModel,
@@ -387,7 +386,7 @@ class TileTests(ArchesTestCase):
     def test_tile_cardinality(self):
         """
         Tests that the tile is not saved if the cardinality is violated
-        by testin to save a tile with the same values as existing one
+        by testing to save a tile with the same values as an existing one.
 
         """
 
@@ -421,7 +420,7 @@ class TileTests(ArchesTestCase):
         }
         second_tile = Tile(second_json)
 
-        with self.assertRaises(ProgrammingError):
+        with self.assertRaises(TileCardinalityError):
             second_tile.save(index=False, request=request)
 
     def test_apply_provisional_edit(self):


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
**Before**
When working with `TileModel` instances, you would have to catch `ProgrammingError` and inspect the string returned from the database to tell whether or not it was a tile cardinality error or something else.

**Now**
Tile cardinality errors can be handled like other ValidationErrors from Django so that a user of the TileModel doesn't have the burden of parsing raw programming errors.

### Issues Solved
Closes #11803

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

### Further comments
The bulk loader doesn't use the `TileModel` to save tiles, so it continues to catch a raw `ProgrammingError`.