### PR TITLE
Notify admins to remove invalid import

### DIFF
--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -287,7 +287,10 @@ JavaScript:
     python manage.py updateproject
     ```
 
-1. Verify in ``<project_name>/apps.py`` that you no longer have a ``ready()`` method.
+1. Verify ``<project_name>/apps.py`` no longer has a ``ready()`` method nor the following import:
+    ```
+    from arches.settings_utils import generate_frontend_configuration
+    ```
 
 1. Update your urls.py to include generic error handlers:
 


### PR DESCRIPTION
### Description of Change
Instruct admins in the project upgrade notes to remove the following, invalid import statement from apps.py
    ```
    from arches.settings_utils import generate_frontend_configuration
    ```

