### PR TITLE
Add command to calculate descriptors

### DIFF
--- a/arches/management/commands/resources.py
+++ b/arches/management/commands/resources.py
@@ -194,23 +194,25 @@ class Command(BaseCommand):
                 .distinct()
             )
             resources = resources.filter(resourceinstanceid__in=resource_ids)
-        elif not force:
-            if not utils.get_yn_input(
-                "Descriptors for all resources will be recalculated. continue?"
-            ):
-                return
 
         if graphid:
             resources = resources.filter(graph_id=graphid)
 
         total = resources.count()
-        self.stdout.write(f"Processing descriptors for {total} resource(s)...")
 
         if total == 0:
             self.stdout.write(
                 self.style.WARNING("No resources matched the given criteria.")
             )
             return
+
+        elif not force:
+            if not utils.get_yn_input(
+                f"Descriptors for {total} resources will be recalculated. Continue?"
+            ):
+                return
+
+        self.stdout.write(f"Processing descriptors for {total} resource(s)...")
 
         graph_ids = list(resources.values_list("graph_id", flat=True).distinct())
         descriptor_functions_by_graph = {}

--- a/arches/management/commands/resources.py
+++ b/arches/management/commands/resources.py
@@ -16,9 +16,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+from collections import defaultdict
+
 from arches.management.commands import utils
 from arches.app.models import models
 from arches.app.models.graph import Graph
+from arches.app.models.system_settings import settings
 from django.core.management.base import BaseCommand, CommandError
 import arches.app.utils.data_management.resources.remover as resource_remover
 
@@ -56,6 +59,24 @@ class Command(BaseCommand):
             help="used to clear the edit log. If a graphid is provided, only the edit log for that graph will be cleared.",
         )
 
+        parser.add_argument(
+            "-t",
+            "--transaction",
+            action="store",
+            dest="transaction",
+            help="A transaction id to limit which resources have their descriptors recalculated.",
+        )
+
+        parser.add_argument(
+            "-b",
+            "--batch-size",
+            action="store",
+            dest="batch_size",
+            type=int,
+            default=2000,
+            help="Number of resources to process per batch (default: 2000).",
+        )
+
     def handle(self, *args, **options):
         if options["operation"] == "remove_resources":
             self.remove_resources(
@@ -66,6 +87,14 @@ class Command(BaseCommand):
 
         if options["operation"] == "clear_edit_log":
             self.clear_edit_log(graphid=options["graph"])
+
+        if options["operation"] == "calculate_descriptors":
+            self.calculate_descriptors(
+                force=options["yes"],
+                graphid=options["graph"],
+                transaction_id=options["transaction"],
+                batch_size=options["batch_size"],
+            )
 
     def remove_resources(
         self, load_id="", graphid=None, force=False, clear_edit_log=False
@@ -105,3 +134,123 @@ class Command(BaseCommand):
             models.EditLog.objects.filter(resourceclassid=graphid).delete()
         else:
             models.EditLog.objects.all().delete()
+
+    def calculate_descriptors(
+        self, transaction_id=None, graphid=None, force=False, batch_size=2000
+    ):
+        """
+        Recalculates and bulk-saves resource descriptors (name, description, map_popup).
+
+        Groups resources by graph to fetch descriptor functions once per graph,
+        pre-fetches tiles per batch, and writes back via bulk_update to avoid
+        per-resource round-trips to the database.
+        """
+        from arches.app.models.resource import Resource
+
+        resources = Resource.objects.all()
+
+        if transaction_id:
+            resource_ids = list(
+                models.EditLog.objects.filter(transactionid=transaction_id)
+                .values_list("resourceinstanceid", flat=True)
+                .distinct()
+            )
+            resources = resources.filter(resourceinstanceid__in=resource_ids)
+        elif not force:
+            if not utils.get_yn_input(
+                "Descriptors for all resources will be recalculated. continue?"
+            ):
+                return
+
+        if graphid:
+            resources = resources.filter(graph_id=graphid)
+
+        total = resources.count()
+        self.stdout.write(f"Processing descriptors for {total} resource(s)...")
+
+        if total == 0:
+            self.stdout.write(
+                self.style.WARNING("No resources matched the given criteria.")
+            )
+            return
+
+        graph_ids = list(resources.values_list("graph_id", flat=True).distinct())
+        descriptor_functions_by_graph = {}
+        for graph_id in graph_ids:
+            funcs = list(
+                models.FunctionXGraph.objects.filter(
+                    graph_id=graph_id, function__functiontype="primarydescriptors"
+                ).select_related("function")
+            )
+            descriptor_functions_by_graph[str(graph_id)] = funcs
+
+        descriptor_keys = ("name", "description", "map_popup")
+        all_resource_ids = list(resources.values_list("resourceinstanceid", flat=True))
+        updated = 0
+
+        for batch_start in range(0, len(all_resource_ids), batch_size):
+            batch_ids = all_resource_ids[batch_start : batch_start + batch_size]
+            batch_resources = list(
+                Resource.objects.filter(resourceinstanceid__in=batch_ids)
+            )
+
+            # Fetch all tiles for this batch in a single query
+            tiles_by_resource = defaultdict(list)
+            for tile in models.TileModel.objects.filter(
+                resourceinstance_id__in=batch_ids
+            ):
+                tiles_by_resource[str(tile.resourceinstance_id)].append(tile)
+
+            for resource in batch_resources:
+                resource.tiles = tiles_by_resource.get(
+                    str(resource.resourceinstanceid), []
+                )
+                descriptor_function = descriptor_functions_by_graph.get(
+                    str(resource.graph_id), []
+                )
+
+                if resource.descriptors is None:
+                    resource.descriptors = {}
+                if resource.name is None:
+                    resource.name = {}
+
+                for lang in settings.LANGUAGES:
+                    language = resource.get_descriptor_language({"language": lang[0]})
+                    context = {"language": language}
+
+                    if len(descriptor_function) == 1:
+                        module = descriptor_function[0].function.get_class_module()()
+                        for descriptor in descriptor_keys:
+                            resource.descriptors[language][descriptor] = (
+                                module.get_primary_descriptor_from_nodes(
+                                    resource,
+                                    descriptor_function[0].config["descriptor_types"][
+                                        descriptor
+                                    ],
+                                    context,
+                                    descriptor,
+                                )
+                            )
+                            if (
+                                descriptor == "name"
+                                and resource.descriptors[language][descriptor]
+                                is not None
+                            ):
+                                resource.name[language] = resource.descriptors[
+                                    language
+                                ][descriptor]
+                    else:
+                        for descriptor in descriptor_keys:
+                            resource.descriptors[language][descriptor] = None
+
+            Resource.objects.bulk_update(
+                batch_resources, ["descriptors", "name"], batch_size=batch_size
+            )
+            updated += len(batch_resources)
+            self.stdout.write(f"  {updated}/{total} resources updated...")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully recalculated descriptors for {updated} resource(s)."
+            )
+        )

