### PR TITLE
Fix broken RunPython operation

### DIFF
--- a/releases/8.0.3.md
+++ b/releases/8.0.3.md
@@ -3,6 +3,7 @@ Arches 8.0.3 Release Notes
 
 ### Bug Fixes and Enhancements
 
+- Fix migration failing to create missing node aliases [#12359](https://github.com/archesproject/arches/pull/12359)
 - Promote lifecycle state management from `Resource` to `ResourceInstance` to better support subclassing [#12321](https://github.com/archesproject/arches/issues/12321)
 - Remove no-op `get_interchange_value()` datatype method [#12324](https://github.com/archesproject/arches/pull/12324)
 


### PR DESCRIPTION
@aarongundel spotted that with unpublished graphs in your database, this RunPython operation crashed with:

```py
django.db.utils.ProgrammingError: column node_groups.groupingnodeid does not exist
LINE 1: ..."cardinality", "node_groups"."parentnodegroupid", "node_grou...
```