### PR TITLE
Rearrange map overlays in the search front-end

### DIFF
--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -531,7 +531,9 @@ define([
                     } else if (direction == "down") {
                         newIndex++
                     }
-                    self.overlays.splice(newIndex, 0, self.overlays.splice(index, 1)[0]);
+                    if (newIndex != -1 && newIndex != self.overlays().length) {
+                        self.overlays.splice(newIndex, 0, self.overlays.splice(index, 1)[0]);
+                    }
                 }
             }
 

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -7,7 +7,8 @@ define([
     'utils/map-popup-provider',
     'utils/map-configurator',
     'utils/aria',
-    'templates/views/components/map-popup.htm'
+    'templates/views/components/map-popup.htm',
+    'bindings/sortable'
 ], function($, _, arches, ko, koMapping, mapPopupProvider, mapConfigurator, ariaUtils) {
     const viewModel = function(params) {
         var self = this;
@@ -477,6 +478,34 @@ define([
                     self.popup = undefined;
                 });
             });
+        };
+
+        this.beforeMove = function(e) {
+            e.cancelDrop = (e.sourceParent!==e.targetParent);
+        },
+
+        this.reorderOverlays = function(e) {
+            const map_order = ko.observableArray(e.sourceParent())
+            var new_order = []
+            for (let i = 0; i < map_order().length; i++) {
+                const element = map_order()[i];
+                if (!(element.is_resource_layer)) {
+                    // filter out the resource layers for now
+                    new_order.push({
+                        "maplayerid": element.maplayerid,
+                        "sortorder": i,
+                        "is_resource_layer": element.is_resource_layer,
+                    })
+                }
+            };
+
+            $.ajax({
+                type: "PUT",
+                data: JSON.stringify({
+                    map_order: new_order
+                }),
+                url: arches.urls.reorder_overlays,
+            })
         };
 
         this.setupMap = function(map) {

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -8,8 +8,7 @@ define([
     'utils/map-configurator',
     'utils/aria',
     'templates/views/components/map-popup.htm',
-    'bindings/sortable',
-    'bindings/key-events-click'
+    'bindings/sortable'
 ], function($, _, arches, ko, koMapping, mapPopupProvider, mapConfigurator, ariaUtils) {
     const viewModel = function(params) {
         var self = this;

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -8,7 +8,8 @@ define([
     'utils/map-configurator',
     'utils/aria',
     'templates/views/components/map-popup.htm',
-    'bindings/sortable'
+    'bindings/sortable',
+    'bindings/key-events-click'
 ], function($, _, arches, ko, koMapping, mapPopupProvider, mapConfigurator, ariaUtils) {
     const viewModel = function(params) {
         var self = this;
@@ -480,33 +481,75 @@ define([
             });
         };
 
-        this.beforeMove = function(e) {
-            e.cancelDrop = (e.sourceParent!==e.targetParent);
-        },
-
-        this.reorderOverlays = function(e) {
-            const map_order = ko.observableArray(e.sourceParent())
-            var new_order = []
-            for (let i = 0; i < map_order().length; i++) {
-                const element = map_order()[i];
+        this.createNewOverlayOrder = function (currentOrder) {
+            var newOrder = []
+            for (let i = 0; i < currentOrder().length; i++) {
+                const element = currentOrder()[i];
                 if (!(element.is_resource_layer)) {
                     // filter out the resource layers for now
-                    new_order.push({
+                    newOrder.push({
                         "maplayerid": element.maplayerid,
                         "sortorder": i,
                         "is_resource_layer": element.is_resource_layer,
                     })
                 }
-            };
-
-            $.ajax({
-                type: "PUT",
-                data: JSON.stringify({
-                    map_order: new_order
-                }),
-                url: arches.urls.reorder_overlays,
-            })
+            }
+            return newOrder;
         };
+
+        this.sendNewOverlayOrder = function(newOrder) {
+            if (newOrder) {
+                $.ajax({
+                    type: "PUT",
+                    data: JSON.stringify({
+                        map_order: newOrder
+                    }),
+                    url: arches.urls.reorder_overlays,
+                })
+            }
+        };
+
+        this.beforeMove = function(e) {
+            e.cancelDrop = (e.sourceParent!==e.targetParent);
+        };
+
+        this.reorderOverlays = function(e) {
+            const mapOrder = ko.observableArray(e.sourceParent());
+            const newOrder = self.createNewOverlayOrder(mapOrder);
+            self.sendNewOverlayOrder(newOrder)
+        };
+
+        this.keyDownHandler = function (context, e) {
+            // reorder list in the front-end by only using keyboard inputs
+            var li = $(this);
+            var moveOverlays = function (direction) {
+                if (self.overlays().includes(li[0])) {
+                    var index = self.overlays().indexOf(li[0]);
+                    var newIndex = index
+                    if (direction == "up") {
+                        newIndex--
+                    } else if (direction == "down") {
+                        newIndex++
+                    }
+                    self.overlays.splice(newIndex, 0, self.overlays.splice(index, 1)[0]);
+                }
+            }
+
+            if (e.ctrlKey) {
+                switch (e.which) {
+                    case 38:
+                        moveOverlays("up");
+                        newOrder = self.createNewOverlayOrder(self.overlays)
+                        self.sendNewOverlayOrder(newOrder)
+                        break;
+                    case 40:
+                        moveOverlays("down");
+                        newOrder = self.createNewOverlayOrder(self.overlays)
+                        self.sendNewOverlayOrder(newOrder)
+                        break;
+                }
+            }
+        }
 
         this.setupMap = function(map) {
             map.on('load', function() {

--- a/arches/app/media/js/viewmodels/map.js
+++ b/arches/app/media/js/viewmodels/map.js
@@ -532,7 +532,9 @@ define([
                         newIndex++
                     }
                     if (newIndex != -1 && newIndex != self.overlays().length) {
-                        self.overlays.splice(newIndex, 0, self.overlays.splice(index, 1)[0]);
+                        var newArr = self.overlays()
+                        newArr.splice(newIndex, 0, newArr.splice(index, 1)[0]);
+                        self.overlays(newArr);
                     }
                 }
             }

--- a/arches/app/templates/arches_urls.htm
+++ b/arches/app/templates/arches_urls.htm
@@ -58,6 +58,7 @@
     tile="{% url 'tile' %}"
     reorder_tiles="{% url 'reorder_tiles' %}"
     reorder_nodes="{% url 'reorder_nodes' %}"
+    reorder_overlays="{% url 'reorder_overlays' %}"
     delete_provisional_tile="{% url 'delete_provisional_tile' %}"
     edit_history="{% url 'edit_history' %}"
     tile_history="{% url 'tile_history' %}"

--- a/arches/app/templates/views/components/map.htm
+++ b/arches/app/templates/views/components/map.htm
@@ -94,7 +94,10 @@
                 <div class="workbench-card-sidepanel-border"></div>
                 <div class="workbench-card-sidepanel-body">
                 <div class="overlays-listing-container" data-bind="sortable: {
-                    data: overlays
+                    data: overlays,
+                    as: 'overlay',
+                    beforeMove: beforeMove,
+                    afterMove: reorderOverlays
                 }">
                     <div class="overlay-listing" data-bind="css: {'active-overlay': onMap}">
                         <div class="overlay-name" tabindex="0" role="switch" data-bind="

--- a/arches/app/templates/views/components/map.htm
+++ b/arches/app/templates/views/components/map.htm
@@ -99,7 +99,7 @@
                     beforeMove: beforeMove,
                     afterMove: reorderOverlays
                 }">
-                    <div class="overlay-listing" data-bind="css: {'active-overlay': onMap}">
+                    <div class="overlay-listing" tabindex="0" role="option" data-bind="css: {'active-overlay': onMap}, event: {keyup: $parent.keyDownHandler}">
                         <div class="overlay-name" tabindex="0" role="switch" data-bind="
                             click: function() {
                                 onMap(!onMap());

--- a/arches/app/views/map.py
+++ b/arches/app/views/map.py
@@ -163,3 +163,21 @@ class TileserverProxyView(ProxyView):
         if settings.TILESERVER_URL is None:
             raise Http404(_("Tileserver proxy not configured"))
         return headers
+
+
+@method_decorator(group_required("Resource Editor"), name="dispatch")
+class OverlayOrderView(BaseManagerView):
+    def put(self, request):
+        json = request.body
+        data = JSONDeserializer().deserialize(json)
+        map_layers = models.MapLayer.objects.all()
+
+        for layer in data["map_order"]:
+            try:
+                db_layer = map_layers.get(maplayerid=layer["maplayerid"])
+                db_layer.sortorder = layer["sortorder"]
+                db_layer.save()
+            except models.MapLayer.DoesNotExist:
+                pass  # will be resource overlay
+
+        return JSONResponse(data)

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -781,6 +781,11 @@ urlpatterns = [
         api.SpatialView.as_view(),
         name="spatialview_api",
     ),
+    re_path(
+        r"^reorder_overlays",
+        map.OverlayOrderView.as_view(),
+        name="reorder_overlays",
+    ),
 ]
 
 handler400 = "arches.app.views.main.custom_400"


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
A remake of https://github.com/archesproject/arches/pull/9602 for V8 using the map_layer SortOrder field.  Also adds the ability to reorder map overlays using keyboard shortcuts (holding Ctrl + up/down arrow key).

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
The bullet point "Ordering can be achieved by drag and drop." from #9309

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |     x    |    x      |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Knowledge Integration<!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @SDScandrettKint  <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @SDScandrettKint  <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @SDScandrettKint  <!--- Who designed this new feature-->

### Further comments

Demonstration of moving overlays using keyboard control:

https://github.com/user-attachments/assets/c7c2b575-3382-4dd0-8a8b-6b7225a846b1

Of course this feature uses the SortOrder field from MapLayers, meaning that moving the resource overlays does nothing because they come from the Node, which doesn't have a sortorder for the layer.  The original PR https://github.com/archesproject/arches/pull/9602 added a layersortorder to both map_layers and the resource layers (from node), which meant that both could be sorted in the same.  Are there plans to move the resource layers into MapLayers?  

Final question, at the moment this only affects overlays, should we extend the sorting to basemaps too?