### PR TITLE
Fix missing case in check_cache_backend_for_production()

### DIFF
--- a/arches/apps.py
+++ b/arches/apps.py
@@ -32,17 +32,22 @@ if settings.FILE_TYPE_CHECKING not in (None, "lenient", "strict"):
 
 
 ### SYSTEM CHECKS ###
+supported_by_django_ratelimit = (
+    "django.core.cache.backends.memcached.PyLibMCCache",
+    "django.core.cache.backends.memcached.PyMemcacheCache",
+    "django.core.cache.backends.redis.RedisCache",
+)
+
+
 @register(Tags.security)
 def check_cache_backend_for_production(app_configs, **kwargs):
     errors = []
     your_cache = settings.CACHES["default"]["BACKEND"]
-    if (
-        not settings.DEBUG
-        and your_cache == "django.core.cache.backends.dummy.DummyCache"
-    ):
+    if not settings.DEBUG and your_cache not in supported_by_django_ratelimit:
         errors.append(
             Error(
-                "Using dummy cache in production",
+                "Cache backend does not support rate-limiting",
+                hint=f"Your cache: {your_cache}\n\tSupported caches: {supported_by_django_ratelimit}",
                 obj=settings.APP_NAME,
                 id="arches.E001",
             )
@@ -53,11 +58,6 @@ def check_cache_backend_for_production(app_configs, **kwargs):
 @register(Tags.security)
 def check_cache_backend(app_configs, **kwargs):
     errors = []
-    supported_by_django_ratelimit = (
-        "django.core.cache.backends.memcached.PyLibMCCache",
-        "django.core.cache.backends.memcached.PyMemcacheCache",
-        "django.core.cache.backends.redis.RedisCache",
-    )
     your_cache = settings.CACHES["default"]["BACKEND"]
     if your_cache not in supported_by_django_ratelimit:
         errors.append(


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, this check for inappropriate cache backends in production was only checking DummyCache, not LocMemCache.

### Further comments
This change makes `check_cache_backend_for_production` identical to `check_cache_backend` except for the warning vs. error severity (and the error id). This means they can be silenced separately with `SILENCED_SYSTEM_CHECKS`.

Discussed in standup 2025-02-25, for someone to see this, they'd have to be either:
- running `manage.py check` with their production settings as mentioned in the release notes
- running `runserver` in production, which is against best practice