### PR TITLE
Check for "Date of Data Entry" in date default value

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -717,6 +717,17 @@ class DateDataType(BaseDataType):
                 errors.append(error_message)
         return errors
 
+    def clean(self, tile, nodeid):
+        super().clean(tile, nodeid)
+        if tile.data[nodeid] == "Date of Data Entry":
+            cnw = models.CardXNodeXWidget.objects.get(node__nodeid=nodeid)
+            if cnw.config.get("dateFormat", None):
+                tile.data[nodeid] = datetime.now().strftime(
+                    self.date_format_lookup[cnw.config.get("dateFormat")]
+                )
+            else:
+                tile.data[nodeid] = ""
+
     def get_valid_date_format(self, value):
         valid = False
         valid_date_format = ""

--- a/releases/8.1.0.md
+++ b/releases/8.1.0.md
@@ -20,6 +20,7 @@
 -   Add global function support for running arches functions regardless of configuration [#12465](https://github.com/archesproject/arches/pull/12465)
 -   Add normalizer to the indexing of the displayname property which supports special characters in alphabetical search results [#12519](https://github.com/archesproject/arches/pull/12519)
 -   Add capability to import the file with the metadata with the bulk data importer. Also the metadata is added to index so that the resource can be searched. [#12370](https://github.com/archesproject/arches/pull/12370)
+-   Add clean() to DateDataType to convert "Date of Data Entry" string to a date. [#12614](https://github.com/archesproject/arches/pull/12614)
 -   Fix issue with the null value in the file-list node for the excel importers by not creating the staged value [#12430](https://github.com/archesproject/arches/pull/12430)
 -   Fix `generate_urls_json` function to properly namespace applications [#12449](https://github.com/archesproject/arches/issues/12449)
 -   Allow for widget configurations to be updated through the workflow configuration via the `nodeOptions` [#12437](https://github.com/archesproject/arches/pull/12437)

--- a/tests/utils/datatypes/date_datatype_tests.py
+++ b/tests/utils/datatypes/date_datatype_tests.py
@@ -2,8 +2,11 @@ import datetime
 from tests.base_test import ArchesTestCase
 from zoneinfo import ZoneInfo
 from django.test import override_settings
-from arches.app.datatypes.datatypes import DataTypeFactory
+from arches.app.datatypes.datatypes import DataTypeFactory, DateDataType
 from arches.app.models.system_settings import settings
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
 
 # these tests can be run from the command line via
 # python manage.py test tests.utils.datatypes.date_datatype_tests --settings="tests.test_settings"
@@ -97,6 +100,57 @@ class DateDataTypeTests(ArchesTestCase):
         chicago_date_tz = datatype.set_timezone(chicago_date)
 
         self.assertEqual(los_angeles_date_tz, chicago_date_tz)
+
+    def test_clean(self):
+
+        date_datatype = DateDataType()
+
+        # Create a mock tile
+        class MockTile:
+            def __init__(self, data):
+                self.data = data
+
+        nodeid = "test_node"
+
+        # Test normal case (not "Date of Data Entry")
+        tile = MockTile({nodeid: "2022-01-01"})
+        date_datatype.clean(tile, nodeid)
+        self.assertEqual(tile.data[nodeid], "2022-01-01")
+
+        # Test "Date of Data Entry" with date format config
+        with patch("arches.app.models.models.CardXNodeXWidget.objects.get") as mock_get:
+            # Setup mock with config
+            mock_widget = MagicMock()
+            mock_widget.config = {"dateFormat": "YYYY-MM-DD"}
+            mock_get.return_value = mock_widget
+
+            tile = MockTile({nodeid: "Date of Data Entry"})
+            date_datatype.clean(tile, nodeid)
+
+            # The date format YYYY-MM-DD corresponds to '%Y-%m-%d' in strftime
+            expected_format = "%Y-%m-%d"
+            # Try to parse the result to verify it's a valid date in expected format
+            try:
+                datetime.strptime(tile.data[nodeid], expected_format)
+                is_valid_date = True
+            except ValueError:
+                is_valid_date = False
+
+            self.assertTrue(
+                is_valid_date,
+                f"Date {tile.data[nodeid]} should be in format YYYY-MM-DD",
+            )
+
+        # Test "Date of Data Entry" without date format config
+        with patch("arches.app.models.models.CardXNodeXWidget.objects.get") as mock_get:
+            # Setup mock without dateFormat in config
+            mock_widget = MagicMock()
+            mock_widget.config = {}
+            mock_get.return_value = mock_widget
+
+            tile = MockTile({nodeid: "Date of Data Entry"})
+            date_datatype.clean(tile, nodeid)
+            self.assertEqual(tile.data[nodeid], "")
 
     @override_settings(DATE_IMPORT_EXPORT_FORMAT="%Y-%m-%d %H:%M:%S")
     def test_set_timezone_no_z(self, **kwarg):

--- a/tests/utils/datatypes/date_datatype_tests.py
+++ b/tests/utils/datatypes/date_datatype_tests.py
@@ -4,7 +4,6 @@ from zoneinfo import ZoneInfo
 from django.test import override_settings
 from arches.app.datatypes.datatypes import DataTypeFactory, DateDataType
 from arches.app.models.system_settings import settings
-from datetime import datetime
 from unittest.mock import patch, MagicMock
 
 
@@ -131,7 +130,7 @@ class DateDataTypeTests(ArchesTestCase):
             expected_format = "%Y-%m-%d"
             # Try to parse the result to verify it's a valid date in expected format
             try:
-                datetime.strptime(tile.data[nodeid], expected_format)
+                datetime.datetime.strptime(tile.data[nodeid], expected_format)
                 is_valid_date = True
             except ValueError:
                 is_valid_date = False


### PR DESCRIPTION
The Date widget configuration uses a `defaultValue` string  of "Date of Data Entry" to represent when it should be pre-filled with the current date when a new tile is created. This is substituted with the current date in the front end javascript tier, however when setting the default value in the Python tier, there is nothing that does the conversion from that magic string to the actual date.

Transferred from arches-querysets.

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
This PR adds the `clean()` function to the DateDataType class, checking for "Date of Data Entry" as the node value, and substituting it with the current date in the appropriate format.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes archesproject/arches#12616

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Self Funded
*   Found by: @bferguso
*   Tested by: @bferguso
*   Designed by: @bferguso

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
