### PR TITLE
Fix handling of empty iterables to update_fields kwarg

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -93,7 +93,7 @@ class CardModel(SaveSupportsBlindOverwriteMixin, models.Model):
     def save(self, **kwargs):
         if self.pk == self.source_identifier_id:
             self.source_identifier_id = None
-            add_to_update_fields(kwargs, "source_identifier_id")
+            kwargs = add_to_update_fields(kwargs, "source_identifier_id")
         super(CardModel, self).save(**kwargs)
 
     class Meta:
@@ -170,7 +170,7 @@ class CardXNodeXWidget(SaveSupportsBlindOverwriteMixin, models.Model):
     def save(self, **kwargs):
         if self.pk == self.source_identifier_id:
             self.source_identifier_id = None
-            add_to_update_fields(kwargs, "source_identifier_id")
+            kwargs = add_to_update_fields(kwargs, "source_identifier_id")
         super(CardXNodeXWidget, self).save(**kwargs)
 
     def __str__(self):
@@ -307,7 +307,7 @@ class Edge(SaveSupportsBlindOverwriteMixin, models.Model):
     def save(self, **kwargs):
         if self.pk == self.source_identifier_id:
             self.source_identifier_id = None
-            add_to_update_fields(kwargs, "source_identifier_id")
+            kwargs = add_to_update_fields(kwargs, "source_identifier_id")
         super(Edge, self).save(**kwargs)
 
     class Meta:
@@ -414,7 +414,7 @@ class File(SaveSupportsBlindOverwriteMixin, models.Model):
                 self.thumbnail_data = ThumbnailGeneratorInstance.get_thumbnail_data(
                     self.path.file
                 )
-                add_to_update_fields(kwargs_from_save_call, "thumbnail_data")
+                kwargs = add_to_update_fields(kwargs_from_save_call, "thumbnail_data")
         except Exception as e:
             logger.error(f"Thumbnail not generated for {self.path}: {e}")
             traceback.print_exc(file=sys.stdout)
@@ -741,11 +741,11 @@ class GraphModel(SaveSupportsBlindOverwriteMixin, models.Model):
             self.resource_instance_lifecycle_id = (
                 settings.DEFAULT_RESOURCE_INSTANCE_LIFECYCLE_ID
             )
-            add_to_update_fields(kwargs, "resource_instance_lifecycle_id")
+            kwargs = add_to_update_fields(kwargs, "resource_instance_lifecycle_id")
 
         if self.has_unpublished_changes is not False:
             self.has_unpublished_changes = True
-            add_to_update_fields(kwargs, "has_unpublished_changes")
+            kwargs = add_to_update_fields(kwargs, "has_unpublished_changes")
 
         super(GraphModel, self).save(**kwargs)
 
@@ -1087,10 +1087,10 @@ class Node(SaveSupportsBlindOverwriteMixin, models.Model):
 
     def save(self, **kwargs):
         if not self.alias:
-            add_to_update_fields(kwargs, "alias")
-            add_to_update_fields(kwargs, "hascustomalias")
+            kwargs = add_to_update_fields(kwargs, "alias")
+            kwargs = add_to_update_fields(kwargs, "hascustomalias")
         if self.pk == self.source_identifier_id:
-            add_to_update_fields(kwargs, "source_identifier_id")
+            kwargs = add_to_update_fields(kwargs, "source_identifier_id")
 
         self.clean()
 
@@ -1420,9 +1420,9 @@ class ResourceXResource(SaveSupportsBlindOverwriteMixin, models.Model):
 
         if not self.created:
             self.created = datetime.datetime.now()
-            add_to_update_fields(kwargs, "created")
+            kwargs = add_to_update_fields(kwargs, "created")
         self.modified = datetime.datetime.now()
-        add_to_update_fields(kwargs, "modified")
+        kwargs = add_to_update_fields(kwargs, "modified")
 
         super(ResourceXResource, self).save(**kwargs)
 
@@ -1520,8 +1520,8 @@ class ResourceInstance(SaveSupportsBlindOverwriteMixin, models.Model):
                 self.get_initial_resource_instance_lifecycle_state()
             )
 
