### PR TITLE
Remove intermediate forced refreshes during bulk indexing

### DIFF
--- a/arches/app/search/base_index.py
+++ b/arches/app/search/base_index.py
@@ -94,7 +94,7 @@ class BaseIndex(object):
                 if len(resources) > 1
                 else None
             )
-        with self.se.BulkIndexer(batch_size=batch_size, refresh=True) as indexer:
+        with self.se.BulkIndexer(batch_size=batch_size) as indexer:
             for resource in resources:
                 if quiet is False and bar is not None:
                     bar.update(item_id=resource)

--- a/arches/app/utils/index_database.py
+++ b/arches/app/utils/index_database.py
@@ -253,8 +253,8 @@ def index_resources_using_singleprocessing(
         for nodeid, datatype in models.Node.objects.values_list("nodeid", "datatype")
     }
     all_users = User.objects.prefetch_related("groups")
-    with se.BulkIndexer(batch_size=batch_size, refresh=True) as doc_indexer:
-        with se.BulkIndexer(batch_size=batch_size, refresh=True) as term_indexer:
+    with se.BulkIndexer(batch_size=batch_size) as doc_indexer:
+        with se.BulkIndexer(batch_size=batch_size) as term_indexer:
             if quiet is False:
                 if isinstance(resources, QuerySet):
                     resource_count = resources.count()
@@ -298,6 +298,9 @@ def index_resources_using_singleprocessing(
                     term_indexer.add(
                         index=TERMS_INDEX, id=term["_id"], data=term["_source"]
                     )
+
+    se.refresh(index=RESOURCES_INDEX)
+    se.refresh(index=TERMS_INDEX)
 
     return os.getpid()
 
@@ -465,7 +468,7 @@ def index_concepts(clear_index=True, batch_size=settings.BULK_IMPORT_BATCH_SIZE)
         q = Query(se=se)
         q.delete(index=CONCEPTS_INDEX)
 
-    with se.BulkIndexer(batch_size=batch_size, refresh=True) as concept_indexer:
+    with se.BulkIndexer(batch_size=batch_size) as concept_indexer:
         indexed_values = []
         for conceptValue in models.Value.objects.filter(
             Q(concept__nodetype="Collection") | Q(concept__nodetype="ConceptScheme"),
@@ -546,6 +549,8 @@ def index_concepts(clear_index=True, batch_size=settings.BULK_IMPORT_BATCH_SIZE)
                 "top_concept": conceptValue.concept_id,
             }
             concept_indexer.add(index=CONCEPTS_INDEX, id=doc["id"], data=doc)
+
+    se.refresh(index=CONCEPTS_INDEX)
 
     cursor.execute(
         "SELECT count(*) from values WHERE valuetype in ({0})".format(valueTypes)


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Looking into elastic refreshing behavior recently, I don't think we want to force intermediate refreshes for each chunk of resources for a bulk index (e.g. 1 refresh per 2000), as it's possible this could be quite slow. Instead, one explicit refresh at the end should ensure un-searched indexes are up-to-date. (Actively searched indexes should still get default refreshes every second.)

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch