### PR TITLE
Fix failure to restore graph from prior version #11838

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -2863,7 +2863,9 @@ class Graph(models.GraphModel):
             ]
         ).delete()
 
+        nodegroups_to_update_again = []
         for serialized_nodegroup in serialized_graph["nodegroups"]:
+            grouping_node_id = serialized_nodegroup["grouping_node_id"]
             for key, value in serialized_nodegroup.items():
                 try:
                     serialized_nodegroup[key] = uuid.UUID(value)
@@ -2871,7 +2873,11 @@ class Graph(models.GraphModel):
                     pass
 
             nodegroup = models.NodeGroup(**serialized_nodegroup)
+            # Delay the grouping node update until nodes have been recreated.
+            nodegroup.grouping_node = None
             nodegroup.save()
+            nodegroup.grouping_node_id = grouping_node_id
+            nodegroups_to_update_again.append(nodegroup)
 
         for serialized_node in serialized_graph["nodes"]:
             for key, value in serialized_node.items():
@@ -2885,6 +2891,10 @@ class Graph(models.GraphModel):
 
             node = models.Node(**serialized_node)
             node.save()
+
+        models.NodeGroup.objects.bulk_update(
+            nodegroups_to_update_again, ["grouping_node_id"]
+        )
 
         for serialized_edge in serialized_graph["edges"]:
             for key, value in serialized_edge.items():

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -17,6 +17,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import uuid
+from copy import deepcopy
+from unittest import mock
+
+from django.conf import settings
 
 from tests.base_test import ArchesTestCase
 from arches.app.models import models
@@ -1430,6 +1434,48 @@ class GraphTests(ArchesTestCase):
             models.Node.objects.get(pk=child_node_source_identifier)
 
         self.assertEqual(len(updated_source_graph.nodes), 2)
+
+    def test_restore_state_from_serialized_graph_after_node_deletion(self):
+        source_graph = Graph.new(name="TEST RESOURCE")
+        source_graph.append_branch(
+            "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as",
+            graphid=self.NODE_NODETYPE_GRAPHID,
+        )
+        source_graph.save()
+        self.assertEqual(len(source_graph.nodes), 3)
+
+        editable_future_graph = source_graph.create_editable_future_graph()
+        source_graph.publish()
+        original_publication = models.PublishedGraph.objects.get(
+            publication=source_graph.publication, language=settings.LANGUAGE_CODE
+        )
+
+        # Delete a node, and republish.
+        child_node = [node for node in editable_future_graph.nodes.values()][-1]
+        editable_future_graph.delete_node(child_node)
+        updated_source_graph = source_graph.update_from_editable_future_graph()
+        updated_source_graph.publish()
+        serialized_graph = original_publication.serialized_graph
+        updated_source_graph = Graph.objects.get(pk=source_graph.pk)
+
+        # Attempt to restore.
+        serialized_graph_copy = deepcopy(serialized_graph)
+        # This save fails in real life but not under test for some reason
+        # (need to set this up in a TransactionTestCase?). Workaround:
+        # mock save() to query for grouping node. Before fix, it would raise
+        # models.Node.DoesNotExist. Then try again.
+        try:
+            with mock.patch(
+                "arches.app.models.models.NodeGroup.save", lambda x: x.grouping_node
+            ):
+                updated_source_graph.restore_state_from_serialized_graph(
+                    {**serialized_graph_copy}
+                )
+        except models.NodeGroup.DoesNotExist:
+            pass
+        updated_source_graph.restore_state_from_serialized_graph(serialized_graph)
+
+        self.assertEqual(len(updated_source_graph.nodes), 3)
 
     def test_add_resource_instance_lifecycle(self):
         resource_instance_lifecycle = {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Nodegroups can't be created with a grouping_node until the grouping node exists. Unreleased bug.

### Issues Solved
Closes #11838

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch
