### PR TITLE
12303 Resource Instance datatype not handling null values

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2116,21 +2116,22 @@ class ResourceInstanceDataType(BaseDataType):
 
         resourceid = None
         data = self.get_tile_data(tile)
-        nodevalue = self.get_nodevalues(data[str(node.nodeid)])
+        if data:
+            nodevalue = self.get_nodevalues(data[str(node.nodeid)])
 
-        items = []
-        for resourceXresource in nodevalue:
-            try:
-                resourceid = resourceXresource["resourceId"]
-                related_resource = Resource.objects.get(pk=resourceid)
-                displayname = related_resource.displayname()
-                if displayname is not None:
-                    items.append(displayname)
-            except (TypeError, KeyError):
-                pass
-            except:
-                logger.info(f'Resource with id "{resourceid}" not in the system.')
-        return ", ".join(items)
+            items = []
+            for resourceXresource in nodevalue:
+                try:
+                    resourceid = resourceXresource["resourceId"]
+                    related_resource = Resource.objects.get(pk=resourceid)
+                    displayname = related_resource.displayname()
+                    if displayname is not None:
+                        items.append(displayname)
+                except (TypeError, KeyError):
+                    pass
+                except:
+                    logger.info(f'Resource with id "{resourceid}" not in the system.')
+            return ", ".join(items)
 
     def get_relationship_display_value(self, relationship_valueid):
         preflabel = get_preflabel_from_valueid(relationship_valueid, get_language())


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
An issue occurs when fetching tile data for a resource instance select.
The issue only occurs for a null node set in the resource instance tile data. This happens from creating the node and then deleting the entry in the UI using the bin icon.

When using the resource_tiles endpoint to fetch the data but receive a None Type Error is not subscriptable


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes # [12303](https://github.com/archesproject/arches/issues/12303)

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @StuCM
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
