### PR TITLE
12205 Clear Filters i18n fix

### DIFF
--- a/arches/app/templates/javascript.htm
+++ b/arches/app/templates/javascript.htm
@@ -378,6 +378,7 @@
         filter='{% trans "Filter" as filter %} "{{ filter|escapejs }}"'
         clear='{% trans "Clear" as clear %} "{{ clear|escapejs }}"'
         clear-filter='{% trans "Clear Filter" as clearFilter %} "{{ clearFilter|escapejs }}"'
+        clear-filters='{% trans "Clear Filters" as clearFilters %} "{{ clearFilters|escapejs }}"'
         buffer='{% trans "Buffer" as buffer %} "{{ buffer|escapejs }}"'
         distance='{% trans "Distance" as distance %} "{{ distance|escapejs }}"'
         buffer-distance='{% trans "Buffer Distance" as bufferDistance %} "{{ bufferDistance|escapejs }}"'

--- a/arches/app/templates/views/components/search/standard-search-view.htm
+++ b/arches/app/templates/views/components/search/standard-search-view.htm
@@ -43,7 +43,7 @@
             </div>
             <div class="search-tools-item">
                 <div class="search-controls-container">
-                    <button class="btn-sm btn btn-mint btn-labeled clear-filter" data-bind="click: function() {clearQuery();}"><span>{% trans "Clear Filters" %}</span></button>
+                    <button class="btn-sm btn btn-mint btn-labeled clear-filter" data-bind="click: function() {clearQuery();}"><span data-bind="text:$root.translations.clearFilters"></span></button>
                     <div data-bind="component: {
                         name: 'sort-results',
                         params: sharedStateObject

--- a/releases/7.6.12.md
+++ b/releases/7.6.12.md
@@ -8,6 +8,7 @@
 -   Fixes failures in `to_json()` datatype methods given node values of `None` [#12275](https://github.com/archesproject/arches/issues/12275)
 -   Fixes rich text formatting in reports [#10909](https://github.com/archesproject/arches/issues/10909)
 -   Prevents unpublished graphs from appearing in the resource model search filter [#12092](https://github.com/archesproject/arches/pull/12092)
+-   Fixes "Clear Filters" i18 bug
 
 ### Dependency changes:
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
"Clear Filters" button needed JS string translation in same manner as other search components. 

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12205 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

### Further comments

This bug also exists in v8, though I was only able to reproduce it on Linux servers and VMs and not on Mac. 12 errors running unit tests all related to being unable to find a webpack stats file.
