### PR TITLE
Fix dummy saves

### DIFF
--- a/arches/app/models/utils.py
+++ b/arches/app/models/utils.py
@@ -3,7 +3,7 @@ def add_to_update_fields(kwargs, field_name):
     Update the `update_field` arg inside `kwargs` (if present) in-place
     with `field_name`.
     """
-    if (update_fields := kwargs.get("update_fields")) is not None:
+    if update_fields := kwargs.get("update_fields"):
         if isinstance(update_fields, set):
             # Django sends a set from update_or_create()
             update_fields.add(field_name)

--- a/releases/7.6.13.md
+++ b/releases/7.6.13.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
--   
+-   Respect empty `update_fields` arguments [#12300](https://github.com/archesproject/arches/pull/12300)
 
 ### Dependency changes:
 

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -822,3 +822,14 @@ class TileTests(ArchesTestCase):
         tile.save()
 
         self.assertEqual(tile.data, {data_collecting_grouping_node_id: None})
+
+    def test_dummy_save(self):
+        """Providing update_fields=set() will abort the save and only run side effects."""
+        data_collecting_grouping_node_id = "72048cb3-adbc-11e6-9ccf-14109fd34195"
+        tile = Tile(
+            resourceinstance_id=UUID("40000000-0000-0000-0000-000000000000"),
+            nodegroup_id=UUID(data_collecting_grouping_node_id),
+            data={},  # v8: can just omit
+        )
+        tile.save(update_fields=set())
+        self.assertFalse(Tile.objects.filter(pk=tile.pk).exists())


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
arches-querysets overrides `TileModel.save()` to orchestrate saving child tiles in bulk, but an [attempt is made](https://github.com/archesproject/arches-querysets/blob/214582e3bf6843c2d6d20e71db695d48aea0d6c6/arches_querysets/models.py#L501) to still run any other side effects from the `save()` method without re-saving the tile by passing `update_fields=set()`. This ran afoul of this helper's assumption any not-None value should have update fields appended. Falsy values like an empty set should be left alone: I feel in that case the caller knows what they're doing.


### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch
