### PR TITLE
Avoid queries in LanguageDataType.lookup_language for None

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2662,6 +2662,8 @@ class LanguageDataType(BaseDataType):
     def lookup_language(self, value) -> models.Language | None:
         if type(value) == list and len(value) > 0:
             value = value[0]  # Arches with i18n may send list of values
+        if not value:
+            return None
         if value in self.language_lookup:
             return self.language_lookup[value]
         language = models.Language.objects.filter(Q(code=value) | Q(name=value)).first()

--- a/tests/utils/datatypes/datatype_tests.py
+++ b/tests/utils/datatypes/datatype_tests.py
@@ -324,6 +324,13 @@ class LanguageDataTypeTests(ArchesTestCase):
         some_errors = language.validate("jc")
         self.assertEqual(len(some_errors), 1)
 
+    def test_get_display_value_none_no_query(self):
+        language = DataTypeFactory().get_instance("language")
+        node = Node()
+        tile = TileModel(data={str(node.pk): None})
+        with self.assertNumQueries(0):
+            self.assertEqual(language.get_display_value(tile, node), "")
+
     def test_tile_transform(self):
         language = DataTypeFactory().get_instance("language")
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Noticed while updating arches-querysets to test against Arches 8.1 that there are avoidable queries in LanguageDataType for node values of None.
