### PR TITLE
Prevent resaving nodegroups after they've been saved in the view

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -500,8 +500,8 @@ class Graph(models.GraphModel):
         with transaction.atomic():
             super(Graph, self).save()
 
-            for nodegroup in self.get_nodegroups():
-                nodegroup.save()
+            # for nodegroup in self.get_nodegroups():
+            #     nodegroup.save()
 
             se = SearchEngineFactory().create()
             datatype_factory = DataTypeFactory()


### PR DESCRIPTION
### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

The cause of #12384 seems to be that we are saving the nodegroups twice on saving a graph in the graph designer. The first time is in the view here: https://github.com/archesproject/arches/blob/f5fe650bc4458bafd7de18a94d55aceec0a9d6df/arches/app/views/graph.py#L177-L179

At that point the nodegroup saves with the proper cardinality. 

The second time that we save nodegroups is in the graph save method after calling `self.get_nodegroups` here:

https://github.com/archesproject/arches/blob/f5fe650bc4458bafd7de18a94d55aceec0a9d6df/arches/app/models/graph.py#L503-L504 

In this case, get_nodegroups is getting the nodegroup data using prefetch, and pulling the old data out of the database rather than using the newly saved nodegroup from the view which seems to still just be in memory. Commenting out the above lines and preventing the nodegroups from being resaved fixes the issue. Obviously, this is not a practical solution because it seems likely that graphs will need to be saved from parts of the application other than the view. 
