### PR TITLE
Remove obsoleted tests re #11808

### DIFF
--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -100,30 +100,6 @@ class TileTests(ArchesTestCase):
         sample_tile.nodegroup = None
         self.assertEqual(f"{sample_tile!r}", f"<None ({sample_tile.pk})>")
 
-    def test_nodegroup_lookups(self):
-        sample_tile = self.create_tile()
-        query = TileModel.objects.filter(pk=sample_tile.pk).select_related(
-            "nodegroup__grouping_node"
-        )
-        with self.assertNumQueries(1):
-            query[0].nodegroup.grouping_node.alias
-
-        self.assertSequenceEqual(
-            TileModel.objects.filter(nodegroup__grouping_node__alias="Statement").all(),
-            [sample_tile],
-        )
-
-    def test_nodegroup_assignment(self):
-        """Django's ForeignObject is only recently public, so add coverage."""
-        sample_tile = self.create_tile()
-        other_nodegroup = NodeGroup.objects.get(
-            pk="41111111-0000-0000-0000-000000000000"
-        )
-        sample_tile.nodegroup = other_nodegroup
-        sample_tile.save()
-        refreshed = TileModel.objects.get(pk=sample_tile.pk)
-        self.assertEqual(refreshed.nodegroup, other_nodegroup)
-
     def test_load_from_python_dict(self):
         """
         Test that we can initialize a Tile object from a Python dictionary


### PR DESCRIPTION
Follow-up to e8996b3.

These tests aren't relevant now that we don't have to demonstrate that joining via the ORM still works -- we're back on the rails and no longer using a quasi-private Django api.