### PR TITLE
Cnh/cherry pick phudson 12653

### DIFF
--- a/arches/app/media/css/accessibility.scss
+++ b/arches/app/media/css/accessibility.scss
@@ -66,7 +66,10 @@ a, button {
 
 .btn-primary,
 .library-icon .bg-primary,
-.select2-container-multi .select2-choices .select2-search-choice {
+.select2-container-multi .select2-choices .select2-search-choice,
+.select2-container--default .select2-selection--single .select2-selection__choice,
+.select2-container--default .select2-selection--multiple .select2-selection__choice,
+.select2-container--default .select2-results__option--highlighted[data-selected] {
     background-color: $btn-primary;
 }
 

--- a/releases/7.6.23.md
+++ b/releases/7.6.23.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Remove copy-webpack dependency[arches-dev-dependencies#61](https://github.com/archesproject/arches-dev-dependencies/pull/61)
+- Fix contrast for search suggestions/choices[#12617](https://github.com/archesproject/arches/pull/12653)
 
 ### Dependency changes
 


### PR DESCRIPTION
Cherry picks commits from @phudson-he's PR #12653 to address merge conflicts

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Upon accessibility testing, it was found that the search suggestions/choice colour contrast did not meet the accessibility guidelines. The changes included ensure the colour contrast tests now pass when in accessibility mode. This issue is also present in other instances where this type of select2 field was used, and is now resolved.

With the changes it now looks like this:

<img width="487" height="301" alt="image" src="https://github.com/user-attachments/assets/4517bf14-a935-4dd2-aa99-16a1955f7918" />
...and...
<img width="623" height="280" alt="image" src="https://github.com/user-attachments/assets/554f77ca-d4e0-4f09-889e-8a8f0b096670" />



### Issues Solved
Closes #12617 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |    x     |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @phudson-he 
*   Tested by: @imogenroberts 
*   Designed by: @phudson-he 