### PR TITLE
Speed up serialization by ~50%

### DIFF
--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -11,6 +11,7 @@ Arches 8.0.0 Release Notes
 
 ### Performance improvements
 - Improve indexing and bulk deletion performance [#11382](https://github.com/archesproject/arches/issues/11382)
+- Improve serialization performance [#11962](https://github.com/archesproject/arches/pull/11962)
 - The following methods or functions in the permissions framework now take an optional ``resource`` keyword argument to avoid refetching an instance that a caller may already have:
     - `user_can_read_resource()`
     - `user_can_edit_resource()`


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Speed up serialization by ~50% by using structural pattern matching (`match` statement) instead of if/elif/else and repeating isinstance()

### Benchmark
in arches/app/management
```py
import timeit

from django.core.management.base import BaseCommand

class Command(BaseCommand):
    def handle(self, *args, **options):
        t = timeit.Timer(
            stmt="serializer.handle_object(obj)",
            setup="from arches.app.utils.betterJSONSerializer import JSONSerializer; import uuid; obj = uuid.uuid4(); serializer = JSONSerializer()",
        )
        print("Best of 5:", min(t.repeat()))
```

**Before**
Best of 5: 1.4309943750267848
**After**
Best of 5: 0.8083759160363115