### PR TITLE
Fix: Front end cardinality n tile error

### DIFF
--- a/arches/app/media/js/viewmodels/widget.js
+++ b/arches/app/media/js/viewmodels/widget.js
@@ -126,7 +126,7 @@ var WidgetViewModel = function(params) {
             this.value(defaultValue);
         }
 
-        if (!self.form) {
+        if (params.hasOwnProperty('graphDesignerHasDirtyWidget')) {
             if (ko.isObservable(self.value)) {
                 self.valueSubscription = self.value.subscribe(function(val){
                     if (self.defaultValue() != val) {

--- a/releases/8.2.0.md
+++ b/releases/8.2.0.md
@@ -28,6 +28,7 @@
 - Fix back-to-top button visibility and keyboard accessibility [#12738](https://github.com/archesproject/arches/pull/12738)
 - Resolved issue with `Resource.copy()`, `context` is now required to be a dict [#12695](https://github.com/archesproject/arches/pull/12695)
 - Fix default search bar debounce not working correctly [#12776](https://github.com/archesproject/arches/pull/12776)
+- Fix cross-tile contamination on cardinality-n cards: widget values were two-way-bound to the shared `node.config.defaultValue` observable in display contexts, so editing one tile overwrote its siblings [#12789](https://github.com/archesproject/arches/pull/12789)
 - Fix CKEditor attempts to intialize before element is connected to document [#12748](https://github.com/archesproject/arches/pull/12748)
 - Fix load of default values for domain datatypes during graph import [#12800](https://github.com/archesproject/arches/pull/12800)
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
When updating tile data on a node with cardinality n, the last tile save would update all the values for the tiles so that they were identical. This was an issue with the default value being shared across the tiles. This was happening on the front end and not directly affecting the database but saving in certain cards would then update data.

The default value is only needed for the graph designer page, a check was added against to check for an attribute only present within the designer so that the default value would not then be shared across tile data.


### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12795

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Accessibility Checklist
<!-- If your changes impacted the following areas, mark the appropriate columns. -->
[Developer Guide](https://arches.readthedocs.io/en/stable/developing/advanced/accessibility/)

| Topic            | Changed | Retested |
| ---------------- | ------- | -------- |
| Color contrast   |         |          |
| Form fields      |         |          |
| Headings         |         |          |
| Links            |         |          |
| Keyboard         |         |          |
| Responsive Design|         |          |
| HTML validation  |         |          |
| Screen reader    |         |          |


#### Ticket Background
*   Sponsored by: <!--- Who is funding this effort? Getty Conservation Institute|Self Funded -->
*   Found by: @ <!--- This could be the person who files the bug, but not always. -->
*   Tested by: @ <!--- Testing is an important step in development. Who tested this? -->
*   Designed by: @ <!--- Who designed this new feature-->

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
