### PR TITLE
Add missing entry to arches URLs for `api_instance_permissions`

### DIFF
--- a/arches/app/templates/arches_urls.htm
+++ b/arches/app/templates/arches_urls.htm
@@ -106,6 +106,7 @@
     api_resource_report='(resourceid)=>{return "{% url "api_resource_report" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", resourceid)}'
     api_bulk_resource_report="{% url 'api_bulk_resource_report' %}"
     api_bulk_disambiguated_resource_instance="{% url 'api_bulk_disambiguated_resource_instance' %}"
+    api_instance_permissions = "{% url 'api_instance_permissions' %}"
     api_resources='(resourceid)=>{return "{% url "resources" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", resourceid)}'
     api_search_component_data='"{% url "api_search_component_data" "aaaa"%}".replace("aaaa", "")'
     api_user_incomplete_workflows="{% url 'api_user_incomplete_workflows' %}"

--- a/releases/7.6.12.md
+++ b/releases/7.6.12.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
+-   Add missing entry to arches URLs for `api_instance_permissions` [#12278](https://github.com/archesproject/arches/pulls/12278)
 -   Improves permissions performance with search results [#12264](https://github.com/archesproject/arches/issues/12264)
 -   Fixes rich text formatting in reports [#10909](https://github.com/archesproject/arches/issues/10909)
 


### PR DESCRIPTION
Looks like this was missed in 0b3161a6ec46657b4abb1c2eebc704e38eed7ad6.