### PR TITLE
Fixes issue where term search may only return one result of many matching terms #12555

### DIFF
--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -153,7 +153,9 @@ def search_terms(request):
     i = 0
     ret = {"terms": [], "concepts": []}
     if len(permitted_nodegroups) == 0:
-        return JSONResponse(ret)
+        return JSONResponse(ret)    
+    nodegroup_ids = set()
+    queries = {}
     for index in list(ret.keys()):
         query = Query(se, start=0, limit=0)
         boolquery = Bool()
@@ -214,7 +216,24 @@ def search_terms(request):
         base_agg.add_aggregation(nodegroupid_agg)
         query.add_aggregation(base_agg)
 
+        queries[index] = query
+
+    results_dict = {}
+    for index, query in queries.items():
         results = query.search(index=index)
+        results_dict[index] = results
+        if results is not None:
+            for result in results["aggregations"]["value_agg"]["buckets"]:
+                if len(result["top_concept"]["buckets"]) == 0:
+                    for nodegroup in result["nodegroupid"]["buckets"]:
+                        nodegroup_ids.add(nodegroup["key"])
+
+    nodes = Node.objects.filter(nodeid__in=nodegroup_ids).select_related('graph')
+    node_lookup = {str(node.nodeid): (node.graph.name, node.name) for node in nodes}
+
+    i = 0
+    for index in list(ret.keys()):
+        results = results_dict[index]        
         if results is not None:
             for result in results["aggregations"]["value_agg"]["buckets"]:
                 if len(result["top_concept"]["buckets"]) > 0:
@@ -238,9 +257,8 @@ def search_terms(request):
                 else:
                     for nodegroup in result["nodegroupid"]["buckets"]:
                         nodegroup_id = nodegroup["key"]
-                        node = Node.objects.get(nodeid=nodegroup_id)
-                        graph = node.graph
-                        context_label = "{0} - {1}".format(graph.name, node.name)
+                        graph_name, node_name = node_lookup.get(str(nodegroup_id), ("", ""))										  
+                        context_label = "{0} - {1}".format(graph_name, node_name)
                         ret[index].append(
                             {
                                 "type": "term",

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -153,7 +153,7 @@ def search_terms(request):
     i = 0
     ret = {"terms": [], "concepts": []}
     if len(permitted_nodegroups) == 0:
-        return JSONResponse(ret)    
+        return JSONResponse(ret)
     nodegroup_ids = set()
     queries = {}
     for index in list(ret.keys()):
@@ -228,12 +228,12 @@ def search_terms(request):
                     for nodegroup in result["nodegroupid"]["buckets"]:
                         nodegroup_ids.add(nodegroup["key"])
 
-    nodes = Node.objects.filter(nodeid__in=nodegroup_ids).select_related('graph')
+    nodes = Node.objects.filter(nodeid__in=nodegroup_ids).select_related("graph")
     node_lookup = {str(node.nodeid): (node.graph.name, node.name) for node in nodes}
 
     i = 0
     for index in list(ret.keys()):
-        results = results_dict[index]        
+        results = results_dict[index]
         if results is not None:
             for result in results["aggregations"]["value_agg"]["buckets"]:
                 if len(result["top_concept"]["buckets"]) > 0:
@@ -257,7 +257,9 @@ def search_terms(request):
                 else:
                     for nodegroup in result["nodegroupid"]["buckets"]:
                         nodegroup_id = nodegroup["key"]
-                        graph_name, node_name = node_lookup.get(str(nodegroup_id), ("", ""))										  
+                        graph_name, node_name = node_lookup.get(
+                            str(nodegroup_id), ("", "")
+                        )
                         context_label = "{0} - {1}".format(graph_name, node_name)
                         ret[index].append(
                             {

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -232,7 +232,7 @@ def search_terms(request):
     node_lookup = {str(node.nodeid): (node.graph.name, node.name) for node in nodes}
 
     i = 0
-    for index in list(ret.keys()):
+    for index in ret.keys():
         results = results_dict[index]
         if results is not None:
             for result in results["aggregations"]["value_agg"]["buckets"]:

--- a/arches/app/views/search.py
+++ b/arches/app/views/search.py
@@ -236,31 +236,25 @@ def search_terms(request):
                             )
                         i = i + 1
                 else:
-                    ret[index].append(
-                        {
-                            "type": "term",
-                            "context": "",
-                            "context_label": get_resource_model_label(result),
-                            "id": i,
-                            "text": result["key"],
-                            "value": result["key"],
-                            "nodegroupid": result["nodegroupid"]["buckets"][0]["key"],
-                        }
-                    )
-                    i = i + 1
+                    for nodegroup in result["nodegroupid"]["buckets"]:
+                        nodegroup_id = nodegroup["key"]
+                        node = Node.objects.get(nodeid=nodegroup_id)
+                        graph = node.graph
+                        context_label = "{0} - {1}".format(graph.name, node.name)
+                        ret[index].append(
+                            {
+                                "type": "term",
+                                "context": "",
+                                "context_label": context_label,
+                                "id": i,
+                                "text": result["key"],
+                                "value": result["key"],
+                                "nodegroupid": nodegroup_id,
+                            }
+                        )
+                        i = i + 1
 
     return JSONResponse(ret)
-
-
-def get_resource_model_label(result):
-    if len(result["nodegroupid"]["buckets"]) > 0:
-        for nodegroup in result["nodegroupid"]["buckets"]:
-            nodegroup_id = nodegroup["key"]
-            node = Node.objects.get(nodeid=nodegroup_id)
-            graph = node.graph
-        return "{0} - {1}".format(graph.name, node.name)
-    else:
-        return ""
 
 
 @group_required("Resource Exporter")

--- a/releases/7.6.21.md
+++ b/releases/7.6.21.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
+-  Handles Term Search results set and nodegroup labeling issues  #[12555](https://github.com/archesproject/arches/pull/12555)
 
 ### Dependency changes:
 

--- a/releases/7.6.21.md
+++ b/releases/7.6.21.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes and Enhancements
 
--  Handles Term Search results set and nodegroup labeling issues  #[12555](https://github.com/archesproject/arches/pull/12555)
+-  Handles Term Search results set and nodegroup labeling issues  #[12556](https://github.com/archesproject/arches/pull/12556)
 
 ### Dependency changes:
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This fixes an issue that occurs when a search term is matched multiple times, such as if there are multiple instances of a name across resources, it would only return the first match (whilst ascribing it the model label of the last results nodegroup), and may link to a different match. This fix ensures that all term matches are returned and are correctly linked.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12555 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [X] dev/7.6.x (extended support): major security issues, data loss issues
    
- [X] I added a changelog in arches/releases
- [ ] I submitted a PR to arches-docs (if appropriate)
- [x] Unit tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] My test fails on the target branch
