### PR TITLE
Remove further queries [May 2025]

### DIFF
--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -81,7 +81,9 @@ class BaseConceptDataType(BaseDataType):
             return self.value_lookup[valueid]
         except:
             try:
-                self.value_lookup[valueid] = models.Value.objects.get(pk=valueid)
+                self.value_lookup[valueid] = models.Value.objects.select_related(
+                    "concept", "valuetype"
+                ).get(pk=valueid)
                 return self.value_lookup[valueid]
             except ObjectDoesNotExist:
                 return models.Value()
@@ -107,8 +109,7 @@ class BaseConceptDataType(BaseDataType):
         date_range = {}
         cache_value = cache.get("concept-" + str(concept.conceptid), "no result")
         if cache_value == "no result":
-            values = models.Value.objects.filter(concept=concept)
-            for value in values:
+            for value in concept.value_set.select_related("valuetype"):
                 if value.valuetype.valuetype in ("min_year" "max_year"):
                     date_range[value.valuetype.valuetype] = value.value
             if "min_year" in date_range and "max_year" in date_range:

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -86,7 +86,7 @@ class DataTypeFactory(object):
         if DataTypeFactory._datatypes is None:
             DataTypeFactory._datatypes = {
                 datatype.datatype: datatype
-                for datatype in models.DDataType.objects.all()
+                for datatype in models.DDataType.objects.select_related("defaultwidget")
             }
         self.datatypes = DataTypeFactory._datatypes
         self.datatype_instances = DataTypeFactory._datatype_instances
@@ -97,7 +97,7 @@ class DataTypeFactory(object):
         except KeyError:
             DataTypeFactory._datatypes = {
                 datatype.datatype: datatype
-                for datatype in models.DDataType.objects.all()
+                for datatype in models.DDataType.objects.select_related("defaultwidget")
             }
             d_datatype = DataTypeFactory._datatypes[datatype]
             self.datatypes = DataTypeFactory._datatypes

--- a/arches/app/etl_modules/bulk_data_deletion.py
+++ b/arches/app/etl_modules/bulk_data_deletion.py
@@ -205,7 +205,9 @@ class BulkDataDeletion(BaseBulkEditor):
                 )
             else:
                 tiles = Tile.objects.filter(nodegroup_id=nodegroupid)
-            for tile in tiles.iterator(chunk_size=2000):
+            for tile in tiles.select_related("nodegroup__grouping_node").iterator(
+                chunk_size=2000
+            ):
                 request = HttpRequest()
                 request.user = user
                 tile.delete(request=request, index=False, transaction_id=loadid)

--- a/arches/app/models/concept.py
+++ b/arches/app/models/concept.py
@@ -179,7 +179,9 @@ class Concept(object):
                 exclude = []
 
                 if len(include) > 0:
-                    values = models.Value.objects.filter(concept=self.id)
+                    values = models.Value.objects.filter(
+                        concept=self.id
+                    ).select_related("valuetype")
                     for value in values:
                         if value.valuetype.category in include:
                             self.values.append(ConceptValue(value))
@@ -1586,7 +1588,7 @@ class ConceptValue(object):
         )
 
     def get(self, id=""):
-        self.load(models.Value.objects.get(pk=id))
+        self.load(models.Value.objects.select_related("valuetype").get(pk=id))
         return self
 
     def save(self):

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -182,9 +182,9 @@ class Graph(models.GraphModel):
         self.cards = {}
         self.widgets = {}
 
-        nodes = self.node_set.all()
+        nodes = self.node_set.prefetch_related("nodegroup")
         edges = self.edge_set.all()
-        cards = self.cardmodel_set.all()
+        cards = self.cardmodel_set.prefetch_related("nodegroup")
 
         edge_lookup = {
             edge["edgeid"]: edge

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1480,10 +1480,14 @@ class Graph(models.GraphModel):
                 if nodeid is not None
                 else self.root.ontologyclass
             )
