### PR TITLE
Log exceptions in celery tasks

### DIFF
--- a/arches/app/tasks.py
+++ b/arches/app/tasks.py
@@ -252,7 +252,7 @@ def load_excel_data(
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         load_event.status = "failed"
         load_event.save()
@@ -328,7 +328,7 @@ def export_excel_data(
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         load_event.status = "failed"
         load_event.save()
@@ -416,7 +416,7 @@ def load_single_csv(
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         load_event.status = "failed"
         load_event.save()
@@ -445,7 +445,7 @@ def load_json_ld(userid, files, summary, result, temp_dir, loadid, moduleid):
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.filter(loadid=loadid).update(
             status="failed"
         )
@@ -491,7 +491,7 @@ def edit_bulk_string_data(
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         load_event.status = "failed"
         load_event.save()
@@ -533,7 +533,7 @@ def edit_bulk_concept_data(
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         load_event.status = "failed"
         load_event.save()
@@ -559,7 +559,7 @@ def bulk_data_deletion(userid, load_id, graph_id, nodegroup_id, resourceids):
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=load_id)
         load_event.status = "failed"
         load_event.save()
@@ -610,7 +610,7 @@ def run_etl_task(**kwargs):
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         status = _("Completed") if load_event.status == "indexed" else _("Failed")
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         load_event = models.LoadEvent.objects.get(loadid=loadid)
         load_event.status = "failed"
         load_event.save()
@@ -725,7 +725,7 @@ def update_resource_instance_data_based_on_graph_diff(
         )
 
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         notify_completion(
             _(
                 "Business data update failed. Check the error logs for more information."

--- a/releases/8.1.0.md
+++ b/releases/8.1.0.md
@@ -1,0 +1,27 @@
+Arches 8.1.0 Release Notes
+--------------------------
+
+### Major enhancements
+
+### Performance improvements
+
+### Additional highlights
+
+-   Log exceptions in background tasks [#12214](https://github.com/archesproject/arches/pull/12214)
+
+```
+Python:
+    Upgraded:
+    Added:
+    Removed:
+JavaScript:
+    Upgraded:
+    Added:
+    Removed:
+```
+
+### Breaking changes
+
+### Upgrading Arches
+
+### Upgrading an Arches project


### PR DESCRIPTION
Before, this was as much context as you got about failed celery tasks:

```py
2025-06-11 12:11:16,328 arches.app.tasks ERROR    'child_date'
```

Now you get this:
```py
2025-06-11 12:13:47,000 arches.app.tasks ERROR    'child_date'
Traceback (most recent call last):
  File "/Users/jwalls/prj/arches/arches/app/tasks.py", line 319, in export_excel_data
    import_module.run_export_task(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        load_id,
        ^^^^^^^^
    ...<4 lines>...
        filename=filename,
        ^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jwalls/prj/arches/arches/app/etl_modules/branch_excel_exporter.py", line 140, in run_export_task
    wb = create_workbook(graph_id, tiles_to_export)
  File "/Users/jwalls/prj/arches/arches/management/commands/etl_template.py", line 177, in create_workbook
    if tile[node["alias"]] is not None:
       ~~~~^^^^^^^^^^^^^^^
KeyError: 'child_date'
```