### PR TITLE
Spruce up readme and release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ The following a general plan for the Arches project. Be aware this plan is tenta
 - RDM officially deprecated in favor of controlled lists
 
 ## 8.0 - Supported Applications
-- Arches Controlled Lists, June 15, 2025
-- Arches Lingo, beta version released June 15, 2025 beta. Final 1.0 released August 15,2025 
+- Arches Controlled Lists, June 30, 2025
+- Arches Lingo, alpha version released June 30, 2025. Final 1.0 released August 15, 2025.
+- Arches QuerySets, beta version released June 30, 2025.
+- Arches Modular Reports, beta version released June 30, 2025.
 
 ## 9.0 - Release date: Sept 15, 2027
 - Full migration to Vue

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -453,7 +453,7 @@ JavaScript:
 
     ```
 
-1. Update the JavaScript files in your project as follows. (Note that even projects without custom JavaScript may have been templated with a `media/js/reports/default.js` that needs updating.)
+1. Update the JavaScript files in your project as follows. (Note that even projects without custom JavaScript may have been templated with a `media/js/reports/default.js`. This file may be removed if it is not intentionally overriding default.js in core Arches. Otherwise, it must be updated.)
     1. Update the import and export logic. 
         - Imports should follow the typical ES6 import pattern
         - Anything `return`-ed from a RequireJS function should be the default export of the file.

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -230,11 +230,11 @@ JavaScript:
 
 ### Upgrading Arches
 
-1. You must be upgraded to at least version before proceeding. If you are on an earlier version, please refer to the upgrade process in the []()
+1. You must be upgraded to at least version 7.6.0 before proceeding. If you are on an earlier version, please refer to the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md).
 
 1. Be sure to backup your database before proceeding.
 
-1. Upgrade to Arches 8.0.0
+1. Upgrade to Arches 8.0.0:
     ```
     pip install --upgrade pip
     pip install --upgrade arches==8.0.0
@@ -249,7 +249,7 @@ JavaScript:
     - Add `"Programming Language :: Python :: 3.13"`
     - Remove `"Framework :: Django :: 4.2"`
     - Add `"Framework :: Django :: 5.2"`
-    - Remove any classifier beginning with "License :: "
+    - Remove any classifier beginning with `"License :: "`
     - Replace the heading `[project.optional-dependencies]` with `[dependency-groups]`
     - Unless you have already published your project to PyPI, in the `name = ...` key replace underscores with hyphens to follow PEP 8 conventions.
 
@@ -268,13 +268,13 @@ JavaScript:
         dist/
         ```
 
-1. Replace any references to `arches-project` management commands with `arches-admin`
-    - `arches-project create` no longer exists, instead use `arches-admin startproject`
+1. Replace any references to `arches-project` management commands with `arches-admin`.
+    - `arches-project create` no longer exists, instead use `arches-admin startproject`.
 
-1. In `MANIFEST.in`, remove "graft *". Add exclusions for local settings files, e.g. `exclude <my_project>/settings_local.py`.
+1. In `MANIFEST.in`, remove `graft *`. Add exclusions for local settings files, e.g. `exclude <my_project>/settings_local.py`.
 
 1. In settings.py:
-    - Add the following key to `DATABASES` to [potentially improve indexing performance](https://github.com/archesproject/arches/issues/11382):
+    - Add the following key to `DATABASES["default"]` to [potentially improve indexing performance](https://github.com/archesproject/arches/issues/11382):
         ```
         DATABASES = {
             "default": {
@@ -285,7 +285,7 @@ JavaScript:
             }
         }
         ```
-    - Change the "captcha" entry in `INSTALLED_APPS` to reflect its new name and add pgtrigger:
+    - Change the `"captcha"` entry in `INSTALLED_APPS` to reflect its new name and add pgtrigger:
         ```
         INSTALLED_APPS = [
             ...
@@ -294,8 +294,8 @@ JavaScript:
             ...
         ]
         ```
-    - Remove "django.contrib.admin" from the first section of INSTALLED_APPS.
-    - Add django.contrib.admin to the existing post addition to INSTALLED_APPS:  
+    - Remove "`django.contrib.admin"` from the first section of `INSTALLED_APPS`.
+    - Add `"django.contrib.admin"` to the existing post addition to `INSTALLED_APPS`:  
         ```
         INSTALLED_APPS += (
             "arches.app",
@@ -345,7 +345,7 @@ JavaScript:
     handler500 = "arches.app.views.main.custom_500"
     ```
 
