### PR TITLE
Clean up logs from test_spatial_search_srid_not_number()

### DIFF
--- a/tests/search/spatial_search_tests.py
+++ b/tests/search/spatial_search_tests.py
@@ -180,5 +180,11 @@ class SpatialSearchTests(ArchesTestCase):
                 ],
             }
             query = {"map-filter": spatial_filter}
-            response_json = get_response_json(self.client, query=query)
+            with (
+                self.assertLogs(
+                    "arches.app.search.components.standard_search_view", level="ERROR"
+                ),
+                self.assertLogs("django.request", level="ERROR"),
+            ):
+                response_json = get_response_json(self.client, query=query)
             self.assertFalse(response_json["success"])


### PR DESCRIPTION
See verbose output from recent CI runs:

```
............................................................................................................................................................................................................................................2025-02-28 23:55:33,097 arches.app.search.components.standard_search_view ERROR    Settings ANALYSIS_COORDINATE_SYSTEM_SRID value is not a number.
Traceback (most recent call last):
  File "/home/runner/work/arches/arches/arches/app/search/components/map_filter.py", line 66, in _buffer
    int(settings.ANALYSIS_COORDINATE_SYSTEM_SRID)
ValueError: invalid literal for int() with base 10: 'Not an SRID'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/arches/arches/arches/app/search/components/standard_search_view.py", line 218, in handle_search_results_query
    search_filter.append_dsl(
  File "/home/runner/work/arches/arches/arches/app/search/components/map_filter.py", line 39, in append_dsl
    buffered_feature_geom = add_geoshape_query_to_search_query(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/arches/arches/arches/app/search/components/map_filter.py", line 104, in add_geoshape_query_to_search_query
    search_buffer = _buffer(feature_geom, int(buffer["width"]), buffer["unit"])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/arches/arches/arches/app/search/components/map_filter.py", line 68, in _buffer
    raise ValueError(
ValueError: Settings ANALYSIS_COORDINATE_SYSTEM_SRID value is not a number.
Internal Server Error: /search/resources
.............................................................................................................................
```

Until we decide to turn off logging in tests entirely (I think leaving logging on is okay for the moment, since we still have "interesting" failures sometimes), I've been silencing logging from expected failures like so. Open to better ideas of course.