### PR TITLE
Annotations batch

### DIFF
--- a/arches/app/media/js/views/components/iiif-viewer.js
+++ b/arches/app/media/js/views/components/iiif-viewer.js
@@ -3,6 +3,7 @@ import ko from 'knockout';
 import koMapping from 'knockout-mapping';
 import L from 'leaflet';
 import arches from 'arches';
+import Cookies from 'js-cookie';
 import WorkbenchViewmodel from 'views/components/workbench';
 import iiifPopup from 'templates/views/components/iiif-popup.htm';
 import iiifViewerTemplate from 'templates/views/components/iiif-viewer.htm';
@@ -152,6 +153,73 @@ var IIIFViewerViewmodel = function(params) {
     this.buildAnnotationNodes = params.buildAnnotationNodes || function(json) {
         const nodeProcessingStatus = {};
 
+        const buildAnnotationsUrl = function(canvasId, nodeId) {
+            return arches.urls.iiifannotations + '?canvas=' + canvasId + '&nodeid=' + nodeId;
+        };
+
+        // Fetch the annotations of every canvas of the manifest in a single
+        // request and cache them under the urls the per-canvas fetches use, so
+        // that those only have to read them back. Returns false when the batch
+        // is unavailable or fails, leaving the per-canvas fetches to do the work.
+        const fetchAnnotationsInBatch = async function(canvasIds, nodeIds) {
+            if (!arches.urls.iiifannotations_batch) return false;
+            // Stay under the number of canvases the endpoint accepts per request.
+            const MAX_CANVASES_PER_REQUEST = 200;
+            for (let i = 0; i < canvasIds.length; i += MAX_CANVASES_PER_REQUEST) {
+                const canvases = canvasIds.slice(i, i + MAX_CANVASES_PER_REQUEST);
+                let batch;
+                try {
+                    const response = await window.fetch(arches.urls.iiifannotations_batch, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': Cookies.get('csrftoken')
+                        },
+                        body: JSON.stringify({canvases: canvases})
+                    });
+                    if (!response.ok) return false;
+                    batch = await response.json();
+                } catch (error) {
+                    console.error('Error loading annotations in batch:', error);
+                    return false;
+                }
+                if (!batch.canvases) return false;
+                const featuresByUrl = {};
+                Object.keys(batch.canvases).forEach(function(canvasId) {
+                    batch.canvases[canvasId].features.forEach(function(feature) {
+                        const url = buildAnnotationsUrl(canvasId, feature.properties.nodeId);
+                        featuresByUrl[url] = featuresByUrl[url] || [];
+                        featuresByUrl[url].push(feature);
+                    });
+                });
+                // A canvas without annotations is absent from the response, so cache
+                // an empty collection for it rather than fetching it again per canvas.
+                canvases.forEach(function(canvasId) {
+                    nodeIds.forEach(function(nodeId) {
+                        const url = buildAnnotationsUrl(canvasId, nodeId);
+                        cachedAnnotations[url] = {
+                            type: 'FeatureCollection',
+                            features: featuresByUrl[url] || []
+                        };
+                    });
+                });
+            }
+            return true;
+        };
+
+        let batchPreload;
+        const preloadAnnotationsInBatch = function() {
+            const canvasIds = self.canvases()
+                .map(canvas => self.getCanvasService(canvas))
+                .filter(canvasId => !!canvasId);
+            // The manifest may not be loaded yet, in which case a later call retries.
+            if (canvasIds.length === 0) return Promise.resolve(false);
+            if (!batchPreload) {
+                batchPreload = fetchAnnotationsInBatch(canvasIds, json.map(node => node.nodeid));
+            }
+            return batchPreload;
+        };
+
         self.annotationNodes(
             json.map((node) => {
                 const annotations = ko.observableArray();
@@ -160,7 +228,7 @@ var IIIFViewerViewmodel = function(params) {
                 const updateAnnotations = async function() {
                     const canvas = self.canvas();
                     if (canvas) {
-                        const annotationsUrl = arches.urls.iiifannotations + '?canvas=' + canvas + '&nodeid=' + node.nodeid;
+                        const annotationsUrl = buildAnnotationsUrl(canvas, node.nodeid);
                         try {
                             if(!cachedAnnotations[annotationsUrl]){
                                 const response = await window.fetch(annotationsUrl);
@@ -175,7 +243,7 @@ var IIIFViewerViewmodel = function(params) {
                             annotations(annotation.features);
 
                             const counts = {...self.annotationCounts()};
-                            counts[canvas] = annotation.features.length;
+                            counts[canvas + '::' + node.nodeid] = annotation.features.length;
                             self.annotationCounts(counts);
                         } catch (error) {
                             console.error('Error loading annotations for current canvas:', error);
@@ -206,7 +274,7 @@ var IIIFViewerViewmodel = function(params) {
                                 const canvasId = self.getCanvasService(canvas);
 
                                 if (canvas && canvasId) {
-                                    const annotationsUrl = arches.urls.iiifannotations + '?canvas=' + canvasId + '&nodeid=' + node.nodeid;
+                                    const annotationsUrl = buildAnnotationsUrl(canvasId, node.nodeid);
 
                                     batchPromises.push((async () => {
                                         try {
@@ -218,10 +286,7 @@ var IIIFViewerViewmodel = function(params) {
                                             // get state before update
                                             const currentCounts = {...self.annotationCounts()};
 
-                                            if (!currentCounts[canvasId]) {
-                                                currentCounts[canvasId] = 0;
-                                            }
-                                            currentCounts[canvasId] += cachedAnnotations[annotationsUrl].features.length;
+                                            currentCounts[canvasId + '::' + node.nodeid] = cachedAnnotations[annotationsUrl].features.length;
                                             processedCount++;
 
                                             // update counts progress
@@ -252,8 +317,10 @@ var IIIFViewerViewmodel = function(params) {
                 };
 
                 const initializeAnnotationLoading = async function() {
+                    const preloading = preloadAnnotationsInBatch();
                     //priorize current canvas
                     await updateAnnotations();
+                    await preloading;
                     setTimeout(() => preloadAllAnnotations(), 100);
                 };
 
@@ -867,7 +934,11 @@ var IIIFViewerViewmodel = function(params) {
 
     this.getAnnotationCount = function(canvasId) {
         const counts = self.annotationCounts();
-        return counts && counts[canvasId] ? counts[canvasId] : 0;
+        if (!counts) return 0;
+        const prefix = canvasId + '::';
+        return Object.keys(counts)
+            .filter(key => key.startsWith(prefix))
+            .reduce((total, key) => total + counts[key], 0);
     };
 };
 ko.components.register('iiif-viewer', {

--- a/arches/app/templates/arches_urls.htm
+++ b/arches/app/templates/arches_urls.htm
@@ -133,6 +133,7 @@
     etl_manager="{% url 'etl_manager' %}"
     iiifannotations="{% url 'iiifannotations' %}"
     iiifannotationnodes="{% url 'iiifannotationnodes' %}"
+    iiifannotations_batch="{% url 'iiifannotations_batch' %}"
     validatejson='"{% url "validatejson" "aaaa"%}".replace("aaaa", "")'
     get_dsl="{% url 'get_dsl' %}"
     transform_edtf_for_tile="{% url 'transform_edtf_for_tile' %}"

--- a/arches/app/views/api/iiif.py
+++ b/arches/app/views/api/iiif.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 from django.db.models import Q
@@ -8,6 +9,28 @@ from arches.app.models import models
 from arches.app.utils.permission_backend import get_nodegroups_by_perm
 from arches.app.utils.response import JSONResponse
 from arches.app.views.api import APIBase
+
+# Enough for the largest manifests we have seen, small enough to keep a
+# single request cheap: the viewer chunks its requests to stay under this.
+MAX_CANVASES_PER_BATCH = 500
+
+
+def annotation_to_feature(annotation):
+    return {
+        "type": "Feature",
+        "id": annotation.feature["id"],
+        "geometry": annotation.feature["geometry"],
+        "properties": {
+            **annotation.feature["properties"],
+            **{
+                "nodeId": annotation.node_id,
+                "nodegroupId": annotation.nodegroup_id,
+                "resourceId": annotation.resourceinstance_id,
+                "graphId": annotation.node.graph_id,
+                "tileId": annotation.tile_id,
+            },
+        },
+    }
 
 
 class IIIFManifest(APIBase):
@@ -52,22 +75,7 @@ class IIIFAnnotations(APIBase):
             {
                 "type": "FeatureCollection",
                 "features": [
-                    {
-                        "type": "Feature",
-                        "id": annotation.feature["id"],
-                        "geometry": annotation.feature["geometry"],
-                        "properties": {
-                            **annotation.feature["properties"],
-                            **{
-                                "nodeId": annotation.node_id,
-                                "nodegroupId": annotation.nodegroup_id,
-                                "resourceId": annotation.resourceinstance_id,
-                                "graphId": annotation.node.graph_id,
-                                "tileId": annotation.tile_id,
-                            },
-                        },
-                    }
-                    for annotation in annotations
+                    annotation_to_feature(annotation) for annotation in annotations
                 ],
             }
         )
@@ -90,6 +98,80 @@ class IIIFAnnotationNodes(APIBase):
                 }
                 for node in annotation_nodes
             ]
+        )
+
+
+class IIIFAnnotationsBatch(APIBase):
+    """Return the annotations of several canvases in a single request.
+
+    The IIIF viewer needs the annotations of every canvas of a manifest, for
+    every annotation node. Fetching them from IIIFAnnotations costs one request
+    per canvas and per node, which is slow on manifests holding many canvases.
+
+    The canvases are read from the request body rather than the query string
+    because canvas ids are URLs: a few hundred of them do not fit in a URL.
+    """
+
+    def post(self, request):
+        try:
+            body = json.loads(request.body)
+        except json.JSONDecodeError:
+            return JSONResponse(
+                {"error": _("Request body is not valid JSON")}, status=400
+            )
+
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"error": _("Request body must be a JSON object")}, status=400
+            )
+
+        canvases = body.get("canvases")
+        if not isinstance(canvases, list):
+            return JSONResponse({"error": _("canvases must be an array")}, status=400)
+
+        canvases = [
+            canvas.strip()
+            for canvas in canvases
+            if isinstance(canvas, str) and canvas.strip()
+        ]
+        if not canvases:
+            return JSONResponse(
+                {"error": _("canvases must hold at least one canvas id")}, status=400
+            )
+        if len(canvases) > MAX_CANVASES_PER_BATCH:
+            return JSONResponse(
+                {
+                    "error": _("canvases must hold at most {} canvas ids").format(
+                        MAX_CANVASES_PER_BATCH
+                    )
+                },
+                status=400,
+            )
+
+        permitted_nodegroups = get_nodegroups_by_perm(
+            request.user, "models.read_nodegroup"
+        )
+        annotations = models.VwAnnotation.objects.filter(
+            nodegroup__in=permitted_nodegroups, canvas__in=canvases
+        ).select_related("node")
+
+        canvases_with_annotations = {}
+        for annotation in annotations:
+            feature_collection = canvases_with_annotations.setdefault(
+                annotation.canvas, {"type": "FeatureCollection", "features": []}
+            )
+            feature_collection["features"].append(annotation_to_feature(annotation))
+
+        return JSONResponse(
+            {
+                "type": "AnnotationsByCanvas",
+                "canvases": canvases_with_annotations,
+                "total_annotations": sum(
+                    len(feature_collection["features"])
+                    for feature_collection in canvases_with_annotations.values()
+                ),
+                "total_canvases": len(canvases_with_annotations),
+            }
         )
 
 

--- a/arches/urls.py
+++ b/arches/urls.py
@@ -740,6 +740,11 @@ urlpatterns = [
         r"^iiifannotations$", api.IIIFAnnotations.as_view(), name="iiifannotations"
     ),
     re_path(
+        r"^iiifannotations/batch$",
+        api.IIIFAnnotationsBatch.as_view(),
+        name="iiifannotations_batch",
+    ),
+    re_path(
         r"^iiifannotationnodes$",
         api.IIIFAnnotationNodes.as_view(),
         name="iiifannotationnodes",

--- a/releases/8.2.0.md
+++ b/releases/8.2.0.md
@@ -23,6 +23,7 @@
 - Reduce queries for published graphs when indexing [#11513](https://github.com/archesproject/arches/pull/11513)
 - Improve performance of arches-admin tests by avoiding calls to npm [#12761](https://github.com/archesproject/arches/pull/12761)
 - Improve memory management and performance in the bulk loader [#12767](https://github.com/archesproject/arches/pull/12767)
+- Load the annotations of a IIIF manifest in one request instead of one per canvas and per node [#12576](https://github.com/archesproject/arches/pull/12576)
 
 ### Bug fixes
 
@@ -35,6 +36,7 @@
 - Fix CKEditor attempts to intialize before element is connected to document [#12748](https://github.com/archesproject/arches/pull/12748)
 - Fix load of default values for domain datatypes during graph import [#12800](https://github.com/archesproject/arches/pull/12800)
 - Fix Vitest failing to resolve cross-Arches-application type imports and runtime dependencies when an application is installed via pip [#12898](https://github.com/archesproject/arches/issues/12898)
+- Fix the IIIF viewer annotation count showing only one node per canvas instead of the sum of every annotation node [#12576](https://github.com/archesproject/arches/pull/12576)
 
 ### Deprecations
 

--- a/tests/views/api/test_iiif.py
+++ b/tests/views/api/test_iiif.py
@@ -1,0 +1,256 @@
+"""
+ARCHES - a program developed to inventory and manage immovable cultural heritage.
+Copyright (C) 2013 J. Paul Getty Trust and World Monuments Fund
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+import uuid
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.urls import reverse
+from guardian.shortcuts import assign_perm
+
+from arches.app.models import models
+from arches.app.models.graph import Graph
+from arches.app.models.models import ResourceInstance
+from arches.app.views.api.iiif import MAX_CANVASES_PER_BATCH
+
+from tests.base_test import ArchesTestCase
+
+# these tests can be run from the command line via
+# python manage.py test tests.views.api.test_iiif --settings="tests.test_settings"
+
+FIRST_CANVAS = "https://iiif.test/iiif/2/first"
+SECOND_CANVAS = "https://iiif.test/iiif/2/second"
+UNANNOTATED_CANVAS = "https://iiif.test/iiif/2/unannotated"
+
+
+class IIIFAnnotationsBatchTests(ArchesTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.add_users()
+        cls.user = User.objects.get(username="ben")
+
+        cls.graph = Graph.objects.create_graph(
+            name="IIIF_ANNOTATIONS_BATCH_TEST_GRAPH",
+            is_resource=False,  # creates a nodegroup, undone below.
+        )
+        cls.graph.isresource = True
+        cls.graph.resource_instance_lifecycle_id = (
+            settings.DEFAULT_RESOURCE_INSTANCE_LIFECYCLE_ID
+        )
+        cls.graph.save(validate=False)
+        cls.resource = ResourceInstance.objects.create(graph=cls.graph)
+
+        cls.readable_node = cls.create_annotation_node("readable annotation")
+        cls.unreadable_node = cls.create_annotation_node("unreadable annotation")
+        assign_perm("no_access_to_nodegroup", cls.user, cls.unreadable_node.nodegroup)
+
+        # Two annotations on the first canvas, one on the second, so that the
+        # response has to group several annotations under the same canvas.
+        cls.create_annotation_tile(
+            cls.readable_node, [FIRST_CANVAS, FIRST_CANVAS, SECOND_CANVAS]
+        )
+        cls.create_annotation_tile(cls.unreadable_node, [FIRST_CANVAS])
+
+    @classmethod
+    def create_annotation_node(cls, name):
+        nodeid = uuid.uuid4()
+        nodegroup = models.NodeGroup.objects.create(pk=nodeid)
+        node = models.Node.objects.create(
+            pk=nodeid,
+            graph=cls.graph,
+            name=name,
+            datatype="annotation",
+            nodegroup=nodegroup,
+            istopnode=False,
+        )
+        nodegroup.grouping_node = node
+        nodegroup.save()
+        return node
+
+    @classmethod
+    def create_annotation_tile(cls, node, canvases):
+        return models.TileModel.objects.create(
+            resourceinstance=cls.resource,
+            nodegroup=node.nodegroup,
+            data={
+                str(node.pk): {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "id": str(uuid.uuid4()),
+                            "type": "Feature",
+                            "geometry": {"type": "Point", "coordinates": [0, 0]},
+                            "properties": {"canvas": canvas},
+                        }
+                        for canvas in canvases
+                    ],
+                }
+            },
+        )
+
+    def post_batch(self, body):
+        return self.client.post(
+            reverse("iiifannotations_batch"),
+            data=body,
+            content_type="application/json",
+        )
+
+    def test_body_is_not_valid_json(self):
+        self.client.force_login(self.user)
+        response = self.post_batch("this is not json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"], "Request body is not valid JSON"
+        )
+
+    def test_body_is_not_an_object(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps([FIRST_CANVAS]))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"], "Request body must be a JSON object"
+        )
+
+    def test_canvases_is_missing(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({}))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"], "canvases must be an array"
+        )
+
+    def test_canvases_is_not_an_array(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({"canvases": FIRST_CANVAS}))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"], "canvases must be an array"
+        )
+
+    def test_canvases_is_empty(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({"canvases": []}))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"],
+            "canvases must hold at least one canvas id",
+        )
+
+    def test_canvases_holds_no_usable_canvas_id(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({"canvases": ["   ", "", 42, None]}))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"],
+            "canvases must hold at least one canvas id",
+        )
+
+    def test_canvases_holds_too_many_canvas_ids(self):
+        self.client.force_login(self.user)
+        canvases = [
+            "%s/%s" % (FIRST_CANVAS, index)
+            for index in range(MAX_CANVASES_PER_BATCH + 1)
+        ]
+        response = self.post_batch(json.dumps({"canvases": canvases}))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content)["error"],
+            "canvases must hold at most %s canvas ids" % MAX_CANVASES_PER_BATCH,
+        )
+
+    def test_canvas_without_annotations_is_absent_from_the_response(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({"canvases": [UNANNOTATED_CANVAS]}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                "type": "AnnotationsByCanvas",
+                "canvases": {},
+                "total_annotations": 0,
+                "total_canvases": 0,
+            },
+        )
+
+    def test_annotations_are_grouped_by_canvas(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(
+            json.dumps({"canvases": [FIRST_CANVAS, SECOND_CANVAS, UNANNOTATED_CANVAS]})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        batch = json.loads(response.content)
+        self.assertEqual(batch["type"], "AnnotationsByCanvas")
+        self.assertEqual(sorted(batch["canvases"]), [FIRST_CANVAS, SECOND_CANVAS])
+        self.assertEqual(len(batch["canvases"][FIRST_CANVAS]["features"]), 2)
+        self.assertEqual(len(batch["canvases"][SECOND_CANVAS]["features"]), 1)
+        self.assertEqual(batch["canvases"][FIRST_CANVAS]["type"], "FeatureCollection")
+        self.assertEqual(batch["total_annotations"], 3)
+        self.assertEqual(batch["total_canvases"], 2)
+
+    def test_canvas_ids_are_stripped(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({"canvases": ["  %s  " % SECOND_CANVAS]}))
+
+        self.assertEqual(response.status_code, 200)
+        batch = json.loads(response.content)
+        self.assertEqual(list(batch["canvases"]), [SECOND_CANVAS])
+
+    def test_annotations_of_an_unreadable_nodegroup_are_excluded(self):
+        self.client.force_login(self.user)
+        response = self.post_batch(json.dumps({"canvases": [FIRST_CANVAS]}))
+
+        self.assertEqual(response.status_code, 200)
+        batch = json.loads(response.content)
+        node_ids = {
+            feature["properties"]["nodeId"]
+            for feature in batch["canvases"][FIRST_CANVAS]["features"]
+        }
+        self.assertEqual(node_ids, {str(self.readable_node.pk)})
+        self.assertEqual(batch["total_annotations"], 2)
+
+    def test_features_match_the_single_canvas_endpoint(self):
+        self.client.force_login(self.user)
+        batch = json.loads(
+            self.post_batch(json.dumps({"canvases": [SECOND_CANVAS]})).content
+        )
+        single = json.loads(
+            self.client.get(
+                reverse("iiifannotations"),
+                QUERY_STRING="canvas=%s&nodeid=%s"
+                % (SECOND_CANVAS, self.readable_node.pk),
+            ).content
+        )
+
+        self.assertEqual(batch["canvases"][SECOND_CANVAS], single)
+
+    def test_get_is_not_allowed(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("iiifannotations_batch"))
+
+        self.assertEqual(response.status_code, 405)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ x ] New feature (non-breaking change which adds functionality)
-   [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->

  Add batch endpoint for IIIF annotations and fix annotation count display           
                                                                                              
  When loading a IIIF manifest with many canvases (e.g., a 500-page manuscript), the viewer   
  was making individual HTTP requests for each canvas, causing performance issues.            
                                                                                              
  **Changes:**                                                                                
                                                                                              
  1. **New batch endpoint** (`POST /iiifannotations/batch`)                                   
     - Fetches annotations for all canvases in a single request                               
     - Uses POST with JSON body to avoid URL length limits                                    
     - Includes CSRF protection                                                               
                                                                                              
  2. **Frontend optimization** (`iiif-viewer.js`)                                             
     - Preloads all canvas annotations via the batch endpoint                                 
     - Caches results to avoid redundant requests                                             
                                                                                              
  3. **Annotation count display**                                                     
     - Fixed issue where only the last node's annotation count was shown                      
     - Counts are now stored per canvas+node and summed correctly                             
     - Example: canvas with 24 + 4 annotations from different nodes now shows 28 total  

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
