### PR TITLE
[7.6] Remove module-level query in URL datatype #11821

### DIFF
--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -20,7 +20,6 @@ import re
 import json
 from arches.app.models.system_settings import settings
 from arches.app.datatypes.base import BaseDataType
-from arches.app.models.models import Widget
 from arches.app.search.elasticsearch_dsl_builder import Match, Exists, Term
 from arches.app.search.search_term import SearchTerm
 
@@ -31,34 +30,6 @@ from django.utils.translation import gettext as _
 
 archesproject = Namespace(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
 cidoc_nm = Namespace("http://www.cidoc-crm.org/cidoc-crm/")
-
-import logging
-
-logger = logging.getLogger(__name__)
-
-default_widget_name = "urldatatype"
-default_url_widget = None
-try:
-    default_url_widget = Widget.objects.get(name=default_widget_name)
-except Widget.DoesNotExist as e:
-    logger.warning(
-        "Setting 'url' datatype's default widget to None ({0} widget not found).".format(
-            default_widget_name
-        )
-    )
-
-details = {
-    "datatype": "url",
-    "iconclass": "fa fa-location-arrow",
-    "modulename": "url.py",
-    "classname": "URLDataType",
-    "defaultwidget": default_url_widget,
-    "defaultconfig": None,
-    "configcomponent": "views/components/datatypes/url",
-    "configname": "url-datatype-config",
-    "isgeometric": False,
-    "issearchable": True,
-}
 
 
 class FailRegexURLMatch(Exception):


### PR DESCRIPTION
I think backporting this fix to 7.6 is better than adding awkward workarounds in arches-querysets to enable testing on 7.6, see [logs](https://github.com/archesproject/arches-querysets/actions/runs/15681704641/job/44174483381).