### PR TITLE
Fix failures in `to_json()` datatype methods given None #12275

### DIFF
--- a/arches/app/datatypes/concept_types.py
+++ b/arches/app/datatypes/concept_types.py
@@ -287,9 +287,12 @@ class ConceptDataType(BaseConceptDataType):
         data = self.get_tile_data(tile)
         if data:
             val = data[str(node.nodeid)]
-            value_data = JSONSerializer().serializeToPython(
-                self.get_value(uuid.UUID(val))
-            )
+            if val is None:
+                value_data = {}
+            else:
+                value_data = JSONSerializer().serializeToPython(
+                    self.get_value(uuid.UUID(val))
+                )
             return self.compile_json(tile, node, **value_data)
 
     def get_rdf_uri(self, node, data, which="r", c=None):
@@ -473,7 +476,7 @@ class ConceptListDataType(BaseConceptDataType):
         new_values = []
         data = self.get_tile_data(tile)
         if data:
-            for val in data[str(node.nodeid)]:
+            for val in data[str(node.nodeid)] or []:
                 new_val = self.get_value(uuid.UUID(val))
                 new_values.append(new_val)
         return self.compile_json(tile, node, concept_details=new_values)

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -442,8 +442,9 @@ class StringDataType(BaseDataType):
 
     def to_json(self, tile, node):
         data = self.get_tile_data(tile)
+        value_data = data.get(str(node.nodeid)) or {}
         if data:
-            return self.compile_json(tile, node, **data.get(str(node.nodeid)))
+            return self.compile_json(tile, node, **value_data)
 
     def pre_structure_tile_data(self, tile, nodeid, **kwargs):
         all_language_codes = {lang.code for lang in kwargs["languages"]}
@@ -2139,10 +2140,6 @@ class ResourceInstanceDataType(BaseDataType):
             return None
 
     def to_json(self, tile, node):
-        from arches.app.models.resource import (
-            Resource,
-        )  # import here rather than top to avoid circular import
-
         data = self.get_tile_data(tile)
         if data:
             nodevalue = self.get_nodevalues(data[str(node.nodeid)])
@@ -2155,6 +2152,7 @@ class ResourceInstanceDataType(BaseDataType):
                 except:
                     resourceid = resourceXresource["resourceId"]
                     logger.info(f'Resource with id "{resourceid}" not in the system.')
+            return self.compile_json(tile, node)
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
         nodevalue = self.get_nodevalues(nodevalue)

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -120,8 +120,9 @@ class URLDataType(BaseDataType):
 
     def to_json(self, tile, node):
         data = self.get_tile_data(tile)
+        value_data = data.get(str(node.nodeid)) or {}
         if data:
-            return self.compile_json(tile, node, **data.get(str(node.nodeid)))
+            return self.compile_json(tile, node, **value_data)
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
         if nodevalue.get("url") is not None:

--- a/releases/7.6.12.md
+++ b/releases/7.6.12.md
@@ -4,6 +4,7 @@
 
 -   Improves permissions performance with search results [#12264](https://github.com/archesproject/arches/issues/12264)
 -   Fixes a display descriptors issue when pushing data with the JSON-ld endpoint [#12272](https://github.com/archesproject/arches/issues/12272)
+-   Fixes failures in `to_json()` datatype methods given node values of `None` [#12275](https://github.com/archesproject/arches/issues/12275)
 -   Fixes rich text formatting in reports [#10909](https://github.com/archesproject/arches/issues/10909)
 
 ### Dependency changes:


### PR DESCRIPTION
### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, all datatype methods didn't handle `None` as a node value when calling their `to_json()` method.

### Issues Solved
Closes #12275

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [x] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Conservation Institute
*   Found by: @jacobtylerwalls