### PR TITLE
Add controlled lists to template project

### DIFF
--- a/arches/install/arches-templates/package.json
+++ b/arches/install/arches-templates/package.json
@@ -18,7 +18,9 @@
         "vitest": "vitest --run --coverage"
     },
     "dependencies": {
-        "arches": "archesproject/arches#{{ arches_version }}"
+        "arches": "archesproject/arches#{{ arches_version }}",
+        "arches-controlled-lists": "archesproject/arches-controlled-lists#dev/1.3.x",
+        "arches-vue-components": "archesproject/arches-vue-components#stable/2.0.2"
     },
     "nodeModulesPaths": {
     },

--- a/arches/install/arches-templates/project_name/settings.py-tpl
+++ b/arches/install/arches-templates/project_name/settings.py-tpl
@@ -126,6 +126,7 @@ DATABASES = {
 SEARCH_THUMBNAILS = False
 
 INSTALLED_APPS = (
+    "{{ project_name }}",  # Ensure the project is listed before any other arches applications
     "webpack_loader",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -133,7 +134,11 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.gis",
+    "django.contrib.postgres",
     "django_hosts",
+    "arches_controlled_lists",
+    "arches_querysets",
+    "arches_vue_components",
     "arches.app.models",
     "arches.management",
     "guardian",
@@ -145,7 +150,6 @@ INSTALLED_APPS = (
     "django_migrate_sql",
     "pgtrigger",
     # "silk",
-    "{{ project_name }}",  # Ensure the project is listed before any other arches applications
 )
 
 # Placing this last ensures any templates and modules provided by
@@ -437,6 +441,41 @@ SHOW_LANGUAGE_SWITCH = len(LANGUAGES) > 1
 # Implement this class to associate custom documents to the ES resource index
 # See tests.views.search_tests.TestEsMappingModifier class for example
 # ES_MAPPING_MODIFIER_CLASSES = ["{{ project_name }}.search.es_mapping_modifier.EsMappingModifier"]
+
+
+REFERENCES_INDEX_NAME = "references"
+ELASTICSEARCH_CUSTOM_INDEXES = [
+    {
+        "module": "arches_controlled_lists.search_indexes.reference_index.ReferenceIndex",
+        "name": REFERENCES_INDEX_NAME,
+        "should_update_asynchronously": True,
+    }
+]
+TERM_SEARCH_TYPES = [
+    {
+        "type": "term",
+        "label": _("Term Matches"),
+        "key": "terms",
+        "module": "arches.app.search.search_term.TermSearch",
+    },
+    {
+        "type": "concept",
+        "label": _("Concepts"),
+        "key": "concepts",
+        "module": "arches.app.search.concept_search.ConceptSearch",
+    },
+    {
+        "type": "reference",
+        "label": _("References"),
+        "key": REFERENCES_INDEX_NAME,
+        "module": "arches_controlled_lists.search_indexes.reference_index.ReferenceIndex",
+    },
+]
+
+ES_MAPPING_MODIFIER_CLASSES = [
+    "arches_controlled_lists.search.references_es_mapping_modifier.ReferencesEsMappingModifier"
+]
+
 
 try:
     from .package_settings import *

--- a/arches/install/arches-templates/project_name/urls.py-tpl
+++ b/arches/install/arches-templates/project_name/urls.py-tpl
@@ -13,6 +13,8 @@ handler404 = "arches.app.views.main.custom_404"
 handler500 = "arches.app.views.main.custom_500"
 
 # Ensure Arches core urls are superseded by project-level urls
+urlpatterns.append(path("", include("arches_controlled_lists.urls")))
+urlpatterns.append(path("", include("arches_vue_components.urls")))
 urlpatterns.append(path('', include('arches.urls')))
 
 # Adds URL pattern to serve media files during development

--- a/arches/install/arches-templates/pyproject.toml
+++ b/arches/install/arches-templates/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "arches>={{ arches_semantic_version }},<{{ arches_next_minor_version }}",
+    "arches-controlled-lists>=1.3.0a0",
 ]
 version = "0.0.1"
 


### PR DESCRIPTION
Adds arches-controlled-lists to the template project so that it is installed and configured by default for new projects.