### PR TITLE
Handle case where project_requirements is None

### DIFF
--- a/arches/apps.py
+++ b/arches/apps.py
@@ -106,6 +106,8 @@ def check_arches_compatibility(app_configs, **kwargs):
 
         try:
             project_requirements = requires(config.name)
+            if project_requirements is None:
+                raise PackageNotFoundError
         except PackageNotFoundError:
             # Not installed by pip: read pyproject.toml directly
             project_requirements = read_project_requirements_from_toml_file(config)

--- a/releases/7.6.14.md
+++ b/releases/7.6.14.md
@@ -1,0 +1,48 @@
+## Arches 7.6.14 Release Notes
+
+### Bug Fixes and Enhancements
+
+-   Handle for null value in compatibility check [#12312](https://github.com/archesproject/arches/pull/12312)
+
+### Dependency changes:
+
+```
+Python:
+    Upgraded:
+        None
+JavaScript:
+    Upgraded:
+        none
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 7.6.0 before proceeding by following the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md)
+
+2. Upgrade to Arches 7.6.14
+
+    ```
+    pip install --upgrade arches==7.6.14
+    ```
+
+3.  Rebuild your frontend bundle:
+
+    - If you plan on doing active development, and need to see frontend changes automatically, run:
+        ```
+        npm start
+        ```
+
+    - If you do not plan to do active development, run:
+        ```
+        npm run build_development
+        ```
+
+    - if you are running in production, collect your static files
+        ```
+        python manage.py collectstatic
+        ```
+
+3. If you are running Arches on Apache, restart your server:
+    ```
+    sudo service apache2 reload
+    ```


### PR DESCRIPTION
`requires` can return None, was raising `NoneType is not iterable` in some cases.