### PR TITLE
fix: resolve project src before installed module in tsconfig paths

### DIFF
--- a/arches/app/utils/frontend_configuration_utils/generate_tsconfig_paths.py
+++ b/arches/app/utils/frontend_configuration_utils/generate_tsconfig_paths.py
@@ -9,6 +9,7 @@ from arches.app.utils.frontend_configuration_utils.get_base_path import get_base
 def generate_tsconfig_paths():
     base_path = get_base_path()
     root_dir_path = os.path.realpath(settings.ROOT_DIR)
+    project_path = os.path.join("..", os.path.basename(base_path), "src")
 
     path_lookup = dict(
         zip(list_arches_app_names(), list_arches_app_paths(), strict=True)
@@ -19,6 +20,7 @@ def generate_tsconfig_paths():
         "compilerOptions": {
             "paths": {
                 "@/arches/*": [
+                    os.path.join(project_path, "arches", "*"),
                     os.path.join(
                         "..",
                         os.path.relpath(
@@ -29,21 +31,22 @@ def generate_tsconfig_paths():
                         "src",
                         "arches",
                         "*",
-                    )
+                    ),
                 ],
                 **{
                     os.path.join("@", path_name, "*"): [
+                        os.path.join(project_path, path_name, "*"),
                         os.path.join(
                             "..",
                             os.path.relpath(path, os.path.join(base_path, "..")),
                             "src",
                             path_name,
                             "*",
-                        )
+                        ),
                     ]
                     for path_name, path in path_lookup.items()
                 },
-                "*": ["../node_modules/*"],
+                "*": ["../node_modules/@types/*", "../node_modules/*"],
             }
         },
     }

--- a/tests/utils/frontend_configuration_utils/test_generate_tsconfig_paths.py
+++ b/tests/utils/frontend_configuration_utils/test_generate_tsconfig_paths.py
@@ -45,10 +45,19 @@ class TestGenerateTsconfigPaths(TestCase):
             "_comment": "This is a generated file. Do not edit directly.",
             "compilerOptions": {
                 "paths": {
-                    "@/arches/*": ["../arches/app/src/arches/*"],
-                    "@/app_one/*": ["../arches_apps/app_one/src/app_one/*"],
-                    "@/app_two/*": ["../arches_apps/app_two/src/app_two/*"],
-                    "*": ["../node_modules/*"],
+                    "@/arches/*": [
+                        "../arches/src/arches/*",
+                        "../arches/app/src/arches/*",
+                    ],
+                    "@/app_one/*": [
+                        "../arches/src/app_one/*",
+                        "../arches_apps/app_one/src/app_one/*",
+                    ],
+                    "@/app_two/*": [
+                        "../arches/src/app_two/*",
+                        "../arches_apps/app_two/src/app_two/*",
+                    ],
+                    "*": ["../node_modules/@types/*", "../node_modules/*"],
                 }
             },
         }
@@ -78,11 +87,16 @@ class TestGenerateTsconfigPaths(TestCase):
         self.assertIn("_comment", result)
         self.assertIn("compilerOptions", result)
         paths_mapping = result["compilerOptions"]["paths"]
-        self.assertEqual(paths_mapping["@/arches/*"], ["../arches/app/src/arches/*"])
+        self.assertEqual(
+            paths_mapping["@/arches/*"],
+            ["../arches/src/arches/*", "../arches/app/src/arches/*"],
+        )
         self.assertEqual(
             sorted(k for k in paths_mapping.keys() if k not in {"@/arches/*", "*"}), []
         )
-        self.assertEqual(paths_mapping["*"], ["../node_modules/*"])
+        self.assertEqual(
+            paths_mapping["*"], ["../node_modules/@types/*", "../node_modules/*"]
+        )
 
     def test_generate_tsconfig_paths_raises_error_when_application_names_and_paths_do_not_match(
         self,
@@ -137,6 +151,14 @@ class TestGenerateTsconfigPaths(TestCase):
                 result = self.generate_tsconfig_paths_function()
 
         paths_mapping = result["compilerOptions"]["paths"]
-        self.assertEqual(paths_mapping["@/arches/*"], [".././app/src/arches/*"])
-        self.assertEqual(paths_mapping["@/alpha/*"], ["../apps/alpha/src/alpha/*"])
-        self.assertEqual(paths_mapping["*"], ["../node_modules/*"])
+        self.assertEqual(
+            paths_mapping["@/arches/*"],
+            ["../arches/src/arches/*", ".././app/src/arches/*"],
+        )
+        self.assertEqual(
+            paths_mapping["@/alpha/*"],
+            ["../arches/src/alpha/*", "../apps/alpha/src/alpha/*"],
+        )
+        self.assertEqual(
+            paths_mapping["*"], ["../node_modules/@types/*", "../node_modules/*"]
+        )


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
tsconfig.paths mapped @/arches/* and @/<application>/* only at the installed module, so a file a project overrode under its own src was never resolved — type checking ran against the original instead of the override.

Fix is to add the project's src path first for each namespace, so it is the first location checked. paths entries are tried in order and a path that doesn't resolve falls through, so where there is no override (or no project at all) resolution falls back to the installed module exactly as before. This matches how the @ alias in webpack.common.js already resolves.

Also puts ../node_modules/@types/* ahead of ../node_modules/* so a plain-JS package resolves to its bundled declarations rather than succeeding at the package itself.

### Issues Solved
<!--- If this Pull Request solves any issues, list them here, and mark the ticket "In Review" in the pipeline project -->
Closes #

### Checklist
<!--- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.  -->
-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
-   [ ] I added a changelog in arches/releases
-   [ ] I submitted a PR to arches-docs (if appropriate)
-   [ ] Unit tests pass locally with my changes
-   [ ] I added tests that prove my fix is effective or that my feature works
-   [ ] My test fails on the target branch

