### PR TITLE
Remove no-op get_interchange_value()

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -75,14 +75,6 @@ class BaseDataType(object):
         """
         return value
 
-    def get_interchange_value(self, value, **kwargs):
-        """
-        Transforms values for use in api's that will provide data for programmatic use on the frontend.
-        The interchange value is a shape that is more useful on the frontend than the node value shape.
-        The return value can be more or less complex than the value passed in, depending on the datatype.
-        """
-        return value
-
     def update(self, tile, data, nodeid, action):
         """
         Updates the tile.data value of a given datatype and returns the updated

--- a/releases/8.0.3.md
+++ b/releases/8.0.3.md
@@ -3,7 +3,7 @@ Arches 8.0.3 Release Notes
 
 ### Bug Fixes and Enhancements
 
-- 
+- Remove no-op `get_interchange_value()` datatype method [#12324](https://github.com/archesproject/arches/pull/12324)
 
 ### Dependency changes:
 ```

--- a/tests/utils/datatypes/datatype_tests.py
+++ b/tests/utils/datatypes/datatype_tests.py
@@ -88,11 +88,6 @@ class BaseDataTypeTests(ArchesTestCase):
 
         self.assertEqual(base.get_tile_data(tile_holding_only_none), tile_data)
 
-    def test_get_interchange_value(self):
-        base = BaseDataType()
-        value = "test values should be the same"
-        self.assertEqual(base.get_interchange_value(value), value)
-
 
 class BooleanDataTypeTests(ArchesTestCase):
     def test_validate(self):


### PR DESCRIPTION
This abstract method was added in core to support rapid prototyping in arches-component-lab and arches-querysets, but the need for it is no more, see https://github.com/archesproject/arches-querysets/pull/64.

It would just be misleading to keep maintaining it here.