### PR TITLE
Avoid hand-escaping percent signs in I18n_JSON #12060

### DIFF
--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -245,9 +245,9 @@ class I18n_JSON(NothingNode):
 
         if isinstance(value, str):
             try:
-                ret = json.loads(value.replace("%%", "%"))
+                ret = json.loads(value)
             except:
-                ret = json.loads(json.dumps(value.replace("%%", "%")))
+                ret = json.loads(json.dumps(value))
         elif value is None:
             ret[lang] = None if use_nulls else ""
         elif isinstance(value, I18n_JSON):
@@ -321,7 +321,7 @@ class I18n_JSON(NothingNode):
                 ELSE %s
                 END
             """
-            params.append(json.dumps(self.to_localized_object()).replace("%", "%%"))
+            params.append(json.dumps(self.to_localized_object()))
 
         return sql, tuple(params)
 

--- a/arches/app/models/fields/i18n.py
+++ b/arches/app/models/fields/i18n.py
@@ -245,9 +245,9 @@ class I18n_JSON(NothingNode):
 
         if isinstance(value, str):
             try:
-                ret = json.loads(value)
+                ret = json.loads(value.replace("%%", "%"))
             except:
-                ret = json.loads(json.dumps(value))
+                ret = json.loads(json.dumps(value.replace("%%", "%")))
         elif value is None:
             ret[lang] = None if use_nulls else ""
         elif isinstance(value, I18n_JSON):

--- a/arches/app/models/migrations/12002_percent_sign_fix.py
+++ b/arches/app/models/migrations/12002_percent_sign_fix.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("models", "11848_alter_spatialview_geometrynode"),
+    ]
+
+    forward = """
+        UPDATE cards_x_nodes_x_widgets
+        SET config = jsonb_set(
+            config,
+            '{width}',
+            to_jsonb(
+                regexp_replace(config->>'width', '^(\d+)%{2,}$', '\1%', 'g')
+            )
+        )
+        WHERE config ? 'width'
+        AND config->>'width' ~ '^\d+%{2,}$';
+    """
+
+    operations = [
+        migrations.RunSQL(
+            forward,
+            migrations.RunSQL.noop,  # No reverse operation needed
+        ),
+    ]

--- a/arches/app/models/migrations/12002_percent_sign_fix.py
+++ b/arches/app/models/migrations/12002_percent_sign_fix.py
@@ -4,10 +4,10 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("models", "11848_alter_spatialview_geometrynode"),
+        ("models", "11959_unique_node_source_widget"),
     ]
 
-    forward = """
+    forward = r"""
         UPDATE cards_x_nodes_x_widgets
         SET config = jsonb_set(
             config,

--- a/arches/app/utils/data_management/resource_graphs/importer.py
+++ b/arches/app/utils/data_management/resource_graphs/importer.py
@@ -179,8 +179,7 @@ def import_graph(graphs, overwrite_graphs=True, user=None):
                             # Comparing the entire object against the database
                             # may fail because the incoming json may differ
                             # slightly from the database representation, e.g.
-                            # 'width': '100%' -> 'width': '100%%' in db (escaped)
-                            # or 'placeholder': 'Enter text'
+                            # 'placeholder': 'Enter text'
                             # -> 'placeholder': {'en': 'Enter text'} in db
                             card_id=card_x_node_x_widget["card_id"],
                             node_id=card_x_node_x_widget["node_id"],

--- a/tests/fixtures/resource_graphs/Search Sort Test Model.json
+++ b/tests/fixtures/resource_graphs/Search Sort Test Model.json
@@ -52,7 +52,7 @@
                             "en": "Enter text"
                         },
                         "uneditable": false,
-                        "width": "100%%%%%%%%"
+                        "width": "100%"
                     },
                     "id": "9f32c24c-7aa4-477a-857e-362c9b487b0c",
                     "label": {

--- a/tests/fixtures/resource_graphs/SpatialViews_Test_Model.json
+++ b/tests/fixtures/resource_graphs/SpatialViews_Test_Model.json
@@ -415,7 +415,7 @@
                             "en": "Enter text"
                         },
                         "uneditable": false,
-                        "width": "100%%"
+                        "width": "100%"
                     },
                     "id": "ef14873a-6675-4eb9-80d6-c60ffb4e59e5",
                     "label": {

--- a/tests/fixtures/resource_graphs/branch_excel_test.json
+++ b/tests/fixtures/resource_graphs/branch_excel_test.json
@@ -77,7 +77,7 @@
                             "en": "Enter text"
                         },
                         "uneditable": false,
-                        "width": "100%%"
+                        "width": "100%"
                     },
                     "id": "376d98fb-04e9-40aa-85a5-ee22ba1f3662",
                     "label": {

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -283,6 +283,27 @@ class Customi18nJSONFieldTests(ArchesTestCase):
         j = I18n_JSON(test_json)
         self.assertEqual(str(j), expected_output)
 
+    def test_i18n_json_percent_encoding(self):
+        test_json = json.dumps(
+            {
+                "i18n_properties": ["placeholder"],
+                "placeholder": {"en": "choose one", "es": "elija uno"},
+                "width": "100%",
+                "min_length": 19,
+            }
+        )
+        expected_output = json.dumps(
+            {
+                "i18n_properties": ["placeholder"],
+                "placeholder": "choose one",
+                "width": "100%",
+                "min_length": 19,
+            }
+        )
+        translation.activate("en")
+        j = I18n_JSON(test_json)
+        self.assertEqual(str(j), expected_output)
+
     def test_i18n_json_field(self):
         test_json = {
             "i18n_properties": ["placeholder"],

--- a/tests/localization/field_tests.py
+++ b/tests/localization/field_tests.py
@@ -283,27 +283,6 @@ class Customi18nJSONFieldTests(ArchesTestCase):
         j = I18n_JSON(test_json)
         self.assertEqual(str(j), expected_output)
 
-    def test_i18n_json_percent_encoding(self):
-        test_json = json.dumps(
-            {
-                "i18n_properties": ["placeholder"],
-                "placeholder": {"en": "choose one", "es": "elija uno"},
-                "width": "100%",
-                "min_length": 19,
-            }
-        )
-        expected_output = json.dumps(
-            {
-                "i18n_properties": ["placeholder"],
-                "placeholder": "choose one",
-                "width": "100%",
-                "min_length": 19,
-            }
-        )
-        translation.activate("en")
-        j = I18n_JSON(test_json)
-        self.assertEqual(str(j), expected_output)
-
     def test_i18n_json_field(self):
         test_json = {
             "i18n_properties": ["placeholder"],
@@ -500,3 +479,14 @@ class AsSqlTests(ArchesTestCase):
         # Apostrophe in "it's" is doubly-escaped so it doesn't close the string
         expected = "jsonb_set('{}'::jsonb, array['en'], '\"it''s a bird\"')"
         self.assertEqual(datatype.i18n_as_sql(domain_value, None, None), expected)
+
+    def test_percent_sign_encoding(self):
+        widget_config = I18n_JSON(
+            {
+                "i18n_properties": ["placeholder"],
+                "placeholder": "Enter text",
+                "width": "100%",
+            }
+        )
+        _, params = widget_config.as_sql(None, None)
+        self.assertEqual(json.loads(params[0])["width"], "100%")


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
Change the i18n json code to unpack the %% as %.  This stops the percent sign explosion.  Though it seems like this should also affect 7.6, based on my testing it doesn't.  This probably has something to do with how publishing and such is done in 8 vs 7.  

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12060

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
