### PR TITLE
Only show source resource models in resource type dropdown 

### DIFF
--- a/arches/app/media/js/views/components/search/resource-type-filter.js
+++ b/arches/app/media/js/views/components/search/resource-type-filter.js
@@ -17,7 +17,7 @@ const viewModel = BaseFilter.extend({
         if (response.ok) {
             const data = await response.json();
             data.resources.forEach(function (res) {
-                if (res.is_active === true && res.source_identifier_id === null) {
+                if (res.is_active === true && !res.source_identifier_id) {
                     self.resourceModels.push(res);
                 }
             });

--- a/arches/app/media/js/views/components/search/resource-type-filter.js
+++ b/arches/app/media/js/views/components/search/resource-type-filter.js
@@ -16,10 +16,10 @@ const viewModel = BaseFilter.extend({
         const response = await fetch(arches.urls.api_search_component_data + componentName);
         if (response.ok) {
             const data = await response.json();
-            data.resources.forEach(function(res) {
-                //if (res.isactive === true) { // TODO: Uncomment once active flag is re-added to graph model
-                self.resourceModels.push(res);
-                //}
+            data.resources.forEach(function (res) {
+                if (res.is_active === true && res.source_identifier_id === null) {
+                    self.resourceModels.push(res);
+                }
             });
             self.resourceModels.sort(function(a,b) {
                 return a.name.toLowerCase().localeCompare(b.name.toLowerCase());


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The resource-type-filter.js `self.resourceModels` array was including editable graph copies with `source_identifier_id`, thus showing each model twice in the list (plus an instance of system settings).  This fix not only adds a filter for `source_identifier_id`, but it also adds back the filter for `is_active`, as this flag is back in V8.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes [#11937 ](https://github.com/archesproject/arches/issues/11936)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Knowledge Integration <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @chiatt  @SDScandrettKint  <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @SDScandrettKint  <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @SDScandrettKint  <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
