### PR TITLE
BDM bulk delete speed improvements

### DIFF
--- a/arches/app/etl_modules/base_data_editor.py
+++ b/arches/app/etl_modules/base_data_editor.py
@@ -3,6 +3,7 @@ import json
 import logging
 from urllib.parse import urlsplit, parse_qs
 import uuid
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db import connection
@@ -10,7 +11,7 @@ from django.http import HttpRequest
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from arches.app.datatypes.datatypes import DataTypeFactory
-from arches.app.models.models import GraphModel, Node, ETLModule, LoadStaging
+from arches.app.models.models import GraphModel, Node, ETLModule, LoadStaging, LoadEvent
 from arches.app.models.system_settings import settings
 from arches.app.search.elasticsearch_dsl_builder import (
     Bool,
@@ -51,12 +52,17 @@ class BaseBulkEditor:
         self.node_lookup = {}
 
     def reverse_load(self, loadid):
+        user = (
+            User.objects.get(id=self.userid)
+            if self.userid
+            else LoadEvent.objects.get(loadid=loadid).user
+        )
         with connection.cursor() as cursor:
             cursor.execute(
                 """UPDATE load_event SET status = %s WHERE loadid = %s""",
                 ("reversing", loadid),
             )
-            resources_changed_count = reverse_edit_log_entries(loadid)
+            resources_changed_count = reverse_edit_log_entries(loadid, user=user)
             cursor.execute(
                 """UPDATE load_event SET status = %s, load_details = load_details::jsonb || ('{"resources_removed":' || %s || '}')::jsonb WHERE loadid = %s""",
                 ("unloaded", resources_changed_count, loadid),

--- a/arches/app/etl_modules/base_import_module.py
+++ b/arches/app/etl_modules/base_import_module.py
@@ -7,6 +7,7 @@ import uuid
 import zipfile
 from openpyxl import load_workbook
 
+from django.contrib.auth.models import User
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -17,7 +18,7 @@ from django.db import connection
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.etl_modules.decorators import load_data_async
 from arches.app.etl_modules.save import save_to_tiles
-from arches.app.models.models import ETLModule, Node
+from arches.app.models.models import ETLModule, Node, LoadEvent
 from arches.app.models.system_settings import settings
 from arches.app.utils.decorators import user_created_transaction_match
 from arches.app.utils.file_validator import FileValidator
@@ -63,14 +64,31 @@ class BaseImportModule:
     def reverse_load(self, loadid):
         with connection.cursor() as cursor:
             cursor.execute(
+                """SELECT status FROM load_event WHERE loadid = %s""",
+                [loadid],
+            )
+            original_status = cursor.fetchone()[0]
+            cursor.execute(
                 """UPDATE load_event SET status = %s WHERE loadid = %s""",
                 ("reversing", loadid),
             )
-            resources_changed_count = reverse_edit_log_entries(loadid)
-            cursor.execute(
-                """UPDATE load_event SET status = %s, load_details = load_details::jsonb || ('{"resources_removed":' || %s || '}')::jsonb WHERE loadid = %s""",
-                ("unloaded", resources_changed_count, loadid),
+            user = (
+                User.objects.get(id=self.userid)
+                if self.userid
+                else LoadEvent.objects.get(loadid=loadid).user
             )
+            try:
+                resources_changed_count = reverse_edit_log_entries(loadid, user=user)
+                cursor.execute(
+                    """UPDATE load_event SET status = %s, load_details = load_details::jsonb || ('{"resources_removed":' || %s || '}')::jsonb WHERE loadid = %s""",
+                    ("unloaded", resources_changed_count, loadid),
+                )
+            except Exception as e:
+                cursor.execute(
+                    """UPDATE load_event SET status = %s WHERE loadid = %s""",
+                    (original_status, loadid),
+                )
+                raise e
 
     @method_decorator(user_created_transaction_match, name="dispatch")
     def reverse(self, request, **kwargs):

--- a/arches/app/etl_modules/bulk_data_deletion.py
+++ b/arches/app/etl_modules/bulk_data_deletion.py
@@ -208,7 +208,12 @@ class BulkDataDeletion(BaseBulkEditor):
             for tile in tiles.iterator(chunk_size=2000):
                 request = HttpRequest()
                 request.user = user
-                tile.delete(request=request, index=False, transaction_id=loadid)
+                tile.delete(
+                    request=request,
+                    index=False,
+                    transaction_id=loadid,
+                    recalculate_descriptors=False,
+                )
             result["success"] = True
         except Exception as e:
             logger.exception(e)

--- a/arches/app/etl_modules/bulk_data_deletion.py
+++ b/arches/app/etl_modules/bulk_data_deletion.py
@@ -16,7 +16,10 @@ from arches.app.models.resource import Resource
 from arches.app.models.system_settings import settings
 from arches.app.models.tile import Tile
 import arches.app.tasks as tasks
-from arches.app.utils.index_database import index_resources_by_transaction
+from arches.app.utils.index_database import (
+    index_resources_by_transaction,
+    optimize_resource_iteration,
+)
 from arches.app.utils.label_based_graph_v2 import LabelBasedGraph as LabelBasedGraphV2
 
 logger = logging.getLogger(__name__)
@@ -176,8 +179,10 @@ class BulkDataDeletion(BaseBulkEditor):
 
             if verbose is True:
                 bar = pyprind.ProgBar(deleted_count)
-            for resource in resources.iterator(chunk_size=2000):
-                resource.delete(user=user, index=False, transaction_id=loadid)
+            for resource in optimize_resource_iteration(resources, chunk_size=2000):
+                resource.delete(
+                    user=user, index=False, transaction_id=loadid, fetch_relations=False
+                )
                 if verbose is True:
                     bar.update()
 

--- a/arches/app/etl_modules/bulk_data_deletion.py
+++ b/arches/app/etl_modules/bulk_data_deletion.py
@@ -6,8 +6,8 @@ import uuid
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import connection
-from django.http import HttpRequest
 from django.utils.translation import gettext as _
+from arches.app.utils import task_management
 from arches.app.etl_modules.base_data_editor import BaseBulkEditor
 from arches.app.etl_modules.decorators import load_data_async
 from arches.app.etl_modules.save import get_resourceids_from_search_url
@@ -211,10 +211,8 @@ class BulkDataDeletion(BaseBulkEditor):
             else:
                 tiles = Tile.objects.filter(nodegroup_id=nodegroupid)
             for tile in tiles.iterator(chunk_size=2000):
-                request = HttpRequest()
-                request.user = user
                 tile.delete(
-                    request=request,
+                    user=user,
                     index=False,
                     transaction_id=loadid,
                     recalculate_descriptors=False,
@@ -312,7 +310,7 @@ class BulkDataDeletion(BaseBulkEditor):
                     },
                 }
 
-        use_celery_bulk_delete = True
+        celery_worker_running = task_management.check_if_celery_available()
 
         load_details = {
             "graph": graph_name,
@@ -323,7 +321,7 @@ class BulkDataDeletion(BaseBulkEditor):
         with connection.cursor() as cursor:
             event_created = self.create_load_event(cursor, load_details)
             if event_created["success"]:
-                if use_celery_bulk_delete:
+                if celery_worker_running:
                     response = self.run_bulk_task_async(request, self.loadid)
                 else:
                     response = self.run_bulk_task(

--- a/arches/app/functions/primary_descriptors.py
+++ b/arches/app/functions/primary_descriptors.py
@@ -55,7 +55,7 @@ class PrimaryDescriptorsFunction(AbstractPrimaryDescriptorsFunction):
                 and config["nodegroup_id"] != ""
                 and config["nodegroup_id"] is not None
             ):
-                tile = context.get("tile")
+                tile = context.get("tile") if context else None
 
                 if not tile or tile.sortorder:
                     tile = (

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1304,19 +1304,21 @@ class ResourceXResource(SaveSupportsBlindOverwriteMixin, models.Model):
         # update the resource-instance tile by removing any references to a deleted resource
         deletedResourceId = kwargs.pop("deletedResourceId", None)
         if deletedResourceId and self.tile and self.node_id:
-            newTileData = []
-            data = self.tile.data[str(self.node_id)]
-            if type(data) != list:
-                data = [data]
-            for relatedresourceItem in data:
-                if relatedresourceItem:
-                    if relatedresourceItem["resourceId"] != str(deletedResourceId):
-                        newTileData.append(relatedresourceItem)
-            if len(newTileData):
-                self.tile.data[str(self.node_id)] = newTileData
-                self.tile.save()
-            else:
+            if self.from_resource_id == deletedResourceId:
                 self.tile.delete(index=False, recalculate_descriptors=False)
+            elif self.to_resource_id == deletedResourceId:
+                newTileData = []
+                data = self.tile.data[str(self.node_id)]
+                if type(data) != list:
+                    data = [data]
+                newTileData = list(
+                    filter(lambda x: x["resourceId"] != str(deletedResourceId), data)
+                )
+                if len(newTileData):
+                    self.tile.data[str(self.node_id)] = newTileData
+                    self.tile.save()
+                else:
+                    self.tile.delete()
 
         super(ResourceXResource, self).delete()
 

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1312,8 +1312,11 @@ class ResourceXResource(SaveSupportsBlindOverwriteMixin, models.Model):
                 if relatedresourceItem:
                     if relatedresourceItem["resourceId"] != str(deletedResourceId):
                         newTileData.append(relatedresourceItem)
-            self.tile.data[str(self.node_id)] = newTileData
-            self.tile.save()
+            if len(newTileData):
+                self.tile.data[str(self.node_id)] = newTileData
+                self.tile.save()
+            else:
+                self.tile.delete(index=False, recalculate_descriptors=False)
 
         super(ResourceXResource, self).delete()
 

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1303,7 +1303,7 @@ class ResourceXResource(SaveSupportsBlindOverwriteMixin, models.Model):
     def delete(self, *args, **kwargs):
         # update the resource-instance tile by removing any references to a deleted resource
         deletedResourceId = kwargs.pop("deletedResourceId", None)
-        if deletedResourceId and self.tile and self.node:
+        if deletedResourceId and self.tile and self.node_id:
             newTileData = []
             data = self.tile.data[str(self.node_id)]
             if type(data) != list:

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -76,6 +76,8 @@ class Resource(models.ResourceInstance):
         # self.resourceinstancesecurity
         # end from models.ResourceInstance
         self.tiles = []
+        self.fromrelations = []
+        self.torelations = []
         self.descriptor_function = None
         self.serialized_graph = None
         self.node_datatypes = None

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -677,7 +677,7 @@ class Resource(models.ResourceInstance):
 
         return document, terms
 
-    def delete(self, user={}, index=True, transaction_id=None):
+    def delete(self, user={}, index=True, transaction_id=None, fetch_relations=True):
         """
         Deletes a single resource and any related indexed data
 
@@ -714,11 +714,15 @@ class Resource(models.ResourceInstance):
             permit_deletion = True
 
         if permit_deletion is True:
-            for related_resource in models.ResourceXResource.objects.filter(
-                Q(from_resource_id=self.resourceinstanceid)
-                | Q(to_resource_id=self.resourceinstanceid)
-            ):
-                related_resource.delete(deletedResourceId=self.resourceinstanceid)
+            if fetch_relations:
+                for related_resource in models.ResourceXResource.objects.filter(
+                    Q(from_resource_id=self.resourceinstanceid)
+                    | Q(to_resource_id=self.resourceinstanceid)
+                ).select_related("tile"):
+                    related_resource.delete(deletedResourceId=self.resourceinstanceid)
+            else:
+                for related_resource in self.fromrelations + self.torelations:
+                    related_resource.delete(deletedResourceId=self.resourceinstanceid)
 
             if index:
                 self.delete_index()

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -308,8 +308,10 @@ class Resource(models.ResourceInstance):
                 index=False,
                 resource_creation=True,
                 transaction_id=transaction_id,
+                recalculate_descriptors=False,
                 context=context,
             )
+        self.save_descriptors()
 
         if index is True:
             self.index(context)

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -547,6 +547,7 @@ class Tile(models.TileModel):
                     request=request,
                     resource_creation=resource_creation,
                     index=False,
+                    recalculate_descriptors=recalculate_descriptors,
                     **kwargs,
                 )
 

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -438,6 +438,7 @@ class Tile(models.TileModel):
     def save(self, **kwargs):
         request = kwargs.pop("request", None)
         index = kwargs.pop("index", True)
+        recalculate_descriptors = kwargs.pop("recalculate_descriptors", True)
         user = kwargs.pop("user", None)
         new_resource_created = kwargs.pop("new_resource_created", False)
         resource_creation = kwargs.pop("resource_creation", False)
@@ -549,11 +550,12 @@ class Tile(models.TileModel):
                     **kwargs,
                 )
 
-            resource = Resource.objects.get(pk=self.resourceinstance_id)
-            resource.save_descriptors(context={"tile": self})
-
-            if index:
-                self.index(resource=resource)
+            if index or recalculate_descriptors:
+                resource = Resource.objects.get(pk=self.resourceinstance_id)
+                if recalculate_descriptors:
+                    resource.save_descriptors(context={"tile": self})
+                if index:
+                    self.index(resource=resource)
 
     def populate_missing_nodes(self):
         first_node = next(iter(self.data.items()), None)

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -570,6 +570,7 @@ class Tile(models.TileModel):
     def delete(self, *args, **kwargs):
         se = SearchEngineFactory().create()
         request = kwargs.pop("request", None)
+        user = kwargs.pop("user", None)
         index = kwargs.pop("index", True)
         recalculate_descriptors = kwargs.pop("recalculate_descriptors", True)
         transaction_id = kwargs.pop("transaction_id", None)
@@ -577,7 +578,8 @@ class Tile(models.TileModel):
         for tile in self.tiles:
             tile.delete(*args, request=request, **kwargs)
         try:
-            user = request.user
+            if user is None and request is not None:
+                user = request.user
             user_is_reviewer = user_is_resource_reviewer(user)
         except AttributeError:  # no user
             user = None

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -545,9 +545,11 @@ class Tile(models.TileModel):
                 tile.parenttile = self
                 tile.save(
                     request=request,
+                    user=user,
                     resource_creation=resource_creation,
                     index=False,
                     recalculate_descriptors=recalculate_descriptors,
+                    transaction_id=transaction_id,
                     **kwargs,
                 )
 
@@ -576,7 +578,15 @@ class Tile(models.TileModel):
         transaction_id = kwargs.pop("transaction_id", None)
         provisional_edit_log_details = kwargs.pop("provisional_edit_log_details", None)
         for tile in self.tiles:
-            tile.delete(*args, request=request, **kwargs)
+            tile.delete(
+                *args,
+                request=request,
+                user=user,
+                recalculate_descriptors=recalculate_descriptors,
+                index=index,
+                transaction_id=transaction_id,
+                **kwargs,
+            )
         try:
             if user is None and request is not None:
                 user = request.user

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -568,6 +568,7 @@ class Tile(models.TileModel):
         se = SearchEngineFactory().create()
         request = kwargs.pop("request", None)
         index = kwargs.pop("index", True)
+        recalculate_descriptors = kwargs.pop("recalculate_descriptors", True)
         transaction_id = kwargs.pop("transaction_id", None)
         provisional_edit_log_details = kwargs.pop("provisional_edit_log_details", None)
         for tile in self.tiles:
@@ -615,11 +616,12 @@ class Tile(models.TileModel):
                     datatype = self.datatype_factory.get_instance(node.datatype)
                     datatype.post_tile_delete(self, nodeid, index=index)
 
-                resource = Resource.objects.get(pk=self.resourceinstance_id)
-                resource.save_descriptors()
-
-                if index:
-                    self.index(resource=resource)
+                if index or recalculate_descriptors:
+                    resource = Resource.objects.get(pk=self.resourceinstance_id)
+                    if recalculate_descriptors:
+                        resource.save_descriptors()
+                    if index:
+                        self.index(resource=resource)
             except IntegrityError as e:
                 logger.error(e)
 

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -13,7 +13,7 @@ from arches.app.models import models
 from arches.app.models.resource import Resource
 from arches.app.models.system_settings import settings
 from arches.app.search.search_engine_factory import SearchEngineInstance as se
-from arches.app.search.elasticsearch_dsl_builder import Query, Term
+from arches.app.search.elasticsearch_dsl_builder import Query, Term, Bool, Terms
 from arches.app.search.base_index import get_index
 from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX
 from arches.app.datatypes.datatypes import DataTypeFactory
@@ -674,3 +674,52 @@ def index_resources_by_time(
             title="time {}".format(start_time),
             recalculate_descriptors=recalculate_descriptors,
         )
+
+
+def index_tile_deletion_by_transaction(
+    transaction_id,
+    batch_size=settings.BULK_IMPORT_BATCH_SIZE,
+):
+    """
+    Bulk delete index for tiles
+
+    Keyword Arguments:
+    transaction_id -- the transaction id to delete
+    batch_size -- the number of records to index as a group, the larger the number to more memory required
+    """
+
+    try:
+        uuid.UUID(transaction_id)
+    except ValueError:
+        logger.error("A transaction id must be a valid uuid")
+        return
+
+    transaction_changes = EditLog.objects.filter(
+        transactionid=transaction_id,
+        edittype="tile create",
+    )
+    number_of_db_changes = transaction_changes.count()
+    to_delete_tileids_iter = transaction_changes.values_list(
+        "tileinstanceid", flat=True
+    ).iterator(chunk_size=batch_size)
+
+    batch = []
+    for tileid in to_delete_tileids_iter:
+        batch.append(tileid)
+        if len(batch) == batch_size:
+            query = Query(se)
+            bool_query = Bool()
+            bool_query.filter(Terms(field="tileid", terms=batch))
+            query.add_query(bool_query)
+            query.delete(index=TERMS_INDEX)
+            batch.clear()
+
+    if len(batch):
+        query = Query(se)
+        bool_query = Bool()
+        bool_query.filter(Terms(field="tileid", terms=batch))
+        query.add_query(bool_query)
+        query.delete(index=TERMS_INDEX)
+        batch.clear()
+
+    return number_of_db_changes

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -221,17 +221,39 @@ def optimize_resource_iteration(resources: Iterable[Resource], chunk_size: int):
         to_attr="descriptor_function",
     )
 
+    from_resource_prefetch = Prefetch(
+        "from_resxres",
+        queryset=models.ResourceXResource.objects.select_related("tile"),
+        to_attr="prefetched_from_relations",
+    )
+    to_resource_prefetch = Prefetch(
+        "to_resxres",
+        queryset=models.ResourceXResource.objects.select_related("tile"),
+        to_attr="prefetched_to_relations",
+    )
+
     if isinstance(resources, QuerySet):
         return (
             resources.select_related("graph")
-            .prefetch_related(tiles_prefetch, descriptor_prefetch)
+            .prefetch_related(
+                tiles_prefetch,
+                descriptor_prefetch,
+                from_resource_prefetch,
+                to_resource_prefetch,
+            )
             .iterator(chunk_size=chunk_size)
         )
     else:  # public API that arches itself does not currently use
         for r in resources:
             r.clean_fields()  # ensure strings become UUIDs
 
-        prefetch_related_objects(resources, tiles_prefetch, descriptor_prefetch)
+        prefetch_related_objects(
+            resources,
+            tiles_prefetch,
+            descriptor_prefetch,
+            from_resource_prefetch,
+            to_resource_prefetch,
+        )
         return resources
 
 
@@ -263,6 +285,10 @@ def index_resources_using_singleprocessing(
                 resources, chunk_size=chunk_size
             ):
                 resource.tiles = resource.prefetched_tiles
+                resource.fromrelations = getattr(
+                    resource, "prefetched_from_relations", []
+                )
+                resource.torelations = getattr(resource, "prefetched_to_relations", [])
                 resource.descriptor_function = resource.graph.descriptor_function
                 resource.set_node_datatypes(node_datatypes)
                 resource.set_serialized_graph(get_serialized_graph(resource.graph))

--- a/arches/app/utils/transaction.py
+++ b/arches/app/utils/transaction.py
@@ -1,7 +1,12 @@
 import logging
+import uuid
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from arches.app.models.models import IIIFManifest, EditLog, WorkflowHistory
+from arches.app.utils.index_database import (
+    index_resources_by_transaction,
+    optimize_resource_iteration,
+)
 from django.db import transaction, DatabaseError
 
 # Get an instance of a logger
@@ -10,32 +15,64 @@ logger = logging.getLogger(__name__)
 
 # Given a transaction ID, reverse (delete or update) tiles and resources created/updated during the transaction
 def reverse_edit_log_entries(transaction_id):
-    transaction_changes = (
-        EditLog.objects.filter(transactionid=transaction_id)
-        .order_by("-timestamp")
-        .all()
+    revserse_operation_transactionid = str(uuid.uuid4())
+
+    transaction_changes = EditLog.objects.filter(transactionid=transaction_id)
+
+    resource_create_changes = transaction_changes.filter(edittype="create")
+    tile_edit_changes = transaction_changes.filter(edittype="tile edit")
+    tile_create_changes = transaction_changes.filter(edittype="tile create")
+
+    number_of_db_changes = (
+        resource_create_changes.count()
+        + tile_edit_changes.count()
+        + tile_create_changes.count()
     )
-    number_of_db_changes = 0
+
+    created_resources_query_set = Resource.objects.filter(
+        resourceinstanceid__in=resource_create_changes.values_list(
+            "resourceinstanceid", flat=True
+        )
+    )
+
     try:
         with transaction.atomic():
-            for edit_log in transaction_changes:
-                if edit_log.edittype == "create":
-                    for obj in Resource.objects.filter(
-                        resourceinstanceid=edit_log.resourceinstanceid
-                    ):
-                        obj.delete()
-                        number_of_db_changes += 1
-                elif edit_log.edittype == "tile create":
-                    for obj in Tile.objects.filter(tileid=edit_log.tileinstanceid):
-                        obj.delete()
-                        number_of_db_changes += 1
-                elif edit_log.edittype == "tile edit":
-                    for obj in Tile.objects.filter(tileid=edit_log.tileinstanceid):
-                        obj.data = edit_log.oldvalue
-                        obj.save()
-                        number_of_db_changes += 1
+            for resource in optimize_resource_iteration(
+                created_resources_query_set, chunk_size=2000
+            ):
+                resource.delete(
+                    fetch_relations=False,
+                    transaction_id=revserse_operation_transactionid,
+                )
+
+            for tile in Tile.objects.filter(
+                tileid__in=tile_create_changes.values_list("tileinstanceid", flat=True)
+            ):
+                tile.delete(
+                    recalculate_descriptors=False,
+                    transaction_id=revserse_operation_transactionid,
+                )
+
+            for tile in Tile.objects.filter(
+                tileid__in=tile_edit_changes.values_list("tileinstanceid", flat=True)
+            ):
+                tile.data = tile_edit_changes.get(
+                    tileinstanceid=str(tile.tileid)
+                ).oldvalue
+                tile.save(
+                    index=False,
+                    recalculate_descriptors=False,
+                    transaction_id=revserse_operation_transactionid,
+                )
+        if tile_edit_changes.count() > 0:
+            index_resources_by_transaction(
+                transaction_id,
+                recalculate_descriptors=True,
+            )
+
     except DatabaseError:
         logger.error("Error connecting to database")
+        number_of_db_changes = 0
 
     return number_of_db_changes
 

--- a/arches/app/utils/transaction.py
+++ b/arches/app/utils/transaction.py
@@ -6,15 +6,17 @@ from arches.app.models.models import IIIFManifest, EditLog, WorkflowHistory
 from arches.app.utils.index_database import (
     index_resources_by_transaction,
     optimize_resource_iteration,
+    index_tile_deletion_by_transaction,
 )
 from django.db import transaction, DatabaseError
+from django.db.models import Func, F
 
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
 
 
 # Given a transaction ID, reverse (delete or update) tiles and resources created/updated during the transaction
-def reverse_edit_log_entries(transaction_id):
+def reverse_edit_log_entries(transaction_id, user=None, chunk_size=2000):
     revserse_operation_transactionid = str(uuid.uuid4())
 
     transaction_changes = EditLog.objects.filter(transactionid=transaction_id)
@@ -29,50 +31,62 @@ def reverse_edit_log_entries(transaction_id):
         + tile_create_changes.count()
     )
 
+    # cast resourceinstanceid to UUID
+    resource_create_changes = resource_create_changes.annotate(
+        resourceinstanceid_uuid=Func(F("resourceinstanceid"), function="UUID")
+    )
     created_resources_query_set = Resource.objects.filter(
         resourceinstanceid__in=resource_create_changes.values_list(
-            "resourceinstanceid", flat=True
+            "resourceinstanceid_uuid", flat=True
         )
     )
 
-    try:
-        with transaction.atomic():
-            for resource in optimize_resource_iteration(
-                created_resources_query_set, chunk_size=2000
-            ):
-                resource.delete(
-                    fetch_relations=False,
-                    transaction_id=revserse_operation_transactionid,
-                )
+    for resource in optimize_resource_iteration(
+        created_resources_query_set, chunk_size=chunk_size
+    ):
+        resource.delete(
+            fetch_relations=False,
+            user=user,
+            transaction_id=revserse_operation_transactionid,
+        )
 
-            for tile in Tile.objects.filter(
-                tileid__in=tile_create_changes.values_list("tileinstanceid", flat=True)
-            ):
-                tile.delete(
-                    recalculate_descriptors=False,
-                    transaction_id=revserse_operation_transactionid,
-                )
+    # cast tileinstanceid to UUID
+    tile_create_changes = tile_create_changes.annotate(
+        tileinstanceid_uuid=Func(F("tileinstanceid"), function="UUID")
+    )
 
-            for tile in Tile.objects.filter(
-                tileid__in=tile_edit_changes.values_list("tileinstanceid", flat=True)
-            ):
-                tile.data = tile_edit_changes.get(
-                    tileinstanceid=str(tile.tileid)
-                ).oldvalue
-                tile.save(
-                    index=False,
-                    recalculate_descriptors=False,
-                    transaction_id=revserse_operation_transactionid,
-                )
-        if tile_edit_changes.count() > 0:
-            index_resources_by_transaction(
-                transaction_id,
-                recalculate_descriptors=True,
+    for tile in Tile.objects.filter(
+        tileid__in=tile_create_changes.values_list("tileinstanceid_uuid", flat=True)
+    ).iterator(chunk_size=chunk_size):
+        tile.delete(
+            recalculate_descriptors=False,
+            index=False,
+            transaction_id=revserse_operation_transactionid,
+            user=user,
+        )
+    index_tile_deletion_by_transaction(transaction_id)
+
+    with transaction.atomic():
+        # cast tileinstanceid to UUID
+        tile_edit_changes = tile_edit_changes.annotate(
+            tileinstanceid_uuid=Func(F("tileinstanceid"), function="UUID")
+        )
+
+        for tile in Tile.objects.filter(
+            tileid__in=tile_edit_changes.values_list("tileinstanceid_uuid", flat=True)
+        ).iterator(chunk_size=2000):
+            tile.data = tile_edit_changes.get(tileinstanceid=str(tile.tileid)).oldvalue
+            tile.save(
+                index=False,
+                recalculate_descriptors=False,
+                transaction_id=revserse_operation_transactionid,
+                user=user,
             )
-
-    except DatabaseError:
-        logger.error("Error connecting to database")
-        number_of_db_changes = 0
+    if tile_edit_changes.count() > 0:
+        index_resources_by_transaction(
+            transaction_id,
+            recalculate_descriptors=True,
+        )
 
     return number_of_db_changes
 

--- a/arches/app/views/transaction.py
+++ b/arches/app/views/transaction.py
@@ -18,7 +18,9 @@ class ReverseTransaction(View):
         response = dict()
         success = False
         if transactionid is not None:
-            response["changes"] = reverse_edit_log_entries(transactionid)
+            response["changes"] = reverse_edit_log_entries(
+                transactionid, user=request.user
+            )
             response["changes"] += delete_manifests(transactionid)
             response["changes"] += delete_workflow_histories(transactionid)
             success = True

--- a/arches/management/commands/transaction.py
+++ b/arches/management/commands/transaction.py
@@ -20,6 +20,7 @@ import os
 import uuid
 from arches.management.commands import utils
 from arches.app.models import models
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from django.db.utils import IntegrityError
 from arches.app.utils import transaction
@@ -40,4 +41,5 @@ class Command(BaseCommand):
             self.reverse(options["transaction_id"])
 
     def reverse(self, transaction_id):
-        print(transaction.reverse_edit_log_entries(transaction_id))
+        user = User.objects.get(username="admin")
+        print(transaction.reverse_edit_log_entries(transaction_id, user=user))

--- a/releases/8.1.0.md
+++ b/releases/8.1.0.md
@@ -1,0 +1,24 @@
+Arches 8.1.0 Release Notes
+--------------------------
+
+### Major enhancements
+- 
+
+### Performance improvements
+- Further Improvements to indexing and bulk deletion performance [#12015](https://github.com/archesproject/arches/issues/12015)
+
+### Additional highlights
+- 
+
+### Dependency changes
+
+
+### Breaking changes
+- 
+
+
+### Upgrading Arches
+
+
+### Upgrading an Arches project
+

--- a/tests/search/search_sort_tests.py
+++ b/tests/search/search_sort_tests.py
@@ -26,19 +26,19 @@ class SearchSortTests(ArchesTestCase):
 
         Resource.objects.create(
             graph=test_graph,
-            name="B Resource (first created)",
+            name={"en": "B Resource (first created)"},
             resourceinstanceid="8ec120f4-61cd-4fa1-8f9a-3d12cff3176f",
         )
 
         Resource.objects.create(
             graph=test_graph,
-            name="C Resource (second created)",
+            name={"en": "C Resource (second created)"},
             resourceinstanceid="a94c81c5-2047-4b53-8341-495f12bfad95",
         )
 
         Resource.objects.create(
             graph=test_graph,
-            name="A Resource (third created)",
+            name={"en": "A Resource (third created)"},
             resourceinstanceid="09ba8b82-b6db-4ece-9a46-98f6d381a7b2",
         )
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Deleting data should be the fastest CRUD operation, so why does it take as long as (or longer than) Load inserts? The short answer is: 
- too much stored in-memory which can lead to costly swaps
- various unnecessary indexing operations
- a few too many ORM queries


A few highlights:
- in the `ResourceXResource.delete` method, deletes a tile that has no related resources in tile.data array
- creates a new kwarg for `tile.save` and `tile.delete`: `recalculate_descriptors=True` since most of the time it's not needed, especially when bulk indexing usually handles `recalculate_descriptors` in its own block of code
- `Resource` proxy model now has `self.torelations = []` and `self.fromrelations = []` properties for storing prefetched relations
- `Resource` proxy model `save` method now calls `self.save_descriptors` and passes `recalculate_descriptors=False` to local `tile.save`s
- `index_database.optimize_resource_iteration` now prefetches a resource's related resources
- `BulkDataDeletion.delete_resources` uses `optimize_resource_iteration` instead of doing its own thing
- `reverse_edit_log_entries` now uses `iterators`, bulk indexes tile deletion, and doesn't index until necessary
- failed `load.reverse` will reset the load status to the original status instead of being stuck in "unloading"


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Addresses #12015

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.1.x (under development): features, bugfixes not covered below    
    - [ ] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
