### PR TITLE
Refresh graph model from database before unpublishing

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -2180,6 +2180,7 @@ class Graph(models.GraphModel):
         """
         Unassigns GraphXPublishedGraph id from Graph
         """
+        self.refresh_from_database()
         self.publication = None
         self.save(validate=False)
 

--- a/releases/7.6.7.md
+++ b/releases/7.6.7.md
@@ -6,6 +6,7 @@
 -   Removes need for required cantaloupe directory [#10289](https://github.com/archesproject/arches/issues/10289)
 -   Fixes frontend build for systems using poetry or uv [#11764](https://github.com/archesproject/arches/issues/11764)
 -   Fixes accessibility issues from extra scroll bar caused by CKEditor screen reader css class [#11713](https://github.com/archesproject/arches/issues/11713)
+-   Fixes the loss of map styling when graphs are unpublished [#11633](https://github.com/archesproject/arches/issues/11633)
 
 ### Dependency changes:
 

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -1222,3 +1222,63 @@ class GraphTests(ArchesTestCase):
         branch.publish(user=admin)
 
         graph.append_branch("http://www.nasa.gov/", graphid=self.NODE_NODETYPE_GRAPHID)
+
+    def test_geometry_config_persists_after_unpublishing_graph(self):
+
+        models.GraphModel.objects.create(
+            **{
+                "name": "Test Graph",
+                "graphid": "49a7eea8-2e2b-48e3-8b6e-650f25ec2954",
+                "isresource": True,
+            }
+        )
+
+        models.Node.objects.create(
+            **{
+                "name": "Top Node",
+                "graph_id": "49a7eea8-2e2b-48e3-8b6e-650f25ec2954",
+                "datatype": "semantic",
+                "istopnode": True,
+                "nodeid": "c1257d42-9275-40df-835e-5b99eee818fa",
+            }
+        )
+
+        models.Node.objects.create(
+            **{
+                "name": "GeoJSON Node",
+                "graph_id": "49a7eea8-2e2b-48e3-8b6e-650f25ec2954",
+                "datatype": "geojson-feature-collection",
+                "istopnode": False,
+                "config": {
+                    "fillColor": "rgba(130, 130, 130, 0.7)",
+                },
+                "nodeid": "88677159-dccf-4629-9210-f6a2a7463552",
+            }
+        )
+
+        models.Edge.objects.create(
+            **{
+                "domainnode_id": "c1257d42-9275-40df-835e-5b99eee818fa",
+                "edgeid": "16a8ec0d-7d8c-422a-aa33-fac1ac3a07b0",
+                "graph_id": "49a7eea8-2e2b-48e3-8b6e-650f25ec2954",
+                "rangenode_id": "88677159-dccf-4629-9210-f6a2a7463552",
+            }
+        )
+
+        graph = Graph.objects.get(pk="49a7eea8-2e2b-48e3-8b6e-650f25ec2954")
+        admin = User.objects.get(username="admin")
+        graph.publish(user=admin)
+
+        node = models.Node.objects.get(pk="88677159-dccf-4629-9210-f6a2a7463552")
+        node.config["fillColor"] = "rgba(200, 130, 130, 0.7)"
+        node.save()
+
+        graph.unpublish()
+
+        graph_from_db = Graph.objects.get(pk="49a7eea8-2e2b-48e3-8b6e-650f25ec2954")
+        self.assertEqual(
+            graph_from_db.nodes[
+                uuid.UUID("88677159-dccf-4629-9210-f6a2a7463552")
+            ].config["fillColor"],
+            "rgba(200, 130, 130, 0.7)",
+        )


### PR DESCRIPTION
### Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When styling is changed the map layer manager, this is saved to the relevant node config. 

When unpublishing a graph, the current instance of the graph is saved to the published_graph table. This graph instance, however, does not include the changes the user has made to the node configs, which are then lost as a result. 

Calling self.refresh_from_database ensures that the graph instance includes these changes before the graph gets saved, meaning that they persist when the graph is later republished. 

This change is targeted at 7.6 as the current bug loses users data. 

### Issues Solved
Closes #11633

### Checklist

-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [X] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
* Sponsored by: Knowledge Integration
* Found by: @CWDamm-Kint @SDScandrettKint
* Tested by: @CWDamm-Kint @SDScandrettKint
* Designed by: @CWDamm-Kint
