### PR TITLE
Remove user query deluge during indexing #11553

### DIFF
--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -501,7 +501,7 @@ class Resource(models.ResourceInstance):
         document["root_ontology_class"] = self.get_root_ontology()
         document["legacyid"] = self.legacyid
         document["resource_instance_lifecycle_state_id"] = str(
-            self.resource_instance_lifecycle_state.pk
+            self.resource_instance_lifecycle_state_id
         )
 
         document["displayname"] = []

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -471,7 +471,13 @@ class Resource(models.ResourceInstance):
             resource_indexed.send(sender=self.__class__, instance=self)
 
     def get_documents_to_index(
-        self, fetchTiles=True, datatype_factory=None, node_datatypes=None, context=None
+        self,
+        fetchTiles=True,
+        datatype_factory=None,
+        node_datatypes=None,
+        context=None,
+        *,
+        all_users=None,
     ):
         """
         Gets all the documents nessesary to index a single resource
@@ -482,6 +488,7 @@ class Resource(models.ResourceInstance):
         datatype_factory -- refernce to the DataTypeFactory instance
         node_datatypes -- a dictionary of datatypes keyed to node ids
         context -- a string such as "copy" to indicate conditions under which a document is indexed
+        all_users -- an iterable of User objects, e.g. User.objects.prefetch_related("groups")
 
         """
 
@@ -571,7 +578,9 @@ class Resource(models.ResourceInstance):
                 [int(self.principaluser_id)] if self.principaluser_id else []
             )
         }
-        document["permissions"].update(permission_backend.get_index_values(self))
+        document["permissions"].update(
+            permission_backend.get_index_values(self, all_users=all_users)
+        )
 
         document["strings"] = []
         document["dates"] = []

--- a/arches/app/permissions/arches_default_allow.py
+++ b/arches/app/permissions/arches_default_allow.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from typing import Iterable
 
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -111,7 +112,12 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
         # We do not do set filtering - None is allow-all for sets.
         return None
 
