### PR TITLE
Add csv-like printing for too many cardxnodexwidget validator

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -166,6 +166,9 @@ class CardXNodeXWidget(SaveSupportsBlindOverwriteMixin, models.Model):
             add_to_update_fields(kwargs, "source_identifier_id")
         super(CardXNodeXWidget, self).save(**kwargs)
 
+    def __str__(self):
+        return f"{self.label}"
+
     class Meta:
         managed = True
         db_table = "cards_x_nodes_x_widgets"

--- a/arches/management/commands/validate.py
+++ b/arches/management/commands/validate.py
@@ -281,17 +281,17 @@ class Command(BaseCommand):
 
             if self.options["verbosity"] > 1:
                 self.stdout.write("\t" + "-" * 36)
-                if check.value == 1016:
+                if count and check.value == IntegrityCheck.TOO_MANY_WIDGETS.value:
                     self.stdout.write(
                         "\tNode alias,nodeid,draft_or_published,graph,nodegroup,cardxnodexwidgets"
                     )
                 if queryset:
                     for i, n in enumerate(queryset):
                         if i < limit:
-                            if check.value == 1016:
-                                card_set = list(n.cardxnodexwidget_set.all())
+                            if check.value == IntegrityCheck.TOO_MANY_WIDGETS.value:
+                                card_set = n.cardxnodexwidget_set.all()
                                 cards = " & ".join(
-                                    f"{card}({card.pk})" for card in card_set
+                                    f"{card} ({card.pk})" for card in card_set
                                 )
                                 self.stdout.write(f"\t{n},{n.nodegroup.pk},{cards}")
                             else:

--- a/arches/management/commands/validate.py
+++ b/arches/management/commands/validate.py
@@ -281,10 +281,21 @@ class Command(BaseCommand):
 
             if self.options["verbosity"] > 1:
                 self.stdout.write("\t" + "-" * 36)
+                if check.value == 1016:
+                    self.stdout.write(
+                        "\tNode alias,nodeid,draft_or_published,graph,nodegroup,cardxnodexwidgets"
+                    )
                 if queryset:
                     for i, n in enumerate(queryset):
                         if i < limit:
-                            self.stdout.write(f"\t{n}")
+                            if check.value == 1016:
+                                card_set = list(n.cardxnodexwidget_set.all())
+                                cards = " & ".join(
+                                    f"{card}({card.pk})" for card in card_set
+                                )
+                                self.stdout.write(f"\t{n},{n.nodegroup.pk},{cards}")
+                            else:
+                                self.stdout.write(f"\t{n}")
                         else:
                             self.stdout.write("\t\t(truncated...)")
                             break


### PR DESCRIPTION
We can follow up with exporting validation results to csv's, but for now, this makes the validation report _a little_ more useful if you do have too many cardxnodexwidget records