### PR TITLE
Restore the VERSION tuple

### DIFF
--- a/arches/__init__.py
+++ b/arches/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import importlib.metadata
+from packaging.version import Version
 
 try:
     # This will make sure the app is always imported when
@@ -11,3 +12,16 @@ except Exception as e:
     pass
 
 __version__ = importlib.metadata.version(__package__)
+
+version = Version(__version__)
+major, minor, micro = version.major, version.minor, version.micro
+
+if version.pre:
+    pre_type_mapping = {"a": "alpha", "b": "beta", "rc": "rc"}
+    pre_type = pre_type_mapping.get(version.pre[0], version.pre[0])
+    pre_num = version.pre[1]
+else:
+    pre_type = "final"
+    pre_num = 0
+
+VERSION = (major, minor, micro, pre_type, pre_num)

--- a/releases/8.1.3.md
+++ b/releases/8.1.3.md
@@ -4,6 +4,7 @@
 
 - Make cards with read or write perms available in reports [#12718](https://github.com/archesproject/arches/issues/12718)
 - Fix the issue with ArcGIS Pro Addin failing to create a new resource by updating the nodevalue api and conversion from Esri json to geojson [#12704](https://github.com/archesproject/arches/issues/12704)
+- Restore the `VERSION` tuple in the arches namespace to simplify version checks against pre-releases [#12814](https://github.com/archesproject/arches/pull/12814)
 
 ## Dependency Changes
 

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -1,0 +1,25 @@
+import unittest
+import arches
+
+# these tests can be run from the command line via
+# python manage.py test tests.utils.test_version --settings="tests.test_settings"
+
+
+class VersionTupleTests(unittest.TestCase):
+
+    def test_version_tuple_imported_from_arches(self):
+        """VERSION exported by the package is a 5-tuple with the expected shape."""
+
+        version_tuple = arches.VERSION
+        self.assertIsInstance(version_tuple, tuple)
+        self.assertEqual(len(version_tuple), 5)
+        major, minor, micro, pre_type, pre_num = version_tuple
+        self.assertIsInstance(major, int)
+        self.assertIsInstance(minor, int)
+        self.assertIsInstance(micro, int)
+        self.assertIn(pre_type, ("alpha", "beta", "rc", "final"))
+        self.assertIsInstance(pre_num, int)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Shortly after 1f5f9bb021878f92663ab5d3f0a96473799b6906 we discussed in a standup how restoring the VERSION tuple would simplify comparisons against pre-releases:

```py
>>> # has 8.0 source_identifier field?
>>> Version("8.0.0a0") > Version("8.0")
False
>>> (8, 0, 0, "alpha", 0)  >= (8, 0)
True
```

To make the first flavor work, where the right-hand side is a `Version`, as far as I understand you would need to definitively know how the pre-releases are named ("a", "a0", "alpha", "a1", etc.)

Seems like in harmony with #12633?

This reverts commit 1f5f9bb021878f92663ab5d3f0a96473799b6906.

### Further comments
Unblocks archesproject/arches-querysets#175