### PR TITLE
Allow arches apps to depend on either captcha version

### DIFF
--- a/arches/app/utils/forms.py
+++ b/arches/app/utils/forms.py
@@ -16,6 +16,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import logging
+
 from django import forms
 from django.contrib.auth.forms import (
     UserCreationForm,
@@ -27,8 +29,12 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from django.utils.translation import gettext as _
 from arches.app.models import models
-from django_recaptcha.fields import ReCaptchaField
-import logging
+
+# Allow arches apps to depend on django_recaptcha (Django 5.2) or captcha (Django 4.2)
+try:
+    from django_recaptcha.fields import ReCaptchaField
+except ImportError:
+    from captcha.fields import ReCaptchaField
 
 
 class ArchesUserCreationForm(UserCreationForm):


### PR DESCRIPTION
Follow-up to 4ae44e0.
This is blocking arches application development that intends to support both 7.6 & 8