### PR TITLE
Fix usage of startproject command without underscores re #12028

### DIFF
--- a/arches/install/arches_admin.py
+++ b/arches/install/arches_admin.py
@@ -124,6 +124,16 @@ class ArchesProjectCommand(TemplateCommand):
         options["project_name_title_case"] = project_name.title().replace("_", "")
         options["project_name_kebab_case"] = project_name.replace("_", "-")
 
+        if options["project_name_kebab_case"] != project_name:
+            self.stdout.write(
+                self.style.NOTICE(
+                    f"Renamed the directory from {project_name} to {options['project_name_kebab_case']}. "
+                    "If this is not desired, use the --directory option to create "
+                    "a directory with the name you want. Consider using a name "
+                    "distinct from your project name."
+                )
+            )
+
         super(ArchesProjectCommand, self).handle(
             "project", project_name, target, **options
         )
@@ -170,13 +180,19 @@ class ArchesProjectCommand(TemplateCommand):
 def command_startproject(args):
     options = vars(args)
     name = options["name"]
-    if not options["directory"]:
+    make_directory = False
+    if not options["directory"] and "_" in name:
+        # The user is supposed to create the --directory themselves. But we
+        # should do it for them if the command is the one that invented the
+        # --directory argument.
+        # TODO(v8.1): remove (Django 6 creates target dir automatically)
+        make_directory = True
         options["directory"] = name.replace("_", "-")
     directory = options["directory"]
 
-    project_path = os.path.join(os.getcwd(), directory)
+    project_path = os.path.join(os.getcwd(), directory if directory else name)
 
-    if not os.path.exists(project_path):
+    if make_directory and not os.path.exists(project_path):
         os.mkdir(project_path)
 
     cmd = ArchesProjectCommand()

--- a/arches/install/arches_admin.py
+++ b/arches/install/arches_admin.py
@@ -124,7 +124,7 @@ class ArchesProjectCommand(TemplateCommand):
         options["project_name_title_case"] = project_name.title().replace("_", "")
         options["project_name_kebab_case"] = project_name.replace("_", "-")
 
-        if options["project_name_kebab_case"] != project_name:
+        if options["project_name_kebab_case"] != project_name and not target:
             self.stdout.write(
                 self.style.NOTICE(
                     f"Renamed the directory from {project_name} to {options['project_name_kebab_case']}. "

--- a/arches/install/arches_admin.py
+++ b/arches/install/arches_admin.py
@@ -185,7 +185,7 @@ def command_startproject(args):
         # The user is supposed to create the --directory themselves. But we
         # should do it for them if the command is the one that invented the
         # --directory argument.
-        # TODO(v8.1): remove (Django 6 creates target dir automatically)
+        # RemovedInArches81Warning (Django 6 creates target dir automatically)
         make_directory = True
         options["directory"] = name.replace("_", "-")
     directory = options["directory"]


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Regression in #12029 for project names without underscores.

Issue: by creating the directory name eagerly instead of letting the Django command do it, it was failing the check in the Django command that checks for existing python modules on your path.

Solution: only create the directory if the underscore -> hyphen transform took place.

Future: Django 6 allows deleting all this code, see [djangoproject/django#18387](https://github.com/django/django/pull/18387)


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ekansa
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->