### PR TITLE
Prevent reversing transactions into out-of-date graphs #12216

### DIFF
--- a/arches/app/utils/request.py
+++ b/arches/app/utils/request.py
@@ -1,7 +1,8 @@
 def looks_like_api_call(request):
     known_api_paths_without_api_signposting = [
-        # Until these are renamed for consistency, just list them.
+        # Until these are renamed or moved for consistency, just list them.
         "arches.app.views.etl_manager",
+        "arches.app.views.transaction",
     ]
     if "/api/" in request.path:
         return True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -109,6 +109,8 @@ DOCKER = False
 
 PERMISSION_DEFAULTS = {}
 
+CELERY_CHECK_ONLY_INSPECT_BROKER = True
+
 
 try:
     from arches.settings_local import *

--- a/tests/utils/test_transactions.py
+++ b/tests/utils/test_transactions.py
@@ -1,0 +1,38 @@
+import uuid
+
+from django.conf import settings
+from django.test import TestCase
+
+from arches.app.models.graph import Graph
+from arches.app.models.models import (
+    EditLog,
+    ResourceInstance,
+    ResourceInstanceLifecycle,
+)
+from arches.app.utils.transaction import reverse_edit_log_entries
+
+# these tests can be run from the command line via
+# python manage.py test tests.utils.test_transactions --settings="tests.test_settings"
+
+
+class TestTransactions(TestCase):
+    def test_reverse_edit_log_entries_errors_if_publication_differs(self):
+        transaction_id = uuid.uuid4()
+        graph = Graph.objects.create_graph()
+        lifecycle = ResourceInstanceLifecycle.objects.get(
+            pk=settings.DEFAULT_RESOURCE_INSTANCE_LIFECYCLE_ID
+        )
+        state = lifecycle.resource_instance_lifecycle_states.first()
+        resource = ResourceInstance.objects.create(
+            graph=graph,
+            graph_publication=graph.publication,
+            resource_instance_lifecycle_state=state,
+        )
+        EditLog.objects.create(
+            transactionid=str(transaction_id), resourceinstanceid=str(resource.pk)
+        )
+
+        graph.publish()
+
+        with self.assertRaises(RuntimeError):
+            reverse_edit_log_entries(transaction_id=transaction_id)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Now we reject attempts to reverse bulk data manager loads into out of date graph versions.

Note that if you are running celery for these tasks, the errors will be swallowed. This is a larger issue, see #12217.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12216

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch


#### Ticket Background
*   Sponsored by:  Getty Conservation Institute
*   Found by: @jacobtylerwalls
