### PR TITLE
Fix search export error when a linked tile is missing for a node-value node

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -2439,6 +2439,10 @@ class NodeValueDataType(BaseDataType):
                 datatype = datatype_factory.get_instance(value_node.datatype)
                 return datatype.get_display_value(value_tile, value_node)
             return ""
+
+        except models.TileModel.DoesNotExist:
+            return "Linked Tile Not Found"
+
         except:
             raise Exception(
                 f'Node with name "{node.name}" is not configured correctly.'

--- a/releases/7.6.26.md
+++ b/releases/7.6.26.md
@@ -1,8 +1,7 @@
 # Arches 7.6.26 Release Notes
 
 ## Bug Fixes
-
--
+- Handle missing linked tiles for node-value nodes during csv search export [#12897](https://github.com/archesproject/arches/pull/12897)
 
 ## Dependency changes
 

--- a/tests/fixtures/resource_graphs/Search Test Model.json
+++ b/tests/fixtures/resource_graphs/Search Test Model.json
@@ -5,6 +5,62 @@
             "cards": [
                 {
                     "active": true,
+                    "cardid": "22feac17-bb09-4e6a-9d37-448469ed3f5f",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": "",
+                    "description": {
+                        "en": "Represents a node and node type pairing"
+                    },
+                    "graph_id": "d291a445-fa5f-11e6-afa8-14109fd34195",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": null
+                    },
+                    "helptitle": {
+                        "en": null
+                    },
+                    "instructions": {
+                        "en": null
+                    },
+                    "is_editable": true,
+                    "name": {
+                        "en": "Target Node"
+                    },
+                    "nodegroup_id": "81fd5456-9ae8-11f1-96bb-3d59943af363",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
+                    "cardid": "8a000cd0-d606-4fa3-b9d6-d98cca28c2e0",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "d291a445-fa5f-11e6-afa8-14109fd34195",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "is_editable": false,
+                    "name": {
+                        "en": "Link Node"
+                    },
+                    "nodegroup_id": "fda12368-9ae7-11f1-96bb-3d59943af363",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "7a18294a-fa60-11e6-829c-14109fd34195",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -118,7 +174,43 @@
                     "visible": true
                 }
             ],
-            "cards_x_nodes_x_widgets": [],
+            "cards_x_nodes_x_widgets": [
+                {
+                    "card_id": "8a000cd0-d606-4fa3-b9d6-d98cca28c2e0",
+                    "config": {
+                        "displayOnlySelectedNode": false,
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Link to Cultural Period",
+                        "placeholder": {
+                            "en": ""
+                        }
+                    },
+                    "id": "784695ce-36f2-4ff8-8ac5-af5cbb4e7aff",
+                    "label": {
+                        "en": "Link to Cultural Period"
+                    },
+                    "node_id": "fda12368-9ae7-11f1-96bb-3d59943af363",
+                    "sortorder": 0,
+                    "visible": true,
+                    "widget_id": "f5d6b190-bbf0-4dc9-b991-1debab8cb4a9"
+                },
+                {
+                    "card_id": "22feac17-bb09-4e6a-9d37-448469ed3f5f",
+                    "config": {
+                        "en": ""
+                    },
+                    "id": "dcba3235-f125-4263-b19b-4776f8ab1b2c",
+                    "label": {
+                        "en": null
+                    },
+                    "node_id": "81fd5456-9ae8-11f1-96bb-3d59943af363",
+                    "sortorder": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                }
+            ],
             "color": null,
             "config": {},
             "deploymentdate": null,
@@ -178,6 +270,24 @@
                     "name": null,
                     "ontologyproperty": null,
                     "rangenode_id": "e771b8a1-65fe-11e7-9163-14109fd34195"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e50257a6-fa5f-11e6-8820-14109fd34195",
+                    "edgeid": "e9c82810-6a08-44a5-8a5e-77777459226a",
+                    "graph_id": "d291a445-fa5f-11e6-afa8-14109fd34195",
+                    "name": null,
+                    "ontologyproperty": null,
+                    "rangenode_id": "fda12368-9ae7-11f1-96bb-3d59943af363"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e50257a6-fa5f-11e6-8820-14109fd34195",
+                    "edgeid": "db08d389-b17c-44bd-b7c6-8273503a551a",
+                    "graph_id": "d291a445-fa5f-11e6-afa8-14109fd34195",
+                    "name": null,
+                    "ontologyproperty": null,
+                    "rangenode_id": "81fd5456-9ae8-11f1-96bb-3d59943af363"
                 }
             ],
             "functions_x_graphs": [],
@@ -222,6 +332,18 @@
                     "cardinality": "n",
                     "legacygroupid": null,
                     "nodegroupid": "3ebc6785-fa61-11e6-8c85-14109fd34195",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "fda12368-9ae7-11f1-96bb-3d59943af363",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "81fd5456-9ae8-11f1-96bb-3d59943af363",
                     "parentnodegroup_id": null
                 }
             ],
@@ -380,6 +502,53 @@
                     "ontologyclass": null,
                     "parentproperty": "",
                     "sortorder": 0
