### PR TITLE
Prevent deadlocks from signals #12207

### DIFF
--- a/arches/app/signals.py
+++ b/arches/app/signals.py
@@ -299,9 +299,9 @@ def ensure_single_default_searchview(sender, instance, **kwargs):
 @receiver(post_save, sender=models.GraphXPublishedGraph)
 @receiver(post_delete, sender=models.GraphXPublishedGraph)
 def set_related_graph_has_unpublished_changes_to_true(sender, instance, **kwargs):
-    models.GraphModel.objects.filter(pk=instance.graph_id).update(
-        has_unpublished_changes=True
-    )
+    models.GraphModel.objects.filter(
+        pk=instance.graph_id, has_unpublished_changes=False
+    ).update(has_unpublished_changes=True)
 
 
 @receiver(post_save, sender=models.NodeGroup)
@@ -309,11 +309,13 @@ def set_related_graph_has_unpublished_changes_to_true(sender, instance, **kwargs
 def set_related_graph_has_unpublished_changes_to_true(sender, instance, **kwargs):
     # NodeGroups have no direct relation to the GraphModel objects,
     # so this signal can fail to find the node when deleting a Graphs
+    if not instance.grouping_node_id:
+        return
     try:
-        models.GraphModel.objects.filter(pk=instance.grouping_node.graph_id).update(
-            has_unpublished_changes=True
-        )
-    except:
+        models.GraphModel.objects.filter(
+            pk=instance.grouping_node.graph_id, has_unpublished_changes=False
+        ).update(has_unpublished_changes=True)
+    except models.Node.DoesNotExist:
         pass
 
 
@@ -322,9 +324,11 @@ def set_related_graph_has_unpublished_changes_to_true(sender, instance, **kwargs
 def set_related_graph_has_unpublished_changes_to_true(sender, instance, **kwargs):
     # CardXNodeXWidgets have no direct relation to the GraphModel objects,
     # so this signal can fail to find the node when deleting a Graphs
+    if not instance.node_id:
+        return
     try:
-        models.GraphModel.objects.filter(pk=instance.node.graph_id).update(
-            has_unpublished_changes=True
-        )
-    except:
+        models.GraphModel.objects.filter(
+            pk=instance.node.graph_id, has_unpublished_changes=False
+        ).update(has_unpublished_changes=True)
+    except models.Node.DoesNotExist:
         pass


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
We're firing thousands of these signals now. Only one out of those thousands really needs to set `has_unpublished_changes=True`. By filtering the query a little further, we can avoid getting a lock that would violate someone else's lock (e.g. the locks in `Card.save()` that support the double-requests we're doing via knockout JS in the graph manager as acknowledged as a wart in https://github.com/archesproject/arches/pull/11498#issue-2549227263.)

Ultimately we might look into further reducing the number of queries issued here via signals, but that's something we can take more time to look into.

### Issues Solved
Closes #12207

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by:  Getty Conservation Institute
*   Found by: @chrabyrd @aarongundel