### PR TITLE
Accept datetime.date objects in date datatype #11895

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 import ast
 import time
-from datetime import datetime
+from datetime import date, datetime
 from mimetypes import MimeTypes
 
 from django.core.files.images import get_image_dimensions
@@ -735,6 +735,8 @@ class DateDataType(BaseDataType):
                     value = datetime.strptime(value, valid_date_format)
                 else:
                     value = datetime.strptime(value, settings.DATE_IMPORT_EXPORT_FORMAT)
+            if isinstance(value, date):
+                value = datetime(value.year, value.month, value.day)
 
         return self.set_timezone(value)
 

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -724,13 +724,12 @@ class DateDataType(BaseDataType):
     def transform_value_for_tile(self, value, **kwargs):
         value = None if value == "" else value
         if value is not None:
-            if type(value) == list:
+            if isinstance(value, list):
                 value = value[0]
-            elif (
-                type(value) == str and len(value) < 4 and value.startswith("-") is False
-            ):  # a year before 1000 but not BCE
-                value = value.zfill(4)
-            if type(value) == str:
+            if isinstance(value, str):
+                if len(value) < 4 and not value.startswith("-"):
+                    # a year before 1000 but not BCE
+                    value = value.zfill(4)
                 valid_date_format, valid = self.get_valid_date_format(value)
                 if valid:
                     value = datetime.strptime(value, valid_date_format)
@@ -744,12 +743,10 @@ class DateDataType(BaseDataType):
             new_year = 1971
             while not is_same_calendar(year, new_year):
                 new_year += 1
-                if (
-                    new_year > 2020
-                ):  # should never happen but don't want a infinite loop
-                    raise Exception(
-                        "Backup timezone conversion failed: no matching year found"
-                    )
+                # should never happen but don't want a infinite loop
+                if new_year > 2020:  # pragma: no cover
+                    msg = "Backup timezone conversion failed: no matching year found"
+                    raise Exception(msg)
             return new_year
 
         def is_same_calendar(year1, year2):

--- a/releases/7.6.8.md
+++ b/releases/7.6.8.md
@@ -5,6 +5,7 @@
 -   Fix severe performance issue in graph manager view [#11898](https://github.com/archesproject/arches/pull/11898)
 -   Fix severe performance issue in related resource view [#11885](https://github.com/archesproject/arches/issues/11885)
 -   Fix sorting concepts with special floats [#11790](https://github.com/archesproject/arches/pull/11790)
+-   Accept `datetime.date` objects in date datatype [#11895](https://github.com/archesproject/arches/issues/11895)
 
 ### Dependency changes:
 

--- a/tests/utils/datatypes/date_datatype_tests.py
+++ b/tests/utils/datatypes/date_datatype_tests.py
@@ -1,6 +1,7 @@
+import datetime
+
 from arches.app.datatypes.datatypes import DataTypeFactory
 from tests.base_test import ArchesTestCase
-from datetime import datetime
 
 # these tests can be run from the command line via
 # python manage.py test tests.utils.datatypes.date_datatype_tests --settings="tests.test_settings"
@@ -26,11 +27,14 @@ class DateDataTypeTests(ArchesTestCase):
 
     def test_tile_transform(self):
         datatype = DataTypeFactory().get_instance("date")
-        self.sample_dates.append(
-            datetime.strptime("2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")
-        )
-        for date in self.sample_dates:
+        python_dates = [
+            datetime.datetime.strptime("2025-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"),
+            datetime.date(2025, 1, 1),
+        ]
+        for date in (*self.sample_dates, *python_dates):
             with self.subTest(input=date):
                 tile_value = datatype.transform_value_for_tile(date)
-                date_value = datetime.strptime(tile_value, "%Y-%m-%dT%H:%M:%S.%f%z")
+                date_value = datetime.datetime.strptime(
+                    tile_value, "%Y-%m-%dT%H:%M:%S.%f%z"
+                )
                 self.assertEqual(date_value.year, 2025)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, `datetime.date` objects couldn't be supplied to the date datatype. In Lingo, our serialization layer is currently using DateField, not DateTimeField, but although that might change, I think it still makes sense to accept both python `date` and `datetime` objects.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11895

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [x] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls