### PR TITLE
Bump minimum version of requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "pytz==2023.3",
     "qrcode>=7.3.1",
     "rdflib==4.2.2",
-    "requests-oauthlib==1.3.1",
+    "requests-oauthlib==2.0.0",
     "requests[security]>=2.32.3",
     "semantic-version==2.10.0",
     "SPARQLWrapper==1.8.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "qrcode>=7.3.1",
     "rdflib==4.2.2",
     "requests-oauthlib==1.3.1",
-    "requests[security]>=2.31.0",
+    "requests[security]>=2.32.3",
     "semantic-version==2.10.0",
     "SPARQLWrapper==1.8.5",
     "urllib3<2",

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -66,7 +66,7 @@ Arches 8.0.0 Release Notes
 - Removes `arches_project` management commands, replacing them with `arches_admin` [#11574](https://github.com/archesproject/arches/issues/11574)
 - Add UserPreference model for storing custom JSON configuration for a user [#11842](https://github.com/archesproject/arches/issues/11842)  
 - Give ETL module permissions to the dev user [#12016](https://github.com/archesproject/arches/pull/12016)
-- Update the ETL status page to display only the status from the current user [#12017](https://github.com/archesproject/arches/pull/12017)
+- Update the ETL status page to display only the status from the current user [#12017](https://github.com/archesproject/arches/issues/12017)
 -   New option for resource-instance datatype advanced search [#11977](https://github.com/archesproject/arches/pull/11977)
 
 ### Dependency changes

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -84,6 +84,7 @@ Python:
         python-memcached: 1.62
         openpyxl: 3.1.5
         requests: >=2.32.3
+        requests-oauthlib: 2.0.0
         setuptools: >=77
 
     Added:

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -77,16 +77,17 @@ Python:
         celery: 5.5.0
         django-celery-results: 2.6.0
         django-cors-headers: 4.7.0
-        django-pgtrigger: 4.15.2
         django-recaptcha: 4.1.0
         django-revproxy: 0.13.0
         django-webpack-loader: 3.1.1
         psycopg2: 2.9.10
         python-memcached: 1.62
         openpyxl: 3.1.5
+        requests: >=2.32.3
         setuptools: >=77
 
     Added:
+        django-pgtrigger: 4.15.2
 
     Removed:
         tomli


### PR DESCRIPTION
At least on 7.6 @bferguso reports oauth still works on these more recent versions of `requests` with security fixes.