### PR TITLE
Use dependency-groups for dev dependencies #12038

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install Python packages
       run: |
         python -m pip install --upgrade pip
-        pip install '.[dev]'
+        pip install . --group dev
         echo Python packages installed
       shell: bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ COPY . ${ARCHES_ROOT}
 WORKDIR ${ARCHES_ROOT}
 
 RUN . ../ENV/bin/activate \
-    && pip install -e '.[dev]' --no-binary :all:
+    && pip install -e . --group dev --no-binary :all:
 
 # Set default workdir
 WORKDIR ${ARCHES_ROOT}

--- a/arches/install/arches-templates/.github/actions/build-and-test-branch/action.yml
+++ b/arches/install/arches-templates/.github/actions/build-and-test-branch/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install Python packages
       run: |
         python -m pip install --upgrade pip
-        pip install '.[dev]'
+        pip install . --group dev
         echo Python packages installed
       shell: bash
     

--- a/arches/install/arches-templates/pyproject.toml
+++ b/arches/install/arches-templates/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 version = "0.0.1"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "black==24.4.2",
     "coverage",

--- a/arches/management/commands/updateproject.py
+++ b/arches/management/commands/updateproject.py
@@ -20,6 +20,7 @@ class Command(BaseCommand):  # pragma: no cover
             "This operation will upgrade your project to version 8.0\n"
             "This will replace the following files in your project:\n"
             "  - <project>/apps.py\n"
+            "  - .github/actions/build-and-test-branch/action.yml\n"
             "  - .github/workflows/main.yml\n"
             "  - tsconfig.json\n"
             "  - vitest.config.mts\n"
@@ -124,6 +125,38 @@ from arches.settings_utils import generate_frontend_configuration"""
         self.stdout.write("Done!")
 
         # Updates github workflows
+        self.stdout.write(
+            "Copying .github/actions/build-and-test-branch/action.yml directory to project..."
+        )
+
+        os.makedirs(
+            os.path.join(
+                settings.APP_ROOT, "..", ".github", "actions", "build-and-test-branch"
+            ),
+            exist_ok=True,
+        )
+
+        shutil.copy(
+            os.path.join(
+                settings.ROOT_DIR,
+                "install",
+                "arches-templates",
+                ".github",
+                "actions",
+                "build-and-test-branch",
+                "action.yml",
+            ),
+            os.path.join(
+                settings.APP_ROOT,
+                "..",
+                ".github",
+                "actions",
+                "build-and-test-branch",
+                "action.yml",
+            ),
+        )
+        self.stdout.write("Done!")
+
         self.stdout.write("Copying .github/workflows/main.yml directory to project...")
 
         os.makedirs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "urllib3<2",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "black==24.4.2",
     "coverage",

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -208,6 +208,7 @@ JavaScript:
 
 1. Upgrade to Arches 8.0.0
     ```
+    pip install --upgrade pip
     pip install --upgrade arches==8.0.0
     ```
 

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -50,6 +50,7 @@ Arches 8.0.0 Release Notes
 - Add support for tile sort order to the bulk data manager [#11638](https://github.com/archesproject/arches/pull/11638)
 - Show the loading UX immediately when the user imports a resource model [#10540](https://github.com/archesproject/arches/issues/10540)
 - Improve default packaging manifest [#11828](https://github.com/archesproject/arches/issues/11828)
+- Migrate dev dependencies to dependency-groups [#12038](https://github.com/archesproject/arches/issues/12038)
 - Improve `ResourceXResource` field and related names [#11869](https://github.com/archesproject/arches/issues/11869)
 - Fix issue that produced an error when cycling between the dropdown options in Advanced search [#11442](https://github.com/archesproject/arches/issues/11442)
 - Add message when copying geojson url to clipboard [#11076](https://github.com/archesproject/arches/issues/11076)
@@ -220,6 +221,7 @@ JavaScript:
     - Remove `"Framework :: Django :: 4.2"`
     - Add `"Framework :: Django :: 5.2"`
     - Remove any classifier beginning with "License :: "
+    - Replace the heading `[project.optional-dependencies]` with `[dependency-groups]`
     - Unless you have already published your project to PyPI, in the `name = ...` key replace underscores with hyphens to follow PEP 8 conventions.
 
 1. Update `.gitignore`:


### PR DESCRIPTION
The `'.[dev]'` is clunky, with its apostrophes for shell-escaping, and wasn't really designed for packages that are not part of your application functionality (as opposed to IIIF which would be). **pip 25.1** has something better now, so use that.

Closes #12038

