### PR TITLE
Elevate level of django request logger to ERROR in tests

### DIFF
--- a/arches/install/arches-templates/tests/test_settings.py-tpl
+++ b/arches/install/arches-templates/tests/test_settings.py-tpl
@@ -66,6 +66,7 @@ CACHES = {
     },
 }
 
+LOGGING["loggers"]["django.request"]["level"] = "ERROR"
 LOGGING["loggers"]["arches"]["level"] = "ERROR"
 
 ELASTICSEARCH_PREFIX = "test"

--- a/tests/bulkdata/jsonld_import_tests.py
+++ b/tests/bulkdata/jsonld_import_tests.py
@@ -128,10 +128,7 @@ class JSONLDImportTests(TransactionTestCase):
         self.basic_resource_1.delete()
         self.basic_graph.delete()
 
-        with (
-            open(self.uploaded_zip_location, "rb") as f,
-            self.assertLogs("django.request", level="WARNING"),
-        ):
+        with open(self.uploaded_zip_location, "rb") as f:
             response = self.client.post(
                 reverse("etl_manager"),
                 data={

--- a/tests/exporter/jsonld_export_tests.py
+++ b/tests/exporter/jsonld_export_tests.py
@@ -146,9 +146,8 @@ class JsonLDExportTests(ArchesTestCase):
         # this 'resources' is from urls.py
         self.client.login(username="admin", password="admin")
         url = self._create_url(resource_id="00000000-f6b5-11e9-8f09-a4d18cec433a")
-        with self.assertLogs("django.request", level="WARNING"):
-            with self.assertLogs("arches.app.views.api", level="ERROR"):
-                response = self.client.get(url, secure=False)
+        with self.assertLogs("arches.app.views.api", level="ERROR"):
+            response = self.client.get(url, secure=False)
         self.assertTrue(response.status_code == 404)
 
     def test_1_basic_export(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -73,6 +73,7 @@ CACHES = {
     },
 }
 
+LOGGING["loggers"]["django.request"]["level"] = "ERROR"
 LOGGING["loggers"]["arches"]["level"] = "ERROR"
 
 ELASTICSEARCH_PREFIX = "test"

--- a/tests/views/api/test_auth.py
+++ b/tests/views/api/test_auth.py
@@ -38,10 +38,7 @@ class AuthAPITests(ArchesTestCase):
 
     @override_settings(FORCE_TWO_FACTOR_AUTHENTICATION=True)
     def test_login_rejected_two_factor_enabled(self):
-        with (
-            sync_overridden_test_settings_to_arches(),
-            self.assertLogs("django.request", level="WARNING"),
-        ):
+        with sync_overridden_test_settings_to_arches():
             response = self.client.post(
                 reverse("api_login"),
                 {"username": "visitor", "password": "jazz"},
@@ -54,10 +51,9 @@ class AuthAPITests(ArchesTestCase):
         )
 
     def test_login_failure_missing_credentials(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("api_login"), {}, content_type="application/json"
-            )
+        response = self.client.post(
+            reverse("api_login"), {}, content_type="application/json"
+        )
         self.assertContains(
             response,
             "Invalid username and/or password.",
@@ -65,12 +61,11 @@ class AuthAPITests(ArchesTestCase):
         )
 
     def test_login_failure_wrong_credentials(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("api_login"),
-                {"username": "visitor", "password": "garbage"},
-                content_type="application/json",
-            )
+        response = self.client.post(
+            reverse("api_login"),
+            {"username": "visitor", "password": "garbage"},
+            content_type="application/json",
+        )
         self.assertContains(
             response,
             "Invalid username and/or password.",
@@ -80,13 +75,10 @@ class AuthAPITests(ArchesTestCase):
     def test_login_failure_inactive_user(self):
         self.visitor.is_active = False
         self.visitor.save()
-        with (
-            self.modify_settings(
-                AUTHENTICATION_BACKENDS={
-                    "prepend": "django.contrib.auth.backends.AllowAllUsersModelBackend"
-                }
-            ),
-            self.assertLogs("django.request", level="WARNING"),
+        with self.modify_settings(
+            AUTHENTICATION_BACKENDS={
+                "prepend": "django.contrib.auth.backends.AllowAllUsersModelBackend"
+            }
         ):
             response = self.client.post(
                 reverse("api_login"),
@@ -100,10 +92,7 @@ class AuthAPITests(ArchesTestCase):
         )
 
     def test_login_get_not_allowed(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            self.client.get(
-                reverse("api_login"), status_code=HTTPStatus.METHOD_NOT_ALLOWED
-            )
+        self.client.get(reverse("api_login"), status_code=HTTPStatus.METHOD_NOT_ALLOWED)
 
     def test_logout(self):
         self.client.force_login(self.visitor)

--- a/tests/views/api/test_resources.py
+++ b/tests/views/api/test_resources.py
@@ -126,20 +126,17 @@ class ResourceAPITests(ArchesTestCase):
 
         request = factory.get(reverse("api_node_value", kwargs={}), {"ver": "2.0"})
         request.user = None
-        with self.assertLogs("django.request", level="WARNING"):
-            response = view(request)
+        response = view(request)
         self.assertEqual(request.GET.get("ver"), "2.0")
 
         request = factory.get(reverse("api_node_value"), kwargs={})
         request.user = None
-        with self.assertLogs("django.request", level="WARNING"):
-            response = view(request)
+        response = view(request)
         self.assertEqual(request.GET.get("ver"), "2.1")
 
     @override_settings(DEBUG=False)
     def test_api_404_returns_json(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get("/api/doesnotexist")
+        response = self.client.get("/api/doesnotexist")
         self.assertContains(
             response,
             "Not Found",
@@ -375,10 +372,7 @@ class ResourceAPITests(ArchesTestCase):
         # ==PUT=============================================================================================
 
         # ==Act : GET confirmation that resource does not exist in database=================================
-        with (
-            self.assertLogs("django.request", level="WARNING"),
-            self.assertLogs("arches.app.views.api", level="ERROR"),
-        ):
+        with self.assertLogs("arches.app.views.api", level="ERROR"):
             resp_get = self.client.get(
                 reverse(
                     "resources",
@@ -440,16 +434,15 @@ class ResourceAPITests(ArchesTestCase):
         # ==================================================================================================
 
         # ==Act : PUT resource changes to database, with invalid URI========================================
-        with self.assertLogs("django.request", level="WARNING"):
-            resp_put_uri_diff = self.client.put(
-                reverse(
-                    "resources",
-                    kwargs={"resourceid": "001fe587-ad3d-4d0d-a3c9-814028766434"},
-                )
-                + "?format=arches-json",
-                payload_modified,
-                content_type,
+        resp_put_uri_diff = self.client.put(
+            reverse(
+                "resources",
+                kwargs={"resourceid": "001fe587-ad3d-4d0d-a3c9-814028766434"},
             )
+            + "?format=arches-json",
+            payload_modified,
+            content_type,
+        )
         # ==Assert==========================================================================================
         self.assertEqual(resp_put_uri_diff.status_code, 400)  # Bad Request.
         # ==================================================================================================
@@ -511,10 +504,7 @@ class ResourceAPITests(ArchesTestCase):
         # ==================================================================================================
 
         # ==Act : GET confirmation that resource does not exist in database=================================
-        with (
-            self.assertLogs("django.request", level="WARNING"),
-            self.assertLogs("arches.app.views.api", level="ERROR"),
-        ):
+        with self.assertLogs("arches.app.views.api", level="ERROR"):
             resp_get_deleted = self.client.get(
                 reverse(
                     "resources",
@@ -534,11 +524,10 @@ class ResourceAPITests(ArchesTestCase):
         # Bypass validation in .save()
         Graph.objects.filter(pk=self.data_type_graph.pk).update(ontology=None)
 
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse("resources", kwargs={"resourceid": str(self.test_prj_user.pk)})
-                + "?format=json-ld"
-            )
+        response = self.client.get(
+            reverse("resources", kwargs={"resourceid": str(self.test_prj_user.pk)})
+            + "?format=json-ld"
+        )
 
         self.assertEqual(response.status_code, 400)
 

--- a/tests/views/api/test_user.py
+++ b/tests/views/api/test_user.py
@@ -43,8 +43,7 @@ class UserAPITests(TestCase):
         self.visitor.save()
 
         self.client.force_login(self.visitor)
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(reverse("api_user"))
+        response = self.client.get(reverse("api_user"))
         self.assertContains(
             response,
             "This account is no longer active.",

--- a/tests/views/auth_tests.py
+++ b/tests/views/auth_tests.py
@@ -191,16 +191,15 @@ class AuthTests(ArchesTestCase):
         """
         settings.ENABLE_TWO_FACTOR_AUTHENTICATION = True
 
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("two-factor-authentication-login"),
-                {
-                    "username": "test",
-                    "password": "password",
-                    "user-has-enabled-two-factor-authentication": True,
-                    "two-factor-authentication": 123456,
-                },
-            )
+        response = self.client.post(
+            reverse("two-factor-authentication-login"),
+            {
+                "username": "test",
+                "password": "password",
+                "user-has-enabled-two-factor-authentication": True,
+                "two-factor-authentication": 123456,
+            },
+        )
 
         self.assertTemplateUsed(response, "two_factor_authentication_login.htm")
         self.assertTrue(response.status_code == 401)

--- a/tests/views/concept_tests.py
+++ b/tests/views/concept_tests.py
@@ -14,10 +14,9 @@ class ConceptTests(ArchesTestCase):
         client.login(username="admin", password="admin")
 
         collection_concept_id = "00000000-0000-0000-0000-000000000005"
-        with self.assertLogs("django.request", level="WARNING"):
-            response = client.get(
-                reverse("concept", kwargs={"conceptid": collection_concept_id})
-            )
+        response = client.get(
+            reverse("concept", kwargs={"conceptid": collection_concept_id})
+        )
 
         self.assertEqual(response.status_code, 404)
 

--- a/tests/views/edit_log_tests.py
+++ b/tests/views/edit_log_tests.py
@@ -7,6 +7,5 @@ from tests.base_test import ArchesTestCase
 
 class EditLogTests(ArchesTestCase):
     def test_resource_history_view_logged_out(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(reverse("edit_history"))
+        response = self.client.get(reverse("edit_history"))
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)

--- a/tests/views/etl_manager_tests.py
+++ b/tests/views/etl_manager_tests.py
@@ -75,14 +75,12 @@ class ETLManagerTests(ArchesTestCase):
 
     def test_no_loadid(self):
         self.client.force_login(self.admin)
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse("etl_manager"), QUERY_STRING="action=nodeError"
-            )
+        response = self.client.get(
+            reverse("etl_manager"), QUERY_STRING="action=nodeError"
+        )
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_insufficent_permissions(self):
         self.client.force_login(self.anonymous)
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(reverse("etl_manager"))
+        response = self.client.get(reverse("etl_manager"))
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)

--- a/tests/views/graph_manager_tests.py
+++ b/tests/views/graph_manager_tests.py
@@ -314,7 +314,7 @@ class GraphManagerViewTests(ArchesTestCase):
         data = JSONSerializer().serializeToPython(node)
         data["parentproperty"] = "http://www.ics.forth.gr/isl/CRMdig/L54_is_same-as"
 
-        with self.assertLogs("django.request", level="WARNING"):
+        with self.assertLogs("django.request", level="ERROR"):
             response = self.client.post(url, data, content_type="application/json")
         self.assertContains(
             response,

--- a/tests/views/resource_tests.py
+++ b/tests/views/resource_tests.py
@@ -153,8 +153,7 @@ class ResourceViewTests(ArchesTestCase):
         )
         group = Group.objects.get(pk=2)
         assign_perm("change_resourceinstance", group, self.resource)
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(url)
+        response = self.client.get(url)
         self.assertTrue(response.status_code == 403)
 
     def test_user_cannot_edit_without_permission(self):
@@ -242,8 +241,7 @@ class ResourceViewTests(ArchesTestCase):
         assign_perm("change_resourceinstance", group, self.resource)
         assign_perm("delete_resourceinstance", group, self.resource)
         assign_perm("no_access_to_resourceinstance", user, self.resource)
-        with self.assertLogs("django.request", level="WARNING"):
-            view = self.client.get(view_url)
+        view = self.client.get(view_url)
 
         edit = self.client.get(edit_url)
 
@@ -359,8 +357,7 @@ class ResourceViewTests(ArchesTestCase):
 
     def test_resource_report_missing_resource(self):
         self.client.login(username="sam", password="Test12345!")
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse("resource_report", kwargs={"resourceid": str(uuid.uuid4())})
-            )
+        response = self.client.get(
+            reverse("resource_report", kwargs={"resourceid": str(uuid.uuid4())})
+        )
         self.assertEqual(response.status_code, 404)

--- a/tests/views/search_tests.py
+++ b/tests/views/search_tests.py
@@ -857,15 +857,13 @@ class SearchTests(ArchesTestCase):
 
         """
         query = {"search-view": "unavailable-search-view"}
-        with self.assertLogs("django.request", level="WARNING"):
-            response_json = get_response_json(self.client, query=query)
+        response_json = get_response_json(self.client, query=query)
         self.assertFalse(response_json["success"])
 
         # Also test search_home route, not just search_results
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse("search_home"), QUERY_STRING="search-view=nonexistent"
-            )
+        response = self.client.get(
+            reverse("search_home"), QUERY_STRING="search-view=nonexistent"
+        )
         self.assertContains(
             response,
             "Search view instance not found",

--- a/tests/views/spatialview_api_tests.py
+++ b/tests/views/spatialview_api_tests.py
@@ -245,12 +245,9 @@ class SpatialViewApiTest(TransactionTestCase):
         # test create with spatialviewid - should error
         bad_id_create_spatialview = self.generate_valid_spatiatview()
         bad_id_create_spatialview_json = bad_id_create_spatialview.to_json()
-        with self.assertLogs(
-            "django.request", level="WARNING"
-        ):  # suppress expected warning log
-            response = self.client.post(
-                reverse("spatialview_api", kwargs={"identifier": ""}),
-                data=bad_id_create_spatialview_json,
-                content_type="application/json",
-            )
+        response = self.client.post(
+            reverse("spatialview_api", kwargs={"identifier": ""}),
+            data=bad_id_create_spatialview_json,
+            content_type="application/json",
+        )
         self.assertEqual(response.status_code, 400)

--- a/tests/views/user_preference_api_tests.py
+++ b/tests/views/user_preference_api_tests.py
@@ -64,24 +64,22 @@ class UserPrefApiTest(ArchesTestCase):
         self.assertFalse(isinstance(response_json, list))
 
     def test_detail_get_identifier_no_permission(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse(
-                    "api_user_preference_detail_view",
-                    kwargs={"identifier": self.admin_preference_id},
-                ),
-            )
-            self.assertEqual(response.status_code, 403)
+        response = self.client.get(
+            reverse(
+                "api_user_preference_detail_view",
+                kwargs={"identifier": self.admin_preference_id},
+            ),
+        )
+        self.assertEqual(response.status_code, 403)
 
     def test_detail_get_invalid_identifier(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse(
-                    "api_user_preference_detail_view",
-                    kwargs={"identifier": str(uuid.uuid4())},
-                ),
-            )
-            self.assertEqual(response.status_code, 404)
+        response = self.client.get(
+            reverse(
+                "api_user_preference_detail_view",
+                kwargs={"identifier": str(uuid.uuid4())},
+            ),
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_detail_get_no_identifier(self):
         # Show that providing no identifier returns the listView
@@ -133,33 +131,30 @@ class UserPrefApiTest(ArchesTestCase):
         self.assertEqual(response.status_code, 204)
 
     def test_delete_unauthorised_user(self):
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.delete(
-                reverse(
-                    "api_user_preference_detail_view",
-                    kwargs={"identifier": self.admin_preference_id},
-                ),
-            )
-            self.assertEqual(response.status_code, 403)
+        response = self.client.delete(
+            reverse(
+                "api_user_preference_detail_view",
+                kwargs={"identifier": self.admin_preference_id},
+            ),
+        )
+        self.assertEqual(response.status_code, 403)
 
     def test_delete_with_no_identifier(self):
         self.client.login(username="admin", password="admin")
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.delete(
-                reverse("api_user_preference_detail_view", kwargs={"identifier": ""}),
-            )
-            self.assertEqual(response.status_code, 405)
+        response = self.client.delete(
+            reverse("api_user_preference_detail_view", kwargs={"identifier": ""}),
+        )
+        self.assertEqual(response.status_code, 405)
 
     def test_delete_invalid_identifier(self):
         self.client.login(username="admin", password="admin")
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.delete(
-                reverse(
-                    "api_user_preference_detail_view",
-                    kwargs={"identifier": str(uuid.uuid4())},
-                ),
-            )
-            self.assertEqual(response.status_code, 404)
+        response = self.client.delete(
+            reverse(
+                "api_user_preference_detail_view",
+                kwargs={"identifier": str(uuid.uuid4())},
+            ),
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_post_valid(self):
         self.client.login(username="admin", password="admin")
@@ -179,44 +174,40 @@ class UserPrefApiTest(ArchesTestCase):
         user_pref = self.user_preference_json_data("admin")
         del user_pref["username"]
         del user_pref["config"]
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("api_user_preference_list_view"),
-                data=user_pref,
-                content_type="application/json",
-            )
-            response_json = json.loads(response.content)
+        response = self.client.post(
+            reverse("api_user_preference_list_view"),
+            data=user_pref,
+            content_type="application/json",
+        )
+        response_json = json.loads(response.content)
         self.assertEqual(response.status_code, 400)
 
     def test_post_unauthorised_user(self):
         user_pref = self.user_preference_json_data("anonymous")
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("api_user_preference_list_view"),
-                data=user_pref,
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, 403)
+        response = self.client.post(
+            reverse("api_user_preference_list_view"),
+            data=user_pref,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
 
     def test_post_invalid_user(self):
         self.client.login(username="admin", password="admin")
         user_pref = self.user_preference_json_data("fakeuser")
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("api_user_preference_list_view"),
-                data=user_pref,
-                content_type="application/json",
-            )
+        response = self.client.post(
+            reverse("api_user_preference_list_view"),
+            data=user_pref,
+            content_type="application/json",
+        )
         self.assertEqual(response.status_code, 400)
 
     def test_post_with_userpreferenceid(self):
         self.client.login(username="admin", password="admin")
         user_pref = self.user_preference_json_data("admin")
         user_pref["userpreferenceid"] = str(uuid.uuid4())
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse("api_user_preference_list_view"),
-                data=user_pref,
-                content_type="application/json",
-            )
+        response = self.client.post(
+            reverse("api_user_preference_list_view"),
+            data=user_pref,
+            content_type="application/json",
+        )
         self.assertEqual(response.status_code, 400)

--- a/tests/views/workflow_tests.py
+++ b/tests/views/workflow_tests.py
@@ -76,13 +76,12 @@ class WorkflowHistoryTests(ArchesTestCase):
 
     def test_get_workflow_history(self):
         self.client.force_login(self.anonymous)
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(
-                reverse(
-                    "workflow_history",
-                    kwargs={"workflowid": str(self.history.workflowid)},
-                )
+        response = self.client.get(
+            reverse(
+                "workflow_history",
+                kwargs={"workflowid": str(self.history.workflowid)},
             )
+        )
 
         self.assertContains(
             response, "Permission Denied", status_code=HTTPStatus.FORBIDDEN
@@ -139,15 +138,14 @@ class WorkflowHistoryTests(ArchesTestCase):
 
         # Non-superuser cannot update someone else's workflow.
         self.client.force_login(self.editor)
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse(
-                    "workflow_history",
-                    kwargs={"workflowid": str(self.history.workflowid)},
-                ),
-                post_data,
-                content_type="application/json",
-            )
+        response = self.client.post(
+            reverse(
+                "workflow_history",
+                kwargs={"workflowid": str(self.history.workflowid)},
+            ),
+            post_data,
+            content_type="application/json",
+        )
 
         self.assertContains(
             response, "Permission Denied", status_code=HTTPStatus.FORBIDDEN
@@ -194,18 +192,17 @@ class WorkflowHistoryTests(ArchesTestCase):
         self.history.save()
         self.client.force_login(self.admin)
 
-        with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.post(
-                reverse(
-                    "workflow_history",
-                    kwargs={"workflowid": str(self.history.workflowid)},
-                ),
-                {
-                    "workflowid": str(self.history.workflowid),
-                    "workflowname": "test-name",
-                    "completed": False,
-                },
-                content_type="application/json",
-            )
+        response = self.client.post(
+            reverse(
+                "workflow_history",
+                kwargs={"workflowid": str(self.history.workflowid)},
+            ),
+            {
+                "workflowid": str(self.history.workflowid),
+                "workflowname": "test-name",
+                "completed": False,
+            },
+            content_type="application/json",
+        )
 
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Running the tests, we're accumulating more tests that aren't capturing warnings for 4xx responses, so if we just elevate the log level a little bit (as we're already doing for warnings from arches itself), then, we can fix this and also stop asserting over the logs so much.