### PR TITLE
Create proper resource_x_resource records during resource duplication

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2493,6 +2493,14 @@ class ResourceInstanceDataType(BaseDataType):
         }
         return mapping
 
+    def copy(self, value, **kwargs):
+        # pre_tile_save creates a new resourceXresourceId, post_tile_save creates
+        # the record during __arches_create_resource_x_resource_relationships
+        if value:
+            for val in value:
+                val["resourceXresourceId"] = ""
+        return value
+
 
 class ResourceInstanceListDataType(ResourceInstanceDataType):
     def to_json(self, tile, node):

--- a/arches/app/models/tile.py
+++ b/arches/app/models/tile.py
@@ -469,9 +469,11 @@ class Tile(models.TileModel):
                     if item["nodeid"] == nodeid
                 )
                 datatype = self.datatype_factory.get_instance(node["datatype"])
-                datatype.pre_tile_save(self, nodeid)
                 if mode == "copy":
-                    self.data[nodeid] = datatype.copy(self.data[nodeid])
+                    self.data[nodeid] = datatype.copy(
+                        self.data[nodeid], resource=resource
+                    )
+                datatype.pre_tile_save(self, nodeid)
             self.__preSave(request, context=context)
             self.check_for_missing_nodes()
             self.check_for_constraint_violation()

--- a/releases/8.2.0.md
+++ b/releases/8.2.0.md
@@ -7,6 +7,7 @@
 - Move packages in arches-dev-dependencies repo into local peerDependencies [#12663](https://github.com/archesproject/arches/pull/12663)
 - Extract sidenav into its own template for project-level customization [#12689](https://github.com/archesproject/arches/issues/12689)
 - Datatypes can define their own copy logic when a resource or tile are cloned [#12706](https://github.com/archesproject/arches/pull/12706)
+- During resource cloning, distinct resource_x_resource records are created for resource instance (list) nodes [#12715](https://github.com/archesproject/arches/pull/12715)
 
 ### Performance Improvements
 

--- a/tests/models/resource_test.py
+++ b/tests/models/resource_test.py
@@ -890,6 +890,7 @@ class ResourceTests(ArchesTestCase):
         )
 
     def test_resource_copy(self):
+        self.maxDiff = None
         all_datatypes_resource = self._create_all_datatypes_resource()
         copied_resource = all_datatypes_resource.copy()
 
@@ -897,21 +898,41 @@ class ResourceTests(ArchesTestCase):
         self.assertEqual(all_datatypes_resource.graph_id, copied_resource.graph_id)
         self.assertEqual(len(all_datatypes_resource.tiles), len(copied_resource.tiles))
 
-        all_datatypes_original_tiles = sorted(
-            all_datatypes_resource.tiles,
-            key=lambda tile_instance: tile_instance.sortorder,
-        )
-        all_datatypes_copied_tiles = sorted(
-            copied_resource.tiles,
-            key=lambda tile_instance: tile_instance.sortorder,
-        )
+        original_tiles = models.TileModel.objects.filter(
+            resourceinstance=all_datatypes_resource.pk
+        ).order_by("sortorder")
+        copied_tiles = models.TileModel.objects.filter(
+            resourceinstance=copied_resource.pk
+        ).order_by("sortorder")
 
         for original_tile, copied_tile in zip(
-            all_datatypes_original_tiles,
-            all_datatypes_copied_tiles,
+            original_tiles,
+            copied_tiles,
         ):
             self.assertEqual(
                 str(original_tile.nodegroup_id), str(copied_tile.nodegroup_id)
             )
-            self.assertEqual(original_tile.data, copied_tile.data)
             self.assertEqual(original_tile.sortorder, copied_tile.sortorder)
+            if original_tile.find_nodegroup_alias() == "resource_instance":
+                nodeids = list(original_tile.data.keys())
+                for nodeid in nodeids:
+                    original_value = original_tile.data[nodeid][0]
+                    copied_value = copied_tile.data[nodeid][0]
+                    self.assertEqual(
+                        original_value["resourceId"],
+                        copied_value["resourceId"],
+                    )
+                    self.assertEqual(
+                        original_value["ontologyProperty"],
+                        copied_value["ontologyProperty"],
+                    )
+                    self.assertEqual(
+                        original_value["inverseOntologyProperty"],
+                        copied_value["inverseOntologyProperty"],
+                    )
+                    self.assertNotEqual(
+                        original_value["resourceXresourceId"],
+                        copied_value["resourceXresourceId"],
+                    )
+            else:
+                self.assertEqual(original_tile.data, copied_tile.data)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
During a Resource / Tile copy, resource instance (list) nodes were copied wholesale. This forces the creation of a new resource_x_resource record so there is a distinct relationship created for the copied resource to the target resource.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12685

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [x] My test fails on the target branch

#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
