### PR TITLE
Hide the loading indicator if the page was loaded via cache

### DIFF
--- a/arches/app/media/js/views/page-view.js
+++ b/arches/app/media/js/views/page-view.js
@@ -76,9 +76,9 @@ define([
                     if (!bypass && self.viewModel.dirty()) {
                         self.viewModel.navDestination(url);
                         self.viewModel.alert(new AlertViewModel(
-                            'ep-alert-blue', 
-                            arches.translations.confirmNav.title, 
-                            arches.translations.confirmNav.text, 
+                            'ep-alert-blue',
+                            arches.translations.confirmNav.title,
+                            arches.translations.confirmNav.text,
                             function() {
                                 self.viewModel.showConfirmNav(false);
                             }, function() {
@@ -173,6 +173,13 @@ define([
 
             window.addEventListener('beforeunload', function() {
                 self.viewModel.loading(true);
+            });
+
+            window.addEventListener('pageshow', function(event) {
+                if (event.persisted) {
+                    // If the page was restored from cache, hide the loading mask
+                    self.viewModel.loading(false);
+                }
             });
 
             Backbone.View.apply(this, arguments);

--- a/releases/7.6.13.md
+++ b/releases/7.6.13.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
--   
+-   Hide the loading indicator when the page is loaded through cache [#12280](https://github.com/archesproject/arches/issues/12280)
 
 ### Dependency changes:
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
When the page is loaded via cache, the loading indicator is shown incorrectly. Handle this case and hide the loading indicator to show the page.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12280

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Getty Conservation Institute <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

