### PR TITLE
Fix ResourceInstanceDataType to use the language passed for calculating the display value

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2124,7 +2124,7 @@ class ResourceInstanceDataType(BaseDataType):
                 try:
                     resourceid = resourceXresource["resourceId"]
                     related_resource = Resource.objects.get(pk=resourceid)
-                    displayname = related_resource.displayname()
+                    displayname = related_resource.displayname(kwargs)
                     if displayname is not None:
                         items.append(displayname)
                 except (TypeError, KeyError):

--- a/releases/7.6.20.md
+++ b/releases/7.6.20.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
--  
+-  Fixes resource-instance nodes not localizing correctly in descriptor functions. [#12539](https://github.com/archesproject/arches/pull/12539)
 
 ### Dependency changes:
 

--- a/releases/7.6.21.md
+++ b/releases/7.6.21.md
@@ -6,6 +6,8 @@
 
 -  Added a sql patch (see below) to fix the performance of tile cardinality checks against large datasets  #[12586](https://github.com/archesproject/arches/pull/12586)
 
+-  Fixes resource-instance nodes not localizing correctly in descriptor functions. [#12539](https://github.com/archesproject/arches/pull/12539)
+
 ### Dependency changes:
 
 ```


### PR DESCRIPTION
This fixes the issue where the display value being calculated for a ResourceInstanceDataType object wasn't using the language value passed to the function and always defaulted to the currently active language.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
The `kwargs` parameter is now passed through the `get_display_value()` function to the `displayname()` function being called within it to get the string displayname value.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12538 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Parks Canada Agency<!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @jkemper-pca  <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @jkemper-pca  <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @jkemper-pca  <!--- Who designed this new feature-->

### Further comments

I have targeted this change to the dev/7.6.x branch because I found it on our 7.6 install but I also believe this to be a bug in the 8.x version as well. If it makes more sense to target v8 I can change the PR.
