### PR TITLE
Cnh/support docx validation

### DIFF
--- a/arches/app/utils/file_validator.py
+++ b/arches/app/utils/file_validator.py
@@ -29,9 +29,16 @@ class FileValidator(object):
                 and (settings.FILE_TYPE_CHECKING != "lenient" or extension is not None)
             ):
                 errors.append(f"File type is not permitted: {extension}")
+            case "docx":
+                try:
+                    with zipfile.ZipFile(io.BytesIO(file)) as zf:
+                        if "word/document.xml" not in zf.namelist():
+                            raise zipfile.BadZipFile("Missing word/document.xml")
+                except (zipfile.BadZipFile, KeyError):
+                    errors.append("Invalid docx file")
             case "xlsx":
                 try:
-                    load_workbook(io.BytesIO(file))
+                    load_workbook(io.BytesIO(file), read_only=True)
                 except (InvalidFileException, zipfile.BadZipFile):
                     errors.append("Invalid xlsx workbook")
             case "csv":
@@ -66,7 +73,7 @@ class FileValidator(object):
         if settings.FILE_TYPE_CHECKING:
             contents = file.read()
             file_type = filetype.guess(contents)
-            if file_type is None or extension == "xlsx":
+            if file_type is None or extension in ("xlsx", "docx"):
                 errors = errors + self.test_unknown_filetypes(contents, extension)
                 return errors
 

--- a/releases/7.6.25.md
+++ b/releases/7.6.25.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- Add validation for docx uploads [#12834](https://github.com/archesproject/arches/pull/12834)
 - Change project template license to AGPL to be consistent with Arches [#12772](https://github.com/archesproject/arches/pull/12772)
 
 ## Dependency changes

--- a/tests/utils/test_file_validator.py
+++ b/tests/utils/test_file_validator.py
@@ -1,5 +1,7 @@
+import io
 import os
 import shutil
+import zipfile
 from pathlib import Path
 
 from unittest.mock import Mock, patch
@@ -28,6 +30,15 @@ class MockFile:
 class MockFileType:
     def __init__(self, extension):
         self.extension = extension
+
+
+def _make_docx_bytes(include_document_xml=True):
+    """Return minimal in-memory docx (ZIP) bytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        if include_document_xml:
+            zf.writestr("word/document.xml", "<document/>")
+    return buf.getvalue()
 
 
 class FileValidatorTests(SimpleTestCase):
@@ -116,7 +127,22 @@ class FileValidatorTests(SimpleTestCase):
         self.assertEqual(errors, ["File type is not permitted: DS_Store"])
 
     @patch("filetype.guess", Mock(return_value=None))
-    @patch("arches.app.utils.file_validator.load_workbook", lambda noop: None)
+    def test_valid_docx(self):
+        with self.modify_settings(FILE_TYPES={"append": "docx"}):
+            file = io.BytesIO(_make_docx_bytes())
+            errors = self.validator.validate_file_type(file, extension="docx")
+        self.assertEqual(errors, [])
+
+    @patch("filetype.guess", Mock(return_value=None))
+    def test_docx_missing_document_xml(self):
+        with self.modify_settings(FILE_TYPES={"append": "docx"}):
+            file = io.BytesIO(_make_docx_bytes(include_document_xml=False))
+            with self.assertLogs("arches.app.utils.file_validator", level="ERROR"):
+                errors = self.validator.validate_file_type(file, extension="docx")
+        self.assertEqual(errors, ["Invalid docx file"])
+
+    @patch("filetype.guess", Mock(return_value=None))
+    @patch("arches.app.utils.file_validator.load_workbook", Mock(return_value=None))
     def test_valid_xlsx(self):
         errors = self.validator.validate_file_type(self.mock_file, extension="xlsx")
         self.assertEqual(errors, [])


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Security fix 
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
There is a need for ArchesHER to upload docx files, but no reasonable way to override the file_validator class. This PR provides a light solution. @aj-he proposes a better long-term solution [here](https://github.com/archesproject/arches-her/pull/1481), but it's a significant change to arches allowing Apps to provide their own file validators. I think that such a change would be well suited for the 8.2 release, but for 7.6, we should aim for the smallest change we can make to minimize impacts to core. 



### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [ ] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [x] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [x] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

### Further comments

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
