### PR TITLE
Fix type suggestion and default value for get_filtered_instances

### DIFF
--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -199,7 +199,10 @@ def get_restricted_users(resource):
 
 
 def get_filtered_instances(
-    user, search_engine=None, allresources=False, resources=list[str]
+    user,
+    search_engine=None,
+    allresources=False,
+    resources: list[str] | None = None,
 ) -> tuple[bool, list[str]]:
     return _get_permission_framework().get_filtered_instances(
         user,

--- a/releases/7.6.22.md
+++ b/releases/7.6.22.md
@@ -4,6 +4,7 @@
 
 -  Allow creation of new resources when posting to tile or nodevalue api endpoints[#12605](https://github.com/archesproject/arches/pull/12605)
 -  Handle for case in which payload is on the request body - not the POST payload[#12626](https://github.com/archesproject/arches/pull/12626)
+-  Fix type suggestion and default value for get_filtered_instances in permission_backend [#12624](https://github.com/archesproject/arches/pull/12624)
 
 ### Dependency changes:
 


### PR DESCRIPTION
### Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)

### Description of Change

- The default value in this function is set to the type description, which results in an error unless a valid argument is passed instead. The versions of this function in `arches_default_allow.py` and `arches_default_deny.py`, however, suggest that the parameter should be optional. 


### Issues Solved
Closes #12618

### Checklist
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: K-Int
*   Found by: @CWDamm-Kint 
*   Tested by: @CWDamm-Kint 
*   Designed by: @CWDamm-Kint 