-    def get_restricted_users(self, resource: ResourceInstance) -> dict[str, set[int]]:
+    def get_restricted_users(
+        self,
+        resource: ResourceInstance,
+        *,
+        all_users: Iterable[User] = User.objects.none(),
+    ) -> dict[str, set[int]]:
         """
         Takes a resource instance and identifies which users are explicitly restricted from
         reading, editing, deleting, or accessing it.
@@ -131,7 +137,7 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
             "cannot_write": set(),
             "cannot_delete": set(),
         }
-        for user in User.objects.prefetch_related("groups"):
+        for user in all_users or User.objects.prefetch_related("groups"):
             default_permissions = self.get_default_permissions(
                 user, resource, all_permissions=True
             )
@@ -327,8 +333,10 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
         mappings["users_with_no_access"] = {"type": "integer"}
         return mappings
 
-    def get_index_values(self, resource: Resource):
-        restrictions = self.get_restricted_users(resource)
+    def get_index_values(
+        self, resource: Resource, *, all_users: Iterable[User] = User.objects.none()
+    ):
+        restrictions = self.get_restricted_users(resource, all_users=all_users)
         permissions = {}
         permissions["users_without_read_perm"] = list(restrictions["cannot_read"])
         permissions["users_without_edit_perm"] = list(restrictions["cannot_write"])

--- a/arches/app/permissions/arches_default_allow.py
+++ b/arches/app/permissions/arches_default_allow.py
@@ -131,7 +131,7 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
             "cannot_write": set(),
             "cannot_delete": set(),
         }
-        for user in User.objects.all():
+        for user in User.objects.prefetch_related("groups"):
             default_permissions = self.get_default_permissions(
                 user, resource, all_permissions=True
             )
@@ -270,7 +270,7 @@ class ArchesDefaultAllowPermissionFramework(ArchesPermissionBase):
             result["resource"] = resource
 
             if str(resource.pk) == settings.SYSTEM_SETTINGS_RESOURCE_ID:
-                if not user.groups.filter(name="System Administrator").exists():
+                if not self.user_in_group_by_name(user, ["System Administrator"]):
                     result["permitted"] = False
                     return result
 

--- a/arches/app/permissions/arches_default_deny.py
+++ b/arches/app/permissions/arches_default_deny.py
@@ -13,6 +13,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+from typing import Iterable
+
 from django.contrib.auth.models import User
 
 from arches.app.models.models import ResourceInstance
@@ -34,7 +36,12 @@ class ArchesDefaultDenyPermissionFramework(ArchesPermissionBase):
         # We do not do set filtering - None is allow-all for sets.
         return None if user and user.username != "anonymous" else set()
 
-    def get_restricted_users(self, resource: ResourceInstance) -> dict[str, list[int]]:
+    def get_restricted_users(
+        self,
+        resource: ResourceInstance,
+        *,
+        all_users: Iterable[User] = User.objects.none(),
+    ) -> dict[str, list[int]]:
         pass
 
     def get_filtered_instances(
@@ -157,7 +164,9 @@ class ArchesDefaultDenyPermissionFramework(ArchesPermissionBase):
         else:  # for default deny, explicit permissions are required.  Model level permissions are bypassed.
             return False
 
-    def get_index_values(self, resource: Resource):
+    def get_index_values(
+        self, resource: Resource, *, all_users: Iterable[User] = User.objects.none()
+    ):
         permissions = {}
         group_read_allowances = [
             group.id

--- a/arches/app/permissions/arches_default_deny.py
+++ b/arches/app/permissions/arches_default_deny.py
@@ -121,7 +121,7 @@ class ArchesDefaultDenyPermissionFramework(ArchesPermissionBase):
             raise ValueError("resourceid and resource are mutually incompatible")
         if str(resource.pk) == settings.SYSTEM_SETTINGS_RESOURCE_ID:
             result["resource"] = resource
-            if not user.groups.filter(name="System Administrator").exists():
+            if not self.user_in_group_by_name(user, ["System Administrator"]):
                 result["permitted"] = False
             else:
                 result["permitted"] = True

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -7,6 +7,7 @@ import pyprind
 import sys
 
 from datetime import datetime
+from django.contrib.auth.models import User
 from django.db import connection, connections
 from django.db.models import prefetch_related_objects, Prefetch, Q, QuerySet
 from arches.app.models import models
@@ -19,8 +20,6 @@ from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_IN
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.utils import import_class_from_string
 from typing import Iterable
-
-from arches.app.models.models import EditLog
 
 
 logger = logging.getLogger(__name__)
@@ -247,6 +246,7 @@ def index_resources_using_singleprocessing(
         str(nodeid): datatype
         for nodeid, datatype in models.Node.objects.values_list("nodeid", "datatype")
     }
+    all_users = User.objects.prefetch_related("groups")
     with se.BulkIndexer(batch_size=batch_size, refresh=True) as doc_indexer:
         with se.BulkIndexer(batch_size=batch_size, refresh=True) as term_indexer:
             if quiet is False:
@@ -274,6 +274,7 @@ def index_resources_using_singleprocessing(
                     fetchTiles=False,
                     datatype_factory=datatype_factory,
                     node_datatypes=node_datatypes,
+                    all_users=all_users,
                 )
                 doc_indexer.add(
                     index=RESOURCES_INDEX,

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -1,4 +1,7 @@
 from abc import abstractmethod, ABCMeta
+from typing import Iterable
+
+from django.contrib.auth.models import User
 
 from arches.app.const import ExtensionType
 from arches.app.models.models import EditLog, GraphModel
@@ -63,7 +66,9 @@ class PermissionFramework(metaclass=ABCMeta):
     def get_permission_backend(self): ...
 
     @abstractmethod
-    def get_restricted_users(self, resource): ...
+    def get_restricted_users(
+        self, resource, *, all_users: Iterable[User] = User.objects.none()
+    ): ...
 
     @abstractmethod
     def get_filtered_instances(
@@ -133,7 +138,9 @@ class PermissionFramework(metaclass=ABCMeta):
     def update_mappings(self): ...
 
     @abstractmethod
-    def get_index_values(self, resource): ...
+    def get_index_values(
+        self, resource, *, all_users: Iterable[User] = User.objects.none()
+    ): ...
 
     @abstractmethod
     def get_permission_inclusions(self): ...
@@ -194,8 +201,10 @@ def _get_permission_backend():
     return _get_permission_framework().get_permission_backend()
 
 
-def get_restricted_users(resource):
-    return _get_permission_framework().get_restricted_users(resource)
+def get_restricted_users(resource, *, all_users: Iterable[User] = User.objects.none()):
+    return _get_permission_framework().get_restricted_users(
+        resource, all_users=all_users
+    )
 
 
 def get_filtered_instances(
@@ -379,8 +388,8 @@ def update_mappings():
     return _get_permission_framework().update_mappings()
 
 
-def get_index_values(resource):
-    return _get_permission_framework().get_index_values(resource)
+def get_index_values(resource, *, all_users: Iterable[User] = User.objects.none()):
+    return _get_permission_framework().get_index_values(resource, all_users=all_users)
 
 
 def get_permission_search_filter(user):

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -177,9 +177,7 @@ def _get_permission_framework():
 
 
 def get_createable_resource_models(user):
-    return GraphModel.objects.filter(
-        pk__in=list(get_createable_resource_types(user))
-    ).all()
+    return GraphModel.objects.filter(pk__in=list(get_createable_resource_types(user)))
 
 
 def assign_perm(perm, user_or_group, obj=None):

--- a/arches/app/views/resource.py
+++ b/arches/app/views/resource.py
@@ -499,7 +499,7 @@ class ResourcePermissionDataView(View):
                     user_is_resource_editor(user) or user_is_resource_reviewer(user)
                 ),
             }
-            for user in User.objects.all()
+            for user in User.objects.prefetch_related("groups")
         ]
         identities += [
             {

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -10,7 +10,7 @@ Arches 8.0.0 Release Notes
 - Support Django 5.2 [#11797](https://github.com/archesproject/arches/pull/11797)
 
 ### Performance improvements
-- Improve indexing and bulk deletion performance [#11382](https://github.com/archesproject/arches/issues/11382)
+- Improve indexing and bulk deletion performance [#11382](https://github.com/archesproject/arches/issues/11382) [#11553](https://github.com/archesproject/arches/issues/11553)
 - Improve serialization performance [#11962](https://github.com/archesproject/arches/pull/11962)
 - The following methods or functions in the permissions framework now take an optional ``resource`` keyword argument to avoid refetching an instance that a caller may already have:
     - `user_can_read_resource()`

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -486,6 +486,13 @@ class ResourceTests(ArchesTestCase):
                 ]
                 self.assertEqual(len(tile_selects), 1)
 
+                non_guardian_user_selects = [
+                    q
+                    for q in queries
+                    if q["sql"].endswith('FROM "auth_user"') and "guardian" not in q
+                ]
+                self.assertEqual(len(non_guardian_user_selects), 1)
+
     def test_self_referring_resource_instance_descriptor(self):
         # Create a nodegroup with a string node and a resource-instance node.
         graph = Graph.objects.create_graph(

--- a/tests/permissions/base_permissions_framework_test.py
+++ b/tests/permissions/base_permissions_framework_test.py
@@ -38,6 +38,6 @@ class ArchesPermissionFrameworkTestCase(ArchesTestCase):
         cls.group = Group.objects.get(pk=2)
         cls.legacy_load_testing_package()
         cls.framework = cls.FRAMEWORK()
-        resource = Resource.objects.get(pk=cls.resource_instance_id)
-        resource.graph_id = cls.data_type_graphid
-        resource.remove_resource_instance_permissions()
+        cls.resource = Resource.objects.get(pk=cls.resource_instance_id)
+        cls.resource.graph_id = cls.data_type_graphid
+        cls.resource.remove_resource_instance_permissions()

--- a/tests/permissions/permissions_arches_default_allow_tests.py
+++ b/tests/permissions/permissions_arches_default_allow_tests.py
@@ -55,16 +55,13 @@ class ArchesDefaultAllowPermissionsTests(ArchesPermissionFrameworkTestCase):
                 implicit_permission = self.framework.user_can_read_resource(
                     self.user, self.resource_instance_id
                 )
-                resource = ResourceInstance.objects.get(
-                    resourceinstanceid=self.resource_instance_id
-                )
                 can_access_without_view_permission = (
                     self.framework.user_can_read_resource(
                         self.user, self.resource_instance_id
                     )
                 )
                 self.framework.assign_perm(
-                    "view_resourceinstance", self.group, resource
+                    "view_resourceinstance", self.group, self.resource
                 )
                 can_access_with_view_permission = self.framework.user_can_read_resource(
                     self.user, self.resource_instance_id
@@ -105,10 +102,7 @@ class ArchesDefaultAllowPermissionsTests(ArchesPermissionFrameworkTestCase):
                 "arches.app.permissions.arches_default_allow.settings",
                 default_permissions,
             ):
-                resource = ResourceInstance.objects.get(
-                    resourceinstanceid=self.resource_instance_id
-                )
-                result = self.framework.get_restricted_users(resource)
+                result = self.framework.get_restricted_users(self.resource)
                 self.assertIn(self.user.id, result["no_access"])
 
     def test_get_search_ui_permissions(self):
@@ -147,14 +141,11 @@ class ArchesDefaultAllowPermissionsTests(ArchesPermissionFrameworkTestCase):
         implicit_permission = self.framework.user_can_read_resource(
             self.user, self.resource_instance_id
         )
-        resource = ResourceInstance.objects.get(
-            resourceinstanceid=self.resource_instance_id
-        )
-        self.framework.assign_perm("change_resourceinstance", self.group, resource)
+        self.framework.assign_perm("change_resourceinstance", self.group, self.resource)
         can_access_without_view_permission = self.framework.user_can_read_resource(
             self.user, self.resource_instance_id
         )
-        self.framework.assign_perm("view_resourceinstance", self.group, resource)
+        self.framework.assign_perm("view_resourceinstance", self.group, self.resource)
         can_access_with_view_permission = self.framework.user_can_read_resource(
             self.user, self.resource_instance_id
         )
@@ -202,17 +193,14 @@ class ArchesDefaultAllowPermissionsTests(ArchesPermissionFrameworkTestCase):
 
         """
 
