### PR TITLE
Match permission guard in POST to model method re #12176

### DIFF
--- a/arches/app/views/api/resource.py
+++ b/arches/app/views/api/resource.py
@@ -31,7 +31,7 @@ from arches.app.utils.permission_backend import (
     get_nodegroups_by_perm,
 )
 from arches.app.utils.permission_backend import get_nodegroups_by_perm
-from arches.app.utils.permission_backend import user_is_resource_editor
+from arches.app.utils.permission_backend import user_is_resource_reviewer
 from arches.app.utils.response import JSONResponse, JSONErrorResponse
 from arches.app.views.api import APIBase
 from arches.app.views.resource import (
@@ -484,7 +484,7 @@ class ResourceInstanceLifecycleState(APIBase):
         return JSONResponse(resource_instance.resource_instance_lifecycle_state)
 
     def post(self, request, resourceid):
-        if not user_is_resource_editor(request.user):
+        if not user_is_resource_reviewer(request.user):
             return JSONErrorResponse(
                 _("Request Failed"), _("Permission Denied"), status=403
             )


### PR DESCRIPTION
The model method called by this view checks `user_is_resource_reviewer`, but since this view only checks at the perimeter for `user_is_resource_editor` before returning a JSON error, provisional editors (e.g. `tester3/Test12345!` were sneaking through, raising `PermissionDenied` in the model method, which returns an HTML response.

An HTML response is displayed in knockout as "Request Failed ... please contact your administrator", when that's not desired.

If we need to check _both_ permissions, then let's make that change.