### PR TITLE
Prevent key error during migration #12290

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -648,18 +648,19 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
             published_graph = self.get_published_graph()
 
             function_slugs = []
-            for function_dict in published_graph.serialized_graph["functions_x_graphs"]:
-                function_slug = {}
+            if "functions_x_graphs" in published_graph.serialized_graph:
+                for function_dict in published_graph.serialized_graph["functions_x_graphs"]:
+                    function_slug = {}
 
-                for key, value in function_dict.items():
-                    if isinstance(value, str):
-                        try:
-                            value = uuid.UUID(value)
-                        except ValueError:
-                            pass
-                    function_slug[key] = value
+                    for key, value in function_dict.items():
+                        if isinstance(value, str):
+                            try:
+                                value = uuid.UUID(value)
+                            except ValueError:
+                                pass
+                        function_slug[key] = value
 
-                function_slugs.append(function_slug)
+                    function_slugs.append(function_slug)
 
             return [
                 models.FunctionXGraph(**function_dict)

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -649,7 +649,9 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
 
             function_slugs = []
             if "functions_x_graphs" in published_graph.serialized_graph:
-                for function_dict in published_graph.serialized_graph["functions_x_graphs"]:
+                for function_dict in published_graph.serialized_graph[
+                    "functions_x_graphs"
+                ]:
                     function_slug = {}
 
                     for key, value in function_dict.items():

--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -653,14 +653,19 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
                     "functions_x_graphs"
                 ]:
                     function_slug = {}
-
-                    for key, value in function_dict.items():
-                        if isinstance(value, str):
-                            try:
-                                value = uuid.UUID(value)
-                            except ValueError:
-                                pass
-                        function_slug[key] = value
+                    try:
+                        for key, value in function_dict.items():
+                            if isinstance(value, str):
+                                try:
+                                    value = uuid.UUID(value)
+                                except ValueError:
+                                    pass
+                            function_slug[key] = value
+                    except AttributeError:
+                        return [
+                            function_x_graph
+                            for function_x_graph in self.functionxgraph_set.all()
+                        ]
 
                     function_slugs.append(function_slug)
 

--- a/releases/8.0.1.md
+++ b/releases/8.0.1.md
@@ -3,7 +3,7 @@ Arches 8.0.1 Release Notes
 
 ### Bug Fixes and Enhancements
 
-- 
+-   Prevent KeyError during migration of graphs without function_x_graphs objects in their publication [#12290](https://github.com/archesproject/arches/pull/12291)
 
 ### Dependency changes:
 ```

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -2930,3 +2930,44 @@ class DraftGraphTests(ArchesTestCase):
         self._compare_serialized_updated_source_graph_and_serialized_draft_graph(
             serialized_updated_source_graph, serialized_draft_graph
         )
+
+    def test_get_functions_x_graphs(self):
+        """
+        Test that an invalid function_x_graph property in a published graph returns valid function_x_graph objects
+
+        """
+
+        graph = Graph.objects.create_graph(name="TEST RESOURCE")
+        graph.delete_draft_graph()
+
+        graph.append_branch(
+            "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+            graphid=self.NODE_NODETYPE_GRAPHID,
+        )
+
+        node_dict = {}
+        for key, value in graph.nodes.items():
+            node_dict[str(key)] = str(value.nodeid)
+
+        graph.add_function_x_graph(
+            {
+                "id": str(uuid.uuid4()),
+                "function_id": "60000000-0000-0000-0000-000000000001",
+                "graph_id": graph.graphid,
+                "config": {"test": node_dict},
+            }
+        )
+
+        graph.save()
+        graph.publish()
+        graph.publication_id
+        functions_x_graphs_1 = graph.get_functions_x_graphs()
+
+        # save invalid functions_x_graphs value to publication's serialized graph
+        publication = graph.publication.publishedgraph_set.get(language_id="en")
+        publication.serialized_graph["functions_x_graphs"] = [
+            "60000000-0000-0000-0000-000000000001",
+        ]
+        publication.save()
+        functions_x_graphs_2 = graph.get_functions_x_graphs()
+        self.assertEqual(functions_x_graphs_1, functions_x_graphs_2)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Prevents KeyError when migrating graphs without a 'function_x_graphs' key in their publication.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12290