+                },
+                {
+                    "alias": "link_node",
+                    "config": {
+                        "nodeid": "81fd5456-9ae8-11f1-96bb-3d59943af363",
+                        "property": null
+                    },
+                    "datatype": "node-value",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "link",
+                    "graph_id": "d291a445-fa5f-11e6-afa8-14109fd34195",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Link Node",
+                    "nodegroup_id": "fda12368-9ae7-11f1-96bb-3d59943af363",
+                    "nodeid": "fda12368-9ae7-11f1-96bb-3d59943af363",
+                    "ontologyclass": null,
+                    "parentproperty": null,
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                                {
+                    "alias": "target_node",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "target",
+                    "graph_id": "d291a445-fa5f-11e6-afa8-14109fd34195",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Target Node",
+                    "nodegroup_id": "81fd5456-9ae8-11f1-96bb-3d59943af363",
+                    "nodeid": "81fd5456-9ae8-11f1-96bb-3d59943af363",
+                    "ontologyclass": null,
+                    "parentproperty": null,
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
                 }
             ],
             "ontology_id": null,

--- a/tests/search/search_export_tests.py
+++ b/tests/search/search_export_tests.py
@@ -1,3 +1,5 @@
+import os
+import glob
 import uuid
 import csv
 import io
@@ -6,6 +8,7 @@ from base64 import b64encode
 from http import HTTPStatus
 from arches.app.models import models
 from arches.app.models.tile import Tile
+from arches.app.models.resource import Resource
 from arches.app.search.elasticsearch_dsl_builder import Query
 from arches.app.search.mappings import TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX
 from arches.app.search.search_engine_factory import SearchEngineFactory
@@ -89,6 +92,13 @@ class SearchExportTests(ArchesTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        export_dir = "tests/fixtures/data/export_deliverables/"
+        for zip_file in glob.glob(os.path.join(export_dir, "*.zip")):
+            try:
+                os.remove(zip_file)
+            except OSError:
+                pass
+
         se = SearchEngineFactory().create()
         q = Query(se=se)
         for indexname in [TERMS_INDEX, CONCEPTS_INDEX, RESOURCES_INDEX]:
@@ -236,6 +246,58 @@ class SearchExportTests(ArchesTestCase):
         request.user = self.user
         exporter = SearchResultsExporter(search_request=request)
         exporter.export(format="tilecsv", report_link="false")
+
+    def test_missing_node_value_tile(self):
+
+        target_tile_data = {
+            "81fd5456-9ae8-11f1-96bb-3d59943af363": {
+                "en": {"value": "Test Node", "direction": "ltr"}
+            }
+        }
+
+        link_tile_data = {
+            "fda12368-9ae7-11f1-96bb-3d59943af363": "694a67a9-52be-4e59-8c30-7c6855137a9d"
+        }
+
+        resource = Resource.objects.create(
+            resourceinstanceid="26ad70b1-dc07-4105-80a9-fc0a351e3b7d",
+            graph_id="d291a445-fa5f-11e6-afa8-14109fd34195",
+        )
+
+        target_tile = Tile.objects.create(
+            resourceinstance_id="26ad70b1-dc07-4105-80a9-fc0a351e3b7d",
+            data=target_tile_data,
+            nodegroup_id="81fd5456-9ae8-11f1-96bb-3d59943af363",
+            tileid="694a67a9-52be-4e59-8c30-7c6855137a9d",
+        )
+
+        Tile.objects.create(
+            resourceinstance_id="26ad70b1-dc07-4105-80a9-fc0a351e3b7d",
+            data=link_tile_data,
+            nodegroup_id="fda12368-9ae7-11f1-96bb-3d59943af363",
+        )
+
+        # synchronous
+        resource.index()
+        se = SearchEngineFactory().create()
+        sync_es(se)
+
+        target_tile.delete()
+
+        request = self.factory.get("/search?tiles=True&export=True&format=tilecsv")
+        request.user = self.user
+        exporter = SearchResultsExporter(search_request=request)
+        files, _ = exporter.export(format="tilecsv", report_link="false")
+
+        csv_content = files[0]["outputfile"].getvalue()
+        csv_reader = list(csv.DictReader(io.StringIO(csv_content)))
+
+        exported_value = [
+            record["Link Node"]
+            for record in csv_reader
+            if record["resourceid"] == "26ad70b1-dc07-4105-80a9-fc0a351e3b7d"
+        ]
+        self.assertEqual(exported_value[0], "Linked Tile Not Found")
 
 
 def is_valid_uuid(value, version=4):


### PR DESCRIPTION
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)

### Description of Change
This PR handles the scenario where a node with the datatype `node-value` is included in search export, but a linked tile recorded using this node has been deleted. As described in #12574, this causes an error when the datatype `get_display_value` is run, as part of `flatten_tiles`. 

The solution catches the specific error for a missing Tile, and returns "Linked Tile Not Found" for inclusion in the csv. 

Running the search export tests was also creating zip files in `tests/fixtures/data/export_deliverables/` every time `test_write_export_to_zip` was run. I've added a snippet to delete these during `tearDownClass`, but could move this to another PR if shouldn't be included here. 

### Issues Solved
Closes #12574

### Checklist
-   I targeted one of these branches:
    - [ ] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [x] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [x] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

#### Ticket Background
*   Sponsored by: K-int
*   Found by: @CWDamm-Kint 
*   Tested by: @CWDamm-Kint 
*   Designed by: @CWDamm-Kint 