-        add_to_update_fields(kwargs, "resource_instance_lifecycle_state")
-        add_to_update_fields(kwargs, "graph_publication")
+        kwargs = add_to_update_fields(kwargs, "resource_instance_lifecycle_state")
+        kwargs = add_to_update_fields(kwargs, "graph_publication")
         super(ResourceInstance, self).save(**kwargs)
 
 
@@ -1859,13 +1859,13 @@ class TileModel(SaveSupportsBlindOverwriteMixin, models.Model):  # Tile
 
     def save(self, **kwargs):
         if self.set_missing_keys_to_none():
-            add_to_update_fields(kwargs, "data")
+            kwargs = add_to_update_fields(kwargs, "data")
         if self.sortorder is None or self.is_fully_provisional():
             self.set_next_sort_order()
-            add_to_update_fields(kwargs, "sortorder")
+            kwargs = add_to_update_fields(kwargs, "sortorder")
         if not self.tileid:
             self.tileid = uuid.uuid4()
-            add_to_update_fields(kwargs, "tileid")
+            kwargs = add_to_update_fields(kwargs, "tileid")
 
         # Query for this first instead of during a transaction rollback.
         nodegroup_alias = self.find_nodegroup_alias()

--- a/arches/app/models/resource.py
+++ b/arches/app/models/resource.py
@@ -283,7 +283,7 @@ class Resource(models.ResourceInstance):
 
         if not self.principaluser_id and user:
             self.principaluser_id = user.id
-            add_to_update_fields(kwargs, "principaluser_id")
+            kwargs = add_to_update_fields(kwargs, "principaluser_id")
 
         super(Resource, self).save(**kwargs)
 

--- a/releases/8.1.0.md
+++ b/releases/8.1.0.md
@@ -1,0 +1,44 @@
+Arches 8.1.0 Release Notes
+--------------------------
+
+### Major enhancements
+
+### Performance improvements
+
+### Additional highlights
+
+
+```
+Python:
+    Upgraded:
+
+    Added:
+
+    Removed:
+
+
+JavaScript:
+    Upgraded:
+
+    Added:
+
+    Removed:
+```
+
+### Breaking changes
+
+- Recent versions of Arches made a "best" effort to ensure that field values injected by Django model `save()` methods were not evaded by the use of `update_or_create()` in recent versions of Django. Such uses of `update_or_create()` now raise `FutureWarning`. If you find this warning in your logs or tests, assess whether you need the injected values and opt-in by providing such field names in `defaults`:
+
+```py
+TileModel.objects.update_or_create(
+    pk=provisional_tile.pk,
+    nodegroup_id=provisional_tile.nodegroup_id,
+    # presence of "sortorder" in defaults signifies that the
+    # sortorder re-calculation in TileModel.save() is wanted.
+    defaults={"sortorder": random.randint()},
+)
+```
+
+### Upgrading Arches
+
+### Upgrading an Arches project

--- a/tests/models/tile_model_tests.py
+++ b/tests/models/tile_model_tests.py
@@ -386,9 +386,10 @@ class TileTests(ArchesTestCase):
         provisional_tile.save(index=False, request=request)
         self.assertEqual(provisional_tile.sortorder, 0)
 
-        obj, _ = TileModel.objects.update_or_create(
-            pk=provisional_tile.pk, nodegroup_id=provisional_tile.nodegroup_id
-        )
+        with self.assertWarns(FutureWarning):
+            obj, _ = TileModel.objects.update_or_create(
+                pk=provisional_tile.pk, nodegroup_id=provisional_tile.nodegroup_id
+            )
         obj.refresh_from_db()  # give test opportunity to fail on Django 4.2+
 
         self.assertEqual(obj.sortorder, 1)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
We had a workaround for a behavior change in Django 4.2 with `update_or_create()`, but it still wasn't correct:
- it mishandled empty iterables, which are supposed to abort a save
- it mutated `kwargs` in place

As mentioned in #12300 there was an attempt to use an empty iterable to abort a save in arches-querysets, but I'll find a different workaround for that given that I'm now only target 8.1 with these changes. At least in 8.1, you should be able to use this special `FUTURE_UPDATE_FIELDS_SENTINEL` if you want the future behavior.


### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch