### PR TITLE
Fix missing arg following #12883

### DIFF
--- a/arches/app/etl_modules/jsonld_importer.py
+++ b/arches/app/etl_modules/jsonld_importer.py
@@ -333,7 +333,13 @@ class JSONLDImporter(BaseImportModule):
         return None
 
     def save_to_tiles(
-        self, cursor, userid, loadid, multiprocessing=False, max_subprocesses=0
+        self,
+        cursor,
+        userid,
+        loadid,
+        multiprocessing=False,
+        max_subprocesses=0,
+        index=True,
     ):
         error_saving_tiles = None
         error_response = {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds index argument in the `save_to_tiles` method of the jsonld importer that became required as a result of making indexing optional during bulk load #12883.