-        resource = ResourceInstance.objects.get(
-            resourceinstanceid=self.resource_instance_id
-        )
-        nodes = Node.objects.filter(graph_id=resource.graph_id)
+        nodes = Node.objects.filter(graph_id=self.resource.graph_id)
         for node in nodes:
             if node.nodegroup:
                 self.framework.assign_perm(
                     "no_access_to_nodegroup", self.group, node.nodegroup
                 )
         hasperms = self.framework.user_has_resource_model_permissions(
-            self.user, ["models.read_nodegroup"], resource
+            self.user, ["models.read_nodegroup"], self.resource
         )
         self.assertFalse(hasperms)
 
@@ -221,20 +209,17 @@ class ArchesDefaultAllowPermissionsTests(ArchesPermissionFrameworkTestCase):
         Tests that users are properly identified as restricted.
         """
 
-        resource = ResourceInstance.objects.get(
-            resourceinstanceid=self.resource_instance_id
-        )
         self.framework.assign_perm(
-            "no_access_to_resourceinstance", self.group, resource
+            "no_access_to_resourceinstance", self.group, self.resource
         )
         ben = self.user
         jim = User.objects.get(username="jim")
         sam = User.objects.get(username="sam")
         admin = User.objects.get(username="admin")
-        self.framework.assign_perm("view_resourceinstance", ben, resource)
-        self.framework.assign_perm("change_resourceinstance", jim, resource)
+        self.framework.assign_perm("view_resourceinstance", ben, self.resource)
+        self.framework.assign_perm("change_resourceinstance", jim, self.resource)
 
-        restrictions = self.framework.get_restricted_users(resource)
+        restrictions = self.framework.get_restricted_users(self.resource)
 
         results = [
             jim.id in restrictions["cannot_read"],

--- a/tests/permissions/permissions_arches_default_deny_tests.py
+++ b/tests/permissions/permissions_arches_default_deny_tests.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, Mock, patch
 from tests.permissions.base_permissions_framework_test import (
     ArchesPermissionFrameworkTestCase,
 )
-from arches.app.models.models import Node, ResourceInstance
+from arches.app.models.models import Node
 from arches.app.permissions.arches_default_deny import (
     ArchesDefaultDenyPermissionFramework,
 )
@@ -66,14 +66,11 @@ class ArchesDefaultDenyPermissionTests(ArchesPermissionFrameworkTestCase):
         implicit_permission = self.framework.user_can_read_resource(
             self.user, self.resource_instance_id
         )
-        resource = ResourceInstance.objects.get(
-            resourceinstanceid=self.resource_instance_id
-        )
-        self.framework.assign_perm("change_resourceinstance", self.group, resource)
+        self.framework.assign_perm("change_resourceinstance", self.group, self.resource)
         can_access_without_view_permission = self.framework.user_can_read_resource(
             self.user, self.resource_instance_id
         )
-        self.framework.assign_perm("view_resourceinstance", self.group, resource)
+        self.framework.assign_perm("view_resourceinstance", self.group, self.resource)
         can_access_with_view_permission = self.framework.user_can_read_resource(
             self.user, self.resource_instance_id
         )
@@ -87,17 +84,14 @@ class ArchesDefaultDenyPermissionTests(ArchesPermissionFrameworkTestCase):
 
         """
 
