### PR TITLE
Make `UserProfile.{*}able_nodegroups` a `@cached_property`

### DIFF
--- a/arches/app/models/models.py
+++ b/arches/app/models/models.py
@@ -18,6 +18,7 @@ from django.db.models.constraints import UniqueConstraint
 from django.db.models.expressions import CombinedExpression
 from django.db.models.functions import Concat, Lower
 from django.utils import translation
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from arches.app.const import ExtensionType
@@ -2067,7 +2068,7 @@ class UserProfile(models.Model):
     phone = models.CharField(max_length=16, blank=True)
     encrypted_mfa_hash = models.CharField(max_length=128, null=True, blank=True)
 
-    @property
+    @cached_property
     def viewable_nodegroups(self):
         from arches.app.utils.permission_backend import get_nodegroups_by_perm
 
@@ -2078,7 +2079,7 @@ class UserProfile(models.Model):
             )
         )
 
-    @property
+    @cached_property
     def editable_nodegroups(self):
         from arches.app.utils.permission_backend import get_nodegroups_by_perm
 
@@ -2089,7 +2090,7 @@ class UserProfile(models.Model):
             )
         )
 
-    @property
+    @cached_property
     def deletable_nodegroups(self):
         from arches.app.utils.permission_backend import get_nodegroups_by_perm
 

--- a/releases/8.1.0.md
+++ b/releases/8.1.0.md
@@ -8,6 +8,7 @@ Arches 8.1.0 Release Notes
 ### Additional highlights
 
 -   Log exceptions in background tasks [#12214](https://github.com/archesproject/arches/pull/12214)
+-   Make `UserProfile.{viewable|editable|deletable}_nodegroups` a `@cached_property` [#12363](https://github.com/archesproject/arches/pull/12363)
 -   Update ESLint config to allow prepending underscores to unused args and variables [#12338](https://github.com/archesproject/arches/issues/12338)
 
 ```


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
arches-querysets has a use case for checking `.user.userprofile.editable_nodegroups` several times, and I've had to store off the result of this property to avoid repetitive queries, when really it would be a better DX to make sure that it was only calculated once at the source (per instance / request).
