### PR TITLE
Lift up lifecycle handlers and edit log saves from Resource to ResourceInstance #12321

### DIFF
--- a/releases/8.0.3.md
+++ b/releases/8.0.3.md
@@ -1,0 +1,31 @@
+Arches 8.0.3 Release Notes
+--------------------------
+
+### Bug Fixes and Enhancements
+
+- Promote lifecycle state management from `Resource` to `ResourceInstance` to better support subclassing [#12321](https://github.com/archesproject/arches/issues/12321)
+
+### Dependency changes:
+```
+Python:
+    Upgraded:
+        None
+
+JavaScript:
+    Upgraded:
+        none
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 8.0.0 before proceeding by following the upgrade process in the [Version 8.0.0 release notes](https://github.com/archesproject/arches/blob/dev/8.0.x/releases/8.0.0.md)
+
+2. Upgrade to Arches 8.0.3
+    ```
+    pip install --upgrade arches==8.0.3
+    ```
+
+3. If you are running Arches on Apache, restart your server:
+    ```
+    sudo service apache2 reload
+    ```


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, the lifecycle handlers and edit log saves were trapped on `Resource`, making it impossible to run these side effects from any other `ResourceInstance` subclasses.

Now, other subclasses can run these side effects.

This is part of the campaign to move any functionality that does not strictly depend on the data-fetching philosophy of the existing proxy models out of the proxy models.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12321

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [x] dev/8.0.x (main support): regressions, crashing bugs, security issues, _major bugs in new features_
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch
