### PR TITLE
Fix widget collection #12502, #12513

### DIFF
--- a/arches/app/views/api/resource.py
+++ b/arches/app/views/api/resource.py
@@ -706,11 +706,11 @@ class ResourceReport(APIBase):
             permitted_card_ids = [card.pk for card in permitted_cards]
             cardwidgets = sorted(
                 [
-                    widget
-                    for widget in graph.widgets
-                    if widget["card_id"] in permitted_card_ids
+                    card_node_widget
+                    for card_node_widget in graph.cards_x_nodes_x_widgets
+                    if uuid.UUID(card_node_widget["card_id"]) in permitted_card_ids
                 ],
-                key=lambda widget: widget["sortorder"] or 0,
+                key=lambda card_node_widget: card_node_widget["sortorder"] or 0,
             )
 
             resp["cards"] = permitted_cards

--- a/arches/test/views/resource_tests.py
+++ b/arches/test/views/resource_tests.py
@@ -1,0 +1,11 @@
+def test_api_resource_report_response(self):
+    """
+    Ensure api_resource_report returns proper response
+
+    """
+    self.client.login(username="admin", password="admin")
+    url = reverse(
+        "api_resource_report", kwargs={"resourceid": self.resource_instance_id}
+    )
+    response = self.client.get(url)
+    self.assertTrue(len(response.json()["cardwidgets"]) > 0)

--- a/releases/8.1.0.md
+++ b/releases/8.1.0.md
@@ -25,7 +25,7 @@
 -   Allow for bulk file uploading from a location local to the default storage type.  [#12545](https://github.com/archesproject/arches/issues/12545) and [#12562](https://github.com/archesproject/arches/issues/12562)
 -   Optimize IIIF thumbnail loading with size parameters. [#12529](https://github.com/archesproject/arches/pull/12529)
 -   Fix bug preventing SQL functions from properly returning the value and label for the node_value datatype [#12548](https://github.com/archesproject/arches/pull/12548) 
-
+-   Fix widget collection so rich text and localization display correctly in reports [#12502](https://github.com/archesproject/arches/issues/12502), [#12513](https://github.com/archesproject/arches/issues/12513)
 
 ```
 Python:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

Previously resource.py was looking for the non-existent "widgets" in the serialized graph, when it should be looking for "cards_x_nodes_x_widgets." As a result, no card/node/widget information was included in the API response and cards were not pulling the correct widget templates in the case of string fields (see issue #12502), nor including localized labels for widgets (see #12513).  This change gets the correct values so this information is included in the API response.  

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12502 and #12513 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch


#### Ticket Background
*   Found by: @yshng 

### Further comments

No tests found when running `python manage.py test tests --settings="tests.test_settings"`