--- a/arches/management/commands/resources.py
+++ b/arches/management/commands/resources.py
@@ -28,12 +28,45 @@ import arches.app.utils.data_management.resources.remover as resource_remover
 
 class Command(BaseCommand):
     """
-    Commands for managing Arches functions
+    Commands for managing Arches resources
 
     """
 
+    help = (
+        "Manage Arches resource instances.\n\n"
+        "Operations:\n"
+        "  remove_resources      Delete resource instances, optionally filtered by graph.\n"
+        "  clear_edit_log        Truncate the edit log, optionally filtered by graph.\n"
+        "  calculate_descriptors Recalculate and persist the name, description, and\n"
+        "                        map_popup descriptors for resource instances without\n"
+        "                        triggering an Elasticsearch (re)index.  Useful for\n"
+        "                        correcting stale or missing descriptor values after a\n"
+        "                        data migration.  Processes resources in batches and\n"
+        "                        writes results back via a single bulk_update per batch.\n"
+        "\n"
+        "Examples:\n"
+        "  # Recalculate descriptors for every resource (skips confirmation prompt):\n"
+        "  python manage.py resources calculate_descriptors --yes\n"
+        "\n"
+        "  # Recalculate descriptors for one Resource Model only:\n"
+        "  python manage.py resources calculate_descriptors -g <graph-uuid> --yes\n"
+        "\n"
+        "  # Recalculate descriptors only for resources touched in a given transaction:\n"
+        "  python manage.py resources calculate_descriptors -t <transaction-uuid>\n"
+        "\n"
+        "  # Use a smaller batch size to reduce peak memory usage:\n"
+        "  python manage.py resources calculate_descriptors --yes --batch-size 500\n"
+    )
+
     def add_arguments(self, parser):
