### PR TITLE
Remove obsolete POSTGIS_VERSION setting

### DIFF
--- a/arches/settings.py
+++ b/arches/settings.py
@@ -234,8 +234,6 @@ ENABLE_USER_SIGNUP = True
 # If True, users must authenticate their accout via email to complete the account creation process.
 FORCE_USER_SIGNUP_EMAIL_AUTHENTICATION = True
 
-POSTGIS_VERSION = (3, 0, 0)
-
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = True


### PR DESCRIPTION
The `POSTGIS_VERSION` [setting](https://docs.djangoproject.com/en/6.0/ref/contrib/gis/testing/#postgis-version) is used to lie to Django about the PostGIS version to potentially save a query, however, in current versions of Django with PostGIS, it's not used for anything.

I was debugging recently and thought that this was my PostGIS version, but I was actually on 3.5.5. Since it's potentially confusing and has no current benefit, my thought was to remove it.