### PR TITLE
avoids extra updates to number widget value transforming default

### DIFF
--- a/arches/app/media/js/views/components/widgets/number.js
+++ b/arches/app/media/js/views/components/widgets/number.js
@@ -19,13 +19,13 @@ import 'bindings/formattedNumber';
 var NumberWidget = function(params) {
     params.configKeys = ['placeholder', 'width', 'min', 'max', 'step', 'precision', 'prefix', 'suffix', 'defaultValue', 'format', 'uneditable'];
 
-        
+
     WidgetViewModel.apply(this, [params]);
 
     var self = this;
 
     this.disable = ko.computed(() => {
-        return ko.unwrap(self.disabled) || ko.unwrap(self.uneditable); 
+        return ko.unwrap(self.disabled) || ko.unwrap(self.uneditable);
     }, self);
 
     this.updateVal = ko.computed(function(){
@@ -47,7 +47,9 @@ var NumberWidget = function(params) {
         return val || self.value() || null;
     }, self).extend({throttle: 600});
 
-    this.value(Number(this.updateVal()));
+    if (this.inResourceEditor) {
+        this.value(Number(this.updateVal()));
+    }
 
     this.displayValue = ko.pureComputed(function() {
         if (self.value() !== null && self.value() !== undefined) {

--- a/arches/app/media/js/views/components/widgets/number.js
+++ b/arches/app/media/js/views/components/widgets/number.js
@@ -1,5 +1,6 @@
 import ko from 'knockout';
 import _ from 'underscore';
+import arches from 'arches';
 import WidgetViewModel from 'viewmodels/widget';
 import numberWidgetTemplate from 'templates/views/components/widgets/number.htm';
 import 'bindings/formattedNumber';
@@ -18,7 +19,7 @@ import 'bindings/formattedNumber';
 
 var NumberWidget = function(params) {
     params.configKeys = ['placeholder', 'width', 'min', 'max', 'step', 'precision', 'prefix', 'suffix', 'defaultValue', 'format', 'uneditable'];
-
+    this.preview = arches.graphs.length > 0;
 
     WidgetViewModel.apply(this, [params]);
 
@@ -47,7 +48,7 @@ var NumberWidget = function(params) {
         return val || self.value() || null;
     }, self).extend({throttle: 600});
 
-    if (this.inResourceEditor) {
+    if (!this.preview) {
         this.value(Number(this.updateVal()));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
fixes a bug in number widget viewmodel where updating value caused default value to transform.  simply added a condition to only apply this when editing data.  to achieve this, I used the approach established in the `resource-instance-select` widget viewmodel to detect when a user is in the designer by checking for graphs on the arches object.  this is implicit and feels a bit wrong but is an established pattern, so I went with it.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12220

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @alexwuthrich 
*   Tested by: @robgaston 
*   Designed by: @robgaston 

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
