### PR TITLE
Remove @method_decorator from ExternalOauth.callback #12121

### DIFF
--- a/arches/app/views/auth.py
+++ b/arches/app/views/auth.py
@@ -753,9 +753,9 @@ class ExternalOauth(View):
         request.session["user"] = username
         return redirect(authorization_url)
 
-    @method_decorator(
-        csrf_exempt, name="dispatch"
-    )  # exempt; returned from other oauth2 authorization server, handled by 'oauth_state' in session
+    # exempt; returned from other oauth2 authorization server
+    # handled by 'oauth_state' in session
+    @csrf_exempt
     def callback(request):
         next_url = (
             request.session["next"] if "next" in request.session else reverse("home")

--- a/releases/7.6.11.md
+++ b/releases/7.6.11.md
@@ -3,6 +3,7 @@
 ### Bug Fixes and Enhancements
 
 - Fixes issue in URL widget where saving null would prevent the entry of any further data. [#10796](https://github.com/archesproject/arches/issues/10796)
+- Fix incorrectly decorated oauth callback view [#12121](https://github.com/archesproject/arches/issues/12121)
 - Fixes bug where the complete report didn't print. [#11957](https://github.com/archesproject/arches/issues/11957)
 
 ### Dependency changes:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This method was incorrectly decorated. By grace this was working on Django 4.2, but on 5.x it's no longer lenient.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12121

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Found by: @bferguso

### Further comments
A more invasive change would have been to make these class-based views actually class-based with methods instead of pure functions. But we defer that to another day.