### PR TITLE
Let TypeError propagate from tile functions #11805

### DIFF
--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -795,30 +795,18 @@ class Tile(models.TileModel):
         context -- string e.g. "copy" indicating conditions under which a resource is saved and how functions should behave.
         """
 
-        try:
-            for function in self._getFunctionClassInstances():
-                try:
-                    function.save(self, request, context=context)
-                except NotImplementedError:
-                    pass
-        except TypeError as e:
-            logger.warning(
-                _("No associated functions or other TypeError raised by a function")
-            )
-            logger.warning(e)
+        for function in self._getFunctionClassInstances():
+            try:
+                function.save(self, request, context=context)
+            except NotImplementedError:
+                pass
 
     def __preDelete(self, request=None):
-        try:
-            for function in self._getFunctionClassInstances():
-                try:
-                    function.delete(self, request)
-                except NotImplementedError:
-                    pass
-        except TypeError as e:
-            logger.warning(
-                _("No associated functions or other TypeError raised by a function")
-            )
-            logger.warning(e)
+        for function in self._getFunctionClassInstances():
+            try:
+                function.delete(self, request)
+            except NotImplementedError:
+                pass
 
     def __postSave(self, request=None, context=None):
         """
@@ -827,17 +815,11 @@ class Tile(models.TileModel):
         context -- string e.g. "copy" indicating conditions under which a resource is saved and how functions should behave.
         """
 
-        try:
-            for function in self._getFunctionClassInstances():
-                try:
-                    function.post_save(self, request, context=context)
-                except NotImplementedError:
-                    pass
-        except TypeError as e:
-            logger.warning(
-                _("No associated functions or other TypeError raised by a function")
-            )
-            logger.warning(e)
+        for function in self._getFunctionClassInstances():
+            try:
+                function.post_save(self, request, context=context)
+            except NotImplementedError:
+                pass
 
     def _getFunctionClassInstances(self):
         ret = []

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -26,6 +26,7 @@ Arches 8.0.0 Release Notes
 - Support more expressive plugin URLs [#11320](https://github.com/archesproject/arches/issues/11320)
 - Make node aliases not nullable [#10437](https://github.com/archesproject/arches/issues/10437)
 - Add alt text on image placeholder [#10455](https://github.com/archesproject/arches/issues/10455)
+- Tile functions no longer catch TypeError [#11805](https://github.com/archesproject/arches/issues/11805)
 - Make failed login alert message dismissible [#11767](https://github.com/archesproject/arches/issues/11767)
 - Concepts API no longer responds with empty body for error conditions [#11519](https://github.com/archesproject/arches/issues/11519)
 - Removes sample index from new projects, updates test coverage behavior [#11591](https://github.com/archesproject/arches/issues/11519)


### PR DESCRIPTION
Catching this could cause other functions to not run by breaking out of the loop.
Closes #11805

:wave: @aj-he you might be interested as I see in #8472 you elevated the info log to a warning. A hard fail would be nice here, no?