-1. Create draft_graphs for your Resource Models:
+1. Create draft graphs for your Resource Models:
     ```
     python manage.py graph create_draft_graphs
     ``` 
@@ -357,7 +357,15 @@ JavaScript:
     python manage.py graph publish --update -ui
     ```
 
-1. Also consider running validation checks:
+1. Run system checks against your production settings.
+
+    Note: This command not only performs essential system checks but also generates the frontend configuration file required for your application. It is a crucial step in the deployment process and must be executed to ensure that the environment is correctly configured.
+
+    ```
+    python manage.py check --deploy --settings=path.to.production.settings
+    ```
+
+1. Consider running validation checks:
     ```
     python manage.py validate
     python manage.py validate --fix [error]
@@ -445,7 +453,7 @@ JavaScript:
 
     ```
 
-1. Update the JavaScript files in your project:
+1. Update the JavaScript files in your project as follows. (Note that even projects without custom JavaScript may have been templated with a `media/js/reports/default.js` that needs updating.)
     1. Update the import and export logic. 
         - Imports should follow the typical ES6 import pattern
         - Anything `return`-ed from a RequireJS function should be the default export of the file.
@@ -572,7 +580,7 @@ JavaScript:
         ```
 
 1. Update the templates in your project:
-    - Any interpolation of `STATIC_URL` should be replaced with `webpack_static`
+    - Any interpolation of `STATIC_URL` should be replaced with `webpack_static`:
 
         ```html
         <!-- defunct format -->
@@ -585,7 +593,7 @@ JavaScript:
         <img id="map-buffer-search-help-gif" src="{% webpack_static 'img/help/map-buffer-search.gif' %}" aria-hidden="true"></img>
         ```
 
-1. ( optional ) Replace `arches.urls` references:
+1. (optional) Replace `arches.urls` references:
     - Support for `arches.urls` will be removed in later versions.
     - Instead of accessing urls via `import arches from "arches";`, you can instead use the `generateArchesURL` utility.
 
@@ -618,13 +626,11 @@ JavaScript:
         fetch(url).then(resp => {...});
         ```
 
-    - If you update your project to remove any reference to `arches.urls`, you can then safely delete `templates/arches_urls.htm`
+    - If you update your project to remove any reference to `arches.urls`, you can then safely delete `templates/arches_urls.htm`.
 
-1. If you have been relying on copying client secret values from /o/applications - this release will break that behavior and hash those values by default.  Save the value elsewhere before upgrading or delete and recreate your application(s) to save without hashing.   
+1. If you have been relying on copying client secret values from /o/applications - this release will break that behavior and hash those values by default. Save the value elsewhere before upgrading or delete, and recreate your application(s) to save without hashing.
 
 1. Rebuild your static asset bundle:
-    - Ensure your Python 3 virtual environment activated
-
     - If running your project in development:
         - Option 1: Development Mode (Live Rebuilding)
             ```
@@ -649,4 +655,4 @@ JavaScript:
     python manage.py collectstatic
     ```
 
-    This will gather all static files (CSS, JavaScript, Vue, images, etc) and copy them into your projects `STATIC_ROOT` directory. This step does not need to be done if developing locally.
+    This will gather all static files (CSS, JavaScript, Vue, images, etc) and copy them into your project's `STATIC_ROOT` directory. This step does not need to be done if developing locally.


### PR DESCRIPTION
Copy over the note from the 7.6 release notes about the need for running `manage.py check` to generate a frontend configuration.

Any of the other manage.py commands will accomplish that as well, but the experience with 7.6 was that people prefer to see this spelled out so they can evaluate whether to skip steps.