### PR TITLE
Remove unused eslint/js for eslint upgrade

### DIFF
--- a/releases/8.1.3.md
+++ b/releases/8.1.3.md
@@ -28,6 +28,10 @@ JavaScript:
         js-cookie: "3.0.5" -> "3.0.8"
         vitest: "1.6.1" -> "3.2.7"
         webpack-dev-server: "5.2.3" -> "5.2.5"
+        "eslint": "9.39.4" -> "10.8.0"
+        "eslint-plugin-vue": "9.33.0" -> "10.10.0"
+        "vue-tsc": "2.2.12" -> "3.3.8"
+        "postcss": "8.5.8" -> "8.5.23"
 
     Added:
 
@@ -54,7 +58,7 @@ JavaScript:
 
 1. Rebuild your frontend bundle:
 
-    - This version resolves security vulnerabilities in vitest. For this reason, you'll want to be sure that the `arches-dev-dependencies` in your project's package.json file points to either the `dev/8.1.x` or `stable/8.1.3` branch.
+    - This version resolves security vulnerabilities in several frontend depenencies. For this reason, you'll want to be sure that the `arches-dev-dependencies` in your project's package.json file points to either the `dev/8.1.x` or `stable/8.1.3` branch.
 
         ```json
         "devDependencies": {


### PR DESCRIPTION
With an upgrade of eslint in arches-dev-dependencies, @eslint/js is no longer needed.

For details:
https://github.com/eslint/eslint/discussions/20539

This PR is submitted in conjunction with https://github.com/archesproject/arches-dev-dependencies/pull/73
