### PR TITLE
Improve graph publishing performance

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -481,14 +481,13 @@ class Graph(models.GraphModel):
 
     def update_es_node_mapping(self, node, datatype_factory, se):
         if self.isresource:
-            already_saved = models.Node.objects.filter(pk=node.nodeid).exists()
             saved_node_datatype = None
-            if already_saved:
-                saved_node = models.Node.objects.get(pk=node.nodeid)
+            target_node_id = node.source_identifier_id or node.nodeid
+            if saved_node := models.Node.objects.filter(pk=target_node_id).first():
                 saved_node_datatype = saved_node.datatype
             if saved_node_datatype != node.datatype:
                 datatype = datatype_factory.get_instance(node.datatype)
-                datatype_mapping = datatype.get_es_mapping(node.nodeid)
+                datatype_mapping = datatype.get_es_mapping(target_node_id)
                 if (
                     datatype_mapping
                     and datatype_factory.datatypes[node.datatype].defaultwidget

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import uuid
+from unittest import mock
 
 from django.contrib.auth.models import User
 from guardian.models import GroupObjectPermission, UserObjectPermission
@@ -1964,6 +1965,22 @@ class DraftGraphTests(ArchesTestCase):
 
         self.assertFalse(source_graph.has_unpublished_changes)
         self.assertEqual(source_graph.name, "TEST RESOURCE")
+
+    @mock.patch("arches.app.search.search.SearchEngine.create_mapping")
+    def test_saving_draft_graph_does_not_create_es_mapping(self, mocked_create_mapping):
+        source_graph = Graph.objects.create_graph(
+            name="TEST RESOURCE",
+            is_resource=True,
+        )
+        result = source_graph.append_node()
+        result["node"].datatype = "string"
+        source_graph.save()
+        mocked_create_mapping.assert_called_once()
+
+        draft_graph = source_graph.create_draft_graph()
+        draft_graph.save()
+
+        mocked_create_mapping.assert_called_once()
 
     def test_update_empty_graph_from_draft_graph(self):
         source_graph = Graph.objects.create_graph(


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
There was a performance regression of about 4x when publishing graphs in v8. Traced it to creating ES node mappings for draft graph nodes. I don't believe we need to create ES mappings for them.


### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