-            ontology_classes = models.OntologyClass.objects.get(
-                source=source, ontology=self.ontology
+            target_up = (
+                models.OntologyClass.objects.filter(
+                    source=source, ontology=self.ontology
+                )
+                .values_list("target__up", flat=True)
+                .first()
             )
-            return ontology_classes.target["up"]
+            return target_up
         else:
             return []
 

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction, connection
-from django.db.models import Q
+from django.db.models import Q, prefetch_related_objects
 from django.db.utils import IntegrityError
 from arches.app.const import IntegrityCheck
 from arches.app.models import models
@@ -1588,10 +1588,12 @@ class Graph(models.GraphModel):
         if self.should_use_published_graph() and not force_recalculation:
             return super().get_nodegroups()
         else:
+            prefetch_related_objects(list(self.nodes.values()), "nodegroup")
             nodegroups = set()
             for node in self.nodes.values():
                 if node.is_collector:
                     nodegroups.add(node.nodegroup)
+            prefetch_related_objects(list(self.cards.values()), "nodegroup")
             for card in self.cards.values():
                 try:
                     nodegroups.add(card.nodegroup)
@@ -1881,6 +1883,8 @@ class Graph(models.GraphModel):
         """
         if self.should_use_published_graph() and not force_recalculation:
             return super().get_cards()
+
+        prefetch_related_objects(list(self.cards.values()), "constraintmodel_set")
 
         cards = []
         for card in self.cards.values():

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1495,7 +1495,7 @@ class ResourceInstance(SaveSupportsBlindOverwriteMixin, models.Model):
         except ResourceInstance.graph.RelatedObjectDoesNotExist:
             pass
 
-        if not hasattr(self, "resource_instance_lifecycle_state"):
+        if not self.resource_instance_lifecycle_state_id:
             self.resource_instance_lifecycle_state = (
                 self.get_initial_resource_instance_lifecycle_state()
             )

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -565,11 +565,7 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
         if not language:
             language = translation.get_language()
 
-        for published_graph in self.publication.publishedgraph_set.all():
-            if published_graph.language_id == language:
-                return published_graph
-
-        return None
+        return self.publication.find_publication_in_language(language)
 
     def get_cards(self, force_recalculation=False):
         if self.should_use_published_graph() and not force_recalculation:
@@ -809,6 +805,19 @@ class GraphXPublishedGraph(models.Model):
     class Meta:
         managed = True
         db_table = "graphs_x_published_graphs"
+
+    def find_publication_in_language(self, language):
+        if not hasattr(self, "_published_graph_cache"):
+            self._published_graph_cache = {}
+        if language not in self._published_graph_cache:
+            self._published_graph_cache[language] = self.publishedgraph_set.filter(
+                language=language
+            ).first()
+        return self._published_graph_cache[language]
+
+    def refresh_from_db(self, *args, **kwargs):
+        self._published_graph_cache = {}
+        return super().refresh_from_db(*args, **kwargs)
 
 
 class Icon(models.Model):

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -589,7 +589,9 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
 
             return [models.CardModel(**card_slug) for card_slug in card_slugs]
         else:
-            return self.cardmodel_set.all()
+            return self.cardmodel_set.select_related("nodegroup").prefetch_related(
+                "constraintmodel_set"
+            )
 
     def get_nodegroups(self, force_recalculation=False):
         if self.should_use_published_graph() and not force_recalculation:
@@ -639,7 +641,7 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
 
             return [models.Node(**node_slug) for node_slug in node_slugs]
         else:
-            return self.node_set.all()
+            return self.node_set.select_related("nodegroup")
 
     def get_functions_x_graphs(self, force_recalculation=False):
         if self.should_use_published_graph() and not force_recalculation:
@@ -724,7 +726,7 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
         else:
             return [
                 card_x_node_x_widget
-                for card in self.cardmodel_set.all()
+                for card in self.cardmodel_set.prefetch_related("cardxnodexwidget_set")
                 for card_x_node_x_widget in card.cardxnodexwidget_set.all()
             ]
 

--- a/arches/app/models/system_settings.py
+++ b/arches/app/models/system_settings.py
@@ -95,7 +95,7 @@ class SystemSettings(LazySettings):
         # get all the possible settings defined by the Arches System Settings Graph
         for node in models.Node.objects.filter(
             graph_id=self.SYSTEM_SETTINGS_RESOURCE_MODEL_ID
-        ):
+        ).select_related("nodegroup"):
 
             def setup_blank_setting(name, value):
                 if not self.setting_exists(name):
@@ -122,13 +122,17 @@ class SystemSettings(LazySettings):
         n_cardinality_collector_node_names = []
 
         # set any values saved in the instance of the Arches System Settings Graph
-        for tile in models.TileModel.objects.filter(
-            resourceinstance__graph_id=self.SYSTEM_SETTINGS_RESOURCE_MODEL_ID,
-            # Get tiles only from the latest graph publication.
-            resourceinstance__graph_publication=models.F(
-                "resourceinstance__graph__publication"
-            ),
-        ).order_by("sortorder"):
+        for tile in (
+            models.TileModel.objects.filter(
+                resourceinstance__graph_id=self.SYSTEM_SETTINGS_RESOURCE_MODEL_ID,
+                # Get tiles only from the latest graph publication.
+                resourceinstance__graph_publication=models.F(
+                    "resourceinstance__graph__publication"
+                ),
+            )
+            .select_related("nodegroup")
+            .order_by("sortorder")
+        ):
             if tile.nodegroup.cardinality == "1":
                 for node in tile.nodegroup.node_set.all():
                     if node.datatype != "semantic":
@@ -166,7 +170,11 @@ class SystemSettings(LazySettings):
 
     def get_direct_decendent_nodes(self, node):
         nodes = []
-        for edge in models.Edge.objects.filter(domainnode=node):
+        for edge in (
+            models.Edge.objects.filter(domainnode=node)
+            .select_related("rangenode")
+            .prefetch_related("rangenode__nodegroup")
+        ):
             nodes.append(edge.rangenode)
         return nodes
 

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -549,7 +549,9 @@ class Tile(models.TileModel):
                     **kwargs,
                 )
 
-            resource = Resource.objects.get(pk=self.resourceinstance_id)
+            resource = Resource.objects.select_related("graph__publication").get(
+                pk=self.resourceinstance_id
+            )
             resource.save_descriptors(context={"tile": self})
 
             if index:

--- a/arches/app/utils/data_management/resource_graphs/importer.py
+++ b/arches/app/utils/data_management/resource_graphs/importer.py
@@ -189,7 +189,7 @@ def import_graph(graphs, overwrite_graphs=True, user=None):
 
                 with transaction.atomic():
                     # saves graph publication with serialized graph
-                    graph = Graph.objects.get(
+                    graph = Graph.objects.select_related("ontology").get(
                         pk=graph.graphid, source_identifier_id__isnull=True
                     )  # retrieve graph using the ORM to ensure strings are I18n_Strings
 

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -260,7 +260,7 @@ class GraphDesignerView(GraphBaseView):
             graph=self.graph
         ).filter(function__functiontype="primarydescriptors")
 
-        datatypes = models.DDataType.objects.all()
+        datatypes = models.DDataType.objects.select_related("defaultwidget")
         primary_descriptor_function = JSONSerializer().serialize(
             primary_descriptor_functions[0]
             if len(primary_descriptor_functions) > 0

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -1641,7 +1641,7 @@ class DraftGraphTests(ArchesTestCase):
         }
         models.Node.objects.create(**node_data).save()
 
-        graph = Graph.objects.get(pk=graph_model.pk)
+        graph = Graph.objects.select_related("ontology").get(pk=graph_model.pk)
         graph.save()
         graph.publish()
         return graph


### PR DESCRIPTION
I was testing the version of the django-auto-prefetch that's got a pull request against django/django, which comes with a debug tool similar to charettes/django-seal. I used it to identify queries to remove.

A few reasons I stopped here:
- I'm in a JetBlue window seat ✈️ 
- if the django-auto-prefetch work lands in Django 6 we can just use that and remove a lot of these fiddly-prefetches.
- otherwise, it might be nice to leave this work for someone who wants to get up to speed with the Django ORM.
- some of these ORM calls might be better rewritten as starting from `self` rather than starting from a fresh model manager, to allow reusing a prefetched cache

We should probably look into a CI job that runs charettes/django-seal and compares it to some sort of baseline so that we can "plug the leak before bailing out the leak"