### PR TITLE
Bump Django to 4.2.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "arcgis2geojson==2.0.0",
     "celery==5.3.6",
     "defusedxml==0.7.1",
-    "Django>=4.2.23,<5.0.0",
+    "Django==4.2.30",
     "django-celery-results==2.5.1",
     "django-cors-headers==4.2.0",
     "django-guardian==2.4.0",


### PR DESCRIPTION
Hi! 👋 

Django 4.2 [went End-of-Life today](https://www.djangoproject.com/weblog/2026/apr/07/security-releases/) and is no longer receiving security updates. Pin to the last supported release on dev/7.6.x.

Arches implementers should be encouraged to migrate off 7.6 unless Arches has a plan to fork Django and apply relevant security updates going forward.