### PR TITLE
Get RDFLib failures on Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14-dev"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14-dev"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/arches/app/utils/data_management/resources/formats/rdffile.py
+++ b/arches/app/utils/data_management/resources/formats/rdffile.py
@@ -323,7 +323,7 @@ class JsonLdWriter(RdfWriter):
             graph_id=graph_id, resourceinstanceids=resourceinstanceids, **kwargs
         )
         g = self.get_rdf_graph()
-        value = g.serialize(format="nquads").decode("utf-8")
+        value = g.serialize(format="nquads")
 
         js = from_rdf(value, {"format": "application/nquads", "useNativeTypes": True})
 

--- a/arches/app/utils/skos.py
+++ b/arches/app/utils/skos.py
@@ -117,7 +117,7 @@ class SKOSReader(object):
 
                 for predicate, object in graph.predicate_objects(subject=scheme):
                     if str(DCTERMS) in predicate and predicate.replace(
-                        DCTERMS, ""
+                        str(DCTERMS), ""
                     ) in dcterms_value_types.values_list("valuetype", flat=True):
                         if not self.language_exists(object, allowed_languages):
                             allowed_languages = models.Language.objects.values_list(
@@ -126,9 +126,9 @@ class SKOSReader(object):
 
                         try:
                             # first try and get any values associated with the concept_scheme
-                            # predicate.replace(SKOS, '') should yield something like 'prefLabel' or 'scopeNote', etc..
+                            # predicate.replace(str(SKOS), '') should yield something like 'prefLabel' or 'scopeNote', etc..
                             value_type = dcterms_value_types.get(
-                                valuetype=predicate.replace(DCTERMS, "")
+                                valuetype=predicate.replace(str(DCTERMS), "")
                             )
                             val = self.unwrapJsonLiteral(object)
                             if predicate == DCTERMS.title:
@@ -217,8 +217,8 @@ class SKOSReader(object):
                             # this is essentially the skos element type within a <skos:Concept>
                             # element (eg: prefLabel, broader, etc...)
                             relation_or_value_type = predicate.replace(
-                                SKOS, ""
-                            ).replace(ARCHES, "")
+                                str(SKOS), ""
+                            ).replace(str(ARCHES), "")
 
                             if relation_or_value_type in skos_value_types_list:
                                 value_type = skos_value_types[relation_or_value_type]
@@ -303,9 +303,9 @@ class SKOSReader(object):
 
                         # this is essentially the skos element type within a <skos:Concept>
                         # element (eg: prefLabel, broader, etc...)
-                        relation_or_value_type = predicate.replace(SKOS, "").replace(
-                            ARCHES, ""
-                        )
+                        relation_or_value_type = predicate.replace(
+                            str(SKOS), ""
+                        ).replace(str(ARCHES), "")
 
                         if relation_or_value_type in skos_value_types_list:
                             value_type = skos_value_types[relation_or_value_type]

--- a/arches/install/arches-templates/.github/workflows/main.yml
+++ b/arches/install/arches-templates/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/arches/install/arches-templates/pyproject.toml
+++ b/arches/install/arches-templates/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 5.2",
 ]
@@ -59,7 +60,7 @@ dependencies = [
     "python-slugify==7.0.0",
     "pytz==2023.3",
     "qrcode>=7.3.1",
-    "rdflib==4.2.2",
+    "rdflib==7.1.4",
     "requests-oauthlib==2.0.0",
     "requests[security]>=2.32.3",
     "semantic-version==2.10.0",


### PR DESCRIPTION
Adding Python 3.14 support is going to force us to upgrade RDFLib, so we're going to need some expert help in that area.

[releases](https://github.com/RDFLib/rdflib/releases)