### PR TITLE
Fix str/uuid confusion in Graph

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -307,6 +307,8 @@ class Graph(models.GraphModel):
 
         if edge.pk is None:
             edge.pk = uuid.uuid4()
+        if isinstance(edge.pk, str):
+            edge.pk = uuid.UUID(edge.pk)
         if self.ontology is None:
             edge.ontologyproperty = None
         self.edges[edge.pk] = edge
@@ -318,6 +320,8 @@ class Graph(models.GraphModel):
     def add_card_contraint(self, constraint, card):
         constraint_model = models.ConstraintModel()
         constraint_model.constraintid = constraint.get("constraintid", None)
+        if isinstance(constraint_model.pk, str):
+            constraint_model.pk = uuid.UUID(constraint_model.pk)
         constraint_model.uniquetoallinstances = constraint.get(
             "uniquetoallinstances", False
         )
@@ -366,6 +370,8 @@ class Graph(models.GraphModel):
 
         if card.pk is None:
             card.pk = uuid.uuid4()
+        if isinstance(card.pk, str):
+            card.pk = uuid.UUID(card.pk)
 
         self.cards[card.pk] = card
         self.has_unpublished_changes = True
@@ -385,6 +391,8 @@ class Graph(models.GraphModel):
             function_x_graph = models.FunctionXGraph(**function_x_graph.copy())
 
         function_x_graph.graph = self
+        if isinstance(function_x_graph.pk, str):
+            function_x_graph.pk = uuid.UUID(function_x_graph.pk)
 
         self.functions_x_graphs.append(function_x_graph)
         self.has_unpublished_changes = True
@@ -402,6 +410,9 @@ class Graph(models.GraphModel):
 
         if not isinstance(spatial_view, models.SpatialView):
             spatial_view = models.SpatialView(**spatial_view.copy())
+
+        if isinstance(spatial_view.pk, str):
+            spatial_view.pk = uuid.UUID(spatial_view.pk)
 
         self._spatial_views.append(spatial_view)
         self.has_unpublished_changes = True

--- a/releases/8.0.4.md
+++ b/releases/8.0.4.md
@@ -3,7 +3,7 @@ Arches 8.0.4 Release Notes
 
 ### Bug Fixes and Enhancements
 - Fix bug related to scrolling for bulk importers [#12398] (https://github.com/archesproject/arches/pull/12398)
-- 
+- Fix resource editor failure to render [#12408](https://github.com/archesproject/arches/pull/12408)
 
 ### Dependency changes:
 ```

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -17,12 +17,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import uuid
+from http import HTTPStatus
 
 from arches.app.views.resource import ResourcePermissionDataView
 from tests.base_test import ArchesTestCase
 from django.db import connection
 from django.urls import reverse
-from arches.app.models.models import EditLog
+from arches.app.models.models import EditLog, Graph
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from tests.utils.search_test_utils import sync_es
@@ -63,6 +64,18 @@ class ResourceViewTests(ArchesTestCase):
             edit.userid = user.id
             edit.save()
         cls.resource = Resource.objects.get(pk=cls.resource_instance_id)
+        cls.graph = Graph(cls.resource.graph_id)
+
+    def test_resource_editor_view(self):
+        self.graph.publish()
+        self.client.login(username="admin", password="admin")
+
+        url = reverse(
+            "resource_editor", kwargs={"resourceid": self.resource_instance_id}
+        )
+
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
     def test_resource_instance_permission_assignment(self):
         """


### PR DESCRIPTION
Fixes #12408

The failure of `prefetch_related_objects` is a symptom of providing strings to the pk of a model instance, see #10877.

We had code to fix this in the `add_node()` function, but not the others.