### PR TITLE
Fix test tile value

### DIFF
--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -722,11 +722,13 @@ class ResourceTests(ArchesTestCase):
                 str(string_node.pk): {
                     "en": {"value": "test value", "direction": "ltr"},
                 },
-                str(resource_instance_node.pk): {
-                    "resourceId": str(resource.pk),
-                    "ontologyProperty": "",
-                    "inverseOntologyProperty": "",
-                },
+                str(resource_instance_node.pk): [
+                    {
+                        "resourceId": str(resource.pk),
+                        "ontologyProperty": "",
+                        "inverseOntologyProperty": "",
+                    }
+                ],
             },
             sortorder=0,
         )


### PR DESCRIPTION
:wave: Was running the arches test suite against some pending Django PRs and before remembering to uninstall arches-querysets, it choked on this invalid test data.