### PR TITLE
Remove test flakiness if celery configured #12322

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -122,3 +122,8 @@ if DOCKER:
         from arches.settings_docker import *
     except ImportError:
         pass
+
+
+# Tests shouldn't depend on celery running, so overwrite after settings_local import
+# This is enough to fool check_if_celery_available()
+CELERY_BROKER_URL = ""


### PR DESCRIPTION
Closes #12322

Finally figured out what was up with local test failures, I have a settings_local.py with a celery URL.