### PR TITLE
Ensure all datatypes return a string from `get_display_value()` #12349

### DIFF
--- a/arches/app/datatypes/base.py
+++ b/arches/app/datatypes/base.py
@@ -239,10 +239,7 @@ class BaseDataType(object):
         else:
             return data
 
-    def get_display_value(self, tile, node, **kwargs):
-        """
-        Returns a list of concept values for a given node
-        """
+    def get_display_value(self, tile, node, **kwargs) -> str:
         data = self.get_tile_data(tile)
 
         if data:
@@ -250,6 +247,7 @@ class BaseDataType(object):
 
             if display_value:
                 return str(display_value)
+        return ""  # TODO (arches_version): configure this with a setting in 8.1
 
     def get_search_terms(self, nodevalue, nodeid=None):
         """

--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -397,6 +397,7 @@ class StringDataType(BaseDataType):
                     return raw_value[current_language]["value"]
                 except KeyError:
                     pass
+        return ""
 
     def default_es_mapping(self):
         """
@@ -483,6 +484,7 @@ class NumberDataType(BaseDataType):
             display_value = data.get(str(node.nodeid))
             if display_value is not None:
                 return str(display_value)
+        return ""
 
     def transform_value_for_tile(self, value, **kwargs):
         try:
@@ -596,6 +598,7 @@ class BooleanDataType(BaseDataType):
             raw_value = data.get(str(node.nodeid))
             if raw_value is not None:
                 return str(raw_value)
+        return ""
 
         # TODO: When APIv1 is retired, replace the body of get_display_value with the following
         # data = self.get_tile_data(tile)
@@ -879,7 +882,7 @@ class DateDataType(BaseDataType):
                 new_date_format
             )
         except TypeError:
-            value = data[str(node.nodeid)]
+            value = data[str(node.nodeid)] or ""
         return value
 
 
@@ -921,7 +924,7 @@ class EDTFDataType(BaseDataType):
         try:
             value = data[str(node.nodeid)]["value"]
         except TypeError:
-            value = data[str(node.nodeid)]
+            value = data[str(node.nodeid)] or ""
         return value
 
     def append_to_document(self, document, nodevalue, nodeid, tile, provisional=False):
@@ -2129,6 +2132,7 @@ class ResourceInstanceDataType(BaseDataType):
                 except:
                     logger.info(f'Resource with id "{resourceid}" not in the system.')
             return ", ".join(items)
+        return ""
 
     def get_relationship_display_value(self, relationship_valueid):
         preflabel = get_preflabel_from_valueid(relationship_valueid, get_language())

--- a/arches/app/datatypes/url.py
+++ b/arches/app/datatypes/url.py
@@ -117,6 +117,7 @@ class URLDataType(BaseDataType):
 
             if display_value:
                 return json.dumps(display_value)
+        return ""
 
     def to_json(self, tile, node):
         data = self.get_tile_data(tile)

--- a/releases/7.6.15.md
+++ b/releases/7.6.15.md
@@ -1,0 +1,48 @@
+## Arches 7.6.15 Release Notes
+
+### Bug Fixes and Enhancements
+
+-   Ensure all datatypes return a string from `get_display_value()` [#12349](https://github.com/archesproject/arches/issues/12349)
+
+### Dependency changes:
+
+```
+Python:
+    Upgraded:
+        None
+JavaScript:
+    Upgraded:
+        none
+```
+
+### Upgrading Arches
+
+1. Upgrade to version 7.6.0 before proceeding by following the upgrade process in the [Version 7.6.0 release notes](https://github.com/archesproject/arches/blob/dev/7.6.x/releases/7.6.0.md)
+
+2. Upgrade to Arches 7.6.15
+
+    ```
+    pip install --upgrade arches==7.6.15
+    ```
+
+3.  Rebuild your frontend bundle:
+
+    - If you plan on doing active development, and need to see frontend changes automatically, run:
+        ```
+        npm start
+        ```
+
+    - If you do not plan to do active development, run:
+        ```
+        npm run build_development
+        ```
+
+    - if you are running in production, collect your static files
+        ```
+        python manage.py collectstatic
+        ```
+
+3. If you are running Arches on Apache, restart your server:
+    ```
+    sudo service apache2 reload
+    ```

--- a/tests/utils/datatypes/datatype_tests.py
+++ b/tests/utils/datatypes/datatype_tests.py
@@ -51,9 +51,9 @@ class AllDataTypeTests(ArchesTestCase):
         for datatype in self.datatypes:
             instance = self.factory.get_instance(datatype)
             with self.subTest(datatype=datatype):
-                self.assertIn(
+                self.assertEqual(
                     instance.to_json(mock_tile, self.mock_node)["@display_value"],
-                    ["", None],
+                    "",
                 )
 
 


### PR DESCRIPTION
### Types of changes
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Before, `get_display_value()` might return `None` rather than `""` for empty nodes and sometimes vice versa, violating assumptions on the front-end (e.g. in arches-component-lab) that display_value is always a string.

We can eventually parameterize this in 8.1 to provide a custom empty string via settings?

### Issues Solved
Closes #12349

### Checklist
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Farallon
*   Found by: @jacobtylerwalls