### PR TITLE
Fix importer treatment of missing key/value pairs in tile data #11836

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1375,7 +1375,7 @@ class TileModel(models.Model):  # Tile
         return any_key_set
 
     def save(self, *args, **kwargs):
-        if _any_key_set := self.set_missing_keys_to_none():
+        if self.set_missing_keys_to_none():
             add_to_update_fields(kwargs, "data")
         if self.sortorder is None or self.is_fully_provisional():
             sortorder_max = TileModel.objects.filter(

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1368,14 +1368,14 @@ class TileModel(models.Model):  # Tile
             if node.datatype == "semantic":
                 continue
             node_id_str = str(node.pk)
-            if not node_id_str in self.data:
+            if node_id_str not in self.data:
                 self.data[node_id_str] = None
                 any_key_set = True
 
         return any_key_set
 
     def save(self, *args, **kwargs):
-        if any_key_set := self.set_missing_keys_to_none():
+        if _any_key_set := self.set_missing_keys_to_none():
             add_to_update_fields(kwargs, "data")
         if self.sortorder is None or self.is_fully_provisional():
             sortorder_max = TileModel.objects.filter(

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -1360,14 +1360,24 @@ class TileModel(models.Model):  # Tile
     def is_fully_provisional(self):
         return bool(self.provisionaledits and not any(self.data.values()))
 
-    def save(self, *args, **kwargs):
-        if self.sortorder is None or self.is_fully_provisional():
-            for node in Node.objects.filter(nodegroup_id=self.nodegroup_id).exclude(
-                datatype="semantic"
-            ):
-                if not str(node.pk) in self.data:
-                    self.data[str(node.pk)] = None
+    def set_missing_keys_to_none(self):
+        any_key_set = False
+        if not self.nodegroup_id:
+            return any_key_set
+        for node in self.nodegroup.node_set.all():
+            if node.datatype == "semantic":
+                continue
+            node_id_str = str(node.pk)
+            if not node_id_str in self.data:
+                self.data[node_id_str] = None
+                any_key_set = True
 
+        return any_key_set
+
+    def save(self, *args, **kwargs):
+        if any_key_set := self.set_missing_keys_to_none():
+            add_to_update_fields(kwargs, "data")
+        if self.sortorder is None or self.is_fully_provisional():
             sortorder_max = TileModel.objects.filter(
                 nodegroup_id=self.nodegroup_id,
                 resourceinstance_id=self.resourceinstance_id,

--- a/releases/7.6.11.md
+++ b/releases/7.6.11.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
+- Fix business data importer treatment of missing key/value pairs in tile data [#11836](https://github.com/archesproject/arches/issues/11836)
 - Fixes issue in URL widget where saving null would prevent the entry of any further data. [#10796](https://github.com/archesproject/arches/issues/10796)
 - Fixes an issue where negating a search term causes the whole search page to reload.  [#12115](https://github.com/archesproject/arches/issues/12115)
 - Fix incorrectly decorated oauth callback view [#12121](https://github.com/archesproject/arches/issues/12121)

--- a/tests/importer/jsonld_import_tests.py
+++ b/tests/importer/jsonld_import_tests.py
@@ -1526,7 +1526,13 @@ class JsonLDImportTests(ArchesTestCase):
         )
         tile1_parent = get_tile_by_id(tiles, tile1.parenttile_id)
 
-        self.assertEqual(tile1_parent.data, {})
+        self.assertEqual(
+            tile1_parent.data,
+            {
+                "d155a4c0-1540-11ea-b353-acde48001122": None,
+                "ddc44d9c-1540-11ea-b353-acde48001122": None,
+            },
+        )
         tile1_grandparent = get_tile_by_id(tiles, tile1_parent.parenttile_id)
         self.assertEqual(
             tile1_grandparent.data["02ec0ace-1541-11ea-b353-acde48001122"]["en"],

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -766,3 +766,14 @@ class TileTests(ArchesTestCase):
 
         with self.assertRaisesMessage(TileValidationError, "Widget name"):
             tile.check_for_missing_nodes()
+
+    def test_save_blank_tile(self):
+        data_collecting_grouping_node_id = "72048cb3-adbc-11e6-9ccf-14109fd34195"
+        tile = Tile(
+            resourceinstance_id=UUID("40000000-0000-0000-0000-000000000000"),
+            nodegroup_id=UUID(data_collecting_grouping_node_id),
+            data={},  # v8: can just omit
+        )
+        tile.save()
+
+        self.assertEqual(tile.data, {data_collecting_grouping_node_id: None})


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the check in `TileModel.save()` that initialized empty node values to None only fired if the sortorder was `None` or it was fully provisional. Instead, `Tile()` instances get instantiated with a default sortorder of 0 in the business data importer, evading the check:

https://github.com/archesproject/arches/blob/6ec898d71a486f8920fdb13649c2452ae88a117e/arches/app/utils/data_management/resources/formats/archesfile.py#L229-L230

https://github.com/archesproject/arches/blob/6ec898d71a486f8920fdb13649c2452ae88a117e/arches/app/models/models.py#L1742

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #11836

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [x] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch
