### PR TITLE
Avoid cascade deleting bulk data manager records on graph version restore #12032

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -23,6 +23,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction, connection
+from django.db.models import Q
 from django.db.utils import IntegrityError
 from arches.app.const import IntegrityCheck
 from arches.app.models import models
@@ -1611,11 +1612,13 @@ class Graph(models.GraphModel):
     @transaction.atomic
     def preserve_staging_records(self):
         nodegroups = self.get_nodegroups(force_recalculation=True)
-        error_query = models.LoadErrors.objects.filter(nodegroup__in=nodegroups)
+        error_query = models.LoadErrors.objects.filter(
+            Q(nodegroup__in=nodegroups) | Q(node__in=self.nodes.values())
+        )
         staging_query = models.LoadStaging.objects.filter(nodegroup__in=nodegroups)
         error_objs = set(error_query)
         staging_objs = set(staging_query)
-        error_query.update(nodegroup=None)
+        error_query.update(nodegroup=None, node=None)
         staging_query.update(nodegroup=None)
 
         try:
@@ -1629,12 +1632,13 @@ class Graph(models.GraphModel):
             valid_stagings = {
                 obj for obj in staging_objs if obj.nodegroup_id in all_nodegroup_ids
             }
-            invalid_errors = error_objs - valid_errors
-            invalid_stagings = staging_objs - valid_stagings
             models.LoadErrors.objects.bulk_update(valid_errors, fields=["nodegroup"])
             models.LoadStaging.objects.bulk_update(valid_stagings, fields=["nodegroup"])
-            models.LoadErrors.objects.filter(pk__in=invalid_errors).delete()
-            models.LoadStaging.objects.filter(pk__in=invalid_stagings).delete()
+
+            # Restore the node references that still exist.
+            all_node_ids = models.Node.objects.values_list("pk", flat=True)
+            valid_errors = {obj for obj in error_objs if obj.node_id in all_node_ids}
+            models.LoadErrors.objects.bulk_update(valid_errors, fields=["node"])
 
     def update_permissions_from_serialized_graph(self, serialized_graph):
         if (

--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import json
 import logging
 import uuid
+from contextlib import contextmanager
 from copy import deepcopy
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction, connection
@@ -1606,6 +1607,35 @@ class Graph(models.GraphModel):
                     pass
             return list(nodegroups)
 
+    @contextmanager
+    @transaction.atomic
+    def preserve_staging_records(self):
+        nodegroups = self.get_nodegroups(force_recalculation=True)
+        error_query = models.LoadErrors.objects.filter(nodegroup__in=nodegroups)
+        staging_query = models.LoadStaging.objects.filter(nodegroup__in=nodegroups)
+        error_objs = set(error_query)
+        staging_objs = set(staging_query)
+        error_query.update(nodegroup=None)
+        staging_query.update(nodegroup=None)
+
+        try:
+            yield
+        finally:
+            # Restore the nodegroup references that still exist.
+            all_nodegroup_ids = models.NodeGroup.objects.values_list("pk", flat=True)
+            valid_errors = {
+                obj for obj in error_objs if obj.nodegroup_id in all_nodegroup_ids
+            }
+            valid_stagings = {
+                obj for obj in staging_objs if obj.nodegroup_id in all_nodegroup_ids
+            }
+            invalid_errors = error_objs - valid_errors
+            invalid_stagings = staging_objs - valid_stagings
+            models.LoadErrors.objects.bulk_update(valid_errors, fields=["nodegroup"])
+            models.LoadStaging.objects.bulk_update(valid_stagings, fields=["nodegroup"])
+            models.LoadErrors.objects.filter(pk__in=invalid_errors).delete()
+            models.LoadStaging.objects.filter(pk__in=invalid_stagings).delete()
+
     def update_permissions_from_serialized_graph(self, serialized_graph):
         if (
             "user_permissions" in serialized_graph
@@ -2642,7 +2672,7 @@ class Graph(models.GraphModel):
         """
         Restores a Graph's state from a serialized graph
         """
-        with transaction.atomic():
+        with transaction.atomic(), self.preserve_staging_records():
             self.delete_associated_entities()
 
             for serialized_nodegroup in serialized_graph["nodegroups"]:

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -2014,7 +2014,7 @@ class DraftGraphTests(ArchesTestCase):
             etl_module=models.ETLModule.objects.first(), user=admin
         )
         load_errors = models.LoadErrors.objects.create(
-            load_event=event, nodegroup=nodegroup
+            load_event=event, nodegroup=nodegroup, node=result["node"]
         )
         load_staging = models.LoadStaging.objects.create(
             load_event=event, nodegroup=nodegroup
@@ -2032,6 +2032,7 @@ class DraftGraphTests(ArchesTestCase):
         # The bulk data manager history still exists.
         load_errors.refresh_from_db()
         self.assertEqual(load_errors.nodegroup, nodegroup)
+        self.assertEqual(load_errors.node, result["node"])
         load_staging.refresh_from_db()
         self.assertEqual(load_staging.nodegroup, nodegroup)
 

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -26,7 +26,6 @@ from arches.app.const import IntegrityCheck
 from arches.app.models import models
 from arches.app.models.graph import Graph, GraphValidationError
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
-from arches.app.models.fields.i18n import I18n_JSONField
 from tests.base_test import ArchesTestCase
 
 # these tests can be run from the command line via
@@ -1992,6 +1991,49 @@ class DraftGraphTests(ArchesTestCase):
 
         self.assertFalse(restored_source_graph.has_unpublished_changes)
         self.assertEqual(restored_source_graph.name, "TEST RESOURCE")
+
+    def test_bulk_data_manager_records_preserved_on_state_restoration(self):
+        source_graph = Graph.objects.create_graph(
+            name="TEST RESOURCE",
+            is_resource=True,
+        )
+        draft_graph = source_graph.get_draft_graph()
+        admin = User.objects.get(username="admin")
+
+        result = draft_graph.append_node()
+        result["node"].datatype = "number"
+        draft_graph.save()
+        updated_source_graph = source_graph.promote_draft_graph_to_active_graph()
+        updated_source_graph.publish(user=admin)
+
+        # Record bulk data manager history.
+        nodegroup = models.NodeGroup.objects.get(
+            node__graph=source_graph, node__datatype="number"
+        )
+        event = models.LoadEvent.objects.create(
+            etl_module=models.ETLModule.objects.first(), user=admin
+        )
+        load_errors = models.LoadErrors.objects.create(
+            load_event=event, nodegroup=nodegroup
+        )
+        load_staging = models.LoadStaging.objects.create(
+            load_event=event, nodegroup=nodegroup
+        )
+
+        published_graph = models.PublishedGraph.objects.get(
+            publication=updated_source_graph.publication,
+            language="en",
+        )
+
+        updated_source_graph.restore_state_from_serialized_graph(
+            published_graph.serialized_graph
+        )
+
+        # The bulk data manager history still exists.
+        load_errors.refresh_from_db()
+        self.assertEqual(load_errors.nodegroup, nodegroup)
+        load_staging.refresh_from_db()
+        self.assertEqual(load_staging.nodegroup, nodegroup)
 
     @mock.patch("arches.app.search.search.SearchEngine.create_mapping")
     def test_saving_draft_graph_does_not_create_es_mapping(self, mocked_create_mapping):


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The restore graph version workflow deletes nodegroups, so we were getting cascade deletion of bulk data manager records due to the `on_delete=models.CASCADE`. While we want cascade deletes for graph deletion, I don't believe that's what we want for graph versioning.

### Issues Solved
Closes #12032

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls
