### PR TITLE
#12655 Add python versions to stop artifact conflict

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -9,6 +9,13 @@ inputs:
     required: true
   secrets:
     description: 'Secrets from main.yml as JSON'
+  python-version:
+    description: 'Python version for matrix; used to control artifact uploads'
+    required: false
+  coverage-python-version:
+    description: 'Python version that uploads coverage artifacts'
+    required: false
+    default: '3.12'
 runs:
   using: 'composite'
   steps:
@@ -30,7 +37,7 @@ runs:
         pip install . --group dev
         echo Python packages installed
       shell: bash
-
+    
     - name: Ensure frontend configuration files exist
       run: |
           python manage.py check
@@ -69,7 +76,7 @@ runs:
     - name: Run frontend tests
       run: |
         npm run vitest
-        mv coverage/frontend/coverage.xml ${{ inputs.branch-type }}_branch_frontend_coverage.xml
+        mv coverage/frontend/coverage.xml ${{ inputs.branch-type }}_branch_frontend_coverage_py${{ inputs.python-version }}.xml
       shell: bash
 
     - name: Check for missing migrations
@@ -91,19 +98,21 @@ runs:
       run: |
         coverage report
         coverage json
-        mv coverage/python/coverage.json ${{ inputs.branch-type }}_branch_python_coverage.json
+        mv coverage/python/coverage.json ${{ inputs.branch-type }}_branch_python_coverage_py${{ inputs.python-version }}.json
       shell: bash
 
     - name: Upload frontend coverage report as artifact
+      if: ${{ inputs.python-version == inputs.coverage-python-version }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.branch-type }}-branch-frontend-coverage-report
-        path: ${{ inputs.branch-type }}_branch_frontend_coverage.xml
+        name: ${{ inputs.branch-type }}-branch-frontend-coverage-report-py${{ inputs.python-version }}
+        path: ${{ inputs.branch-type }}_branch_frontend_coverage_py${{ inputs.python-version }}.xml
         overwrite: true
 
     - name: Upload Python coverage report as artifact
+      if: ${{ inputs.python-version == inputs.coverage-python-version }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.branch-type }}-branch-python-coverage-report
-        path: ${{ inputs.branch-type }}_branch_python_coverage.json
+        name: ${{ inputs.branch-type }}-branch-python-coverage-report-py${{ inputs.python-version }}
+        path: ${{ inputs.branch-type }}_branch_python_coverage_py${{ inputs.python-version }}.json
         overwrite: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           project-name: 'arches'
           branch-type: 'target'
+          python-version: ${{ matrix.python-version }}
+          coverage-python-version: '3.12'
 
   build_feature_branch:
     runs-on: ubuntu-latest
@@ -87,10 +89,14 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           project-name: 'arches'
           branch-type: 'feature'
+          python-version: ${{ matrix.python-version }}
+          coverage-python-version: '3.12'
 
   check_frontend_coverage:
     runs-on: ubuntu-latest
     needs: [build_feature_branch, build_target_branch]
+    env:
+      PYTHON_VERSION: '3.12'
     steps:
       - uses: actions/checkout@v4
 
@@ -103,13 +109,13 @@ jobs:
       - name: Download feature branch frontend coverage report artifact
         uses: actions/download-artifact@v4
         with:
-          name: feature-branch-frontend-coverage-report
+          name: feature-branch-frontend-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Extract feature branch frontend coverage data
         shell: pwsh
         run: |
-          [xml]$xml = Get-Content feature_branch_frontend_coverage.xml
+          [xml]$xml = Get-Content feature_branch_frontend_coverage_py${{ env.PYTHON_VERSION }}.xml
           $metrics = $xml.coverage.project.metrics
 
           $statements = [double]$metrics.statements
@@ -158,12 +164,12 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: target-branch-frontend-coverage-report
+          name: target-branch-frontend-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Check if target branch frontend coverage report artifact exists
         run: |
-          if [ -f target_branch_frontend_coverage.xml ]; then
+          if [ -f target_branch_frontend_coverage_py${{ env.PYTHON_VERSION }}.xml ]; then
             echo "target_branch_frontend_coverage_artifact_exists=true" >> $GITHUB_ENV
           else
             echo "Target branch coverage not found. Defaulting to 0% coverage."
@@ -174,7 +180,7 @@ jobs:
         if: ${{ env.target_branch_frontend_coverage_artifact_exists == 'true' }}
         shell: pwsh
         run: |
-          [xml]$xml = Get-Content target_branch_frontend_coverage.xml
+          [xml]$xml = Get-Content target_branch_frontend_coverage_py${{ env.PYTHON_VERSION }}.xml
           $metrics = $xml.coverage.project.metrics
 
           $statements = [double]$metrics.statements
@@ -236,6 +242,8 @@ jobs:
   check_python_coverage:
     runs-on: ubuntu-latest
     needs: [build_feature_branch, build_target_branch]
+    env:
+      PYTHON_VERSION: '3.12'
     steps:
       - uses: actions/checkout@v4
 
@@ -248,20 +256,20 @@ jobs:
       - name: Download feature branch Python coverage report artifact
         uses: actions/download-artifact@v4
         with:
-          name: feature-branch-python-coverage-report
+          name: feature-branch-python-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Download target branch Python coverage report artifact
         uses: actions/download-artifact@v4
         with:
-          name: target-branch-python-coverage-report
+          name: target-branch-python-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Compare Python feature coverage with target coverage
         if: github.event_name == 'pull_request'
         run: |
-          feature_branch_python_coverage=$(cat feature_branch_python_coverage.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
-          target_branch_python_coverage=$(cat target_branch_python_coverage.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
+          feature_branch_python_coverage=$(cat feature_branch_python_coverage_py${{ env.PYTHON_VERSION }}.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
+          target_branch_python_coverage=$(cat target_branch_python_coverage_py${{ env.PYTHON_VERSION }}.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
 
           # Compare feature coverage with target coverage using floating-point comparison
           if awk -v feature="$feature_branch_python_coverage" -v target="$target_branch_python_coverage" 'BEGIN { exit (feature < target) ? 0 : 1 }'; then


### PR DESCRIPTION
NB This does fail in this PR on the python coverage report but that is because there is no python version tagged report with the target branch as the version tagging is introduced in this PR.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds python versions to the builds so there are no artifact conflicts causing a failure of a CI build within a GitHub PR


### Issues Solved
#12655 

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [X] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: Historic England
*   Found by: @csmith-he 
*   Tested by: @csmith-he 
*   Designed by: @aj-he 

