### PR TITLE
Fix --clear_index parameter unable to be set to False in command line

### DIFF
--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
             action="store",
             dest="clear_index",
             default=True,
-            type=lambda x: str(x).lower() == 'true',
+            type=lambda x: str(x).lower() == "true",
             help="Set to True (default) to remove all the resources from the index before the reindexing operation. Set to False to overwrite in place the existing resources in the index.",
         )
 

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -33,6 +33,7 @@ from arches.app.search.mappings import (
     delete_resource_relations_index,
 )
 import arches.app.utils.index_database as index_database_util
+from arches.app.utils.string_utils import str_to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -125,8 +126,8 @@ class Command(BaseCommand):
             action="store",
             dest="clear_index",
             default=True,
-            type=lambda x: str(x).lower() == "true",
-            help="Set to True (default) to remove all the resources from the index before the reindexing operation. Set to False to overwrite in place the existing resources in the index.",
+            type=lambda x: str_to_bool(x),
+            help="Whether to remove all target resources from the index before reindexing. Accepts 'true'/'false', 'yes'/'no', 'y'/'n', 't'/'f', 'on'/'off', or '1'/'0' (case-insensitive). Default is True.",
         )
 
         parser.add_argument(

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -125,7 +125,8 @@ class Command(BaseCommand):
             action="store",
             dest="clear_index",
             default=True,
-            help="Set to True(default) to remove all the resources from the index before the reindexing operation",
+            type=lambda x: str(x).lower() == 'true',
+            help="Set to True (default) to remove all the resources from the index before the reindexing operation. Set to False to overwrite in place the existing resources in the index.",
         )
 
         parser.add_argument(

--- a/arches/management/commands/es.py
+++ b/arches/management/commands/es.py
@@ -126,7 +126,7 @@ class Command(BaseCommand):
             action="store",
             dest="clear_index",
             default=True,
-            type=lambda x: str_to_bool(x),
+            type=str_to_bool,
             help="Whether to remove all target resources from the index before reindexing. Accepts 'true'/'false', 'yes'/'no', 'y'/'n', 't'/'f', 'on'/'off', or '1'/'0' (case-insensitive). Default is True.",
         )
 

--- a/releases/7.6.10.md
+++ b/releases/7.6.10.md
@@ -7,6 +7,7 @@
 - Prevents `settings_utils.generate_frontend_configuration()` from writing to stdout, which breaks some automation scripts [#11979](https://github.com/archesproject/arches/pull/11979)
 - Clear attributes from imported shapefile before ES indexing [#11870](https://github.com/archesproject/arches/issues/11870)
 - Issue Timewheel Clear filter [#11998] (https://github.com/archesproject/arches/issues/11998)
+- Fixes behavior of the `--clear_index` parameter in the `es` management command to accept a False value, e.g. `-c False` [#12048](https://github.com/archesproject/arches/issues/12048)
 - Excludes build directory and staticfiles directory from typescript checking [#11978](https://github.com/archesproject/arches/pull/11978)
 - Fixes graph caching issue that showed up when accessing the Related Resources link from the search results [#12036](https://github.com/archesproject/arches/issues/12036)
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
`--clear_index` parameter of `es` command has no way of being set to `False`, and therefore will always clear the resources out of the index before indexing the resources.

For production systems that may need to use these commands, it removes data from search and causes significant reduction of availability during the process.

Its current behaviour meant that by default it must continue to clear indexes if not explicitly set, but the parameter name must remain the same in case users were explicitly using it (despite it not working as described if using False). Therefore the simplest approach was to use the `type` action to evaluate a string value provided into a boolean using value.lower() == 'true'.

Ideally in the future this would be correctly implemented as an optional flag (store_true) and the default behavior would be non-destructive, but this would be a breaking change.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12048 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @aj-he 
*   Tested by: @aj-he
*   Designed by: @aj-he

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
