### PR TITLE
don't encode diacritics when saving strings in the rich text editor, …

### DIFF
--- a/arches/app/templates/views/components/widgets/rich-text.htm
+++ b/arches/app/templates/views/components/widgets/rich-text.htm
@@ -62,7 +62,10 @@
                     language: currentLanguage.code,
                     direction: currentDirection,
                     placeholder: currentPlaceholder,
-                    ckeditorOptions: {},
+                    ckeditorOptions: {
+                        entities_latin: false,
+                        entities_greek: false
+                    },
                     valueUpdate: 'afterkeydown',
                     attr: {disabled: disabled}
                 "></textarea>

--- a/releases/7.6.17.md
+++ b/releases/7.6.17.md
@@ -1,7 +1,8 @@
 ## Arches 7.6.17 Release Notes
 
 ### Bug Fixes and Enhancements
-
+-   Fixed an issue where diacritics were being html encoded and saved to the database when using the rich-text editor
+[#12460](https://github.com/archesproject/arches/issues/12460)
 -   
 
 ### Dependency changes:


### PR DESCRIPTION
…re #12460

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
when using the rich-text editor strings with diacritics in them are now preserved in the database rather than being html encoded

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12460

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Sponsored by: Getty Digital
*   Found by: Ian Webb from Getty Digital
*   Tested by: @apeters
*   Designed by: @apeters

