### PR TITLE
Remove module-level query in URL datatype #11821

### DIFF
--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -20,7 +20,6 @@ import re
 import json
 from arches.app.models.system_settings import settings
 from arches.app.datatypes.base import BaseDataType
-from arches.app.models.models import Widget
 from arches.app.search.elasticsearch_dsl_builder import Match, Exists, Term
 from arches.app.search.search_term import SearchTerm
 
@@ -31,34 +30,6 @@ from django.utils.translation import gettext as _
 
 archesproject = Namespace(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
 cidoc_nm = Namespace("http://www.cidoc-crm.org/cidoc-crm/")
-
-import logging
-
-logger = logging.getLogger(__name__)
-
-default_widget_name = "urldatatype"
-default_url_widget = None
-try:
-    default_url_widget = Widget.objects.get(name=default_widget_name)
-except Widget.DoesNotExist as e:
-    logger.warning(
-        "Setting 'url' datatype's default widget to None ({0} widget not found).".format(
-            default_widget_name
-        )
-    )
-
-details = {
-    "datatype": "url",
-    "iconclass": "fa fa-location-arrow",
-    "modulename": "url.py",
-    "classname": "URLDataType",
-    "defaultwidget": default_url_widget,
-    "defaultconfig": None,
-    "configcomponent": "views/components/datatypes/url",
-    "configname": "url-datatype-config",
-    "isgeometric": False,
-    "issearchable": True,
-}
 
 
 class FailRegexURLMatch(Exception):

--- a/releases/8.0.0.md
+++ b/releases/8.0.0.md
@@ -36,6 +36,7 @@ Arches 8.0.0 Release Notes
 - Add alt text on image placeholder [#10455](https://github.com/archesproject/arches/issues/10455)
 - Tile functions no longer catch TypeError [#11805](https://github.com/archesproject/arches/issues/11805)
 - Fix querying on related model's I18n_TextField [#11800](https://github.com/archesproject/arches/issues/11800)
+- Remove module-level query in URL datatype [#11821](https://github.com/archesproject/arches/issues/11821)
 - Make failed login alert message dismissible [#11767](https://github.com/archesproject/arches/issues/11767)
 - Concepts API no longer responds with empty body for error conditions [#11519](https://github.com/archesproject/arches/issues/11519)
 - Generates static `urls.json` file for frontend consumption [#11567](https://github.com/archesproject/arches/issues/11567)


### PR DESCRIPTION
I don't think this is truly needed to register this datatype, since the 7224_url_datatype migration creates this datatype.

Leaving this module-level query here causes flaky `RuntimeWarning` depending on whether you happen to import this module:

```py
  File "/Users/jwalls/py313/lib/python3.13/site-packages/django/db/backends/utils.py", line 98, in _execute
    warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeWarning: Accessing the database during app initialization is discouraged. To fix this warning, avoid executing queries in AppConfig.ready() or when your app modules are imported.
```

Closes #11821

Noticed this in archesproject/arches-querysets#22

~The only reason we weren't seeing this in core is because url.py has 0% test coverage~