### PR TITLE
Fix stale card references on widgets after update_node()

### DIFF
--- a/arches/app/models/graph.py
+++ b/arches/app/models/graph.py
@@ -1228,11 +1228,16 @@ class Graph(models.GraphModel):
             else:
                 self._nodegroups_to_delete = [old_node.nodegroup]
                 # remove a card
-                self.cards = {
-                    card_id: card
-                    for card_id, card in self.cards.items()
-                    if card.nodegroup_id != old_node.nodegroup_id
-                }
+                for card in self.cards.values():
+                    if card.nodegroup_id == old_node.nodegroup_id:
+                        removed_card = self.cards.pop(card.pk)
+                        # Check for stale card references on widgets.
+                        self.widgets = {
+                            widget.pk: widget
+                            for widget in self.widgets.values()
+                            if widget.card_id != removed_card.pk
+                        }
+                        break
 
         try:
             new_card = models.CardModel.objects.get(

--- a/releases/8.2.0.md
+++ b/releases/8.2.0.md
@@ -13,6 +13,8 @@
 
 ### Bug fixes
 
+- Fix stale card references on widgets after calling `update_node()` [#12712](https://github.com/archesproject/arches/pull/12712)
+
 ### Dependency changes
 ```
 Python:

--- a/tests/models/graph_tests.py
+++ b/tests/models/graph_tests.py
@@ -153,18 +153,17 @@ class GraphTests(ArchesTestCase):
             },
         ]
 
-        # default_widgets_by_datatype = {
-        #     datatype.pk: datatype.defaultwidget
-        #     for datatype in models.DDataType.objects.select_related("defaultwidget")
-        # }
+        default_widgets_by_datatype = {
+            datatype.pk: datatype.defaultwidget
+            for datatype in models.DDataType.objects.select_related("defaultwidget")
+        }
         for node_data in nodes_data:
             node = models.Node.objects.create(**node_data)
-            # This should be uncommented when it will no longer cause failures.
-            # models.CardXNodeXWidget.objects.create(
-            #     card=node.nodegroup.cardmodel_set.all()[0],
-            #     node=node,
-            #     widget=default_widgets_by_datatype[node.datatype],
-            # )
+            models.CardXNodeXWidget.objects.create(
+                card=node.nodegroup.cardmodel_set.all()[0],
+                node=node,
+                widget=default_widgets_by_datatype[node.datatype],
+            )
 
         models.NodeGroup.objects.filter(
             pk="20000000-0000-0000-0000-100000000001"
@@ -1425,21 +1424,6 @@ class GraphTests(ArchesTestCase):
             graph.save()
 
     def test_graph_validation_of_widget_count(self):
-        # Add missing CardXNodeXWidget instances to the graph
-        # See commented out code in setUpTestData() where this should be done.
-        default_widgets_by_datatype = {
-            datatype.pk: datatype.defaultwidget
-            for datatype in models.DDataType.objects.select_related("defaultwidget")
-        }
-        for node in self.node_node_type_graph.nodes.values():
-            models.CardXNodeXWidget.objects.create(
-                card=node.nodegroup.cardmodel_set.first(),
-                node=node,
-                widget=default_widgets_by_datatype[node.datatype],
-            )
-
-        self.node_node_type_graph.refresh_from_database()
-        self.node_node_type_graph.has_unpublished_changes = True
         superfluous_widgets = {
             uid: models.CardXNodeXWidget(node=node)
             for uid, node in [


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Stumbled over this running the tests. When adding widgets to this test graph (as shown, now commented back in), we had failures from `update_node()` not doing anything about old widgets.

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.1.x (under development): features, bugfixes not covered below
    - [ ] dev/8.0.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [x] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: self