-        resource = ResourceInstance.objects.get(
-            resourceinstanceid=self.resource_instance_id
-        )
-        nodes = Node.objects.filter(graph_id=resource.graph_id)
+        nodes = Node.objects.filter(graph_id=self.resource.graph_id)
         for node in nodes:
             if node.nodegroup:
                 self.framework.assign_perm(
                     "no_access_to_nodegroup", self.group, node.nodegroup
                 )
         hasperms = self.framework.user_has_resource_model_permissions(
-            self.user, ["models.read_nodegroup"], resource
+            self.user, ["models.read_nodegroup"], self.resource
         )
         self.assertFalse(hasperms)
 

--- a/tests/views/api/test_permissions.py
+++ b/tests/views/api/test_permissions.py
@@ -28,12 +28,13 @@ class InstancePermissionsAPITest(ArchesTestCase):
         )
         cls.graph.save(validate=False)
 
+        cls.resource = ResourceInstance.objects.create(graph=cls.graph)
+
     def test_get_with_anonymous_user(self):
-        resource = ResourceInstance.objects.create(graph=self.graph)
         with CaptureQueriesContext(connection) as queries:
             response = self.client.get(
                 reverse("api_instance_permissions"),
-                QUERY_STRING=f"resourceinstanceid={resource.pk}",
+                QUERY_STRING=f"resourceinstanceid={self.resource.pk}",
             )
         resource_selects = [
             q for q in queries if q["sql"].startswith('SELECT "resource_instances"')
@@ -44,7 +45,6 @@ class InstancePermissionsAPITest(ArchesTestCase):
         )
 
     def test_get_with_resource_editor_role(self):
-        resource = ResourceInstance.objects.create(graph=self.graph)
         editor_group = Group.objects.get(name="Resource Editor")
         test_user = User.objects.create()
         test_user.groups.add(editor_group)
@@ -52,7 +52,7 @@ class InstancePermissionsAPITest(ArchesTestCase):
 
         response = self.client.get(
             reverse("api_instance_permissions"),
-            QUERY_STRING=f"resourceinstanceid={resource.pk}",
+            QUERY_STRING=f"resourceinstanceid={self.resource.pk}",
         )
 
         self.assertEqual(


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Indexing tasks queried the User table once per resource. (For 1m resources, that was 999,999 wasteful queries.)

Further, we were also querying for groups individually instead of fetching a user's set of groups and testing that cache.

### Issues Solved
Closes #11553

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.0.x (under development): features, bugfixes not covered below
    - [ ] dev/7.6.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/6.2.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch