### PR TITLE
Limit restricted nodegroups query to single graph

### DIFF
--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -264,7 +264,11 @@ class GraphDesignerView(GraphBaseView):
 
         if not settings.OVERRIDE_RESOURCE_MODEL_LOCK:
             restricted_nodegroups = models.NodeGroup.objects.filter(
-                Exists(models.TileModel.objects.filter(nodegroup=OuterRef("pk")))
+                Exists(models.TileModel.objects.filter(nodegroup=OuterRef("pk"))),
+                pk__in=[
+                    nodegroup_dict["nodegroupid"]
+                    for nodegroup_dict in serialized_graph["nodegroups"]
+                ],
             )
         else:
             restricted_nodegroups = models.NodeGroup.objects.none()


### PR DESCRIPTION
Follow-up to 31dae7e.

To maintain parity with the prior query, this should filter out irrelevant nodegroups belonging to other graphs. Although I don't think it really would make a difference on the frontend, which consults this information in the context of a single graph anyway. Still, better for debugging to not introduce confusion.