-        parser.add_argument("operation", nargs="?")
+        parser.add_argument(
+            "operation",
+            nargs="?",
+            help=(
+                "Operation to perform. One of: "
+                "'remove_resources', 'clear_edit_log', 'calculate_descriptors'."
+            ),
+        )
 
         parser.add_argument(
             "-y",
@@ -48,7 +81,12 @@ class Command(BaseCommand):
             "--graph",
             action="store",
             dest="graph",
-            help="A graphid of the Resource Model you would like to remove all instances from.",
+            help=(
+                "UUID of the Resource Model (graph) to filter by. "
+                "For 'remove_resources': only instances of this graph are deleted. "
+                "For 'calculate_descriptors': only resources of this graph have "
+                "their descriptors recalculated."
+            ),
         )
 
         parser.add_argument(

--- a/arches/management/commands/resources.py
+++ b/arches/management/commands/resources.py
@@ -22,7 +22,7 @@ from arches.management.commands import utils
 from arches.app.models import models
 from arches.app.models.graph import Graph
 from arches.app.models.system_settings import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 import arches.app.utils.data_management.resources.remover as resource_remover
 
 

--- a/releases/8.2.0.md
+++ b/releases/8.2.0.md
@@ -12,6 +12,7 @@
 - During resource cloning, distinct resource_x_resource records are created for resource instance (list) nodes [#12715](https://github.com/archesproject/arches/pull/12715)
 - Re-enable resource cloning in the resource editor and add copy-specify logic for edit-log display [#12749](https://github.com/archesproject/arches/pull/12749)
 - Upgraded rdflib to 7.6.0 and Python 3.14 is now supported [#12790](https://github.com/archesproject/arches/pull/12790)
+- Add command to calculate descriptors independent of ES index [#12828](https://github.com/archesproject/arches/issues/12828)
 
 ### Performance Improvements
 

--- a/tests/commands/test_resources.py
+++ b/tests/commands/test_resources.py
@@ -175,6 +175,7 @@ class CalculateDescriptorsCommandTest(ArchesTestCase):
             "resources",
             "calculate_descriptors",
             transaction=str(transaction_id),
+            yes=True,
             stdout=StringIO(),
         )
 

--- a/tests/commands/test_resources.py
+++ b/tests/commands/test_resources.py
@@ -1,0 +1,220 @@
+# these tests can be run from the command line via
+# python manage.py test tests.commands.test_resources --settings="tests.test_settings"
+
+import uuid
+from io import StringIO
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from arches.app.models import models
+from arches.app.models.graph import Graph
+from arches.app.models.resource import Resource
+from arches.app.models.tile import Tile
+from tests.base_test import ArchesTestCase
+
+
+PRIMARY_DESCRIPTORS_FUNCTION_ID = "60000000-0000-0000-0000-000000000001"
+
+
+def _make_descriptor_graph(name="Descriptor Test Graph"):
+    """
+    Create a published graph with a string node and a primary-descriptors
+    function configured to use that node.  Returns (graph, node_group, string_node).
+    """
+    graph = Graph.objects.create_graph(name=name, is_resource=True)
+    node_group = models.NodeGroup.objects.create()
+    string_node = models.Node.objects.create(
+        graph=graph,
+        nodegroup=node_group,
+        name="String Node",
+        datatype="string",
+        istopnode=False,
+    )
+    graph.add_node(string_node)
+    edge = models.Edge.objects.create(
+        graph=graph, domainnode=graph.root, rangenode=string_node
+    )
+    graph.add_edge(edge)
+    graph.add_card(
+        models.CardModel(
+            graph=graph,
+            nodegroup=node_group,
+            description="Test Card",
+        )
+    )
+    models.FunctionXGraph.objects.create(
+        graph=graph,
+        function_id=PRIMARY_DESCRIPTORS_FUNCTION_ID,
+        config={
+            "descriptor_types": {
+                "name": {
+                    "nodegroup_id": str(node_group.nodegroupid),
+                    "string_template": "<String Node>",
+                },
+                "map_popup": {
+                    "nodegroup_id": str(node_group.nodegroupid),
+                    "string_template": "<String Node>",
+                },
+                "description": {
+                    "nodegroup_id": str(node_group.nodegroupid),
+                    "string_template": "<String Node>",
+                },
+            },
+        },
+    )
+    user = User.objects.get(username="admin")
+    graph.save(validate=False)
+    graph.publish(user=user)
+    return graph, node_group, string_node
+
+
+def _save_resource_with_tile(graph, node_group, string_node, value="test value"):
+    resource = Resource(graph=graph)
+    tile = Tile(
+        nodegroup=node_group,
+        resourceinstance=resource,
+        data={
+            str(string_node.pk): {
+                "en": {"value": value, "direction": "ltr"},
+            }
+        },
+        sortorder=0,
+    )
+    resource.tiles.append(tile)
+    resource.save(index=False)
+    return resource
+
+
+class CalculateDescriptorsCommandTest(ArchesTestCase):
+    """Tests for `python manage.py resources calculate_descriptors`."""
+
+    def test_descriptors_recalculated_with_force_flag(self):
+        graph, node_group, string_node = _make_descriptor_graph()
+        resource = _save_resource_with_tile(graph, node_group, string_node)
+
+        # Blank out the descriptors to confirm the command repopulates them.
+        Resource.objects.filter(pk=resource.pk).update(descriptors={}, name={})
+
+        out = StringIO()
+        call_command(
+            "resources",
+            "calculate_descriptors",
+            graph=str(graph.pk),
+            yes=True,
+            stdout=out,
+        )
+
+        resource.refresh_from_db()
+        output = out.getvalue()
+        self.assertIn("Successfully recalculated", output)
+
+        # At least the English descriptor should be populated.
+        en_name = resource.descriptors.get("en", {}).get("name")
+        self.assertEqual(en_name, "test value")
+
+    def test_descriptors_recalculated_filtered_by_graph(self):
+        """
+        Passing --graph should restrict updates to that graph only.
+        Other resources must not be modified.
+        """
+        graph_a, node_group_a, string_node_a = _make_descriptor_graph("Graph A")
+        graph_b, node_group_b, string_node_b = _make_descriptor_graph("Graph B")
+
+        resource_a = _save_resource_with_tile(
+            graph_a, node_group_a, string_node_a, value="value A"
+        )
+        resource_b = _save_resource_with_tile(
+            graph_b, node_group_b, string_node_b, value="value B"
+        )
+
+        # Clear both.
+        Resource.objects.filter(pk__in=[resource_a.pk, resource_b.pk]).update(
+            descriptors={}, name={}
+        )
+
+        call_command(
+            "resources",
+            "calculate_descriptors",
+            graph=str(graph_a.pk),
+            yes=True,
+            stdout=StringIO(),
+        )
+
+        resource_a.refresh_from_db()
+        resource_b.refresh_from_db()
+
+        # Only graph_a resource should have been updated.
+        self.assertEqual(resource_a.descriptors.get("en", {}).get("name"), "value A")
+        self.assertEqual(resource_b.descriptors, {})
+
+    def test_descriptors_recalculated_filtered_by_transaction(self):
+        """
+        Passing --transaction should restrict updates to resources that appear
+        in the edit log under that transaction id.
+        """
+        graph, node_group, string_node = _make_descriptor_graph("Transaction Graph")
+        resource = _save_resource_with_tile(graph, node_group, string_node)
+
+        transaction_id = uuid.uuid4()
+        models.EditLog.objects.create(
+            resourceinstanceid=str(resource.pk),
+            resourceclassid=str(graph.pk),
+            transactionid=transaction_id,
+            edittype="update",
+        )
+
+        # An unrelated resource that should NOT be touched.
+        other_resource = _save_resource_with_tile(graph, node_group, string_node)
+
+        Resource.objects.filter(pk__in=[resource.pk, other_resource.pk]).update(
+            descriptors={}, name={}
+        )
+
+        call_command(
+            "resources",
+            "calculate_descriptors",
+            transaction=str(transaction_id),
+            stdout=StringIO(),
+        )
+
+        resource.refresh_from_db()
+        other_resource.refresh_from_db()
+
+        self.assertEqual(resource.descriptors.get("en", {}).get("name"), "test value")
+        self.assertEqual(other_resource.descriptors, {})
+
+    def test_resources_without_descriptor_function_get_null_descriptors(self):
+        """
+        Resources whose graph has no primary-descriptors function should have
+        their descriptor fields set to None for each key.
+        """
+        bare_graph = Graph.objects.create_graph(name="Bare Graph", is_resource=True)
+        user = User.objects.get(username="admin")
+        bare_graph.save(validate=False)
+        bare_graph.publish(user=user)
+
+        resource = Resource(graph=bare_graph)
+        resource.save(index=False)
+
+        Resource.objects.filter(pk=resource.pk).update(
+            descriptors={
+                "en": {"name": "stale", "description": "stale", "map_popup": "stale"}
+            },
+        )
+
+        out = StringIO()
+        call_command(
+            "resources",
+            "calculate_descriptors",
+            graph=str(bare_graph.pk),
+            yes=True,
+            stdout=out,
+        )
+
+        resource.refresh_from_db()
+        self.assertIn("Successfully recalculated", out.getvalue())
+        en_descriptors = resource.descriptors.get("en", {})
+        for key in ("name", "description", "map_popup"):
+            with self.subTest(descriptor=key):
+                self.assertIsNone(en_descriptors.get(key))


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds a command to calculate resource descriptors independent of and ES reindex

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #12828

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

Command examples for testing:
```
python manage.py resources calculate_descriptors --yes
python manage.py resources calculate_descriptors -g <graph-uuid> --yes
python manage.py resources calculate_descriptors -t <transaction-uuid>
python manage.py resources calculate_descriptors --yes --batch-size 500
```