### PR TITLE
Fix deadlock when saving new nodes #12030

### DIFF
--- a/arches/app/models/card.py
+++ b/arches/app/models/card.py
@@ -148,7 +148,7 @@ class Card(models.CardModel):
                     for card in args[0]["cards"]:
                         self.cards.append(Card(card))
 
-                if "constraints":
+                if "constraints" in args[0]:
                     self.update_constraints(args[0]["constraints"])
 
                 if "widgets" in args[0]:

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -111,8 +111,9 @@ class GraphSettingsView(GraphBaseView):
             }
         )
 
+    @transaction.atomic
     def post(self, request, graphid):
-        graph = Graph.objects.get(graphid=graphid)
+        graph = Graph.objects.filter(graphid=graphid).select_for_update().get()
         data = JSONDeserializer().deserialize(request.body)
 
         for key, value in data.get("graph").items():
@@ -159,32 +160,32 @@ class GraphSettingsView(GraphBaseView):
             nodegroup_ids_to_serialized_nodegroups[
                 serialized_nodegroup["nodegroupid"]
             ] = serialized_nodegroup
+
+        for nodegroup in models.NodeGroup.objects.filter(
+            nodegroupid__in=nodegroup_ids_to_serialized_nodegroups.keys()
+        ):
+            nodegroup.cardinality = nodegroup_ids_to_serialized_nodegroups[
+                str(nodegroup.nodegroupid)
+            ]["cardinality"]
+            nodegroup.save()
+            node.save()
+
         try:
-            with transaction.atomic():
-                for nodegroup in models.NodeGroup.objects.filter(
-                    nodegroupid__in=nodegroup_ids_to_serialized_nodegroups.keys()
-                ):
-                    nodegroup.cardinality = nodegroup_ids_to_serialized_nodegroups[
-                        str(nodegroup.nodegroupid)
-                    ]["cardinality"]
-                    nodegroup.save()
-
-                node.save()
-                graph.save()
-                graph.refresh_from_database()
-
-            return JSONResponse(
-                {
-                    "success": True,
-                    "graph": graph,
-                    "relatable_resource_ids": [
-                        res.nodeid for res in node.get_relatable_resources()
-                    ],
-                }
-            )
-
+            graph.save()
         except GraphValidationError as e:
             return JSONErrorResponse(e.title, e.message)
+
+        graph.refresh_from_database()
+
+        return JSONResponse(
+            {
+                "success": True,
+                "graph": graph,
+                "relatable_resource_ids": [
+                    res.nodeid for res in node.get_relatable_resources()
+                ],
+            }
+        )
 
 
 @method_decorator(group_required("Graph Editor"), name="dispatch")
@@ -791,7 +792,9 @@ class CardView(GraphBaseView):
         if self.action == "update_card":
             if data:
                 card = Card(data)
-                card.save()
+                with transaction.atomic():
+                    Card.objects.filter(pk=card.pk).select_for_update().get()
+                    card.save()
                 return JSONResponse(card)
 
         if self.action == "reorder_cards":

--- a/arches/app/views/graph.py
+++ b/arches/app/views/graph.py
@@ -793,7 +793,7 @@ class CardView(GraphBaseView):
             if data:
                 card = Card(data)
                 with transaction.atomic():
-                    Card.objects.filter(pk=card.pk).select_for_update().get()
+                    Card.objects.filter(pk=card.pk).select_for_update().first()
                     card.save()
                 return JSONResponse(card)
 

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import json
+import uuid
 from http import HTTPStatus
 
 from tests import test_settings
@@ -496,3 +497,18 @@ class GraphManagerViewTests(ArchesTestCase):
         self.assertEqual(imported_json[0], [])
         self.assertEqual(imported_json[1]["graphs_saved"], 1)
         self.assertEqual(imported_json[1]["name"], "Cardinality Test Model")
+
+    def test_save_new_card(self):
+        self.client.login(username="admin", password="admin")
+        new_card_id = str(uuid.uuid4())
+        response = self.client.post(
+            reverse("card", kwargs={"cardid": new_card_id}),
+            data={
+                "cardid": new_card_id,
+                "graph_id": str(self.test_graph.pk),
+                "nodegroup_id": str(self.test_graph.root.nodegroup_id),
+                "name": "My Card",
+            },
+            content_type="application/json",
+        )
+        self.assertContains(response, "My Card", status_code=HTTPStatus.OK)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, when saving edits to a node in the graph designer, the backend would often raise `OperationalError` for deadlocks. The repro is on the ticket. The sequence of calls that is most problematic was:

- POST card/
- POST card/ (two duplicative calls, see explanation in #11498
- POST graph_settings/

Card.save() holds a transaction open while doing work but without locking any rows. The second call to card.save() and the third call to graph.save() from the graph_settings route then had the potential to deadlock.

The solution proposed here is to get the row locks for card and graph while these views work on them.

### Issues Solved
Closes #12030

### Checklist
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Conservation Institute

### Further comments
We could have refactored the knockout JS to avoid the duplicative front-end calls mentioned in #11498, but that would have allowed this issue to crop up somewhere else again, and probably wouldn't have addressed the graph_settings part.