### PR TITLE
Remove references to related resource index re #8578

### DIFF
--- a/arches/app/search/mappings.py
+++ b/arches/app/search/mappings.py
@@ -26,7 +26,6 @@ from arches.app.search.es_mapping_modifier import EsMappingModifierFactory
 CONCEPTS_INDEX = "concepts"
 TERMS_INDEX = "terms"
 RESOURCES_INDEX = "resources"
-RESOURCE_RELATIONS_INDEX = "resource_relations"
 
 
 ANALYZER = {
@@ -326,46 +325,3 @@ def prepare_search_index(create=False):
 def delete_search_index():
     se = SearchEngineFactory().create()
     se.delete_index(index=RESOURCES_INDEX)
-
-
-def prepare_resource_relations_index(create=False):
-    """
-    Creates the settings and mappings in Elasticsearch to support related resources
-
-    """
-
-    index_settings = {
-        "mappings": {
-            "properties": {
-                "resourcexid": {"type": "keyword"},
-                "notes": {"type": "text"},
-                "relationshiptype": {"type": "keyword"},
-                "inverserelationshiptype": {"type": "keyword"},
-                "resourceinstanceidfrom": {"type": "keyword"},
-                "resourceinstancefrom_graphid": {"type": "keyword"},
-                "resourceinstanceidto": {"type": "keyword"},
-                "resourceinstanceto_graphid": {"type": "keyword"},
-                "created": {"type": "keyword"},
-                "modified": {"type": "keyword"},
-                "datestarted": {"type": "date"},
-                "dateended": {"type": "date"},
-                "tileid": {"type": "keyword"},
-                "nodeid": {"type": "keyword"},
-            }
-        }
-    }
-
-    if create:
-        se = SearchEngineFactory().create()
-        se.create_index(index=RESOURCE_RELATIONS_INDEX, **index_settings)
-
-    return index_settings
-
-
-# the RESOURCE_RELATIONS_INDEX is now deprecated
-# leaving this method here so users can still remove it
-# during a reindex operation
-# TODO: remove in Arches v8
-def delete_resource_relations_index():
-    se = SearchEngineFactory().create()
-    se.delete_index(index=RESOURCE_RELATIONS_INDEX)

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -30,7 +30,6 @@ from arches.app.search.mappings import (
     delete_concepts_index,
     prepare_search_index,
     delete_search_index,
-    delete_resource_relations_index,
 )
 import arches.app.utils.index_database as index_database_util
 
@@ -325,7 +324,6 @@ class Command(BaseCommand):
             delete_terms_index()
             delete_concepts_index()
             delete_search_index()
-            delete_resource_relations_index()
 
             # remove custom indexes
             for index in settings.ELASTICSEARCH_CUSTOM_INDEXES:

--- a/arches/management/commands/process_index_queue.py
+++ b/arches/management/commands/process_index_queue.py
@@ -18,29 +18,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """This module contains commands for building Arches."""
 
-from operator import index
 from typing import Any, Optional
 from django.core.management.base import BaseCommand
 from arches.app.models.resource import Resource
-from arches.app.models.system_settings import settings
-from arches.app.search.base_index import get_index
 from arches.app.search.elasticsearch_dsl_builder import Query, Term
 from arches.app.search.mappings import (
-    RESOURCE_RELATIONS_INDEX,
     RESOURCES_INDEX,
     TERMS_INDEX,
-    prepare_terms_index,
-    prepare_concepts_index,
-    delete_terms_index,
-    delete_concepts_index,
-    prepare_search_index,
-    delete_search_index,
-    prepare_resource_relations_index,
-    delete_resource_relations_index,
 )
 import arches.app.utils.index_database as index_database_util
 
-from arches.app.models.models import BulkIndexQueue, ResourceInstance, TileModel
+from arches.app.models.models import BulkIndexQueue, ResourceInstance
 
 
 class Command(BaseCommand):
@@ -76,7 +64,6 @@ class Command(BaseCommand):
                 deleteq.add_query(term)
             deleteq.delete(index=TERMS_INDEX, refresh=True)
             deleteq.delete(index=RESOURCES_INDEX, refresh=True)
-            deleteq.delete(index=RESOURCE_RELATIONS_INDEX, refresh=True)
             bulk_index_queue.filter(resourceinstanceid__in=delete_ids).delete()
 
         index_database_util.index_resources_using_singleprocessing(

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -121,18 +121,11 @@ JavaScript:
 
 - `TileValidationError` and `TileCardinalityError` now subclass `django.core.exceptions.ValidationError`.
 
-- The related resource index is removed. It was last used in Arches 6.1.
-
 ### Upgrading Arches
 
 1. You must be upgraded to at least version   before proceeding. If you are on an earlier version, please refer to the upgrade process in the []()
 
 1. Be sure to backup your database before proceeding.
-
-1. Consider deleting the related resource index if present, before upgrading. (The commands to delete it are removed in Arches 8.)
-    ```
-    python manage.py shell -c "from arches.app.search.mappings import delete_resource_relations_index as delete; delete()"
-    ```
 
 1. Upgrade to Arches 8.0.0
     ```

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -121,9 +121,23 @@ JavaScript:
 
 - `TileValidationError` and `TileCardinalityError` now subclass `django.core.exceptions.ValidationError`.
 
+- The related resource index is removed. It was last used in Arches 6.1.
+
 ### Upgrading Arches
 
 1. You must be upgraded to at least version   before proceeding. If you are on an earlier version, please refer to the upgrade process in the []()
+
+1. Be sure to backup your database before proceeding.
+
+1. Consider deleting the related resource index if present, before upgrading. (The commands to delete it are removed in Arches 8.)
+    ```
+    python manage.py shell -c "from arches.app.search.mappings import delete_resource_relations_index as delete; delete()"
+    ```
+
+1. Upgrade to Arches 8.0.0
+    ```
+    pip install --upgrade arches==8.0.0
+    ```
 
 ### Upgrading an Arches project
 


### PR DESCRIPTION
Remove this code as promised.

The first commit included a little note about a proactive deletion on upgrade, but I realized any reindex since arches 6.2 would have killed this index anyway, so I removed it.