### PR TITLE
Fix Back to Top button accessibility and visibility #12720

### DIFF
--- a/arches/app/media/css/components/_buttons.scss
+++ b/arches/app/media/css/components/_buttons.scss
@@ -62,14 +62,21 @@
     font-size: 20px;
     right: 20px;
     border-radius: 2px;
+    padding: 10px 15px;
+    border: none;
     opacity: 0;
+    visibility: hidden;
     z-index: 1100;
-    -webkit-transition: opacity .3s;
-    transition: opacity .3s;
-	&:hover {
-		opacity: 1!important;
-    	-webkit-transition: opacity .3s!important;
-    	transition: opacity .3s!important;
+    -webkit-transition: opacity .3s, visibility .3s;
+    transition: opacity .3s, visibility .3s;
+	&:hover,
+	&:focus {
+		opacity: 1;
+		outline: 2px solid #fff;
+		outline-offset: 2px;
+	}
+	&:focus {
+		visibility: visible;
 	}
 	@include break-at(mobile) {
         bottom: 5px;

--- a/arches/app/media/js/utils/back-to-top.js
+++ b/arches/app/media/js/utils/back-to-top.js
@@ -2,23 +2,53 @@ const backToTop = {
     scrollToTopHandler: function() {
         // Get the button:
         let mybutton = document.getElementById("backToTopBtn");
+        if (!mybutton) return;
+        
+        // Set initial hidden state
+        hideButton();
         
         // When the user scrolls down 200px from the top of the document, show the button
         window.onscroll = function() { scrollFunction(); };
         
+        function showButton() {
+            mybutton.style.opacity = "1";
+            mybutton.style.visibility = "visible";
+            mybutton.setAttribute("aria-hidden", "false");
+            mybutton.setAttribute("tabindex", "0");
+        }
+        
+        function hideButton() {
+            mybutton.style.opacity = "0";
+            mybutton.style.visibility = "hidden";
+            mybutton.setAttribute("aria-hidden", "true");
+            mybutton.setAttribute("tabindex", "-1");
+        }
+        
         function scrollFunction() {
             if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
-                mybutton.style.opacity = "0.5";
+                showButton();
             } else {
-                mybutton.style.opacity = "0";
+                hideButton();
             }
         }
     },
 
     // When the user clicks on the button, scroll to the top of the document
-    backToTopHandler: function() {
+    backToTopHandler: function(data, event) {
+        // Handle both click and keyboard events (Enter and Space)
+        if (event && event.type === 'keyup') {
+            if (event.key !== 'Enter' && event.key !== ' ') {
+                return;
+            }
+        }
         document.body.scrollTop = 0; // For Safari
         document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE, and Opera
+        
+        // Return focus to main content for accessibility
+        const mainContent = document.getElementById('main-content') || document.getElementById('skiptocontent');
+        if (mainContent) {
+            mainContent.focus();
+        }
     },
 };
 

--- a/arches/app/templates/base-manager.htm
+++ b/arches/app/templates/base-manager.htm
@@ -370,8 +370,8 @@
 
     </div>
 
-    <button id="backToTopBtn" aria-hidden="true" data-bind="attr: {'aria-label': $root.translations.goToTop}, click: backToTopHandler, event:{keyup: backToTopHandler}">
-        <i class="fa fa-chevron-up"></i>
+    <button id="backToTopBtn" aria-hidden="true" tabindex="-1" data-bind="attr: {'aria-label': $root.translations.goToTop}, click: backToTopHandler, event:{keyup: backToTopHandler}">
+        <i class="fa fa-chevron-up" aria-hidden="true"></i>
     </button>
 
 {% endblock body %}

--- a/releases/8.2.0.md
+++ b/releases/8.2.0.md
@@ -16,6 +16,7 @@
 ### Bug fixes
 
 - Fix stale card references on widgets after calling `update_node()` [#12712](https://github.com/archesproject/arches/pull/12712)
+- Fix back-to-top button visibility and keyboard accessibility [#12738](https://github.com/archesproject/arches/pull/12738)
 
 ### Dependency changes
 ```


### PR DESCRIPTION
- Toggle visibility, aria-hidden, and tabindex when showing/hiding button
- Add proper keyboard handling for Enter and Space keys
- Add focus styles with visible outline for accessibility
- Button now properly appears when scrolling down 200px
- Button is removed from tab order and screen readers when hidden

<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
The "Back to Top" button was present in the DOM but never became visible or properly accessible. The fix updates three files: the JavaScript now toggles [visibility](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), aria-hidden, and tabindex attributes when showing/hiding the button (instead of just changing opacity), and properly handles keyboard events (Enter/Space); the CSS adds [visibility: hidden](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the initial state and includes focus styles with a visible outline for keyboard users; and the HTML template sets the initial tabindex="-1" to remove the hidden button from the tab order. With these changes, the button appears when users scroll down 200+ pixels, is fully visible (opacity 1), can receive keyboard focus, is announced by screen readers, and correctly scrolls the page to the top when activated via click or keyboard.


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12720

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ x] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |    x     |       x   |
| Responsive Design|         |          |
| HTML validation  |    x     |      x    |
| Screen reader    |     x    |      x    |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @phudson-he
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
